### PR TITLE
Tutoriel : remplace l'accordéon inline par un vrai menu à deux écrans

### DIFF
--- a/src/css/tutorial.css
+++ b/src/css/tutorial.css
@@ -58,39 +58,35 @@
    z-index:200 — see style.css's comment above #kitsu-modal. */
 #tut-launcher{z-index:600;}
 #tut-launcher.modal-overlay .modal-box{width:420px;max-height:86vh;display:flex;flex-direction:column;}
+#tut-launcher .modal-hdr{gap:8px;}
+#tut-launcher #tut-launcher-title{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 #tut-launcher .modal-bdy{overflow-y:auto;max-height:calc(86vh - 50px);}
 #tut-launcher .tut-mod-list{display:flex;flex-direction:column;gap:6px;}
+#tut-launcher .tut-launcher-intro{font-size:11px;color:var(--text-dim);margin-bottom:6px;}
 
-/* Accordion category header — a real button, not just a label, since it's
-   now the click target that expands/collapses its group. */
+/* Back arrow, left of the title — hidden on the top-level category screen,
+   shown once a category has been opened. A real drill-down menu (category
+   list -> tap one -> its modules on a fresh screen -> back arrow returns),
+   not an inline accordion — the two screens replace each other's content
+   in #tut-mod-list rather than expanding/collapsing in place. */
+#tut-launcher .tut-launcher-back{
+  flex:none;width:22px;height:22px;border-radius:6px;background:none;border:none;
+  color:var(--text-dim);cursor:pointer;display:flex;align-items:center;justify-content:center;
+}
+#tut-launcher .tut-launcher-back:hover{background:var(--panel3);color:var(--text);}
+
+/* Category screen — one row per category, whole row navigates in. */
 #tut-launcher .tut-cat-hdr{
-  display:flex;align-items:center;gap:8px;width:100%;
+  display:flex;align-items:center;gap:10px;width:100%;
   background:var(--panel3);border:1px solid var(--border);border-radius:8px;
-  padding:9px 12px;cursor:pointer;text-align:left;
-  font-size:10px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;color:var(--text);
+  padding:11px 12px;cursor:pointer;text-align:left;
+  font-size:12px;font-weight:600;color:var(--text);
 }
 #tut-launcher .tut-cat-hdr:hover{border-color:var(--accent);}
-#tut-launcher .tut-cat-hdr.open{border-radius:8px 8px 0 0;border-bottom-color:transparent;}
-#tut-launcher .tut-cat-chevron{flex:none;display:flex;color:var(--text-dim);transition:transform .18s ease;}
-#tut-launcher .tut-cat-hdr.open .tut-cat-chevron{transform:rotate(90deg);color:var(--accent-hover);}
 #tut-launcher .tut-cat-name{flex:1;}
-#tut-launcher .tut-cat-count{flex:none;font-size:9px;font-weight:600;letter-spacing:0;text-transform:none;color:var(--text-dim);background:var(--panel2);border-radius:10px;padding:2px 7px;}
+#tut-launcher .tut-cat-count{flex:none;font-size:9px;font-weight:600;color:var(--text-dim);background:var(--panel2);border-radius:10px;padding:2px 7px;}
+#tut-launcher .tut-cat-chevron{flex:none;display:flex;color:var(--text-dim);}
 
-/* Module list for one category — collapses to zero height instead of
-   display:none so the open/close transition can animate. grid-template-rows
-   0fr->1fr on the OUTER wrapper (a single grid item, .tut-cat-inner) is the
-   standard trick for animating to/from an unknown content height (max-height
-   would need a hardcoded guess); the actual module buttons live inside
-   .tut-cat-inner with normal flex layout, not as direct grid children. */
-#tut-launcher .tut-cat-body{
-  display:grid;grid-template-rows:1fr;
-  background:var(--panel3);border:1px solid var(--border);border-top:none;border-radius:0 0 8px 8px;
-  margin-top:-6px;
-  transition:grid-template-rows .18s ease,opacity .18s ease;
-  opacity:1;
-}
-#tut-launcher .tut-cat-body.collapsed{grid-template-rows:0fr;opacity:0;border:none;margin-top:0;}
-#tut-launcher .tut-cat-inner{display:flex;flex-direction:column;gap:6px;padding:8px;min-height:0;overflow:hidden;}
 #tut-launcher .tut-mod{
   display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:8px;
   background:var(--panel2);border:1px solid var(--border);cursor:pointer;text-align:left;

