### PR TITLE
Motion: parentage de calques style After Effects

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -221,7 +221,12 @@ function nextLayerColor(){return LAYER_COLOR_PALETTE[state.layers.length%LAYER_C
 function createUserLayer(name){
   arcLayer.activate();var l=new Layer({name:'user-'+userLayers.length});l.insertBelow(arcLayer);userLayers.push(l);
   var frames=[];for(var i=0;i<state.totalFrames;i++)frames.push({strokes:[],isKeyframe:i===0,isInterpolated:false});
-  state.layers.push({id:state.layers.length,name:name,visible:true,locked:false,frames:frames,color:nextLayerColor()});
+  // layerUid: stable identity for parenting (motion.js's setLayerParent/
+  // parentChainMats) — a raw array index would silently repoint at the
+  // wrong layer the moment reorderLayer/delete/duplicate splices
+  // state.layers. parentLayerUid stays null (no parent) until the user
+  // picks one in the Motion properties panel.
+  state.layers.push({id:state.layers.length,name:name,visible:true,locked:false,frames:frames,color:nextLayerColor(),layerUid:'ly_'+Date.now().toString(36)+'_'+Math.floor(Math.random()*1e6),parentLayerUid:null});
   return state.layers.length-1;
 }
 createUserLayer('Layer 1');

--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -224,6 +224,13 @@
       // Pivot = auto bounds center + the layer's Anchor Point offset
       // (motionMat.ax/ay) — see motion.js's layerMotionAt header comment.
       var motionPivot = motionMat ? { x: userLayers[i].bounds.center.x + motionMat.ax, y: userLayers[i].bounds.center.y + motionMat.ay } : null;
+      // Layer parenting (motion.js's parentLayerUid/parentChainMats,
+      // 2026-07): every ancestor's OWN layer-level transform, immediate
+      // parent first — applied AFTER this layer's own motionMat, same
+      // nesting order as elMat-then-motionMat above one level further out.
+      // Empty array (the common case, no parent) makes the per-item loop
+      // below a no-op cost.
+      var parentChain = window.SMMotion ? SMMotion.parentChainMats(i, state.currentFrame) : [];
       // Brush-texture companions (isBrushTextureCopy — bitmap raster or
       // vector dab group) don't get their own Elements row in Motion
       // (motion.js's layerElements folds them into their anchor's, "merge
@@ -265,6 +272,8 @@
             nvRect = SMMotion.transformImageRect(nvRect, nvPivot, nvMat);
             nvOp *= nvMat.op;
           }
+          var nvChain = SMMotion.parentChainMats(i, state.currentFrame);
+          for (var nvpc = 0; nvpc < nvChain.length; nvpc++) { nvRect = SMMotion.transformImageRect(nvRect, nvChain[nvpc].pivot, nvChain[nvpc].mat); nvOp *= nvChain[nvpc].mat.op; }
           items.push({ image: { imageId: 'nv:' + i, x: nvRect.x, y: nvRect.y, width: nvRect.width, height: nvRect.height, opacity: nvOp, rotation: nvRect.rotation || 0 } });
         }
       }
@@ -296,6 +305,7 @@
           var imgOp = c.opacity !== undefined ? c.opacity : 1;
           if (elMat) { rb = SMMotion.transformImageRect(rb, elPivot, elMat); imgOp *= elMat.op; }
           if (motionMat) { rb = SMMotion.transformImageRect(rb, motionPivot, motionMat); imgOp *= motionMat.op; }
+          for (var pc = 0; pc < parentChain.length; pc++) { rb = SMMotion.transformImageRect(rb, parentChain[pc].pivot, parentChain[pc].mat); imgOp *= parentChain[pc].mat.op; }
           items.push({
             image: { imageId: imageId, x: rb.x, y: rb.y, width: rb.width, height: rb.height, opacity: imgOp, rotation: rb.rotation || 0 },
           });
@@ -326,12 +336,15 @@
           var sd = serP(sub);
           if (elMat) sd.segments = SMMotion.transformSegments(sd.segments, elPivot, elMat);
           if (motionMat) sd.segments = SMMotion.transformSegments(sd.segments, motionPivot, motionMat);
+          for (var pc2 = 0; pc2 < parentChain.length; pc2++) sd.segments = SMMotion.transformSegments(sd.segments, parentChain[pc2].pivot, parentChain[pc2].mat);
           var op = c.opacity !== undefined ? c.opacity : 1;
           if (elMat) op *= elMat.op;
           if (motionMat) op *= motionMat.op;
