### PR TITLE
Symétrie : étendre à Plume/Ligne/Rectangle/Ellipse

### DIFF
--- a/src/js/shape-bridge.js
+++ b/src/js/shape-bridge.js
@@ -88,6 +88,15 @@
       strokeColor: sc, strokeWidth: state.brushSize,
     };
   }
+  // Symmetry guide (symmetry-bridge.js) live preview — same idea as
+  // draw-bridge.js's overlayItemFor, but for this file's own item shape
+  // (see mirrorSceneItem's header comment for why it's a separate entry
+  // point). Returns [primary] when Symmetry is off/no-op, so every caller
+  // can just always concat this in.
+  function withSymmetryPreview(item) {
+    if (!window.SMSymmetry) return [item];
+    return [item].concat(window.SMSymmetry.mirrorSceneItem(item));
+  }
 
   function onDown(e) {
     if (!shouldIntercept()) return;
@@ -103,7 +112,7 @@
     var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
     shapeStart = [w[0], w[1]];
     window.SMEngineBridge.suspend();
-    window.SMEngineBridge.renderWithOverlayItem(overlayItem(w[0], w[1]));
+    window.SMEngineBridge.renderWithOverlayItem(withSymmetryPreview(overlayItem(w[0], w[1])));
   }
   // Perspective-guide snapping (perspective-bridge.js) only makes sense for
   // the Line tool — a straight ruler line drawn roughly toward a vanishing
@@ -143,7 +152,7 @@
     var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
     var s = maybeSnap(w[0], w[1]);
     if (e.shiftKey) s = constrainEnd(s[0], s[1]);
-    window.SMEngineBridge.renderWithOverlayItem(overlayItem(s[0], s[1]));
+    window.SMEngineBridge.renderWithOverlayItem(withSymmetryPreview(overlayItem(s[0], s[1])));
   }
   function onUp(e) {
     if (!dragging) return;
@@ -186,6 +195,12 @@
     } else {
       if (state.shadowMode) path.data.channelTag = 'shadow';
       tagOwner(path);
+      // Symmetry guide (symmetry-bridge.js, 2026-07): promoted from
+      // brush-only to also cover Line/Rect/Ellipse — this IS the commit
+      // path that actually runs whenever the Rust engine is on (see
+      // maybeSnap's own comment above), so leaving this file out would
+      // have left Symmetry silently brush-only in practice.
+      if (window.SMSymmetry && window.SMSymmetry.onStrokeCommitted) window.SMSymmetry.onStrokeCommitted(path, layer);
     }
     saveActiveLayerFrame();
     // Stale-onion-ghost fix (see select-bridge.js's commit paths).

--- a/src/js/symmetry-bridge.js
+++ b/src/js/symmetry-bridge.js
@@ -219,7 +219,49 @@
     mirrored.insertAbove(path);
     if (typeof tagOwner === 'function') tagOwner(mirrored);
   }
