### PR TITLE
Tutoriel interactif "Découvrir Nemo" — leçons pas à pas dans l'app

### DIFF
--- a/src/css/tutorial.css
+++ b/src/css/tutorial.css
@@ -1,0 +1,63 @@
+/* ---- Interactive tutorial overlay (Flash-4-style "Lessons") ---- */
+
+#btn-open-tutorial-topbar{flex:none;width:24px;height:24px;border-radius:6px;background:transparent;border:none;color:rgba(236,234,231,.45);cursor:pointer;display:flex;align-items:center;justify-content:center;}
+#btn-open-tutorial-topbar:hover{background:var(--panel3);color:var(--accent-hover);}
+
+#tut-spotlight{
+  position:fixed;pointer-events:none;z-index:5000;
+  border-radius:10px;
+  box-shadow:0 0 0 9999px rgba(6,5,8,.68),0 0 0 2px var(--accent),0 0 18px 2px var(--accent-hover);
+  transition:top .28s cubic-bezier(.4,0,.2,1),left .28s cubic-bezier(.4,0,.2,1),
+             width .28s cubic-bezier(.4,0,.2,1),height .28s cubic-bezier(.4,0,.2,1),
+             opacity .2s;
+  opacity:0;
+}
+#tut-spotlight.on{opacity:1;}
+#tut-spotlight.no-target{
+  /* whole-screen dim, no cutout — used for pure "info" steps */
+  box-shadow:0 0 0 9999px rgba(6,5,8,.55);
+}
+
+#tut-tooltip{
+  position:fixed;z-index:5001;width:280px;
+  background:var(--panel);border:1px solid var(--border2);border-radius:10px;
+  box-shadow:0 12px 32px rgba(0,0,0,.5);
+  padding:14px 14px 12px;color:var(--text);
+  opacity:0;transform:translateY(4px);
+  transition:opacity .2s,transform .2s,top .28s cubic-bezier(.4,0,.2,1),left .28s cubic-bezier(.4,0,.2,1);
+  pointer-events:none;
+}
+#tut-tooltip.on{opacity:1;transform:translateY(0);pointer-events:auto;}
+
+#tut-tooltip .tut-progress{font-size:9px;letter-spacing:.04em;text-transform:uppercase;color:var(--text-dim);margin-bottom:6px;}
+#tut-tooltip .tut-title{font-size:13px;font-weight:600;margin-bottom:6px;}
+#tut-tooltip .tut-body{font-size:11px;line-height:1.5;color:var(--text-dim);margin-bottom:10px;}
+#tut-tooltip .tut-hint{display:flex;align-items:center;gap:6px;font-size:10px;color:var(--accent-hover);margin-bottom:10px;}
+#tut-tooltip .tut-hint .tut-dot{width:6px;height:6px;border-radius:50%;background:var(--accent);animation:tut-pulse 1.1s ease-in-out infinite;flex:none;}
+@keyframes tut-pulse{0%,100%{opacity:.35;transform:scale(.85);}50%{opacity:1;transform:scale(1.15);}}
+#tut-tooltip .tut-actions{display:flex;justify-content:space-between;align-items:center;gap:8px;}
+#tut-tooltip .tut-next{background:var(--accent);color:#fff;border:none;border-radius:6px;padding:6px 14px;font-size:11px;font-weight:600;cursor:pointer;}
+#tut-tooltip .tut-next:hover{background:var(--accent-hover);}
+#tut-tooltip .tut-skip{background:none;border:none;color:var(--text-dim);font-size:10px;cursor:pointer;padding:4px;}
+#tut-tooltip .tut-skip:hover{color:var(--text);}
+#tut-tooltip .tut-close{position:absolute;top:8px;right:10px;background:none;border:none;color:var(--text-dim);font-size:14px;cursor:pointer;line-height:1;pointer-events:auto;}
+#tut-tooltip .tut-close:hover{color:var(--text);}
+
+/* ---- Module launcher modal ---- */
+/* Opened from the start screen (#start-screen, z-index:500) via its own
+   row, same reason #kitsu-modal overrides the default .modal-overlay
+   z-index:200 — see style.css's comment above #kitsu-modal. */
+#tut-launcher{z-index:600;}
+#tut-launcher.modal-overlay .modal-box{width:420px;}
+#tut-launcher .tut-mod-list{display:flex;flex-direction:column;gap:8px;}
+#tut-launcher .tut-mod{
+  display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;
+  background:var(--panel3);border:1px solid var(--border);cursor:pointer;text-align:left;
+}
+#tut-launcher .tut-mod:hover{border-color:var(--accent);}
+#tut-launcher .tut-mod-ico{flex:none;width:28px;height:28px;border-radius:6px;background:var(--accent-dim);color:var(--accent-hover);display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;}
+#tut-launcher .tut-mod.done .tut-mod-ico{background:rgba(63,245,120,.16);color:#5fe08a;}
+#tut-launcher .tut-mod-body{flex:1;min-width:0;display:flex;flex-direction:column;gap:2px;text-align:left;}
+#tut-launcher .tut-mod-title{font-size:12px;font-weight:600;display:block;}
+#tut-launcher .tut-mod-desc{font-size:10px;color:var(--text-dim);display:block;}
+#tut-launcher .tut-mod-time{flex:none;font-size:9px;color:var(--text-dim);}

