### PR TITLE
Tutoriel : lanceur en accordéon cliquable + 2 modules (perspective, profil/équipe)

### DIFF
--- a/src/css/tutorial.css
+++ b/src/css/tutorial.css
@@ -59,12 +59,41 @@
 #tut-launcher{z-index:600;}
 #tut-launcher.modal-overlay .modal-box{width:420px;max-height:86vh;display:flex;flex-direction:column;}
 #tut-launcher .modal-bdy{overflow-y:auto;max-height:calc(86vh - 50px);}
-#tut-launcher .tut-mod-list{display:flex;flex-direction:column;gap:8px;}
-#tut-launcher .tut-cat-hdr{font-size:10px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--text-dim);margin:10px 0 -2px;}
-#tut-launcher .tut-cat-hdr:first-child{margin-top:0;}
+#tut-launcher .tut-mod-list{display:flex;flex-direction:column;gap:6px;}
+
+/* Accordion category header — a real button, not just a label, since it's
+   now the click target that expands/collapses its group. */
+#tut-launcher .tut-cat-hdr{
+  display:flex;align-items:center;gap:8px;width:100%;
+  background:var(--panel3);border:1px solid var(--border);border-radius:8px;
+  padding:9px 12px;cursor:pointer;text-align:left;
+  font-size:10px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--text);
+}
+#tut-launcher .tut-cat-hdr:hover{border-color:var(--accent);}
+#tut-launcher .tut-cat-hdr.open{border-radius:8px 8px 0 0;border-bottom-color:transparent;}
+#tut-launcher .tut-cat-chevron{flex:none;display:flex;color:var(--text-dim);transition:transform .18s ease;}
+#tut-launcher .tut-cat-hdr.open .tut-cat-chevron{transform:rotate(90deg);color:var(--accent-hover);}
+#tut-launcher .tut-cat-name{flex:1;}
+#tut-launcher .tut-cat-count{flex:none;font-size:9px;font-weight:600;letter-spacing:0;text-transform:none;color:var(--text-dim);background:var(--panel2);border-radius:10px;padding:2px 7px;}
+
+/* Module list for one category — collapses to zero height instead of
+   display:none so the open/close transition can animate. grid-template-rows
+   0fr->1fr on the OUTER wrapper (a single grid item, .tut-cat-inner) is the
+   standard trick for animating to/from an unknown content height (max-height
+   would need a hardcoded guess); the actual module buttons live inside
+   .tut-cat-inner with normal flex layout, not as direct grid children. */
+#tut-launcher .tut-cat-body{
+  display:grid;grid-template-rows:1fr;
+  background:var(--panel3);border:1px solid var(--border);border-top:none;border-radius:0 0 8px 8px;
+  margin-top:-6px;
+  transition:grid-template-rows .18s ease,opacity .18s ease;
+  opacity:1;
+}
+#tut-launcher .tut-cat-body.collapsed{grid-template-rows:0fr;opacity:0;border:none;margin-top:0;}
+#tut-launcher .tut-cat-inner{display:flex;flex-direction:column;gap:6px;padding:8px;min-height:0;overflow:hidden;}
 #tut-launcher .tut-mod{
   display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;
-  background:var(--panel3);border:1px solid var(--border);cursor:pointer;text-align:left;
+  background:var(--panel2);border:1px solid var(--border);cursor:pointer;text-align:left;
 }
 #tut-launcher .tut-mod:hover{border-color:var(--accent);}
 #tut-launcher .tut-mod-ico{flex:none;width:28px;height:28px;border-radius:6px;background:var(--accent-dim);color:var(--accent-hover);display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;}

--- a/src/index.html
+++ b/src/index.html
@@ -530,7 +530,7 @@
       </div>
     </div>
     <div class="psec">
-      <div class="phdr"><span class="ar">☰</span> <span data-i18n="hdrPerspective">Perspective Guide</span></div>
+      <div class="phdr" id="phdr-perspective"><span class="ar">☰</span> <span data-i18n="hdrPerspective">Perspective Guide</span></div>
       <div class="pbdy">
         <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer" title="Shows the vanishing-point grid and snaps the Line tool toward it, from any tool"><input type="checkbox" id="p-persp-on" style="accent-color:var(--accent)"> Enabled</label></div>
         <div class="pr"><span class="pl">Mode</span><select class="psel" id="p-persp-mode"><option value="1pt">1 point</option><option value="2pt" selected>2 points</option><option value="3pt">3 points</option></select></div>

