### PR TITLE
docs(rust): flag interp_stroke/hit_test as unsafe drop-ins

### DIFF
--- a/geometry-wasm/src/hit.rs
+++ b/geometry-wasm/src/hit.rs
@@ -76,6 +76,21 @@ pub(crate) fn hit_test_scene(scene: &SceneIn, x: f64, y: f64, tolerance: f64) ->
 /// Returns a JSON `{layerIndex,itemIndex,kind}` for the topmost hit item
 /// (last layer, last item within it, scanned first — matches draw order:
 /// last-drawn is topmost), or the literal string `"null"` for no hit.
+///
+/// NOT a drop-in for select-bridge.js's click/marquee hit-testing — that
+/// caller does far more than "which item is under the point": locked-layer
+/// skip (except a symbol/component layer, which must still hit as one
+/// rigid whole), cross-layer active-layer switching when the hit lands on
+/// a non-active layer, a component-layer fallback scan
+/// (hitTestComponentLayers) with its own double-click-to-enter-symbol
+/// timing, and node/handle-level hits (hitTestHandles, for the node-edit
+/// tool) that this function has no concept of at all — it only knows
+/// fill/stroke containment over a static scene snapshot. Wiring this in
+/// would mean re-implementing all of that business logic here too, not
+/// just swapping the geometry test. Verified unused as of the 2026-07-13
+/// optimization pass (grep across src/js/*.js found zero callers) — no
+/// measured slowness in select-bridge.js's current Paper.js hitTest() to
+/// justify the port either, per the same pass.
 #[wasm_bindgen]
 pub fn hit_test(scene_json: &str, x: f64, y: f64, tolerance: f64) -> Result<String, JsValue> {
     let scene: SceneIn = serde_json::from_str(scene_json).map_err(|e| JsValue::from_str(&e.to_string()))?;

--- a/geometry-wasm/src/tween.rs
+++ b/geometry-wasm/src/tween.rs
@@ -87,6 +87,22 @@ fn pick_color(a: &Option<[u8; 4]>, b: &Option<[u8; 4]>, et: f64) -> Option<[u8; 
     }
 }
 
+// NOT a safe drop-in for JS's current interpStroke (tweens.js) — this port
+// predates two behaviors JS has since grown:
+//   1. Per-pair similarity-transform rotation/scale blending (tweens.js
+//      interpStroke, the fitSimilarityTransform + thetaT/scaleT/thetaB/
+//      scaleB block) — gives a swinging arm/turning wheel real rotation
+//      instead of every point sliding straight toward its counterpart.
+//      fit_similarity_transform already exists in tweenmatch.rs (used by
+//      auto_match's own "force line" pass) but is never called from here.
+//   2. Vector-brush (pressure ribbon) width-profile interpolation +
+//      outline reconstruction (tweens.js interpStroke's isVectorBrush
+//      branch, outlineFromCenterSegs) — entirely absent below.
+// Wiring GeometryWasm.interp_stroke into JS as-is would silently drop both:
+// every rotating tween would go back to warping/flattening through its own
+// center, and every pressure-brush tween would lose its width profile. Do
+// NOT wire this in without porting both first — verified unused as of the
+// 2026-07-13 optimization pass (grep across src/js/*.js found zero callers).
 #[wasm_bindgen]
 pub fn interp_stroke(json: &str) -> Result<String, JsValue> {
     let input: InterpInput = serde_json::from_str(json).map_err(|e| JsValue::from_str(&e.to_string()))?;


### PR DESCRIPTION
Cherry-picked from the old local-only `perf/wire-dead-wasm-exports` branch (never pushed) onto current main. Comment-only, no functional change — see commit body for the full investigation.