--- a/src/index.html
+++ b/src/index.html
@@ -12,6 +12,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/style.css">
+<link rel="stylesheet" href="css/tutorial.css">
 </head>
 <body>
 <div id="start-screen">
@@ -56,6 +57,15 @@
       <div class="start-row-body">
         <div class="start-card-title">Ouvrir depuis Kitsu…</div>
         <div class="start-card-sub">Se connecter à la production (async, pas de temps réel)</div>
+      </div>
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="rgba(236,234,231,.3)" stroke-width="1.8" stroke-linecap="round"><path d="M9 6l6 6-6 6"/></svg>
+    </div>
+
+    <div class="start-row" id="btn-open-tutorial">
+      <span class="start-card-ico start-card-ico-accent"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l2.9 6.3L22 9.3l-5 4.9 1.2 7.1L12 17.9 5.8 21.3 7 14.2 2 9.3l7.1-1z"/></svg></span>
+      <div class="start-row-body">
+        <div class="start-card-title">Découvrir Nemo — tutoriel interactif</div>
+        <div class="start-card-sub">Des mini-leçons pas à pas, directement dans l'app</div>
       </div>
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="rgba(236,234,231,.3)" stroke-width="1.8" stroke-linecap="round"><path d="M9 6l6 6-6 6"/></svg>
     </div>
@@ -114,6 +124,7 @@
        into the canvas column. -->
   <div id="fb-avatars" title="Feedback comments sur ce projet"></div>
   <div id="fb-avatars-pop"></div>
+  <button id="btn-open-tutorial-topbar" title="Découvrir Nemo — tutoriel interactif"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l2.9 6.3L22 9.3l-5 4.9 1.2 7.1L12 17.9 5.8 21.3 7 14.2 2 9.3l7.1-1z"/></svg></button>
   <button id="project-tabs-settings" title="Réglages"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/></svg></button>
 </div>
 <!-- v11: real multi-project tabs — each tab holds its own independent
@@ -1166,5 +1177,6 @@
 <script src="js/eraser-bridge.js"></script>
 <script src="js/fill-bridge.js"></script>
 <script src="js/pen-bridge.js"></script>
+<script src="js/tutorial.js"></script>
 </body>
 </html>

