### PR TITLE
Tween : easing par paire de keyframes + courbes sous les calques

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1017,6 +1017,7 @@
     <button class="tb" id="btn-ghost-select" title="Select all keyframes' content to move/transform together" disabled><span style="font-size:12px;line-height:1">&#x2725;</span></button>
     <button class="tb" id="btn-revision-view" title="Vue de révision — cycle Tout / Mes traits / Corrections" style="margin-left:4px;width:auto;padding:0 8px;font-size:10px">Tout</button>
     <button class="tb" id="btn-cycle" title="Cycle — repete N fois la plage de frames selectionnee (walk cycles)" style="margin-left:4px"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 2l4 4-4 4"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><path d="M7 22l-4-4 4-4"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></svg></button>
+    <button class="tb" id="btn-tween-curves" title="Afficher/masquer les courbes d'easing sous les calques avec tween — clic sur un segment pour l'éditer individuellement" style="margin-left:4px"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 17c3 0 3-10 6-10s3 10 6 10 3-8 6-8"/></svg></button>
   </div>
   <div id="tl-content">
     <div id="layer-panel">

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -115,6 +115,16 @@ var state={
   // keyframe B, overriding the auto-matcher for that one pair when it
   // misidentifies correspondence (large shape change, size change).
   tweenOverrides:{},
+  // Per-keyframe-pair easing override — {layer+':'+fA+'-'+fB: {points:[...]}}.
+  // COMPLEMENTS state.easingCurve, never replaces it: a pair with no entry
+  // here just falls back to the global curve (getEasingForPair, tweens.js).
+  // Same on-curve-waypoint shape as easingCurve/motion's curvePoints, so
+  // the one shared widget (_curveEditor.editTweenSeg, ui.js) edits it too.
+  tweenEasing:{},
+  // Timeline toggle (per-project, not per-layer) — show/hide the inline
+  // mini-curve strip under every layer that has at least one tween span.
+  // Purely a display preference; never affects generateTweens() output.
+  showTweenCurves:false,
   selectedStrokeIndices:[],
   undoStack:[],redoStack:[],maxUndo:60,
   // Session-only, deliberately NEVER included in exportJSON()'s field list

--- a/src/js/project.js
+++ b/src/js/project.js
@@ -46,7 +46,7 @@
     var defFrames=Math.max(1,Math.round(cfg.fps*5));
     state.totalFrames=defFrames;state.waIn=0;state.waOut=defFrames-1;
     window._waIn=0;window._waOut=defFrames-1;window._totalF=defFrames;
-    state.motionArcs={};state.tweenOverrides={};state.currentFrame=0;
+    state.motionArcs={};state.tweenOverrides={};state.tweenEasing={};state.currentFrame=0;
     // Viewport/UI state, not document content — reset the same way
     // fitCanvas()/resetView() already do, so a new project doesn't silently
     // inherit the previous project's stage rotation.

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -293,6 +293,14 @@ window.SM={
     // #os-st-panel (la section Onion Skin du panel droit, mockup 2026-07-17).
     ['os-st','os-st-panel'].forEach(function(id){var el=document.getElementById(id);if(!el)return;el.textContent=state.onionSkin?'ON':'OFF';el.style.color=state.onionSkin?'var(--green)':'var(--text-dim)';});
     var b=document.getElementById('btn-os');if(b)b.classList.toggle('active',state.onionSkin);window.updateOmMarkers(state.currentFrame,state.totalFrames);},
+  // Pure display toggle (complements the global/per-pair easing system,
+  // never affects generateTweens' output) — mini curve strips under every
+  // layer row that has at least one tween span, see renderTweenCurveStrips.
+  toggleTweenCurves:function(){
+    state.showTweenCurves=!state.showTweenCurves;
+    var b=document.getElementById('btn-tween-curves');if(b)b.classList.toggle('active',state.showTweenCurves);
+    renderTweenCurveStrips();
+  },
   toggleGhostAll:function(){
     state.ghostAllFrames=!state.ghostAllFrames;
     renderOS();
@@ -924,7 +932,7 @@ window.SM={
       mediaLibrary:(state.mediaLibrary||[]).map(function(m){return{id:m.id,name:m.name,kind:m.kind,thumb:m.thumb,layerName:m.layerName};}),
       perspectiveEnabled:state.perspectiveEnabled,perspectiveMode:state.perspectiveMode,perspectiveDensity:state.perspectiveDensity,perspectiveVPs:state.perspectiveVPs,
       motionArcs:state.motionArcs,easingCurve:state.easingCurve,resamplePts:state.resamplePts,tweenStep:state.tweenStep,
-      tweenOverrides:state.tweenOverrides,comments:state.comments||[],
+      tweenOverrides:state.tweenOverrides,tweenEasing:state.tweenEasing||{},comments:state.comments||[],
       cameraKeys:state.cameraKeys||[],cameraLayerOn:!!state.cameraLayerOn});
   },
   mergeRemoteSnapshot:function(remoteData,remoteProfile){return mergeRemoteSnapshot(remoteData,remoteProfile);},