--- a/src/js/tutorial.js
+++ b/src/js/tutorial.js
@@ -697,13 +697,15 @@
     modal.style.display = 'none';
     modal.innerHTML =
       '<div class="modal-box">' +
-      '<div class="modal-hdr"><span>Découvrir Nemo</span> <button class="modal-x" id="tut-launcher-close">&times;</button></div>' +
+      '<div class="modal-hdr">' +
+      '<button class="tut-launcher-back" id="tut-launcher-back" style="display:none" title="Retour"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M15 6l-6 6 6 6"/></svg></button>' +
+      '<span id="tut-launcher-title">Découvrir Nemo</span> <button class="modal-x" id="tut-launcher-close">&times;</button></div>' +
       '<div class="modal-bdy">' +
-      '<div style="font-size:11px;color:var(--text-dim);margin-bottom:12px">Des mini-leçons pas à pas, directement dans l\'app — comme les tutoriels intégrés de Flash. Choisis un module ; tu peux quitter à tout moment.</div>' +
       '<div class="tut-mod-list" id="tut-mod-list"></div>' +
       '</div></div>';
     document.body.appendChild(modal);
     modal.querySelector('#tut-launcher-close').addEventListener('click', closeLauncher);
+    modal.querySelector('#tut-launcher-back').addEventListener('click', function () { renderCategoryScreen(); });
     modal.addEventListener('mousedown', function (e) { if (e.target === modal) closeLauncher(); });
     return modal;
   }
@@ -713,18 +715,14 @@
   // Nemo would want: draw first, then animate, then organize/output.
   var CATEGORY_ORDER = ['Dessiner', 'Calques et animation', 'Organisation', 'Médias', 'Réglages'];
 