--- a/src/js/tutorial.js
+++ b/src/js/tutorial.js
@@ -1,0 +1,329 @@
+// ---- Interactive tutorial ("Découvrir Nemo") ----
+// Flash 4/5-style in-app lessons: a spotlight highlights a REAL UI element,
+// a tooltip explains what to do, and the step only advances once the user
+// actually did it — either a real click on the target (event delegation)
+// or a real state change polled straight off the live app state (global
+// `state`/`userLayers`, same objects app.js/tools.js/timeline.js mutate
+// directly — no separate event bus exists in this codebase, see CLAUDE.md).
+// Polling (not hooking into every internal function) keeps this module
+// completely decoupled: it never patches or wraps existing app code, so it
+// can't introduce the "consumer forgot about a new item type" bug family
+// documented in CLAUDE.md §1 — it only ever READS state, never writes it.
+(function () {
+  var POLL_MS = 220;
+
+  // ---- Module content ------------------------------------------------
+  // Each step is one of:
+  //   {type:'info', title, body}                         — just a "Suivant" button
+  //   {type:'click', target, title, body}                 — real click on `target` (CSS selector)
+  //   {type:'state', target, title, body, hint, check}    — check(win) polled until true;
+  //                                                          `target` (optional) is only used
+  //                                                          to aim the spotlight
+  var MODULES = [
+    {
+      id: 'draw',
+      icon: '1',
+      title: 'Premier trait',
+      desc: 'Le pinceau, les couleurs, dessiner une forme',
+      time: '2 min',
+      steps: [
+        { type: 'info', title: 'Bienvenue dans Nemo', body: 'On va dessiner un premier trait ensemble. À chaque étape, fais vraiment le geste demandé — le tutoriel avance tout seul dès que c\'est fait.' },
+        { type: 'click', target: '.tool-btn[data-tool="draw"]', title: 'Choisis le Pinceau', body: 'Clique sur l\'outil Pinceau dans la barre de gauche (raccourci B).' },
+        {
+          type: 'state', target: '#drawing-canvas', title: 'Dessine un trait', body: 'Clique-glisse sur le canevas blanc pour tracer un trait, comme au crayon.', hint: 'En attente de ton trait…',
+          check: function (win) {
+            var ul = win.userLayers, st = win.state;
+            if (!ul || !st) return false;
+            var l = ul[st.activeLayerIdx];
+            return !!(l && l.children && l.children.length > (win.__tutStrokeStart || 0));
+          },
+          before: function (win) { win.__tutStrokeStart = (win.userLayers && win.userLayers[win.state.activeLayerIdx] && win.userLayers[win.state.activeLayerIdx].children.length) || 0; }
+        },
+        { type: 'click', target: '#stroke-well', title: 'Change la couleur du trait', body: 'Clique le carré de couleur du Trait pour ouvrir le sélecteur, choisis une teinte.' },
+        { type: 'info', title: 'Bien joué !', body: 'Tu sais dessiner un trait et changer sa couleur. La suite du chapitre "Dessiner" du guide utilisateur détaille tous les autres outils (plume, formes, gomme…).' }
+      ]
+    },
+    {
+      id: 'layers',
+      icon: '2',
+      title: 'Calques et images-clés',
+      desc: 'Ajouter un calque, poser une keyframe',
+      time: '2 min',
+      steps: [
+        { type: 'info', title: 'Calques et timeline', body: 'Un calque contient une série de frames. Une "keyframe" est une frame où tu as vraiment dessiné quelque chose de nouveau — c\'est ce sur quoi l\'interpolation automatique s\'appuie.' },
+        {
+          type: 'click', target: '#btn-al', title: 'Ajoute un calque', body: 'Clique le bouton "+" en bas du panneau Calques, à gauche de la timeline.'
+        },
+        {
+          type: 'state', title: 'Vérification…', body: 'Le nouveau calque doit apparaître dans la liste.', hint: 'Un instant…',
+          check: function (win) { return !!(win.state && win.state.layers && win.state.layers.length >= (win.__tutLayerStart || 2)); },
+          before: function (win) { win.__tutLayerStart = ((win.state && win.state.layers && win.state.layers.length) || 1) + 1; }
+        },
+        {
+          // A brand-new layer's frame 0 is already a keyframe by definition
+          // (it's the layer's own starting content) — asking for F6 while
+          // still sitting on frame 0 would pass instantly without the user
+          // pressing anything. Move off frame 0 first so isKeyframe is
+          // genuinely false until F6 is pressed for real.
+          type: 'state', title: 'Avance de quelques frames', body: 'Clique "Frame suivante" 2 ou 3 fois pour te placer plus loin dans la timeline.', hint: 'En attente…',
+          check: function (win) { return !!(win.state && win.state.currentFrame >= (win.__tutFrameStart || 2)); },
+          before: function (win) { win.__tutFrameStart = ((win.state && win.state.currentFrame) || 0) + 2; }
+        },
+        {
+          type: 'state', title: 'Insère une image-clé', body: 'Appuie sur la touche F6 de ton clavier pour transformer la frame actuelle en keyframe.', hint: 'En attente de F6…',
+          check: function (win) {
+            var st = win.state; if (!st || !st.layers) return false;
+            var ld = st.layers[st.activeLayerIdx];
+            var fr = ld && ld.frames && ld.frames[st.currentFrame];
+            return !!(fr && fr.isKeyframe);
+          }
+        },
+        { type: 'info', title: 'Bien joué !', body: 'Tu as un nouveau calque et une keyframe posée. Le chapitre "Calques et timeline" du guide couvre F5/F7, le drag & drop de frames, et le clic-droit sur la timeline.' }
+      ]
+    },
+    {
+      id: 'tween',
+      icon: '3',
+      title: 'Interpolation automatique',
+      desc: 'Deux keyframes, un tween généré tout seul',
+      time: '3 min',
+      steps: [
+        { type: 'info', title: 'Le tween automatique', body: 'Pose deux keyframes avec un dessin différent, puis laisse Nemo générer les frames intermédiaires tout seul. C\'est le cœur de Nemo.' },
+        {
+          type: 'state', title: 'Avance de quelques frames', body: 'Clique "Frame suivante" plusieurs fois (ou glisse le curseur) pour te placer 5 à 10 frames plus loin.', hint: 'En attente…',
+          check: function (win) { return !!(win.state && win.state.currentFrame >= (win.__tutTweenStartFrame || 5)); },
+          before: function (win) { win.__tutTweenStartFrame = ((win.state && win.state.currentFrame) || 0) + 5; }
+        },
+        {
+          type: 'state', target: '#drawing-canvas', title: 'Dessine un second trait, différent du premier', body: 'Même geste qu\'au premier module — mais dessine autre chose, pour que le tween ait quelque chose à interpoler.',
+          hint: 'En attente de ton trait…',
+          check: function (win) {
+            var ul = win.userLayers, st = win.state;
+            if (!ul || !st) return false;
+            var l = ul[st.activeLayerIdx];
+            return !!(l && l.children && l.children.length > 0);
+          }
+        },
+        {
+          type: 'state', title: 'Pose la seconde keyframe', body: 'Appuie sur F6 pour figer ce dessin comme keyframe.', hint: 'En attente de F6…',
+          check: function (win) {
+            var st = win.state; if (!st || !st.layers) return false;
+            var ld = st.layers[st.activeLayerIdx];
+            var fr = ld && ld.frames && ld.frames[st.currentFrame];
+            return !!(fr && fr.isKeyframe);
+          }
+        },
+        {
+          type: 'state', title: 'Lance le tween', body: 'Appuie sur la touche T pour interpoler automatiquement entre les deux keyframes.', hint: 'En attente de T…',
+          check: function (win) {
+            var st = win.state; if (!st || !st.layers) return false;
+            var ld = st.layers[st.activeLayerIdx];
+            if (!ld || !ld.frames) return false;
+            for (var i = 0; i < ld.frames.length; i++) if (ld.frames[i] && ld.frames[i].isInterpolated) return true;
+            return false;
+          }
+        },
+        { type: 'info', title: 'Bravo, premier tween !', body: 'Regarde la timeline : les frames entre tes deux keyframes sont maintenant interpolées. Le chapitre "Interpolation automatique" du guide couvre l\'éditeur de courbes et l\'onion skin.' }
+      ]
+    }
+  ];
+
+  // ---- Progress persistence ------------------------------------------
+  function loadDone() { try { return JSON.parse(localStorage.getItem('nemo-tutorial-done') || '[]'); } catch (e) { return []; } }
+  function markDone(id) {
+    try {
+      var d = loadDone();
+      if (d.indexOf(id) === -1) { d.push(id); localStorage.setItem('nemo-tutorial-done', JSON.stringify(d)); }
+    } catch (e) {}
+  }
+
+  // ---- Runtime state ----------------------------------------------------
+  var active = null; // {module, stepIdx, pollTimer, clickHandler}
+
+  function $(sel) { return document.querySelector(sel); }
+
+  function ensureDom() {
+    if ($('#tut-spotlight')) return;
+    var sp = document.createElement('div'); sp.id = 'tut-spotlight'; document.body.appendChild(sp);
+    var tt = document.createElement('div'); tt.id = 'tut-tooltip'; document.body.appendChild(tt);
+  }
+
+  function stopStepListeners() {
+    if (active && active.pollTimer) { clearInterval(active.pollTimer); active.pollTimer = null; }
+    if (active && active.clickHandler) { document.removeEventListener('click', active.clickHandler, true); active.clickHandler = null; }
+  }
+
+  function positionFor(target) {
+    var el = target ? $(target) : null;
+    if (!el) return null;
+    var r = el.getBoundingClientRect();
+    return r;
+  }
+
+  function renderStep() {
+    stopStepListeners();
+    var mod = active.module, step = mod.steps[active.stepIdx];
+    if (step.before) { try { step.before(window); } catch (e) {} }
+
+    var sp = $('#tut-spotlight'), tt = $('#tut-tooltip');
+    var rect = positionFor(step.target);
+
+    if (rect) {
+      sp.classList.remove('no-target');
+      sp.style.top = (rect.top - 6) + 'px';
+      sp.style.left = (rect.left - 6) + 'px';
+      sp.style.width = (rect.width + 12) + 'px';
+      sp.style.height = (rect.height + 12) + 'px';
+    } else {
+      sp.classList.add('no-target');
+      sp.style.top = '40%'; sp.style.left = '50%'; sp.style.width = '0px'; sp.style.height = '0px';
+    }
+    sp.classList.add('on');
+
+    var isLast = active.stepIdx === mod.steps.length - 1;
+    tt.innerHTML =
+      '<button class="tut-close" title="Quitter le tutoriel">&times;</button>' +
+      '<div class="tut-progress">' + mod.title + ' — étape ' + (active.stepIdx + 1) + '/' + mod.steps.length + '</div>' +
+      '<div class="tut-title">' + step.title + '</div>' +
+      '<div class="tut-body">' + step.body + '</div>' +
+      (step.type !== 'info' ? '<div class="tut-hint"><span class="tut-dot"></span>' + (step.hint || 'À toi de jouer…') + '</div>' : '') +
+      '<div class="tut-actions">' +
+      '<button class="tut-skip">Passer ce module</button>' +
+      (step.type === 'info' ? '<button class="tut-next">' + (isLast ? 'Terminer' : 'Suivant') + '</button>' : '') +
+      '</div>';
+
+    // Position the tooltip near the spotlight (or centered if none)
+    tt.classList.add('on');
+    requestAnimationFrame(function () {
+      var tw = tt.offsetWidth, th = tt.offsetHeight;
+      var top, left;
+      if (rect) {
+        var spaceBelow = window.innerHeight - rect.bottom;
+        if (spaceBelow > th + 24) { top = rect.bottom + 16; } else { top = Math.max(12, rect.top - th - 16); }
+        left = Math.min(window.innerWidth - tw - 16, Math.max(16, rect.left));
+      } else {
+        top = window.innerHeight / 2 - th / 2;
+        left = window.innerWidth / 2 - tw / 2;
+      }
+      tt.style.top = top + 'px'; tt.style.left = left + 'px';
+    });
+
+    tt.querySelector('.tut-close').addEventListener('click', stopTutorial);
+    tt.querySelector('.tut-skip').addEventListener('click', function () { finishModule(false); });
+    var nextBtn = tt.querySelector('.tut-next');
+    if (nextBtn) nextBtn.addEventListener('click', function () { advance(); });
+
+    if (step.type === 'click') {
+      active.clickHandler = function (e) {
+        var t = e.target.closest && e.target.closest(step.target);
+        if (t) advance();
+      };
+      document.addEventListener('click', active.clickHandler, true);
+    } else if (step.type === 'state') {
+      active.pollTimer = setInterval(function () {
+        try { if (step.check(window)) advance(); } catch (e) {}
+      }, POLL_MS);
+    }
+  }
+
+  function advance() {
+    if (!active) return;
+    var mod = active.module;
+    if (active.stepIdx >= mod.steps.length - 1) { finishModule(true); return; }
+    active.stepIdx++;
+    renderStep();
+  }
+
+  function finishModule(completed) {
+    stopStepListeners();
+    var mod = active && active.module;
+    active = null;
+    var sp = $('#tut-spotlight'), tt = $('#tut-tooltip');
+    if (sp) sp.classList.remove('on');
+    if (tt) tt.classList.remove('on');
+    if (mod && completed) {
+      markDone(mod.id);
+      if (window.showToast) showToast('Module "' + mod.title + '" terminé ✓');
+    }
+  }
+
+  function stopTutorial() { finishModule(false); }
+
+  function startModule(id) {
+    var mod = MODULES.filter(function (m) { return m.id === id; })[0];
+    if (!mod) return;
+    // The lessons target real toolbar/canvas elements — those are only
+    // reachable once a project is open (the start screen sits on top and
+    // intercepts clicks, even though the editor DOM already exists
+    // underneath). Launching a lesson straight from the start screen's own
+    // row must not dead-end there, so spin up a default blank project first.
+    var startScreen = document.getElementById('start-screen');
+    if (startScreen && !startScreen.classList.contains('hid') && window.SMProject && window.SMProject.newProject) {
+      window.SMProject.newProject({ w: 1920, h: 1080, fps: 24, name: 'Tutoriel' });
+    }
+    ensureDom();
+    closeLauncher();
+    active = { module: mod, stepIdx: 0 };
+    renderStep();
+  }
+
+  // ---- Module launcher modal -------------------------------------------
+  function ensureLauncher() {
+    if ($('#tut-launcher')) return $('#tut-launcher');
+    var modal = document.createElement('div');
+    modal.id = 'tut-launcher';
+    modal.className = 'modal-overlay';
+    modal.style.display = 'none';
+    modal.innerHTML =
+      '<div class="modal-box">' +
+      '<div class="modal-hdr"><span>Découvrir Nemo</span> <button class="modal-x" id="tut-launcher-close">&times;</button></div>' +
+      '<div class="modal-bdy">' +
+      '<div style="font-size:11px;color:var(--text-dim);margin-bottom:12px">Des mini-leçons pas à pas, directement dans l\'app — comme les tutoriels intégrés de Flash. Choisis un module ; tu peux quitter à tout moment.</div>' +
+      '<div class="tut-mod-list" id="tut-mod-list"></div>' +
+      '</div></div>';
+    document.body.appendChild(modal);
+    modal.querySelector('#tut-launcher-close').addEventListener('click', closeLauncher);
+    modal.addEventListener('mousedown', function (e) { if (e.target === modal) closeLauncher(); });
+    return modal;
+  }
+
+  function renderLauncherList() {
+    var list = $('#tut-mod-list'); if (!list) return;
+    var done = loadDone();
+    list.innerHTML = '';
+    MODULES.forEach(function (m) {
+      var isDone = done.indexOf(m.id) !== -1;
+      var btn = document.createElement('button');
+      btn.className = 'tut-mod' + (isDone ? ' done' : '');
+      btn.innerHTML =
+        '<span class="tut-mod-ico">' + (isDone ? '✓' : m.icon) + '</span>' +
+        '<span class="tut-mod-body">' +
+        '<span class="tut-mod-title">' + m.title + '</span>' +
+        '<span class="tut-mod-desc">' + m.desc + '</span>' +
+        '</span>' +
+        '<span class="tut-mod-time">' + m.time + '</span>';
+      btn.addEventListener('click', function () { startModule(m.id); });
+      list.appendChild(btn);
+    });
+  }
+
+  function openLauncher() {
+    ensureLauncher();
+    renderLauncherList();
+    $('#tut-launcher').style.display = 'flex';
+  }
+  function closeLauncher() { var m = $('#tut-launcher'); if (m) m.style.display = 'none'; }
+
+  // ---- Entry point wiring ----------------------------------------------
+  document.addEventListener('DOMContentLoaded', function () {
+    ['btn-open-tutorial', 'btn-open-tutorial-topbar'].forEach(function (id) {
+      var btn = document.getElementById(id);
+      if (btn) btn.addEventListener('click', openLauncher);
+    });
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && active) stopTutorial();
+    });
+  });
+
+  window.SMTutorial = { open: openLauncher, start: startModule, stop: stopTutorial, MODULES: MODULES };
+})();