@@ -1046,7 +1054,7 @@ window.SM={
       state.layers[idx].color=ld.color||nextLayerColor();
       ld.frames.forEach(function(f){if(!f.isInterpolated)f.isInterpolated=false;});while(state.layers[idx].frames.length<state.totalFrames)state.layers[idx].frames.push({strokes:[],isKeyframe:false,isInterpolated:false});});
     state.layerFolders=d.layerFolders||{};state.layerLinkGroups=d.layerLinkGroups||{};
-    state.motionArcs=d.motionArcs||{};state.tweenOverrides=d.tweenOverrides||{};if(d.easingCurve){state.easingCurve=d.easingCurve;if(window._curveEditor)window._curveEditor.setState(d.easingCurve);}
+    state.motionArcs=d.motionArcs||{};state.tweenOverrides=d.tweenOverrides||{};state.tweenEasing=d.tweenEasing||{};if(d.easingCurve){state.easingCurve=d.easingCurve;if(window._curveEditor)window._curveEditor.setState(d.easingCurve);}
     state.comments=d.comments||[];
     if(typeof refreshFbAvatars==='function')refreshFbAvatars(); // avatar stack mirrors state.comments — resync on project import
     state.cameraKeys=d.cameraKeys||[];state.cameraLayerOn=!!d.cameraLayerOn;state.cameraView=false;
@@ -1810,7 +1818,77 @@ function renderTimeline(){
   var awrap=document.getElementById('fg-wrap');
   document.getElementById('playhead').style.left=(state.currentFrame*FC)+'px';document.getElementById('playhead').style.height=Math.max(30+rowCount*ROW_H+camGridRowOffset(),awrap?awrap.clientHeight:0)+'px';document.getElementById('playhead-flag').textContent=state.currentFrame+1;
   if(window.SMAudio)SMAudio.renderStrip();
+  renderTweenCurveStrips();
 }
