### PR TITLE
Tutoriel : ajoute le module Exporter

### DIFF
--- a/src/js/tutorial.js
+++ b/src/js/tutorial.js
@@ -536,6 +536,43 @@
         { type: 'click', target: '#settings-close', title: 'Ferme les Réglages', body: 'Clique la croix pour refermer la fenêtre.' },
         { type: 'info', title: 'Bien joué !', body: 'Le chapitre "Travailler à plusieurs" du guide couvre aussi les corrections à Accepter/Rejeter et le feedback d\'équipe.' }
       ]
+    },
+    {
+      id: 'export',
+      category: 'Médias',
+      icon: '18',
+      title: 'Exporter',
+      desc: 'Ouvrir la fenêtre d\'export, choisir un format',
+      time: '1 min',
+      // A real export writes to disk via une boîte de dialogue Tauri
+      // native — pas quelque chose que ce tutoriel sandboxé peut piloter
+      // ni vérifier (voir exportTauriAvailable(), export.js). Le module
+      // reste donc volontairement au niveau "ouvrir/configurer" : chaque
+      // étape est un vrai clic/changement réel sur la vraie fenêtre
+      // d'export, sans jamais cliquer "Exporter" pour de vrai.
+      // #btn-export vit dans le panneau de droite, section "Projet" —
+      // COLLAPSÉE par défaut (même piège que #btn-history, voir module
+      // 'history' plus haut). Étape tolérante façon 'perspective' : si la
+      // section est déjà ouverte (ex. module Historique fait juste avant
+      // dans la même session), un re-clic sur son en-tête la refermerait —
+      // on attend juste que le bouton devienne visible, qu'il ait fallu
+      // cliquer ou non.
+      steps: [
+        { type: 'info', title: 'Sortir ton animation', body: 'Nemo exporte en PNG/TIFF/GIF/MP4/ProRes, en SVG, en Lottie (JSON animé) ou en projet Rive/After Effects — un seul bouton, plusieurs formats.' },
+        {
+          type: 'state', target: '#phdr-project', title: 'Ouvre la section "Projet"', body: 'Clique l\'en-tête "Projet" dans le panneau de droite pour la déplier, si besoin.',
+          hint: 'En attente…',
+          check: function (win) { var el = win.document.getElementById('btn-export'); return !!(el && el.getBoundingClientRect().height > 0); }
+        },
+        { type: 'click', target: '#btn-export', title: 'Ouvre la fenêtre d\'export', body: 'Clique "Export…" dans le panneau de droite (section Projet).' },
+        stateChangedStep({
+          target: '#exp-format', title: 'Choisis un format', body: 'Ouvre le menu déroulant "Format" et choisis "Lottie" pour voir la fenêtre s\'adapter (les options d\'échelle disparaissent, un aperçu scrubbable s\'ouvrira après export).',
+          hint: 'En attente de ton choix…', measure: function (win) { var el = win.document.getElementById('exp-format'); return el ? el.value : ''; }
+        }),
+        { type: 'click', target: '#exp-range', title: 'Choisis la plage à exporter', body: 'Sélectionne "Zone de travail" ou "Toute la timeline" selon ce que tu veux sortir.' },
+        { type: 'click', target: '#export-close', title: 'Ferme la fenêtre', body: 'Clique la croix — on ne lance pas un vrai export ici, juste la découverte de la fenêtre.' },
+        { type: 'info', title: 'Bien joué !', body: 'Le bouton "Exporter" (en bas de la fenêtre) lance le vrai rendu — image par image pour PNG/TIFF, ou en pilotant ffmpeg pour GIF/MP4/ProRes. Le chapitre "Export" du guide détaille chaque format.' }
+      ]
     }
   ];
 


### PR DESCRIPTION
## Résumé
- Ajoute un 18e module au tutoriel interactif « Découvrir Nemo », catégorie **Médias** : ouvrir la fenêtre d'export, changer le format et la plage, refermer — sans jamais déclencher un vrai export sur disque (boîte de dialogue Tauri native, invérifiable dans ce sandbox).
- **Vrai bug trouvé en testant en direct** (pas en lisant le code) : `#btn-export` ne vit PAS dans une barre du haut comme supposé au départ — il est dans le panneau de droite, section « Projet », **collapsée par défaut** (`.pbdy.hid`), exactement le même piège déjà documenté pour `#btn-history`/`#p-persp-on`. Le module utilise le pattern tolérant du module Perspective (`type:'state'`, attend juste que le bouton devienne visible, que la section ait dû être ouverte ou non).

## Test plan
- [x] Nouveau projet, ouverture du lanceur → « Médias » passe de 0/2 à 0/3
- [x] Lancement du module → étape 1 (info) → étape 2 ouvre la section Projet (state, tolère déjà-ouvert)
- [x] Étape 3 clique le vrai `#btn-export` → la fenêtre Export s'ouvre
- [x] Étape 4 changement de format → « Lottie JSON », la ligne Échelle disparaît comme attendu (`NO_SCALE_FORMATS`)
- [x] Étape 5 changement de plage → « Toute la timeline »
- [x] Étape 6 fermeture de la fenêtre (croix) → étape finale « Bien joué ! »
- [x] Relance du lanceur → « Médias » passe à 1/2 (module marqué fait)
- [x] Zéro erreur console à chaque étape

🤖 Generated with [Claude Code](https://claude.com/claude-code)