-  // Accordion open/closed state, keyed by category name — lives for the
-  // whole session (module-level, not per openLauncher() call) so
-  // re-opening the launcher remembers what you had open, same as any
-  // normal accordion UI. Nothing open on first run: with 15+ modules
-  // across 5 categories, showing everything at once defeats the point of
-  // grouping them in the first place.
-  var openCats = {};
-
-  function renderLauncherList() {
-    var list = $('#tut-mod-list'); if (!list) return;
-    var done = loadDone();
-    list.innerHTML = '';
+  // A real two-screen menu, not an inline accordion: the launcher opens on
+  // a list of CATEGORIES only (icon + count, no modules shown yet);
+  // clicking one navigates into a second screen listing just that
+  // category's modules, with a back arrow (in the modal header) to return
+  // to the category list. Matches how a phone Settings app drills down,
+  // per explicit request — a first version that expanded categories inline
+  // in the same list wasn't what was asked for.
+  function groupByCategory() {
     var byCat = {};
     MODULES.forEach(function (m) {
       var cat = m.category || 'Autres';
@@ -732,54 +730,66 @@
     });
     var cats = CATEGORY_ORDER.filter(function (c) { return byCat[c]; })
       .concat(Object.keys(byCat).filter(function (c) { return CATEGORY_ORDER.indexOf(c) === -1; }));
-    cats.forEach(function (cat) {
-      var mods = byCat[cat];
-      var doneCount = mods.filter(function (m) { return done.indexOf(m.id) !== -1; }).length;
-      var isOpen = !!openCats[cat];
+    return { byCat: byCat, cats: cats };
+  }
 
-      var hdr = document.createElement('button');
-      hdr.className = 'tut-cat-hdr' + (isOpen ? ' open' : '');
-      hdr.type = 'button';
-      hdr.innerHTML =
-        '<span class="tut-cat-chevron">' + chevronSvg() + '</span>' +
+  function renderCategoryScreen() {
+    var list = $('#tut-mod-list'); if (!list) return;
+    $('#tut-launcher-title').textContent = 'Découvrir Nemo';
+    $('#tut-launcher-back').style.display = 'none';
+    var done = loadDone();
+    var g = groupByCategory();
+    list.innerHTML = '';
+    var intro = document.createElement('div');
+    intro.className = 'tut-launcher-intro';
+    intro.textContent = 'Des mini-leçons pas à pas, directement dans l\'app — comme les tutoriels intégrés de Flash. Choisis une catégorie, puis un module ; tu peux quitter à tout moment.';
+    list.appendChild(intro);
+    g.cats.forEach(function (cat) {
+      var mods = g.byCat[cat];
+      var doneCount = mods.filter(function (m) { return done.indexOf(m.id) !== -1; }).length;
+      var btn = document.createElement('button');
+      btn.className = 'tut-cat-hdr';
+      btn.type = 'button';
+      btn.innerHTML =
         '<span class="tut-cat-name">' + cat + '</span>' +
-        '<span class="tut-cat-count">' + doneCount + '/' + mods.length + '</span>';
-      var body = document.createElement('div');
-      body.className = 'tut-cat-body' + (isOpen ? '' : ' collapsed');
-      var inner = document.createElement('div');
-      inner.className = 'tut-cat-inner';
-      body.appendChild(inner);
-      mods.forEach(function (m) {
-        var isDone = done.indexOf(m.id) !== -1;
-        var btn = document.createElement('button');
-        btn.className = 'tut-mod' + (isDone ? ' done' : '');
-        btn.innerHTML =
-          '<span class="tut-mod-ico">' + (isDone ? '✓' : m.icon) + '</span>' +
-          '<span class="tut-mod-body">' +
-          '<span class="tut-mod-title">' + m.title + '</span>' +
-          '<span class="tut-mod-desc">' + m.desc + '</span>' +
-          '</span>' +
-          '<span class="tut-mod-time">' + m.time + '</span>';
-        btn.addEventListener('click', function () { startModule(m.id); });
-        inner.appendChild(btn);
-      });
-      hdr.addEventListener('click', function () {
-        openCats[cat] = !openCats[cat];
-        hdr.classList.toggle('open', openCats[cat]);
-        body.classList.toggle('collapsed', !openCats[cat]);
-      });
-      list.appendChild(hdr);
-      list.appendChild(body);
+        '<span class="tut-cat-count">' + doneCount + '/' + mods.length + '</span>' +
+        '<span class="tut-cat-chevron">' + chevronSvg() + '</span>';
+      btn.addEventListener('click', function () { renderModuleScreen(cat); });
+      list.appendChild(btn);
+    });
+  }
+
+  function renderModuleScreen(cat) {
+    var list = $('#tut-mod-list'); if (!list) return;
+    var g = groupByCategory();
+    var mods = g.byCat[cat] || [];
+    var done = loadDone();
+    $('#tut-launcher-title').textContent = cat;
+    $('#tut-launcher-back').style.display = 'flex';
+    list.innerHTML = '';
+    mods.forEach(function (m) {
+      var isDone = done.indexOf(m.id) !== -1;
+      var btn = document.createElement('button');
+      btn.className = 'tut-mod' + (isDone ? ' done' : '');
+      btn.innerHTML =
+        '<span class="tut-mod-ico">' + (isDone ? '✓' : m.icon) + '</span>' +
+        '<span class="tut-mod-body">' +
+        '<span class="tut-mod-title">' + m.title + '</span>' +
+        '<span class="tut-mod-desc">' + m.desc + '</span>' +
+        '</span>' +
+        '<span class="tut-mod-time">' + m.time + '</span>';
+      btn.addEventListener('click', function () { startModule(m.id); });
+      list.appendChild(btn);
     });
   }
 
   function chevronSvg() {
-    return '<svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>';
+    return '<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>';
   }
 
   function openLauncher() {
     ensureLauncher();
-    renderLauncherList();
+    renderCategoryScreen();
     $('#tut-launcher').style.display = 'flex';
   }
   function closeLauncher() { var m = $('#tut-launcher'); if (m) m.style.display = 'none'; }


### PR DESCRIPTION
## Résumé
Suite à un retour : l'accordéon (PR #23) n'était pas ce qui était demandé. Remplacé par un vrai **menu à niveaux** :
- Écran 1 : liste des 5 catégories seulement (nom, compteur fait/total, chevron) — jamais les 17 modules d'un coup.
- Clic sur une catégorie → navigue vers l'écran 2, qui liste uniquement ses modules, avec une **flèche retour** dans l'en-tête du modal pour revenir à l'écran 1.

`renderCategoryScreen()` / `renderModuleScreen(cat)` remplacent tout le contenu de `#tut-mod-list` plutôt que de déplier/replier en place — plus simple, et ça correspond à un vrai historique de navigation à un seul niveau.

## Test plan
- [x] Navigation avant (catégorie → modules) et arrière (flèche retour → catégories) — testé en direct.
- [x] Lancement d'un module depuis le sous-menu ferme bien le lanceur et démarre le tutoriel.
- [x] Réouverture du lanceur après fermeture en plein sous-menu revient proprement à l'écran des catégories (pas de retour au dernier sous-menu).
- [x] Aucune erreur console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)