+// ---- TWEEN EASING CURVE STRIPS (toggle: btn-tween-curves) ----
+// Purely additive display, complements the global/per-pair easing system —
+// never touched by generateTweens(). A thin sparkline of the EFFECTIVE
+// curve (per-pair override if one exists, else the global fallback — same
+// getEasingForPair tweens.js itself uses) along the bottom of every layer
+// row, for each tween span (a keyframe pair with at least one generated
+// isInterpolated frame between them). Clicking a segment's own strip opens
+// the shared curve widget pointed at just that pair (openTweenEaseEditor),
+// same right-click-a-segment idea as camera/motion, just click-to-open
+// since the strip IS the segment here (no separate context-menu item
+// needed once the strip's own visible below the layer).
+function layerKeyframeList(li){
+  var ld=state.layers[li];if(!ld)return[];
+  var keys=[];
+  for(var i=0;i<state.totalFrames;i++)if(ld.frames[i]&&ld.frames[i].isKeyframe)keys.push(i);
+  return keys;
+}
+function renderTweenCurveStrips(){
+  var grid=document.getElementById('frame-grid');
+  if(!grid)return;
+  var old=grid.querySelectorAll('.tw-curve-strip');
+  for(var oi=0;oi<old.length;oi++)old[oi].remove();
+  if(!state.showTweenCurves)return;
+  var rows=grid.querySelectorAll('.frow');
+  rows.forEach(function(row){
+    var firstCell=row.querySelector('.fc');
+    if(!firstCell||firstCell.dataset.layer===undefined)return;
+    var li=parseInt(firstCell.dataset.layer);
+    if(isNaN(li)||!state.layers[li])return;
+    var ld=state.layers[li];
+    var keys=layerKeyframeList(li);
+    if(keys.length<2)return;
+    var STRIP_H=8;
+    var svg=null;
+    for(var k=0;k<keys.length-1;k++){
+      var fA=keys[k],fB=keys[k+1];
+      var hasTween=false;
+      for(var fi=fA+1;fi<fB;fi++){if(ld.frames[fi]&&ld.frames[fi].isInterpolated){hasTween=true;break;}}
+      if(!hasTween)continue;
+      if(!svg){
+        svg=document.createElementNS('http://www.w3.org/2000/svg','svg');
+        svg.setAttribute('class','tw-curve-strip');
+        svg.style.cssText='position:absolute;left:0;bottom:0;width:'+(state.totalFrames*FC)+'px;height:'+STRIP_H+'px;pointer-events:none;';
+        row.style.position='relative';
+        row.appendChild(svg);
+      }
+      var evalFn=getEasingForPair(li,fA,fB);
+      var x0=fA*FC,w=(fB-fA)*FC;
+      var N=Math.max(4,Math.min(24,fB-fA));
+      var pts=[];
+      for(var s=0;s<=N;s++){
+        var t=s/N;
+        var y=Math.max(0,Math.min(1,evalFn(t)));
+        pts.push((x0+t*w).toFixed(1)+','+(STRIP_H-1-y*(STRIP_H-2)).toFixed(1));
+      }
+      var custom=!!(state.tweenEasing&&state.tweenEasing[li+':'+fA+'-'+fB]&&state.tweenEasing[li+':'+fA+'-'+fB].points);
+      var poly=document.createElementNS('http://www.w3.org/2000/svg','polyline');
+      poly.setAttribute('points',pts.join(' '));
+      poly.setAttribute('fill','none');
+      poly.setAttribute('stroke',custom?'#4a9eff':'rgba(255,255,255,.35)');
+      poly.setAttribute('stroke-width',custom?'2':'1.2');
+      poly.style.cursor='pointer';
+      poly.style.pointerEvents='stroke';
+      poly.addEventListener('click',(function(l,a,b){return function(e){e.stopPropagation();openTweenEaseEditor(l,a,b);};})(li,fA,fB));
+      svg.appendChild(poly);
+    }
+  });
+}
+window.renderTweenCurveStrips=renderTweenCurveStrips;
 // Builds one row's worth of frame cells for layer `li` into `rowEl` — shared
 // by the normal per-layer row and a collapsed folder's representative row
 // (see renderTimeline() above) so both stay pixel-identical.