-  window.SMSymmetry = { onPreview: onPreview, onStrokeCommitted: onStrokeCommitted };
+  // Same mirror/rotate math as onPreview/onStrokeCommitted above, but for a
+  // single already-built scene-item object ({segments,closed,fillColor,
+  // strokeColor,strokeWidth} — the Rust ItemIn wire shape) instead of a
+  // [x,y,width] samples array or a live Paper Path. shape-bridge.js's Line/
+  // Rect/Ellipse live preview builds exactly this kind of item directly
+  // (no samples array, no Paper Path to clone), so it needs its own entry
+  // point rather than reusing onPreview/onStrokeCommitted verbatim.
+  // "Stop at axis" clipping intentionally doesn't apply here — clipping a
+  // whole closed Rect/Ellipse mid-shape isn't a meaningful operation the
+  // way it is for a freehand line; skipped for scene items on purpose.
+  function transformSceneItemPoints(segments, fn) {
+    return segments.map(function (s) {
+      var p = fn(s.point[0], s.point[1]);
+      var out = { point: [p.x, p.y] };
+      if (s.handleIn) { var hi = fn(s.handleIn[0], s.handleIn[1], true); out.handleIn = [hi.x, hi.y]; }
+      if (s.handleOut) { var ho = fn(s.handleOut[0], s.handleOut[1], true); out.handleOut = [ho.x, ho.y]; }
+      return out;
+    });
+  }
+  function mirrorSceneItem(item) {
+    if (!state.symmetryEnabled || !item || !item.segments) return [];
+    if (state.symmetryMode === 'radial') {
+      var c = ensureSymmetryRadialCenter();
+      var n = sectorCount();
+      var out = [];
+      for (var k = 1; k < n; k++) {
+        var ang = k * 2 * Math.PI / n, cos = Math.cos(ang), sin = Math.sin(ang);
+        var segs = transformSceneItemPoints(item.segments, function (x, y, isVec) {
+          if (isVec) return { x: x * cos - y * sin, y: x * sin + y * cos };
+          var dx = x - c.x, dy = y - c.y;
+          return { x: c.x + dx * cos - dy * sin, y: c.y + dx * sin + dy * cos };
+        });
+        out.push({ segments: segs, closed: item.closed, fillColor: item.fillColor, strokeColor: item.strokeColor, strokeWidth: item.strokeWidth });
+      }
+      return out;
+    }
+    var axis = ensureSymmetryAxis();
+    var segs2 = transformSceneItemPoints(item.segments, function (x, y, isVec) {
+      return isVec ? reflectVector(x, y, axis) : reflectPoint(x, y, axis);
+    });
+    return [{ segments: segs2, closed: item.closed, fillColor: item.fillColor, strokeColor: item.strokeColor, strokeWidth: item.strokeWidth }];
+  }
+  window.SMSymmetry = { onPreview: onPreview, onStrokeCommitted: onStrokeCommitted, mirrorSceneItem: mirrorSceneItem };
 
   // ---- tool interaction: drag an axis endpoint (Free mode), drag the
   // whole axis (Y/X translate it perpendicular to itself, Free translates

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -3472,9 +3472,15 @@ function finalizePen(){
     p.remove();
     if(state.shadowMode)outline.data.channelTag='shadow';
     tagOwner(outline);
+    if(window.SMSymmetry&&window.SMSymmetry.onStrokeCommitted)window.SMSymmetry.onStrokeCommitted(outline,userLayers[state.activeLayerIdx]);
   }else{
     if(state.shadowMode)_pen.path.data.channelTag='shadow';
     tagOwner(_pen.path);
+    // Symmetry guide (symmetry-bridge.js, 2026-07): promoted from brush-only
+    // to also cover the Pen tool — same single guarded call as
+    // draw-bridge.js's commitStroke, right before the frame is saved so the
+    // mirrored/rotated copy shares the same undo snapshot.
+    if(window.SMSymmetry&&window.SMSymmetry.onStrokeCommitted)window.SMSymmetry.onStrokeCommitted(_pen.path,userLayers[state.activeLayerIdx]);
   }
   _pen.path=null;_pen.draggingHandle=false;
   saveActiveLayerFrame();updateUI();
@@ -4094,6 +4100,7 @@ function onMouseUp(event){
     else{
       if(state.shadowMode)currentPath.data.channelTag='shadow';
       tagOwner(currentPath);
+      if(window.SMSymmetry&&window.SMSymmetry.onStrokeCommitted)window.SMSymmetry.onStrokeCommitted(currentPath,userLayers[state.activeLayerIdx]);
     }
     currentPath=null;shapeStart=null;saveActiveLayerFrame();updateUI();
   }else if(state.tool==='select'){


### PR DESCRIPTION
## Summary
Suite au commentaire "seul le pinceau libre est câblé" — la Symétrie/mandala couvre maintenant aussi Plume, Ligne, Rectangle, Ellipse :
- `finalizePen()` (tools.js) — trait droit ET la branche taper-outline
- `commitShape()` (shape-bridge.js) — le chemin PRINCIPAL (moteur Rust actif, cas par défaut)
- Fallback moteur-désactivé (tools.js) pour Ligne/Rectangle/Ellipse
- Aperçu live pendant le drag (nouveau `SMSymmetry.mirrorSceneItem`)

## Test plan
- [x] `node --check` sur les 3 fichiers touchés
- [x] Testé en direct : Rectangle et Ligne dessinés avec Symétrie Y activée → copie miroir exacte committée via le vrai moteur Rust (coordonnées vérifiées par calcul), rendu confirmé visuellement

🤖 Generated with [Claude Code](https://claude.com/claude-code)