### PR TITLE
Feedback : une écriture échouée ne doit plus se faire passer pour un succès

### DIFF
--- a/src/js/feedback-bridge.js
+++ b/src/js/feedback-bridge.js
@@ -127,7 +127,15 @@
   }
   function lsKey() { return 'nemo-feedback-' + projectKey(); }
   function lsReadAll() { try { return JSON.parse(localStorage.getItem(lsKey()) || '[]'); } catch (e) { return []; } }
-  function lsWriteAll(list) { try { localStorage.setItem(lsKey(), JSON.stringify(list)); } catch (e) {} }
+  // No try/catch here (unlike lsReadAll) — a write failure (most likely
+  // QuotaExceededError: a screenshot-bearing entry list can genuinely blow
+  // past the ~5-10MB per-origin localStorage limit, since this is the ONLY
+  // durable store in a browser-preview session with no dev server reachable)
+  // must propagate up through writeLocal()'s unwrapped `await` to
+  // submitFeedback's caller, so the UI's existing .catch shows "Échec de
+  // l'enregistrement du feedback" instead of the false-positive success
+  // toast — a report entered, "saved", then silently gone with the tab.
+  function lsWriteAll(list) { localStorage.setItem(lsKey(), JSON.stringify(list)); }
 
   var _devServerChecked = null;
   async function devServerAvailable() {


### PR DESCRIPTION
## Résumé
En enquêtant sur des feedbacks envoyés "ce soir" en mode preview navigateur et introuvables (GitHub, appData Tauri, `.feedback/` du dossier principal + 4 worktrees, localStorage de 6 origines — tout vérifié, rien nulle part), j'ai trouvé la cause probable : `lsWriteAll()` avalait silencieusement toute erreur d'écriture localStorage. En preview navigateur (dernier recours de stockage si le serveur dev n'est pas joignable), une écriture qui échoue (le plus probable : quota dépassé, toutes les entrées + captures d'écran base64 tenant dans une seule clé) laissait quand même l'UI afficher "Feedback enregistré" — alors que rien n'avait été persisté.

## Fix
Retire le try/catch avalant dans `lsWriteAll` — l'erreur remonte maintenant jusqu'au `.catch` déjà présent sur le bouton "Enregistrer comme feedback", qui affiche "Échec de l'enregistrement du feedback".

## Test plan
- [x] Mock de `localStorage.setItem` levant `QuotaExceededError` + `fetch('/__feedback/*')` en échec → `submitFeedback()` rejette maintenant correctement (vérifié en live) au lieu de résoudre silencieusement
- [x] `node --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)