+          for (var pc3 = 0; pc3 < parentChain.length; pc3++) op *= parentChain[pc3].mat.op;
           var strokeScale = 1;
           if (elMat) strokeScale *= (Math.abs(elMat.sx) + Math.abs(elMat.sy)) / 2;
           if (motionMat) strokeScale *= (Math.abs(motionMat.sx) + Math.abs(motionMat.sy)) / 2;
+          for (var pc4 = 0; pc4 < parentChain.length; pc4++) strokeScale *= (Math.abs(parentChain[pc4].mat.sx) + Math.abs(parentChain[pc4].mat.sy)) / 2;
           // The path's OWN closed flag (now correctly carried by serP(),
           // see app.js), NOT "has a fillColor" — that heuristic sent an
           // unwanted closing stroke segment across any OPEN path that also

--- a/src/js/export.js
+++ b/src/js/export.js
@@ -43,6 +43,10 @@ function exportBuildFrame(frameIdx,alpha){
     var motionMat=(window.SMMotion&&strokes.length)?SMMotion.layerMotionAt(li,frameIdx):null;
     // Pivot = auto bounds center + Anchor Point offset (motionMat.ax/ay).
     var motionPivot=motionMat?new Point(userLayers[li].bounds.center.x+motionMat.ax,userLayers[li].bounds.center.y+motionMat.ay):null;
+    // Layer parenting (2026-07, motion.js): each ancestor's own motion matrix
+    // applied outermost, same composition order as buildSceneJson
+    // (engine-bridge.js) — see motion.js's parentChainMats header comment.
+    var parentChain=window.SMMotion?SMMotion.parentChainMats(li,frameIdx):[];
     strokes.forEach(function(sd){
       // Raster strokes (isRaster: imported images, SVG-sequence frames,
       // and Bitmap Brush's texture companions, bitmap-brush.js) went
@@ -74,6 +78,14 @@ function exportBuildFrame(frameIdx,alpha){
         p.translate(motionMat.dx,motionMat.dy);
         p.opacity=p.opacity*motionMat.op;
         if(p.strokeWidth)p.strokeWidth*=(Math.abs(motionMat.sx)+Math.abs(motionMat.sy))/2;
+      }
+      for(var pci=0;pci<parentChain.length;pci++){
+        var pc=parentChain[pci];
+        p.scale(pc.mat.sx,pc.mat.sy,pc.pivot);
+        p.rotate(pc.mat.rot,pc.pivot);
+        p.translate(pc.mat.dx,pc.mat.dy);
+        p.opacity=p.opacity*pc.mat.op;
+        if(p.strokeWidth)p.strokeWidth*=(Math.abs(pc.mat.sx)+Math.abs(pc.mat.sy))/2;
       }
     });
   }

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -402,6 +402,90 @@
     // bounds+anchor correctly, matches an ordinary layer.
     return computeMotionMat(ld, frameIdx);
   }
