### PR TITLE
Point d'ancrage pour le gizmo de transformation vidéo

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2433,6 +2433,15 @@
           nvItems.push(rectItem(p.x, p.y, 3.5 * nzs, [255, 255, 255, 255], [74, 158, 255, 255], 1.2 * nzs));
         });
         nvItems.push(circleItem(nvTb.ringCenter.x, nvTb.ringCenter.y, nvTb.ringRadius, null, [74, 158, 255, 160], 1 * nzs));
+        // Anchor/pivot crosshair (2026-07) — same AE-style ringed-cross
+        // glyph as the path selection's own anchor (buildTransformBoxItems
+        // below), same hover-grow convention (state.xformAnchorHovered is
+        // shared: only one gizmo is ever on screen at a time, path OR video).
+        var nvAr = (state.xformAnchorHovered ? 10 : 8) * nzs;
+        var nvAp = nvTb.anchor;
+        nvItems.push(circleItem(nvAp.x, nvAp.y, nvAr, null, [74, 158, 255, 255], 1.2 * nzs));
+        nvItems.push(lineItem([nvAp.x - nvAr, nvAp.y], [nvAp.x + nvAr, nvAp.y], [74, 158, 255, 255], 1 * nzs));
+        nvItems.push(lineItem([nvAp.x, nvAp.y - nvAr], [nvAp.x, nvAp.y + nvAr], [74, 158, 255, 255], 1 * nzs));
         return nvItems;
       }
     }

--- a/src/js/native-video-bridge.js
+++ b/src/js/native-video-bridge.js
@@ -864,9 +864,24 @@
       nw: spin(rect.x, rect.y), ne: spin(rect.x + rect.width, rect.y),
       se: spin(rect.x + rect.width, rect.y + rect.height), sw: spin(rect.x, rect.y + rect.height),
     };
+    // Anchor/pivot (2026-07, "pas de point d'ancrage sur les média vidéo")
+    // — reuses the SAME Motion "Anchor Point" the Transform panel's 5 base
+    // fields already expose for every layer (Position/Anchor/Rotation/
+    // Scale/Opacity), rather than a parallel system: displayRect already
+    // offsets the scale/rotate PIVOT by this value when composing the
+    // layer's Motion transform (see computeMotionMat/transformImageRect) —
+    // this just visualizes/drags that exact same pivot on canvas. A pivot
+    // is invariant to whatever scale/rotate happens AROUND it — only the
+    // position translation moves it — so its world position is simply the
+    // canvas-centered rect's own (untransformed) center, plus the anchor
+    // offset, plus the position delta; no spin() needed (unlike the
+    // corners, which genuinely orbit it).
+    var anc = window.SMMotion ? SMMotion.getLayerValue(li, 'anchor') : [0, 0];
+    var pos = window.SMMotion ? SMMotion.getLayerValue(li, 'position') : [0, 0];
+    var anchor = { x: state.canvasW / 2 + anc[0] + pos[0], y: state.canvasH / 2 + anc[1] + pos[1] };
     var zs = 1 / Math.max(0.0001, view.zoom);
     var ringRadius = Math.min(36 * zs, Math.max(rect.width, rect.height) * 0.3);
-    return { rect: rect, center: { x: cx, y: cy }, rotation: rot, corners: corners, ringCenter: { x: cx, y: cy }, ringRadius: ringRadius };
+    return { rect: rect, center: { x: cx, y: cy }, rotation: rot, corners: corners, anchor: anchor, ringCenter: anchor, ringRadius: ringRadius };
   }
 
   // Instant import: opens a session and creates a nativeVideo layer —

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -923,7 +923,11 @@
         if (tb) {
           var nvTol = 9 / view.zoom, nvRingTol = 7 / view.zoom;
           var hh2 = null;
-          if (Math.abs(pt.getDistance(new Point(tb.ringCenter.x, tb.ringCenter.y)) - tb.ringRadius) < nvRingTol) hh2 = { type: 'rotate' };
+          // Anchor crosshair — Alt-gated, checked first, same convention
+          // (and same reason: a small object's own body can otherwise fall
+          // within the hit tolerance) as the path selection's own anchor.
+          if (e.altKey && pt.getDistance(new Point(tb.anchor.x, tb.anchor.y)) < nvTol) hh2 = { type: 'anchor' };
+          if (!hh2 && Math.abs(pt.getDistance(new Point(tb.ringCenter.x, tb.ringCenter.y)) - tb.ringRadius) < nvRingTol) hh2 = { type: 'rotate' };
           if (!hh2) {
             var bestD2 = nvTol;
             Object.keys(tb.corners).forEach(function (k) {
@@ -931,10 +935,15 @@
               if (d2 < bestD2) { bestD2 = d2; hh2 = { type: 'scale' }; }
             });
           }
+          if (hh2 && hh2.type === 'anchor') {
+            mode = 'nv-anchor-drag';
+            nvIdx = window._nvSelectedLayer;
+            return;
+          }
           if (hh2) {
             pushUndo();
             nvIdx = window._nvSelectedLayer;
-            nvPivot = new Point(tb.center.x, tb.center.y);
+            nvPivot = new Point(tb.anchor.x, tb.anchor.y); // pivot = the SAME anchor displayRect already uses for its scale/rotate, not always the box center
             if (hh2.type === 'rotate') {
               mode = 'nv-rotate';
               nvStartAngle = Math.atan2(pt.y - nvPivot.y, pt.x - nvPivot.x) * 180 / Math.PI;
@@ -944,6 +953,15 @@
               nvOrigDist = Math.max(1e-6, pt.getDistance(nvPivot));
               nvStartScale = SMMotion.getLayerValue(nvIdx, 'scale');
             }
+            return;
+          }
+          // Alt+click anywhere on the selected video relocates its anchor
+          // to that exact point — same Illustrator/Figma convention as the
+          // path selection's own Alt+click-anywhere, consuming the click
+          // entirely (no fall-through to reselect/move below).
+          if (e.altKey) {
+            mode = 'nv-anchor-drag';
+            nvIdx = window._nvSelectedLayer;
             return;
           }
         }
