### PR TITLE
StoryBoard : fix crash quand une image importée est dans un Component

### DIFF
--- a/src/js/storyboard.js
+++ b/src/js/storyboard.js
@@ -122,7 +122,14 @@
     _thumbLayer.activate();
     _thumbLayer.removeChildren();
     var strokes = symbolStrokesAt(symbolId, frame);
-    strokes.forEach(function (sd) { desP(sd, _thumbLayer); });
+    // isRaster (imported image) items have no `.segments` — desP assumes
+    // Path-shaped data and throws (`d.segments.length` undefined) the
+    // moment a Component/symbol placed in StoryBoard contains an imported
+    // image. Same family-of-bug-#1 miss as everywhere else in this
+    // codebase that iterates a layer's strokes without a per-type branch
+    // (CLAUDE.md §1) — found live via a real crash while batch-testing
+    // image import, not a synthetic case.
+    strokes.forEach(function (sd) { if (sd.isRaster) desR(sd, _thumbLayer); else desP(sd, _thumbLayer); });
     var url = null;
     if (_thumbLayer.children.length) {
       _thumbLayer.visible = true;
@@ -596,7 +603,7 @@
     previewLayer.removeChildren();
     if (m && chainMods(m).length) {
       var strokes = montageStrokesAt(m, m.playhead || 0);
-      strokes.forEach(function (sd) { desP(sd, previewLayer); });
+      strokes.forEach(function (sd) { if (sd.isRaster) desR(sd, previewLayer); else desP(sd, previewLayer); });
     }
     window._sceneVersion++;
     if (window.SMEngineBridge && SMEngineBridge.isEnabled()) SMEngineBridge.renderNow();


### PR DESCRIPTION
## Résumé
Vérification demandée : "images en import transformables/animables comme tout autre élément". Confirmé en direct que c'est déjà largement le cas (`layerElements`/`elementMotionAt`/`layerMotionAt` traitent un item `isRaster` normalement, interpolation testée directement pour Position par calque ET par forme).

Bug réel trouvé au passage : dès qu'un calque avec une image importée devient un Component placé dans StoryBoard, `thumbDataUrl`/`applyPreview` plantent (`desP()` appelé sans condition, suppose des données de Path). Même famille de bug que CLAUDE.md §1 documente déjà.

## Fix
Les deux sites dispatchent vers `desR()` pour les items `isRaster`, `desP()` pour le reste.

## Test plan
- [x] Image importée + Component + StoryBoard : plus de crash
- [x] Interpolation Position (calque et par-forme) vérifiée directement sur un item raster
- [x] `node --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)