+  // ---- LAYER PARENTING (2026-07, "parentage de calque comme dans After
+  // Effects, changeable en properties d'animation") ----
+  // A parent reference is stored by a STABLE uid (ld.parentLayerUid), never
+  // a raw array index — state.layers gets spliced on reorder/delete/
+  // duplicate (reorderLayer, app.js), which would silently repoint a
+  // parent at the WRONG layer (or itself) if indices were stored directly.
+  // ensureLayerUid lazily assigns a uid to layers saved before this
+  // feature existed, same lazy-assign contract layerElements() already
+  // has for strokeId.
+  function ensureLayerUid(ld) {
+    if (!ld.layerUid) ld.layerUid = 'ly_' + Date.now().toString(36) + '_' + Math.floor(Math.random() * 1e6);
+    return ld.layerUid;
+  }
+  function findLayerIndexByUid(uid) {
+    if (!uid) return -1;
+    for (var i = 0; i < state.layers.length; i++) if (state.layers[i].layerUid === uid) return i;
+    return -1;
+  }
+  function setLayerParent(li, parentUid) {
+    var ld = state.layers[li];
+    if (!ld) return;
+    if (parentUid) {
+      // Refuse to create a cycle (A parents B parents A) — walk the
+      // CANDIDATE parent's own chain; if `li` (by uid) appears in it,
+      // this assignment would loop. Same visited-set guard as
+      // parentChainMats below, applied up front instead of just capping
+      // depth at read time, so the UI never silently accepts a cycle.
+      var uid = ensureLayerUid(ld);
+      var cur = parentUid, visited = {}, guard = 0;
+      while (cur && !visited[cur] && guard++ < 256) {
+        if (cur === uid) { if (window.showToast) showToast('Parentage refusé : créerait une boucle'); return; }
+        visited[cur] = true;
+        var idx = findLayerIndexByUid(cur);
+        cur = idx >= 0 ? state.layers[idx].parentLayerUid : null;
+      }
+    }
+    ld.parentLayerUid = parentUid || null;
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+  }
+  // Every ANCESTOR's own layer-level Motion transform, immediate parent
+  // first — engine-bridge.js/export.js apply the layer's OWN motionMat,
+  // THEN walk this chain applying each ancestor's transform on top, each
+  // pivoted around ITS OWN bounds+anchor (exactly how layerMotionAt's own
+  // pivot already works, just one level per ancestor) — composes exactly
+  // like AE's parent chain: a child inherits its parent's WHOLE effective
+  // transform, not just a copy of one property. visited-by-index guards
+  // against a cycle that predates setLayerParent's own refusal (e.g. a
+  // project file edited by hand, or a parent later deleted and its uid
+  // reused by coincidence — extremely unlikely but a hard guard costs
+  // nothing here).
+  function parentChainMats(li, frameIdx) {
+    var mats = [];
+    var ld = state.layers[li];
+    if (!ld) return mats;
+    var visited = {};
+    visited[li] = true;
+    var curUid = ld.parentLayerUid;
+    var guard = 0;
+    while (curUid && guard++ < 64) {
+      var idx = findLayerIndexByUid(curUid);
+      if (idx < 0 || visited[idx]) break;
+      visited[idx] = true;
+      var m = computeMotionMat(state.layers[idx], frameIdx);
+      if (m && userLayers[idx] && userLayers[idx].bounds) {
+        mats.push({ mat: m, pivot: { x: userLayers[idx].bounds.center.x + m.ax, y: userLayers[idx].bounds.center.y + m.ay } });
+      }
+      curUid = state.layers[idx].parentLayerUid;
+    }
+    return mats;
+  }
+  function applyParentChainToSegments(segments, li, frameIdx) {
+    var chain = parentChainMats(li, frameIdx);
+    for (var k = 0; k < chain.length; k++) segments = transformSegments(segments, chain[k].pivot, chain[k].mat);
+    return segments;
+  }
+  // Returns {rect, opacityMul} — opacity composes multiplicatively across
+  // the whole chain same as engine-bridge.js already does for elMat/
+  // motionMat on one item.
+  function applyParentChainToImageRect(rect, li, frameIdx) {
+    var chain = parentChainMats(li, frameIdx);
+    var opMul = 1;
+    for (var k = 0; k < chain.length; k++) { rect = transformImageRect(rect, chain[k].pivot, chain[k].mat); opMul *= chain[k].mat.op; }
+    return { rect: rect, opacityMul: opMul };
+  }
   // Nested INSIDE the layer transform (engine-bridge.js/export.js apply this
   // FIRST, pivoted around the item's own bounds, THEN the layer transform on
   // top) — matches AE composing a shape group's transform inside its parent
@@ -1195,7 +1279,44 @@
     // reads clearly as "the whole instance", not its internal content.
     nameRow.textContent = (ld.name || ('Layer ' + (state.activeLayerIdx + 1))) + (ld.symbolId ? ' (composant)' : '');
     body.appendChild(nameRow);
+    renderParentRow(body, ld, state.activeLayerIdx);
     renderTransformGroup(body, ld, 'Transform');