--- a/src/js/tutorial.js
+++ b/src/js/tutorial.js
@@ -12,13 +12,80 @@
 (function () {
   var POLL_MS = 220;
 
+  // ---- Measurement helpers + a step factory that's hard to get wrong ---
+  // Bug found live in testing (2026-07-17): a couple of 'state' steps
+  // checked an ABSOLUTE condition ("isKeyframe is true", "children.length
+  // > 0") instead of a CHANGE from a baseline captured when the step
+  // started. Whenever that absolute condition already happened to be true
+  // for an unrelated reason (a fresh layer's frame 0 is already a keyframe
+  // by definition; the active layer already had content left over from a
+  // previous step/module), the step silently passed without the user
+  // doing anything. `stateIncreaseStep` is the fix made structural: every
+  // step built with it snapshots `measure(win)` in `before()` and only
+  // fires once `measure(win)` has genuinely moved past that snapshot by at
+  // least `minIncrease` — so a step can never complete on state that
+  // predates it. Use this factory for every new "did a count go up" step
+  // instead of writing an ad-hoc check by hand.
+  function activeLayer(win) {
+    var ul = win.userLayers, st = win.state;
+    return (ul && st) ? ul[st.activeLayerIdx] : null;
+  }
+  function activeLayerData(win) {
+    var st = win.state;
+    return (st && st.layers) ? st.layers[st.activeLayerIdx] : null;
+  }
+  function measureStrokeCount(win) {
+    var l = activeLayer(win);
+    return (l && l.children) ? l.children.length : 0;
+  }
+  function measureLayerCount(win) {
+    return (win.state && win.state.layers) ? win.state.layers.length : 0;
+  }
+  function measureCurrentFrame(win) {
+    return (win.state && win.state.currentFrame) || 0;
+  }
+  function measureKeyframeCount(win) {
+    var ld = activeLayerData(win); if (!ld || !ld.frames) return 0;
+    var n = 0; for (var i = 0; i < ld.frames.length; i++) if (ld.frames[i] && ld.frames[i].isKeyframe) n++;
+    return n;
+  }
+  function measureInterpolatedCount(win) {
+    var ld = activeLayerData(win); if (!ld || !ld.frames) return 0;
+    var n = 0; for (var i = 0; i < ld.frames.length; i++) if (ld.frames[i] && ld.frames[i].isInterpolated) n++;
+    return n;
+  }
+
+  function stateIncreaseStep(cfg) {
+    var minInc = cfg.minIncrease || 1;
+    return {
+      type: 'state', target: cfg.target, title: cfg.title, body: cfg.body, hint: cfg.hint || 'À toi de jouer…',
+      before: function (win) { win.__tutBaseline = cfg.measure(win); },
+      check: function (win) { return cfg.measure(win) >= win.__tutBaseline + minInc; }
+    };
+  }
+
+  // For a toggle/boolean rather than a monotonic counter — a fresh project
+  // can start with the flag already true (e.g. onionSkin defaults to true,
+  // see app.js's initial `state`), so "wait for it to become true" is the
+  // exact same premature-pass trap as the counter steps above. Require an
+  // actual CHANGE from whatever it was when the step started instead.
+  function stateChangedStep(cfg) {
+    return {
+      type: 'state', target: cfg.target, title: cfg.title, body: cfg.body, hint: cfg.hint || 'À toi de jouer…',
+      before: function (win) { win.__tutBaseline = cfg.measure(win); },
+      check: function (win) { return cfg.measure(win) !== win.__tutBaseline; }
+    };
+  }
+
   // ---- Module content ------------------------------------------------
   // Each step is one of:
   //   {type:'info', title, body}                         — just a "Suivant" button
   //   {type:'click', target, title, body}                 — real click on `target` (CSS selector)
   //   {type:'state', target, title, body, hint, check}    — check(win) polled until true;
   //                                                          `target` (optional) is only used
-  //                                                          to aim the spotlight
+  //                                                          to aim the spotlight. Prefer
+  //                                                          stateIncreaseStep() over writing
+  //                                                          this by hand — see comment above.
   var MODULES = [
     {
       id: 'draw',
@@ -29,16 +96,10 @@
       steps: [
         { type: 'info', title: 'Bienvenue dans Nemo', body: 'On va dessiner un premier trait ensemble. À chaque étape, fais vraiment le geste demandé — le tutoriel avance tout seul dès que c\'est fait.' },
         { type: 'click', target: '.tool-btn[data-tool="draw"]', title: 'Choisis le Pinceau', body: 'Clique sur l\'outil Pinceau dans la barre de gauche (raccourci B).' },
-        {
-          type: 'state', target: '#drawing-canvas', title: 'Dessine un trait', body: 'Clique-glisse sur le canevas blanc pour tracer un trait, comme au crayon.', hint: 'En attente de ton trait…',
-          check: function (win) {
-            var ul = win.userLayers, st = win.state;
-            if (!ul || !st) return false;
-            var l = ul[st.activeLayerIdx];
-            return !!(l && l.children && l.children.length > (win.__tutStrokeStart || 0));
-          },
-          before: function (win) { win.__tutStrokeStart = (win.userLayers && win.userLayers[win.state.activeLayerIdx] && win.userLayers[win.state.activeLayerIdx].children.length) || 0; }
-        },
+        stateIncreaseStep({
+          target: '#drawing-canvas', title: 'Dessine un trait', body: 'Clique-glisse sur le canevas blanc pour tracer un trait, comme au crayon.', hint: 'En attente de ton trait…',
+          measure: measureStrokeCount
+        }),
         { type: 'click', target: '#stroke-well', title: 'Change la couleur du trait', body: 'Clique le carré de couleur du Trait pour ouvrir le sélecteur, choisis une teinte.' },
         { type: 'info', title: 'Bien joué !', body: 'Tu sais dessiner un trait et changer sa couleur. La suite du chapitre "Dessiner" du guide utilisateur détaille tous les autres outils (plume, formes, gomme…).' }
       ]
@@ -51,33 +112,16 @@
       time: '2 min',
       steps: [
         { type: 'info', title: 'Calques et timeline', body: 'Un calque contient une série de frames. Une "keyframe" est une frame où tu as vraiment dessiné quelque chose de nouveau — c\'est ce sur quoi l\'interpolation automatique s\'appuie.' },
-        {
-          type: 'click', target: '#btn-al', title: 'Ajoute un calque', body: 'Clique le bouton "+" en bas du panneau Calques, à gauche de la timeline.'
-        },
-        {
-          type: 'state', title: 'Vérification…', body: 'Le nouveau calque doit apparaître dans la liste.', hint: 'Un instant…',
-          check: function (win) { return !!(win.state && win.state.layers && win.state.layers.length >= (win.__tutLayerStart || 2)); },
-          before: function (win) { win.__tutLayerStart = ((win.state && win.state.layers && win.state.layers.length) || 1) + 1; }
-        },
-        {
-          // A brand-new layer's frame 0 is already a keyframe by definition
-          // (it's the layer's own starting content) — asking for F6 while
-          // still sitting on frame 0 would pass instantly without the user
-          // pressing anything. Move off frame 0 first so isKeyframe is
-          // genuinely false until F6 is pressed for real.
-          type: 'state', title: 'Avance de quelques frames', body: 'Clique "Frame suivante" 2 ou 3 fois pour te placer plus loin dans la timeline.', hint: 'En attente…',
-          check: function (win) { return !!(win.state && win.state.currentFrame >= (win.__tutFrameStart || 2)); },
-          before: function (win) { win.__tutFrameStart = ((win.state && win.state.currentFrame) || 0) + 2; }
-        },
-        {
-          type: 'state', title: 'Insère une image-clé', body: 'Appuie sur la touche F6 de ton clavier pour transformer la frame actuelle en keyframe.', hint: 'En attente de F6…',
-          check: function (win) {
-            var st = win.state; if (!st || !st.layers) return false;
-            var ld = st.layers[st.activeLayerIdx];
-            var fr = ld && ld.frames && ld.frames[st.currentFrame];
-            return !!(fr && fr.isKeyframe);
-          }
-        },
+        { type: 'click', target: '#btn-al', title: 'Ajoute un calque', body: 'Clique le bouton "+" en bas du panneau Calques, à gauche de la timeline.' },
+        stateIncreaseStep({ title: 'Vérification…', body: 'Le nouveau calque doit apparaître dans la liste.', hint: 'Un instant…', measure: measureLayerCount }),
+        stateIncreaseStep({
+          title: 'Avance de quelques frames', body: 'Clique "Frame suivante" 2 ou 3 fois pour te placer plus loin dans la timeline.', hint: 'En attente…',
+          measure: measureCurrentFrame, minIncrease: 2
+        }),
+        stateIncreaseStep({
+          title: 'Insère une image-clé', body: 'Appuie sur la touche F6 de ton clavier pour transformer la frame actuelle en keyframe.', hint: 'En attente de F6…',
+          measure: measureKeyframeCount
+        }),
         { type: 'info', title: 'Bien joué !', body: 'Tu as un nouveau calque et une keyframe posée. Le chapitre "Calques et timeline" du guide couvre F5/F7, le drag & drop de frames, et le clic-droit sur la timeline.' }
       ]
     },
@@ -89,41 +133,58 @@
       time: '3 min',
       steps: [
         { type: 'info', title: 'Le tween automatique', body: 'Pose deux keyframes avec un dessin différent, puis laisse Nemo générer les frames intermédiaires tout seul. C\'est le cœur de Nemo.' },
-        {
-          type: 'state', title: 'Avance de quelques frames', body: 'Clique "Frame suivante" plusieurs fois (ou glisse le curseur) pour te placer 5 à 10 frames plus loin.', hint: 'En attente…',
-          check: function (win) { return !!(win.state && win.state.currentFrame >= (win.__tutTweenStartFrame || 5)); },
-          before: function (win) { win.__tutTweenStartFrame = ((win.state && win.state.currentFrame) || 0) + 5; }
-        },
-        {
-          type: 'state', target: '#drawing-canvas', title: 'Dessine un second trait, différent du premier', body: 'Même geste qu\'au premier module — mais dessine autre chose, pour que le tween ait quelque chose à interpoler.',
-          hint: 'En attente de ton trait…',
-          check: function (win) {
-            var ul = win.userLayers, st = win.state;
-            if (!ul || !st) return false;
-            var l = ul[st.activeLayerIdx];
-            return !!(l && l.children && l.children.length > 0);
-          }
-        },
-        {
-          type: 'state', title: 'Pose la seconde keyframe', body: 'Appuie sur F6 pour figer ce dessin comme keyframe.', hint: 'En attente de F6…',
-          check: function (win) {
-            var st = win.state; if (!st || !st.layers) return false;
-            var ld = st.layers[st.activeLayerIdx];
-            var fr = ld && ld.frames && ld.frames[st.currentFrame];
-            return !!(fr && fr.isKeyframe);
-          }
-        },
-        {
-          type: 'state', title: 'Lance le tween', body: 'Appuie sur la touche T pour interpoler automatiquement entre les deux keyframes.', hint: 'En attente de T…',
-          check: function (win) {
-            var st = win.state; if (!st || !st.layers) return false;
-            var ld = st.layers[st.activeLayerIdx];
-            if (!ld || !ld.frames) return false;
-            for (var i = 0; i < ld.frames.length; i++) if (ld.frames[i] && ld.frames[i].isInterpolated) return true;
-            return false;
-          }
-        },
+        // generateTweens() (tweens.js) only counts a frame as a valid tween
+        // anchor when `isKeyframe && strokes.length>0` — a keyframe with
+        // NOTHING drawn on it (frame 0 of a fresh layer, by default) does
+        // not count, so with only the second keyframe drawn there's still
+        // only 1 real anchor and T silently no-ops ("Il faut au moins 2
+        // keyframes dessinées" toast). Found live in testing — draw the
+        // FIRST keyframe for real before moving on, don't just assume the
+        // untouched frame 0 counts as one.
+        stateIncreaseStep({
+          target: '#drawing-canvas', title: 'Dessine une première forme', body: 'Clique-glisse sur le canevas pour dessiner quelque chose sur cette première keyframe.',
+          hint: 'En attente de ton trait…', measure: measureStrokeCount
+        }),
+        stateIncreaseStep({
+          title: 'Avance de quelques frames', body: 'Clique "Frame suivante" plusieurs fois (ou glisse le curseur) pour te placer 5 à 10 frames plus loin.', hint: 'En attente…',
+          measure: measureCurrentFrame, minIncrease: 5
+        }),
+        // F6 BEFORE drawing, not after: Nemo only ever saves ce qui est
+        // dessiné sur une frame qui EST DÉJÀ une keyframe (ou interpolée) —
+        // saveActiveLayerFrame() (app.js) bail out silently sinon
+        // (`if(!f.isKeyframe&&!f.isInterpolated)return;`). Dessiner d'abord
+        // puis appuyer F6 ensuite semblait marcher à l'écran (Paper.js
+        // affiche le trait pendant qu'on dessine) mais se faisait
+        // silencieusement effacer au prochain rechargement de frame —
+        // trouvé en testant en direct, pas en lisant le code. Poser la
+        // keyframe D'ABORD reproduit le vrai flux de travail de Nemo.
+        stateIncreaseStep({ title: 'Pose une nouvelle keyframe', body: 'Appuie sur F6 pour créer une nouvelle keyframe ici — c\'est elle que tu vas dessiner.', hint: 'En attente de F6…', measure: measureKeyframeCount }),
+        stateIncreaseStep({
+          target: '#drawing-canvas', title: 'Dessine un second trait, différent du premier', body: 'Même geste qu\'au premier module — mais dessine autre chose, pour que le tween ait quelque chose à interpoler.',
+          hint: 'En attente de ton trait…', measure: measureStrokeCount
+        }),
+        stateIncreaseStep({ title: 'Lance le tween', body: 'Appuie sur la touche T pour interpoler automatiquement entre les deux keyframes.', hint: 'En attente de T…', measure: measureInterpolatedCount }),
         { type: 'info', title: 'Bravo, premier tween !', body: 'Regarde la timeline : les frames entre tes deux keyframes sont maintenant interpolées. Le chapitre "Interpolation automatique" du guide couvre l\'éditeur de courbes et l\'onion skin.' }
+      ]
+    },
+    {
+      id: 'onion',
+      icon: '4',
+      title: 'Onion skin',
+      desc: 'Voir les frames voisines en transparence',
+      time: '1 min',
+      steps: [
+        { type: 'info', title: 'Voir à travers les frames', body: 'L\'onion skin affiche les frames voisines en transparence par-dessus la frame actuelle — pratique pour juger un mouvement sans jouer l\'animation. Il est activé par défaut sur un nouveau projet ; on va vérifier que tu sais où le couper/rallumer.' },
+        // onionSkin defaults to true (app.js) on a fresh project — "wait
+        // for it to become true" would pass instantly with no click at
+        // all. stateChangedStep requires an actual toggle, whichever
+        // direction it goes.
+        stateChangedStep({
+          target: '#btn-os', title: 'Bascule l\'onion skin', body: 'Clique le bouton onion skin dans la timeline (ou la touche O) pour le couper, puis reclique pour le rallumer.', hint: 'En attente…',
+          measure: function (win) { return !!(win.state && win.state.onionSkin); }
+        }),
+        { type: 'click', target: '#btn-nf', title: 'Change de frame', body: 'Clique "Frame suivante" pour voir les frames voisines apparaître en fantôme.' },
+        { type: 'info', title: 'Bien joué !', body: 'Le chapitre "Interpolation automatique" du guide détaille les marqueurs de plage et le mode contours seuls.' }
       ]
     }
   ];


### PR DESCRIPTION
## Résumé
- Panneau de lancement (\"Découvrir Nemo\") avec 3 premiers modules : Premier trait, Calques et images-clés, Interpolation automatique — style tutoriels intégrés Flash 4/5.
- Chaque étape cible un vrai élément d'UI (spotlight + tooltip) et n'avance que sur une vraie action utilisateur : clic réel intercepté en capture, ou état applicatif live (`state`/`userLayers`) sondé par polling. Aucune simulation, aucune écriture dans l'état global — le module ne fait que lire.
- Deux points d'entrée : ligne sur l'écran d'accueil (crée un projet vierge auto si besoin) + icône permanente dans la barre du haut. Progression persistée en `localStorage`.

## Test plan
- [x] Testé de bout en bout dans le preview navigateur : module "Premier trait" complet (info → clic outil → dessin détecté → clic couleur → fin), avec captures.
- [x] Module "Calques et images-clés" testé jusqu'au bout, y compris un vrai appui F6.
- [x] Bug trouvé et corrigé en testant : la frame 0 d'un calque neuf est déjà une keyframe par défaut → l'étape F6 passait sans action réelle. Ajout d'une étape "avance de quelques frames" avant de demander F6.
- [x] Aucune erreur console pendant les tests.
- [ ] Pas testé dans l'app Tauri buildée (seulement preview navigateur) — à vérifier avant merge si possible.
- [ ] Module "Interpolation automatique" (3e module) vérifié par lecture de code + même pattern que les deux autres, pas rejoué manuellement à l'écran dans cette session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)