@@ -1364,6 +1382,20 @@
       SMMotion.setLayerValue(nvIdx, 'rotation', [nvOrigRot + (nvAng - nvStartAngle)]);
       window._sceneVersion++;
       window.SMEngineBridge.renderNow();
+    } else if (mode === 'nv-anchor-drag') {
+      // Writes the SAME Motion 'anchor' property the Transform panel field
+      // already edits — dragging is just this pivot's world position minus
+      // the layer's current position delta and the canvas-centered rect's
+      // own (untransformed) center, inverting transformBox's own anchor
+      // formula. No pushUndo/keyframe semantics beyond what setLayerValue
+      // already does (static override or auto-keyframe at the playhead,
+      // same as typing in the panel) — this is a document edit (unlike the
+      // path anchor, which is pure session UI state), matching how every
+      // OTHER video gesture here already goes straight through Motion.
+      var nvAncPos = SMMotion.getLayerValue(nvIdx, 'position');
+      SMMotion.setLayerValue(nvIdx, 'anchor', [pt.x - nvAncPos[0] - state.canvasW / 2, pt.y - nvAncPos[1] - state.canvasH / 2]);
+      window._sceneVersion++;
+      window.SMEngineBridge.renderNow();
     } else if (mode === 'move') {
       // Same ensureKeyframe()+reselect as the scale/rotate grab above (see
       // its comment) — a plain object-body drag needs it just as much: a
@@ -1672,7 +1704,7 @@
       window.SMEngineBridge.resume(); window.SMEngineBridge.renderNow();
       return;
     }
-    if (mode === 'nv-drag' || mode === 'nv-scale' || mode === 'nv-rotate') {
+    if (mode === 'nv-drag' || mode === 'nv-scale' || mode === 'nv-rotate' || mode === 'nv-anchor-drag') {
       mode = null; nvIdx = -1; nvStartPt = null; nvPivot = null;
       // One panel/timeline refresh at gesture end (not per tick — the
       // Transform fields and Motion rows re-read motionStatic/keys).


### PR DESCRIPTION
## Résumé
- Les médias vidéo natifs avaient déjà bounding box/scale/rotation mais aucune ancre (pivot), contrairement aux paths.
- `transformBox()` (native-video-bridge.js) calcule maintenant l'ancre à partir de la propriété SMMotion `anchor` déjà existante — pas de nouveau système parallèle.
- `engine-bridge.js` dessine un réticule à cette position.
- `select-bridge.js` gère le hit-test (Alt-drag sur le réticule + repli "Alt+clic n'importe où sur la vidéo sélectionnée"), et utilise désormais l'ancre (au lieu du centre de la box) comme pivot pour la rotation et le scale, pour matcher le pivot réellement utilisé au rendu (`computeMotionMat`/`transformImageRect`, motion.js).

## Vérification effectuée
Testé dans le Browser pane avec un calque vidéo factice (WebCodecs ne fonctionne pas dans cet environnement Electron de preview) :
- Alt-drag de l'ancre vers un point cible → position confirmée par round-trip `SMMotion.getLayerValue`/`transformBox`.
- Rotation autour de l'ancre déplacée → distance ancre↔centre de la box invariante, comme attendu pour un pivot correct.
- Scale autour de l'ancre déplacée → distance ancre↔centre multipliée exactement par le facteur de scale appliqué.

**Reste à faire** : confirmation par Cyril avec une vraie vidéo dans son environnement Chrome/Tauri (le test ci-dessus utilise un calque factice car WebCodecs ne fonctionne pas dans le navigateur de preview).

## Plan de test
- [ ] Ouvrir un fichier avec une vidéo importée en Motion
- [ ] Sélectionner la vidéo, vérifier que le réticule d'ancre apparaît
- [ ] Alt-glisser le réticule vers un nouveau point
- [ ] Vérifier que la rotation (anneau) pivote bien autour du nouveau point
- [ ] Vérifier que le scale (coins) pivote bien autour du nouveau point