--- a/src/js/tutorial.js
+++ b/src/js/tutorial.js
@@ -489,6 +489,53 @@
         { type: 'click', target: '#btn-history', title: 'Ouvre l\'historique', body: 'Clique "Historique…" dans le panneau de droite (section Projet).' },
         { type: 'info', title: 'Bien joué !', body: 'Restaurer un ancien instantané prend d\'abord un instantané de l\'état actuel — l\'opération reste donc elle-même annulable.' }
       ]
+    },
+    {
+      id: 'perspective',
+      category: 'Dessiner',
+      icon: '16',
+      title: 'Guide de perspective',
+      desc: 'Placer des points de fuite',
+      time: '1 min',
+      steps: [
+        { type: 'info', title: 'Dessiner en perspective', body: 'Le guide de perspective affiche une grille de points de fuite et aimante l\'outil Ligne dessus, depuis n\'importe quel outil.' },
+        { type: 'click', target: '.tool-btn[data-tool="perspective"]', title: 'Choisis l\'outil Perspective', body: 'Clique sur l\'outil Perspective dans la barre de gauche.' },
+        {
+          type: 'state', target: '#phdr-perspective', title: 'Ouvre la section "Perspective Guide"', body: 'Clique l\'en-tête "Perspective Guide" dans le panneau de droite pour la déplier, si besoin.',
+          hint: 'En attente…',
+          check: function (win) { var el = win.document.getElementById('p-persp-on'); return !!(el && el.getBoundingClientRect().height > 0); }
+        },
+        stateChangedStep({
+          target: '#p-persp-on', title: 'Active le guide', body: 'Coche "Enabled" pour afficher la grille de points de fuite sur le canevas.', hint: 'En attente…',
+          measure: function (win) { var el = win.document.getElementById('p-persp-on'); return el ? el.checked : false; }
+        }),
+        { type: 'click', target: '.tool-btn[data-tool="line"]', title: 'Choisis la Ligne', body: 'Clique sur l\'outil Ligne (raccourci U) — il va s\'aimanter aux points de fuite.' },
+        stateIncreaseStep({
+          target: '#drawing-canvas', title: 'Trace une ligne', body: 'Clique-glisse sur le canevas — la ligne s\'oriente vers un point de fuite.',
+          hint: 'En attente de ton trait…', measure: measureStrokeCount
+        }),
+        { type: 'info', title: 'Bien joué !', body: '1/2/3 points de fuite selon le mode choisi. "Lock vanishing points" évite de les déplacer par erreur en dessinant près d\'eux.' }
+      ]
+    },
+    {
+      id: 'collab',
+      category: 'Réglages',
+      icon: '17',
+      title: 'Profil et travail d\'équipe',
+      desc: 'Se présenter, dossier partagé',
+      time: '1 min',
+      steps: [
+        { type: 'info', title: 'Travailler à plusieurs', body: 'Ton profil (nom + couleur) distingue tes traits de ceux d\'un autre profil qui corrige ton travail. La Sync équipe publie/récupère les modifs via un dossier partagé (Drive, kDrive…), sans temps réel.' },
+        { type: 'click', target: '#project-tabs-settings', title: 'Ouvre les Réglages', body: 'Clique l\'icône en forme de roue crantée en haut de l\'écran.' },
+        stateIncreaseStep({
+          target: '#profile-name', title: 'Indique ton nom', body: 'Tape ton nom dans le champ "Nom" de la section Profil.', hint: 'En attente de ta saisie…',
+          measure: function (win) { var el = win.document.getElementById('profile-name'); return el ? el.value.length : 0; }
+        }),
+        { type: 'click', target: '.settings-tab[data-tab="collab"]', title: 'Ouvre l\'onglet Collaboration', body: 'Clique l\'onglet "Collaboration" en haut de la fenêtre de Réglages.' },
+        { type: 'click', target: '#sync-choose-folder', title: 'Regarde le bouton "Choisir…"', body: 'Clique "Choisir…" pour voir comment on désigne un dossier partagé (nécessite l\'app desktop — un simple message s\'affiche ici en preview navigateur).' },
+        { type: 'click', target: '#settings-close', title: 'Ferme les Réglages', body: 'Clique la croix pour refermer la fenêtre.' },
+        { type: 'info', title: 'Bien joué !', body: 'Le chapitre "Travailler à plusieurs" du guide couvre aussi les corrections à Accepter/Rejeter et le feedback d\'équipe.' }
+      ]
     }
   ];
 
@@ -666,6 +713,14 @@
   // Nemo would want: draw first, then animate, then organize/output.
   var CATEGORY_ORDER = ['Dessiner', 'Calques et animation', 'Organisation', 'Médias', 'Réglages'];
 