+  }
+  // Layer parenting (2026-07, "gestion de parentage de calque dans motion
+  // comme dans after, avec la possibilité de changer de parent en
+  // properties d'animation"): a single dropdown in the properties panel,
+  // AE's own "Parent & Link" column reimagined as a row here since Motion's
+  // right panel is already per-property, not per-layer-columns. Writes
+  // through setLayerParent (cycle-checked) so this is the ONLY UI entry
+  // point — the data model (ld.parentLayerUid) + composition math
+  // (parentChainMats, wired into engine-bridge.js/export.js/
+  // native-video-bridge.js) already existed before this row, but were
+  // otherwise completely inert from the user's side.
+  function renderParentRow(body, ld, li) {
+    var row = document.createElement('div'); row.className = 'lrow motion-prop-row';
+    var label = document.createElement('span'); label.textContent = 'Parent'; label.style.minWidth = '70px';
+    row.appendChild(label);
+    var sel = document.createElement('select'); sel.className = 'motion-parent-select'; sel.style.flex = '1';
+    var noneOpt = document.createElement('option'); noneOpt.value = ''; noneOpt.textContent = 'Aucun (parentage libre)';
+    sel.appendChild(noneOpt);
+    state.layers.forEach(function (other, oi) {
+      if (oi === li) return; // can't parent a layer to itself
+      var opt = document.createElement('option');
+      opt.value = ensureLayerUid(other);
+      opt.textContent = other.name || ('Layer ' + (oi + 1));
+      if (ld.parentLayerUid && ld.parentLayerUid === opt.value) opt.selected = true;
+      sel.appendChild(opt);
+    });
+    if (!ld.parentLayerUid) noneOpt.selected = true;
+    sel.addEventListener('mousedown', function (e) { e.stopPropagation(); });
+    sel.addEventListener('click', function (e) { e.stopPropagation(); });
+    sel.addEventListener('change', function (e) {
+      e.stopPropagation(); pushUndo();
+      setLayerParent(li, sel.value || null);
+      renderLayerList(); renderTimeline();
+    });
+    row.appendChild(sel);
+    body.appendChild(row);
   }
   // Shared by the layer's own Transform group AND each element's — both are
   // just "a holder with .motion/.motionStatic", see the header comment on
@@ -2058,6 +2179,12 @@
     elementMotionAt: elementMotionAt,
     transformSegments: transformSegments,
     transformImageRect: transformImageRect,
+    ensureLayerUid: ensureLayerUid,
+    findLayerIndexByUid: findLayerIndexByUid,
+    setLayerParent: setLayerParent,
+    parentChainMats: parentChainMats,
+    applyParentChainToSegments: applyParentChainToSegments,
+    applyParentChainToImageRect: applyParentChainToImageRect,
     buildOverlayItems: buildOverlayItems,
     renderLayerListMotion: renderLayerListMotion,
     renderTimelineMotion: renderTimelineMotion,

--- a/src/js/native-video-bridge.js
+++ b/src/js/native-video-bridge.js
@@ -750,6 +750,14 @@
       var pivot = { x: rect.x + rect.width / 2 + mm.ax, y: rect.y + rect.height / 2 + mm.ay };
       rect = SMMotion.transformImageRect(rect, pivot, mm);
     }
+    // Layer parenting (2026-07): ancestor chain applied outermost, same
+    // composition order as buildSceneJson/exportBuildFrame — shared by both
+    // the drawn gizmo and select-bridge's gesture hit-testing since both
+    // consume displayRect().
+    if (window.SMMotion) {
+      var pChain = SMMotion.parentChainMats(li, state.currentFrame);
+      for (var pci = 0; pci < pChain.length; pci++) rect = SMMotion.transformImageRect(rect, pChain[pci].pivot, pChain[pci].mat);
+    }
     return rect;
   }
 


### PR DESCRIPTION
## Summary
- Layer parenting for Motion (`ld.parentLayerUid` + stable `ld.layerUid`), composed outermost after element-level and layer-level Motion transforms — same model as AE's parent/link column.
- Cycle rejection (`setLayerParent` walks the ancestor chain before assigning).
- Wired into every render-time consumer of layer Motion: `buildSceneJson` (engine-bridge.js — raster/path/native-video branches), `exportBuildFrame` (export.js), and `displayRect` (native-video-bridge.js, shared by the transform-box gizmo and select-bridge's hit-testing).
- UI: "Parent" dropdown in Motion's properties panel, the only entry point to set/change a layer's parent.

## Test plan
- [x] `node --check` on all 5 touched files
- [x] Live-tested in browser: parented Layer 1 → Layer 2, keyframed Layer 2's position, confirmed via `exportBuildFrame` that Layer 1's stroke inherits the exact same +150,0 shift with zero motion of its own
- [x] Cycle rejection tested (attempting to parent Layer 2 → Layer 1 while already parented the other way is rejected, `parentLayerUid` stays `null`)
- [x] Deleted the parent layer and confirmed `parentChainMats`/`exportBuildFrame` degrade gracefully (empty chain, no crash) rather than corrupting

🤖 Generated with [Claude Code](https://claude.com/claude-code)