### PR TITLE
Tutoriel : barre de recherche + icône aide flat design

### DIFF
--- a/src/css/tutorial.css
+++ b/src/css/tutorial.css
@@ -64,6 +64,22 @@
 #tut-launcher .tut-mod-list{display:flex;flex-direction:column;gap:6px;}
 #tut-launcher .tut-launcher-intro{font-size:11px;color:var(--text-dim);margin-bottom:6px;}
 
+/* Search: always visible above the list, regardless of which screen is
+   showing — typing flattens results across every category (see
+   renderSearchResults in tutorial.js); clearing it restores whatever
+   screen was active before. Explicit color:var(--text) on the input
+   itself — a bare <input> would otherwise inherit the platform's default
+   (often near-black) text color instead of the app's light theme,
+   rendering invisible on this dark background. */
+#tut-launcher .tut-launcher-search-wrap{position:relative;flex:none;padding:0 14px 10px;}
+#tut-launcher .tut-launcher-search-ico{position:absolute;left:24px;top:50%;transform:translateY(-50%);color:var(--text-dim);pointer-events:none;}
+#tut-launcher .tut-launcher-search{
+  width:100%;box-sizing:border-box;background:var(--bg);border:1px solid var(--border);
+  border-radius:7px;padding:7px 10px 7px 30px;font-size:12px;color:var(--text);outline:none;
+}
+#tut-launcher .tut-launcher-search::placeholder{color:var(--text-dim);}
+#tut-launcher .tut-launcher-search:focus{border-color:var(--accent);}
+
 /* Back arrow, left of the title — hidden on the top-level category screen,
    shown once a category has been opened. A real drill-down menu (category
    list -> tap one -> its modules on a fresh screen -> back arrow returns),

--- a/src/index.html
+++ b/src/index.html
@@ -62,7 +62,7 @@
     </div>
 
     <div class="start-row" id="btn-open-tutorial">
-      <span class="start-card-ico start-card-ico-accent"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l2.9 6.3L22 9.3l-5 4.9 1.2 7.1L12 17.9 5.8 21.3 7 14.2 2 9.3l7.1-1z"/></svg></span>
+      <span class="start-card-ico start-card-ico-accent"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></span>
       <div class="start-row-body">
         <div class="start-card-title">Découvrir Nemo — tutoriel interactif</div>
         <div class="start-card-sub">Des mini-leçons pas à pas, directement dans l'app</div>
@@ -124,7 +124,7 @@
        into the canvas column. -->
   <div id="fb-avatars" title="Feedback comments sur ce projet"></div>
   <div id="fb-avatars-pop"></div>
-  <button id="btn-open-tutorial-topbar" title="Découvrir Nemo — tutoriel interactif"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l2.9 6.3L22 9.3l-5 4.9 1.2 7.1L12 17.9 5.8 21.3 7 14.2 2 9.3l7.1-1z"/></svg></button>
+  <button id="btn-open-tutorial-topbar" title="Découvrir Nemo — tutoriel interactif"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></button>
   <button id="project-tabs-settings" title="Réglages"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/></svg></button>
 </div>
 <!-- v11: real multi-project tabs — each tab holds its own independent

--- a/src/js/tutorial.js
+++ b/src/js/tutorial.js
@@ -369,6 +369,8 @@
     ["Découvrir Nemo", "Discover Nemo", "Descubrir Nemo", "Nemoを発見する"],
     ["Des mini-leçons pas à pas, directement dans l'app — comme les tutoriels intégrés de Flash. Choisis une catégorie, puis un module ; tu peux quitter à tout moment.", "Step-by-step mini-lessons, right inside the app — like Flash's built-in tutorials. Choose a category, then a module; you can leave at any time.", "Mini-lecciones paso a paso, directamente en la app — como los tutoriales integrados de Flash. Elige una categoría, luego un módulo; puedes salir en cualquier momento.", "アプリ内で完結するステップバイステップのミニレッスン — Flashの内蔵チュートリアルのようなものです。カテゴリーを選び、次にモジュールを選んでください。いつでも終了できます。"],
     ["Retour", "Back", "Atrás", "戻る"],
+    ["Rechercher un module…", "Search a module…", "Buscar un módulo…", "モジュールを検索…"],
+    ["Aucun module ne correspond à ta recherche.", "No module matches your search.", "Ningún módulo coincide con tu búsqueda.", "検索に一致するモジュールがありません。"],
     ["étape", "step", "paso", "ステップ"],
     ["Module \"%s\" terminé ✓", "Module \"%s\" completed ✓", "Módulo \"%s\" completado ✓", "「%s」モジュール完了 ✓"],
   ]);
@@ -1011,12 +1013,17 @@
       '<div class="modal-hdr">' +
       '<button class="tut-launcher-back" id="tut-launcher-back" style="display:none" title="' + T('Retour') + '"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M15 6l-6 6 6 6"/></svg></button>' +
       '<span id="tut-launcher-title">' + T('Découvrir Nemo') + '</span> <button class="modal-x" id="tut-launcher-close">&times;</button></div>' +
+      '<div class="tut-launcher-search-wrap">' +
+      '<svg class="tut-launcher-search-ico" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.35-4.35"/></svg>' +
+      '<input type="text" id="tut-launcher-search" class="tut-launcher-search" placeholder="' + T('Rechercher un module…') + '">' +
+      '</div>' +
       '<div class="modal-bdy">' +
       '<div class="tut-mod-list" id="tut-mod-list"></div>' +
       '</div></div>';
     document.body.appendChild(modal);
     modal.querySelector('#tut-launcher-close').addEventListener('click', closeLauncher);
     modal.querySelector('#tut-launcher-back').addEventListener('click', function () { renderCategoryScreen(); });
+    modal.querySelector('#tut-launcher-search').addEventListener('input', onSearchInput);
     modal.addEventListener('mousedown', function (e) { if (e.target === modal) closeLauncher(); });
     return modal;
   }
@@ -1044,7 +1051,16 @@
     return { byCat: byCat, cats: cats };
   }
 
+  // Tracks which screen to return to once the search box is cleared —
+  // null means the top-level category list, a category name means that
+  // category's module screen. Only set by the two NORMAL render paths
+  // below (never by renderSearchResults itself), so clearing an active
+  // search always restores wherever the user actually was.
+  var lastScreenCat = null;
+
   function renderCategoryScreen() {
+    lastScreenCat = null;
+    var si = $('#tut-launcher-search'); if (si) si.placeholder = T('Rechercher un module…');
     var list = $('#tut-mod-list'); if (!list) return;
     $('#tut-launcher-title').textContent = T('Découvrir Nemo');
     $('#tut-launcher-back').style.display = 'none';
@@ -1072,6 +1088,7 @@
   }
 
   function renderModuleScreen(cat) {
+    lastScreenCat = cat;
     var list = $('#tut-mod-list'); if (!list) return;
     var g = groupByCategory();
     var mods = g.byCat[cat] || [];
@@ -1080,6 +1097,13 @@
     $('#tut-launcher-back').style.display = 'flex';
     $('#tut-launcher-back').title = T('Retour');
     list.innerHTML = '';
+    renderModuleRows(list, mods, done, false);
+  }
+
+  // Shared row-rendering for both a category's module list and search
+  // results — search results additionally show which category each hit
+  // belongs to, since it flattens across all of them.
+  function renderModuleRows(list, mods, done, showCategory) {
     mods.forEach(function (m) {
       var isDone = done.indexOf(m.id) !== -1;
       var btn = document.createElement('button');
@@ -1088,12 +1112,44 @@
         '<span class="tut-mod-ico">' + (isDone ? '✓' : m.icon) + '</span>' +
         '<span class="tut-mod-body">' +
         '<span class="tut-mod-title">' + T(m.title) + '</span>' +
-        '<span class="tut-mod-desc">' + T(m.desc) + '</span>' +
+        '<span class="tut-mod-desc">' + T(m.desc) + (showCategory ? ' · ' + T(m.category) : '') + '</span>' +
         '</span>' +
         '<span class="tut-mod-time">' + T(m.time) + '</span>';
       btn.addEventListener('click', function () { startModule(m.id); });
       list.appendChild(btn);
     });
+  }
+
+  // Flattens across every category — matches against both the currently
+  // displayed language's title/description AND the raw French source (so
+  // a search still works before a translation exists for a given string,
+  // or if the user is typing in a different language than the UI).
+  function renderSearchResults(query) {
+    var list = $('#tut-mod-list'); if (!list) return;
+    $('#tut-launcher-title').textContent = T('Découvrir Nemo');
+    $('#tut-launcher-back').style.display = 'none';
+    var done = loadDone();
+    var q = query.trim().toLowerCase();
+    var results = MODULES.filter(function (m) {
+      var hay = (T(m.title) + ' ' + T(m.desc) + ' ' + m.title + ' ' + m.desc).toLowerCase();
+      return hay.indexOf(q) !== -1;
+    });
+    list.innerHTML = '';
+    if (!results.length) {
+      var empty = document.createElement('div');
+      empty.className = 'tut-launcher-intro';
+      empty.textContent = T('Aucun module ne correspond à ta recherche.');
+      list.appendChild(empty);
+      return;
+    }
+    renderModuleRows(list, results, done, true);
+  }
+
+  function onSearchInput(e) {
+    var q = e.target.value;
+    if (q.trim()) { renderSearchResults(q); }
+    else if (lastScreenCat) { renderModuleScreen(lastScreenCat); }
+    else { renderCategoryScreen(); }
   }
 
   function chevronSvg() {
@@ -1102,6 +1158,7 @@
 
   function openLauncher() {
     ensureLauncher();
+    var si = $('#tut-launcher-search'); if (si) si.value = '';
     renderCategoryScreen();
     $('#tut-launcher').style.display = 'flex';
   }


### PR DESCRIPTION
## Résumé
- Ajoute une barre de recherche au lanceur « Découvrir Nemo » — filtre les 18 modules par titre/description à travers toutes les catégories, indépendamment de l'écran affiché. Effacer la recherche restaure l'écran d'où on venait (catégorie ouverte ou liste racine), pas systématiquement la racine.
- Remplace l'icône étoile du tutoriel (topbar + ligne sur l'écran de démarrage) par une icône aide (cercle + point d'interrogation), même style flat outline que les autres boutons de la barre (stroke-width 1.8, viewBox 24×24, `currentColor`).
- Le champ de recherche fixe explicitement `color:var(--text)` — un `<input>` nu hérite sinon la couleur de texte par défaut de la plateforme (souvent proche du noir), invisible sur le thème sombre de l'app.

## Test plan
- [x] Ouverture du lanceur : champ de recherche visible, placeholder traduit
- [x] Recherche "caméra" → résultat unique flatten avec suffixe de catégorie ("Caméra — Cadrage animé (zoom/pan) · Organisation")
- [x] Recherche sans résultat → message "Aucun module ne correspond à ta recherche."
- [x] Effacement du champ depuis la racine → retour à la liste de catégories
- [x] Entrée dans "Dessiner", recherche, effacement → retour à l'écran "Dessiner" (pas la racine)
- [x] Icône aide visible et cohérente sur les deux points d'entrée (topbar + écran de démarrage)
- [x] `getComputedStyle` confirme un texte clair (`rgb(236,234,231)`) sur le titre et le champ de recherche, jamais noir
- [x] Zéro erreur console

🤖 Generated with [Claude Code](https://claude.com/claude-code)