+  // Accordion open/closed state, keyed by category name — lives for the
+  // whole session (module-level, not per openLauncher() call) so
+  // re-opening the launcher remembers what you had open, same as any
+  // normal accordion UI. Nothing open on first run: with 15+ modules
+  // across 5 categories, showing everything at once defeats the point of
+  // grouping them in the first place.
+  var openCats = {};
+
   function renderLauncherList() {
     var list = $('#tut-mod-list'); if (!list) return;
     var done = loadDone();
@@ -678,11 +733,23 @@
     var cats = CATEGORY_ORDER.filter(function (c) { return byCat[c]; })
       .concat(Object.keys(byCat).filter(function (c) { return CATEGORY_ORDER.indexOf(c) === -1; }));
     cats.forEach(function (cat) {
-      var hdr = document.createElement('div');
-      hdr.className = 'tut-cat-hdr';
-      hdr.textContent = cat;
-      list.appendChild(hdr);
-      byCat[cat].forEach(function (m) {
+      var mods = byCat[cat];
+      var doneCount = mods.filter(function (m) { return done.indexOf(m.id) !== -1; }).length;
+      var isOpen = !!openCats[cat];
+
+      var hdr = document.createElement('button');
+      hdr.className = 'tut-cat-hdr' + (isOpen ? ' open' : '');
+      hdr.type = 'button';
+      hdr.innerHTML =
+        '<span class="tut-cat-chevron">' + chevronSvg() + '</span>' +
+        '<span class="tut-cat-name">' + cat + '</span>' +
+        '<span class="tut-cat-count">' + doneCount + '/' + mods.length + '</span>';
+      var body = document.createElement('div');
+      body.className = 'tut-cat-body' + (isOpen ? '' : ' collapsed');
+      var inner = document.createElement('div');
+      inner.className = 'tut-cat-inner';
+      body.appendChild(inner);
+      mods.forEach(function (m) {
         var isDone = done.indexOf(m.id) !== -1;
         var btn = document.createElement('button');
         btn.className = 'tut-mod' + (isDone ? ' done' : '');
@@ -694,9 +761,20 @@
           '</span>' +
           '<span class="tut-mod-time">' + m.time + '</span>';
         btn.addEventListener('click', function () { startModule(m.id); });
-        list.appendChild(btn);
+        inner.appendChild(btn);
       });
+      hdr.addEventListener('click', function () {
+        openCats[cat] = !openCats[cat];
+        hdr.classList.toggle('open', openCats[cat]);
+        body.classList.toggle('collapsed', !openCats[cat]);
+      });
+      list.appendChild(hdr);
+      list.appendChild(body);
     });
+  }
+
+  function chevronSvg() {
+    return '<svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>';
   }
 
   function openLauncher() {


### PR DESCRIPTION
## Résumé
- Le lanceur "Découvrir Nemo" devient un **accordéon** : chaque catégorie est un bouton cliquable (chevron + compteur fait/total) qui déplie/replie son groupe de modules, plutôt qu'une liste plate de 17 modules toujours tous affichés.
- 2 nouveaux modules (17 au total) :
  - **Guide de perspective** (Dessiner) — active la grille de points de fuite, trace une ligne qui s'y aimante.
  - **Profil et travail d'équipe** (Réglages) — nom de profil, onglet Collaboration, bouton "Choisir…" du dossier partagé (sûr en preview navigateur : sans l'app desktop il affiche juste un toast, jamais de vrai sélecteur de fichier).

Réutilise le même id stable qu'Historique (`#phdr-project`) pour une section repliée par défaut — ajout de `#phdr-perspective`. Cette fois le check attend simplement que le champ devienne visible plutôt que de forcer un clic, plus tolérant si la section était déjà ouverte.

## Test plan
- [x] Accordéon : ouverture/fermeture au clic, plusieurs groupes ouvrables indépendamment, lancement d'un module depuis un groupe ouvert — tout testé en direct.
- [x] Les 2 nouveaux modules rejoués intégralement à la main (grille de perspective visible à l'écran, ligne tracée dessus ; profil renseigné, onglet Collaboration visité, bouton dossier partagé cliqué sans blocage).
- [x] Aucune erreur console.
- [ ] Pas testé dans l'app Tauri buildée, seulement preview navigateur.

## Note pour la suite
Leçon de test à garder en mémoire : dans cet environnement, les coordonnées de `computer.left_click` correspondent à l'espace pixel de la **capture d'écran** (souvent 800×1012 ou 800×450), pas à `getBoundingClientRect()` (espace CSS réel, parfois 1280×720) — les deux peuvent diverger dans la même session. Prendre un screenshot juste avant de cliquer un champ précis plutôt que de faire confiance à un rect calculé séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)