@@ -2237,7 +2315,14 @@ document.getElementById('frame-grid').addEventListener('contextmenu',function(e)
   if(li!==state.activeLayerIdx)window.SM.setActiveLayer(li);
   goToFrame(fi);
   var hasClip=!!(_sel.clipboard&&_sel.clipboard.length);
-  window.showContextMenu(e.clientX,e.clientY,[
+  // If this cell sits inside (or starts) a tween span, offer to edit JUST
+  // that pair's easing curve (openTweenEaseEditor, tweens.js) — same idea
+  // as the tween-curve-strip's own click-to-edit, reachable even with
+  // state.showTweenCurves off.
+  var twKeys=layerKeyframeList(li),twPair=null;
+  for(var tki=0;tki<twKeys.length-1;tki++){if(fi>=twKeys[tki]&&fi<=twKeys[tki+1]){twPair={a:twKeys[tki],b:twKeys[tki+1]};break;}}
+  var twMenuItems=twPair?[{label:'Éditer la courbe de ce tween…',action:function(){openTweenEaseEditor(li,twPair.a,twPair.b);}},{sep:true}]:[];
+  window.showContextMenu(e.clientX,e.clientY,twMenuItems.concat([
     {label:'Copier',shortcut:'⌘C',action:function(){window.SM.copyFrames();}},
     {label:'Couper',shortcut:'⌘X',action:function(){window.SM.cutFrames();}},
     {label:'Coller',shortcut:'⌘V',disabled:!hasClip,action:function(){window.SM.pasteFrames();}},
@@ -2258,7 +2343,7 @@ document.getElementById('frame-grid').addEventListener('contextmenu',function(e)
     {label:'Générer / refaire le tween',shortcut:'T',action:function(){window.SM.generateTweens();}},
     {sep:true},
     {label:'Supprimer les images',action:function(){window.SM.removeFrameSpan();}},
-  ]);
+  ]));
 });
 
 document.getElementById('frame-grid').addEventListener('mousemove',function(e){
@@ -4370,6 +4455,7 @@ document.getElementById('p-skipmanual').addEventListener('change',function(){sta
 document.getElementById('btn-tw').addEventListener('click',function(){window.SM.generateTweens();});
 document.getElementById('btn-os').addEventListener('click',function(){window.SM.toggleOnion();});
 document.getElementById('btn-ghost-all').addEventListener('click',function(){window.SM.toggleGhostAll();});
+document.getElementById('btn-tween-curves').addEventListener('click',function(){window.SM.toggleTweenCurves();});
 document.getElementById('btn-ghost-select').addEventListener('click',function(){selectGhostAll();});
 // Team review view filter — cycles All -> Mine -> Corrections, purely a
 // render-time filter in engine-bridge.js's buildSceneJson (never touches

--- a/src/js/tweens.js
+++ b/src/js/tweens.js
@@ -641,6 +641,48 @@ function outlineFromCenterSegs(segs){
   return outSegs;
 }
 function getEasing(){if(window._curveEditor)return window._curveEditor.evalCurve;return function(t){return t;};}
+// Per-keyframe-pair override (state.tweenEasing), falling back to the
+// global curve (getEasing()) for any pair that never got its own —
+// COMPLEMENTS the global curve, doesn't replace it. evalPointsCurve is the
+// pure evaluator (ui.js) — independent of whatever the curve widget
+// happens to be showing right now, unlike evalCurve/activePoints which
+// only reflect the currently-open view.
+function getEasingForPair(li,fA,fB){
+  var key=li+':'+fA+'-'+fB;
+  var custom=state.tweenEasing&&state.tweenEasing[key];
+  if(custom&&custom.points&&custom.points.length&&window._curveEditor&&window._curveEditor.evalPointsCurve){
+    var pts=custom.points;
+    return function(t){return window._curveEditor.evalPointsCurve(pts,t);};
+  }
+  return getEasing();
+}
+// Opens the shared curve widget pointed at ONE keyframe pair's own easing
+// (state.tweenEasing[key]) instead of the global curve — mirrors camera.js/
+// motion.js's editCameraSeg/editMotionSeg (right-click a segment → edit
+// just its own curve). Called from timeline.js's frame-grid context menu
+// and from clicking a per-pair curve strip when state.showTweenCurves is
+// on (see renderTweenCurveStrips, timeline.js).
+function openTweenEaseEditor(li,fA,fB){
+  var key=li+':'+fA+'-'+fB;
+  if(!state.tweenEasing)state.tweenEasing={};
+  var seg=state.tweenEasing[key]=state.tweenEasing[key]||{};
+  window._tweenEaseCtx={li:li,fA:fA,fB:fB};
+  if(window._curveEditor)window._curveEditor.editTweenSeg(seg,'Tween : clé '+(fA+1)+' → '+(fB+1));
+}
+// ui.js's pushCurve() calls this (isTweenSegMode branch) whenever a point
+// is added/moved/deleted on a per-pair curve — regenerates just that span,
+// same restrictTo-by-selection mechanism generateTweens already uses for
+// the "Réattribuer un inbetween" tool.
+window.onTweenEaseSegChanged=function(){
+  var ctx=window._tweenEaseCtx;
+  if(!ctx)return;
+  selClear();selAdd(ctx.li,ctx.fA);
+  generateTweens();
+  selClear();
+  if(state.activeLayerIdx===ctx.li)renderOS();
+  updateUI();
+  if(window.renderTweenCurveStrips)window.renderTweenCurveStrips();
+};
 function lerp(a,b,t){return a+(b-a)*t;}function lerpV(a,b,t){return[lerp(a[0],b[0],t),lerp(a[1],b[1],t)];}
 function arcKey(fA,fB,i){return fA+'-'+fB+'-'+i;}
 // Cubic bezier through ptA/ptB with independent OUT (leaving A) and IN
@@ -1138,10 +1180,12 @@ function generateTweens(){
     selOnLayer.forEach(function(fi0){for(var pi=fi0;pi>=0;pi--){if(ld.frames[pi].isKeyframe){restrictTo[pi]=true;break;}}});
   }
   pushUndoLayers();
-  var easFn=getEasing();var resN=state.resamplePts;var step=state.tweenStep;var total=0;
+  var resN=state.resamplePts;var step=state.tweenStep;var total=0;
   for(var ki=0;ki<keys.length-1;ki++){
     var fA=keys[ki],fB=keys[ki+1];
     if(restrictTo&&!restrictTo[fA])continue;
+    // Per-pair override (complements the global curve, see getEasingForPair)
+    var easFn=getEasingForPair(li,fA,fB);
     var sAsplit=splitTweenables(ld.frames[fA].strokes),sBsplit=splitTweenables(ld.frames[fB].strokes);
     var sA=sAsplit.list,sB=sBsplit.list;
     // v16: manual pairing overrides (state.tweenOverrides) take priority
@@ -1502,7 +1546,7 @@ function renderArcs(cached){
   var st=cached||computeArcMatchState();
   if(!st)return;
   var fA=st.fA,fB=st.fB,sA=st.sA,sB=st.sB,matches=st.matches,fm=st.fm;
-  arcLayer.activate();var cols=['#ff6b6b','#4ecdc4','#ffe66d','#a29bfe','#fd79a8','#00cec9'];var easFn=getEasing();
+  arcLayer.activate();var cols=['#ff6b6b','#4ecdc4','#ffe66d','#a29bfe','#fd79a8','#00cec9'];var easFn=getEasingForPair(state.activeLayerIdx,fA,fB);
   // A multi-element selection used to draw every arc at full brightness/
   // width in its own cycling color — with more than a handful selected the
   // dashed lines and endpoint dots pile on top of each other into an

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -46,13 +46,23 @@
   function isMotionMode(){return !!motionEaseSeg;}
   var MOTION_DEFAULT_CURVE=[{x:0,y:0},{x:.42,y:0},{x:.58,y:1},{x:1,y:1}];
   function motionCurve(){return motionEaseSeg.curvePoints||(motionEaseSeg.curvePoints=clonePts(MOTION_DEFAULT_CURVE));}
-  // The points array actually being viewed/edited right now — motion-segment
-  // mode if active, otherwise the tween's own global curve. Every point-
-  // editing code path below (hit-test, drag, add/delete, presets) reads/
-  // writes through this instead of `cs.points` directly, so camera mode
-  // stays the only thing with genuinely separate rendering/interaction.
-  function activePoints(){return isMotionMode()?motionCurve():cs.points;}
-  function setActivePoints(pts){if(isMotionMode())motionEaseSeg.curvePoints=pts;else cs.points=pts;}
+  // Tween-pair points-based ease mode (2026-07, "easing par paire de clé,
+  // complémentaire au système actuel") — same on-curve-waypoint model,
+  // scoped to ONE keyframe pair (state.tweenEasing[layer:fA-fB].points)
+  // instead of the tween's global state.easingCurve, which stays the
+  // fallback for any pair that never got its own curve. Mutually exclusive
+  // with camera/motion mode, same pattern as those two.
+  var tweenEaseSeg=null,tweenEaseLabel='';
+  function isTweenSegMode(){return !!tweenEaseSeg;}
+  function tweenSegCurve(){return tweenEaseSeg.points||(tweenEaseSeg.points=clonePts(cs.points));}
+  // The points array actually being viewed/edited right now — motion- or
+  // tween-segment mode if active, otherwise the tween's own global curve.
+  // Every point-editing code path below (hit-test, drag, add/delete,
+  // presets) reads/writes through this instead of `cs.points` directly, so
+  // camera mode stays the only thing with genuinely separate rendering/
+  // interaction.
+  function activePoints(){return isMotionMode()?motionCurve():isTweenSegMode()?tweenSegCurve():cs.points;}
+  function setActivePoints(pts){if(isMotionMode())motionEaseSeg.curvePoints=pts;else if(isTweenSegMode())tweenEaseSeg.points=pts;else cs.points=pts;}
   // A small easing gallery (After Effects/GreenSock-style grid of named
   // curve families, each in/out/inout where that makes sense) — through-
   // point approximations of their usual off-curve-handle shapes, since the
@@ -209,7 +219,7 @@
     // global evalCurve/cs.points), everything else about the rendering is
     // shared with the tween's own curve view.
     ctx.strokeStyle='#4a9eff';ctx.lineWidth=2.5;ctx.beginPath();
-    var evalFn=isMotionMode()?function(x){return evalPointsCurve(pts,x);}:evalCurve;
+    var evalFn=(isMotionMode()||isTweenSegMode())?function(x){return evalPointsCurve(pts,x);}:evalCurve;
     ctx.moveTo(tX(0),tY(evalFn(0),yr));
     var N=100;for(var s=1;s<=N;s++){var xx=s/N;ctx.lineTo(tX(xx),tY(evalFn(xx),yr));}
     ctx.stroke();
@@ -246,7 +256,7 @@
       });
     }
     var coordsEl=document.getElementById('curve-coords');
-    if(coordsEl)coordsEl.textContent=isMotionMode()?motionEaseLabel:(pts.length+' points');
+    if(coordsEl)coordsEl.textContent=isMotionMode()?motionEaseLabel:isTweenSegMode()?tweenEaseLabel:(pts.length+' points');
   }
   function drawH(nx,ny,c,yr,r){ctx.beginPath();ctx.arc(tX(nx),tY(ny,yr),r,0,Math.PI*2);ctx.fillStyle=c;ctx.fill();ctx.strokeStyle='#fff';ctx.lineWidth=1.5;ctx.stroke();}
   function hitT(mx,my){
@@ -263,6 +273,7 @@
   // onEaseSegChanged hook (if present) picks up the repaint instead.
   function pushCurve(){
     if(isMotionMode()){if(window.SMMotion&&window.SMMotion.onEaseSegChanged)window.SMMotion.onEaseSegChanged();return;}
+    if(isTweenSegMode()){if(window.onTweenEaseSegChanged)window.onTweenEaseSegChanged();return;}
     if(window.SM)window.SM.setCurve(clonePts(cs.points));upP();
   }
 
@@ -472,6 +483,11 @@
 
   window._curveEditor={
     evalCurve:evalCurve,
+    // Pure evaluator for an arbitrary points array — used at TWEEN
+    // GENERATION time (tweens.js getEasingForPair), independent of whether
+    // this widget is even open/editing that pair right now (evalCurve/
+    // activePoints only reflect whatever's currently being VIEWED).
+    evalPointsCurve:evalPointsCurve,
     getState:function(){return cs;},
     setState:function(s){
       // Backward-compat: projects saved before this rewrite stored
@@ -486,7 +502,7 @@
     // Clears motion mode too — only one "currently edited segment" at a
     // time on this one shared canvas.
     editCameraSeg:function(seg,label){
-      motionEaseSeg=null;
+      motionEaseSeg=null;tweenEaseSeg=null;
       camEaseSeg=seg;camEaseLabel=label||'';
       if(window.openPropsSection)window.openPropsSection('easing-sec');
       draw();
@@ -500,7 +516,7 @@
     // lazily created/mutated in place, same live-reference contract
     // editCameraSeg already has for `.ease`).
     editMotionSeg:function(seg,label){
-      camEaseSeg=null;
+      camEaseSeg=null;tweenEaseSeg=null;
       motionEaseSeg=seg;motionEaseLabel=label||'';
       selected=null;
       if(window.openPropsSection)window.openPropsSection('easing-sec');
@@ -510,8 +526,25 @@
       if(!motionEaseSeg)return;
       motionEaseSeg=null;draw();
     },
+    // Tween-pair points-based ease editing — see tweenEaseSeg above. `seg`
+    // is state.tweenEasing[key] itself (created on demand by the caller,
+    // tweens.js), its `.points` lazily filled in by tweenSegCurve() above
+    // (cloned from the CURRENT global curve, not a fixed default — editing
+    // a pair for the first time starts from what it already looks like).
+    editTweenSeg:function(seg,label){
+      camEaseSeg=null;motionEaseSeg=null;
+      tweenEaseSeg=seg;tweenEaseLabel=label||'';
+      selected=null;
+      if(window.openPropsSection)window.openPropsSection('easing-sec');
+      draw();
+    },
+    exitTweenSeg:function(){
+      if(!tweenEaseSeg)return;
+      tweenEaseSeg=null;draw();
+    },
     isCameraMode:isCamMode,
-    isMotionMode:isMotionMode
+    isMotionMode:isMotionMode,
+    isTweenSegMode:isTweenSegMode
   };
   setTimeout(draw,100);
 })();


### PR DESCRIPTION
## Résumé
Deux demandes explicites :
1. Une courbe d'easing différente par paire de keyframes (complète le système global existant, ne le remplace pas).
2. Un bouton pour afficher/masquer les courbes sous les calques dans Animation 2D, comme un logiciel motion, avec clic pour éditer un segment individuellement.

## Détails
- `state.tweenEasing` : override par paire (`{layer:fA-fB: {points}}`), retombe sur `state.easingCurve` (global) si absent. `getEasingForPair` dans `generateTweens()`/`renderArcs()` (déplacé DANS la boucle par paire, au lieu d'un calcul unique avant).
- Le widget de courbe partagé (déjà réutilisé par Caméra/Motion pour la même chose par-segment) gagne un 3e mode `isTweenSegMode`, mutuellement exclusif.
- Bouton toolbar + `renderTweenCurveStrips` : sparkline SVG sous chaque calque avec tween, une par paire de clés, cliquable pour ouvrir l'éditeur de cette paire. Pur affichage, ne touche jamais `generateTweens()`.
- Entrée "Éditer la courbe de ce tween…" dans le menu contextuel de la grille, accessible même courbes masquées.
- Persisté (export/import JSON), réinitialisé à la création d'un projet.

## Test plan
- [x] Vrai clic sur le bouton toolbar → strips apparaissent, forme identique à la courbe globale
- [x] Vrai clic sur un segment → panneau "Tween : clé 1 → 13"
- [x] Modification de la courbe de cette paire → frames intermédiaires suivent, keyframes inchangées
- [x] Export → réimport JSON : `tweenEasing` survit
- [x] `node --check` sur tous les fichiers touchés

🤖 Generated with [Claude Code](https://claude.com/claude-code)