### PR TITLE
Motion : fix z-order des calques au scroll + dernier calque caché

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -712,7 +712,17 @@ body.mode-motion .lrow.act{box-shadow:inset 3px 0 0 #4E6FF2,inset 0 0 0 1px rgba
 .fhc.cur{color:var(--accent);font-weight:700;}
 .fhc.sec{color:var(--accent);font-weight:700;font-size:8.5px;}
 .fhc.sec::before{content:'';position:absolute;left:0;top:0;bottom:-2px;width:1px;background:rgba(255,255,255,.3);}
-#frame-grid{display:flex;flex-direction:column;}
+/* position+z-index gives #frame-grid its OWN stacking context, so any
+   z-index set on its descendants (Motion's per-row .layer-inout-bar,
+   layer-inout.js — inline `position:relative` with no z-index of its own,
+   which does NOT form a stacking context by itself) stays CONTAINED here
+   instead of bubbling up to compete directly against #frame-hdr/#bars-row
+   (z-index:2 each, sticky, meant to stay pinned on top while scrolling).
+   Without this, a scrolled-past layer row painted over the ruler/onion/
+   work-area bars — confirmed live: elementFromPoint() over #bars-row hit
+   a .layer-inout-bar instead. z-index:1 (below frame-hdr/bars-row's 2) so
+   this box itself never outranks them either. */
+#frame-grid{display:flex;flex-direction:column;position:relative;z-index:1;}
 /* Must stay in lockstep with .lrow's height (28px, v3 redesign) — the layer
    name column (#layer-panel) and the frame grid (#fg-wrap) are separate
    flex columns rendered independently, so any mismatch between .lrow's and

--- a/src/js/layer-scroll-sync.js
+++ b/src/js/layer-scroll-sync.js
@@ -15,14 +15,56 @@
     // Re-entrancy guard: setting scrollTop on the OTHER element fires its
     // own 'scroll' event, which would otherwise bounce back and forth.
     var syncing = false;
-    function mirror(from, to) {
+    // Two mismatches stack here, not just one:
+    // 1. grid (#fg-wrap) has an extra header INSIDE its own scrollable
+    //    content — #frame-hdr (ruler) + #bars-row (onion/work-area), ~42px
+    //    — that panel (#layer-list) has no equivalent of (its "Layers"
+    //    title lives OUTSIDE the scroll container, in the fixed panel
+    //    above it): a per-row content offset.
+    // 2. panel's VIEWPORT is also shorter than grid's by ~82px, because
+    //    BOTH that same title bar above AND #layer-ctrls (the +/delete/
+    //    duplicate buttons) below sit OUTSIDE #layer-list, eating into its
+    //    clientHeight — grid has no equivalent chrome on either edge
+    //    reducing ITS clientHeight. So panel.scrollHeight-panel.clientHeight
+    //    (its own true max) and grid.scrollHeight-grid.clientHeight (its
+    //    own true max) don't just differ by the header — confirmed live:
+    //    panelMax 452 vs gridMax 412, a 40px gap ≈ #layer-ctrls' own
+    //    height, not the 42px header.
+    // A raw 1:1 `to.scrollTop = from.scrollTop` mirror (the original bug)
+    // therefore let panel reach ITS true max when scrolled directly
+    // (452, unaffected by clamping since browsers auto-clamp an
+    // OVER-assigned scrollTop down to grid's smaller max — that direction
+    // "worked by accident"), but scrolling GRID to ITS OWN max only ever
+    // pushed panel to 412 — 40px short of 452, hiding the last ~2 rows
+    // (22px each) under #layer-ctrls exactly as reported. A single fixed
+    // per-row offset can't fix the bottom edge case too (the two
+    // mismatches don't cancel out), so: apply the per-row header offset
+    // for ordinary mid-scroll (keeps row K's label roughly aligned with
+    // row K's keyframe track), but SNAP the other side to ITS OWN true
+    // max/min whenever `from` is at (or within half a row of) its own
+    // bound — guarantees scrolling EITHER panel all the way down always
+    // brings the other one all the way down too, regardless of the
+    // viewport-height mismatch neither offset alone can paper over.
+    function headerOffset() {
+      return Math.max(0, grid.scrollHeight - panel.scrollHeight);
+    }
+    function mirror(from, to, fromIsGrid) {
       if (syncing) return;
       syncing = true;
-      to.scrollTop = from.scrollTop;
+      var fromMax = Math.max(0, from.scrollHeight - from.clientHeight);
+      var toMax = Math.max(0, to.scrollHeight - to.clientHeight);
+      var target;
+      if (from.scrollTop >= fromMax - 1) target = toMax;
+      else if (from.scrollTop <= 1) target = 0;
+      else {
+        var off = headerOffset();
+        target = fromIsGrid ? from.scrollTop - off : from.scrollTop + off;
+      }
+      to.scrollTop = Math.max(0, Math.min(toMax, target));
       syncing = false;
     }
-    panel.addEventListener('scroll', function () { mirror(panel, grid); });
-    grid.addEventListener('scroll', function () { mirror(grid, panel); });
+    panel.addEventListener('scroll', function () { mirror(panel, grid, false); });
+    grid.addEventListener('scroll', function () { mirror(grid, panel, true); });
   }
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
 })();


### PR DESCRIPTION
## Résumé
Deux bugs distincts dans la timeline Motion :
1. `#frame-grid` ne formait pas son propre contexte d'empilement — un calque scrollé passait par-dessus le ruler/onion/work-area (`#bars-row`/`#frame-hdr`). Fix : `position:relative;z-index:1` sur `#frame-grid`.
2. Le mirroring de scroll entre `#layer-list` et `#fg-wrap` (1:1 brut) laissait le panneau de calques 40px (~2 lignes) court de son vrai bas quand on scrollait la grille — les 2 derniers calques restaient cachés sous les boutons. Fix : décalage par ligne pour l'alignement courant + accroche explicite au bord quand l'un des deux panneaux atteint son propre extremum.

## Test plan
- [x] 26 calques, grid scrollé à son max → panel atteint aussi son propre max ; dernier calque visible sans chevaucher les boutons
- [x] Point testé au-dessus de `#bars-row` touche `#wa-bar`, pas une ligne de calque scrollée
- [x] `node --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)