### PR TITLE
Guides déplaçables + contrainte perspective + gizmo dégradé (Illustrator/Rive)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -514,22 +514,20 @@
     <div class="psec" id="effects-sec">
       <div class="phdr"><span class="ar">☰</span> <span data-i18n="hdrEffects">Effects</span></div>
       <div class="pbdy">
-        <!-- Gradient fill (2026-07) — applies to the current selection's
-             fillColor (Select tool), same target as Fill's own color swatch
-             above. Two stops + linear/radial + an angle (linear only,
-             ignored/hidden for radial) — direction/size are computed from
-             the selection's own bounding box at that angle, no on-canvas
-             drag-handle gizmo in this first version (see
-             gradient-bridge.js's own header comment). -->
-        <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer" title="Applique un dégradé au fill de la sélection actuelle (outil Sélection)"><input type="checkbox" id="p-grad-on" style="accent-color:var(--accent)"> Dégradé de fill</label></div>
-        <div class="pr" id="p-grad-controls" style="display:none">
-          <span class="pl">Stops</span>
-          <input type="color" id="p-grad-c1" value="#ff0000" style="width:24px;height:22px;border:none;cursor:pointer;padding:0;">
-          <input type="color" id="p-grad-c2" value="#0000ff" style="width:24px;height:22px;border:none;cursor:pointer;padding:0;">
-        </div>
+        <!-- Gradient fill (2026-07, Illustrator/Rive-style) — applies to
+             the SINGLE currently selected shape's fill (Select tool). The
+             from/to endpoints AND each stop's position along the line are
+             edited by dragging the on-canvas gizmo directly (gradient-
+             bridge.js's own pointerdown/move/up, same pattern as
+             perspective-bridge.js/symmetry-bridge.js's guide dragging) —
+             this panel only edits STOP COLORS/count and Linear vs Radial,
+             deliberately no angle/position number fields now that dragging
+             covers that directly. -->
+        <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer" title="Applique un dégradé au fill de la sélection actuelle (une seule forme à la fois, outil Sélection)"><input type="checkbox" id="p-grad-on" style="accent-color:var(--accent)"> Dégradé de fill</label></div>
         <div class="pr" id="p-grad-kind-row" style="display:none"><span class="pl">Type</span><select class="psel" id="p-grad-kind"><option value="linear" selected>Linéaire</option><option value="radial">Radial</option></select></div>
-        <div class="pr" id="p-grad-angle-row" style="display:none"><span class="pl">Angle</span><input type="number" class="pi scrub" id="p-grad-angle" value="0" min="-360" max="360" data-step="5"><span style="font-size:9px;color:var(--text-dim)">°</span></div>
-        <div class="pr" id="p-grad-apply-row" style="display:none;gap:4px"><button class="pbtn" id="btn-grad-apply" style="flex:1">Appliquer à la sélection</button></div>
+        <div id="p-grad-stops-list" style="display:none"></div>
+        <div class="pr" id="p-grad-addstop-row" style="display:none;gap:4px"><button class="pbtn" id="btn-grad-add-stop" style="flex:1">+ Stop</button></div>
+        <div class="pr" id="p-grad-hint-row" style="display:none;font-size:9px;color:var(--text-dim)">Glissez le carré/rond sur le canevas pour repositionner le dégradé, glissez un losange pour déplacer un stop.</div>
       </div>
     </div>
     <div class="psec">

--- a/src/js/draw-bridge.js
+++ b/src/js/draw-bridge.js
@@ -32,6 +32,11 @@
   // Alt-drag-to-rotate explicitly cedes Alt to the brushes for this.
   var sizing = false, sizeStartX = 0, sizeStartVal = 0, sizeAnchorW = null;
   var samples = []; // [x,y,width]
+  // Perspective guide hard-lock (2026-07, perspective-bridge.js's
+  // findGuideRayNear/projectOnRay — see their own header comment for why
+  // this replaced a pure per-point magnet). Set once at pointerdown, held
+  // for the whole gesture, cleared at pointerup.
+  var lockedGuideRay = null;
   var lastMoveT = 0, lastWorldPt = null;
   var lastPenPressure = null; // held across a real-pen gesture, see pressureOf()
   // state.stabilizer (position-averaging while drawing) used to only exist
@@ -176,6 +181,22 @@
     var snapped = window.perspectiveSnapPointMagnetic(new Point(w[0], w[1]));
     return snapped ? [snapped.x, snapped.y] : w;
   }
+  // Hard directional lock (2026-07, perspective-bridge.js's
+  // findGuideRayNear/projectOnRay) — call this instead of magnetSnap at
+  // every point of a Draw/Fillbrush stroke. Locks onto whichever guide ray
+  // is closest at the VERY FIRST call of a gesture (pointerdown) and then
+  // hard-projects every later point onto that same ray for the rest of the
+  // stroke, regardless of distance — falls back to the old per-point
+  // magnetSnap when nothing was close enough to lock at the start (so a
+  // stroke drawn nowhere near the guide still behaves exactly as before).
+  function guideConstrain(w, isStart) {
+    if (isStart) lockedGuideRay = window.perspectiveFindGuideRayNear ? window.perspectiveFindGuideRayNear(new Point(w[0], w[1])) : null;
+    if (lockedGuideRay && window.perspectiveProjectOnRay) {
+      var p = window.perspectiveProjectOnRay(new Point(w[0], w[1]), lockedGuideRay);
+      return [p.x, p.y];
+    }
+    return magnetSnap(w);
+  }
   function hexToRgba(css, opacityPct) {
     if (!css) return null;
     var h = css.replace('#', '');
@@ -299,7 +320,7 @@
     lastMoveT = 0; lastWorldPt = null; lastPenPressure = null;
     stabQueue = []; smoothedPressure = null;
     var w0 = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
-    w0 = magnetSnap(w0);
+    w0 = guideConstrain(w0, true);
     // engine-bridge.js's own tick() loop keeps running unconditionally in
     // the background (it's not started/stopped per-drag) — without
     // suspending it here, it races renderWithOverlayItem below on every
@@ -345,7 +366,7 @@
     e.stopImmediatePropagation();
     e.preventDefault();
     var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
-    w = magnetSnap(w);
+    w = guideConstrain(w, false);
     // Pressure is read from the RAW point (speed-fallback pressure needs
     // the real, un-averaged motion to feel right) — only the drawn
     // POSITION gets stabilized, matching TVPaint-style "smoothing" where
@@ -408,7 +429,8 @@
     // at the true release position so the line always reaches it, same
     // catch-up behavior Photoshop/Clip Studio's stabilized brushes use.
     var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
-    w = magnetSnap(w);
+    w = guideConstrain(w, false);
+    lockedGuideRay = null; // stroke over — next pointerdown re-evaluates from scratch
     var pressure = smoothPressure(wantsPressure() ? pressureOf(e, w) : 1);
     if (modeler) {
       // The modeler's own end-of-stroke catch-up (physics iterated until

--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -491,6 +491,8 @@
     if (perspectiveItems.length) layers.push({ items: perspectiveItems });
     var symmetryItems = window.buildSymmetryGuideItems ? window.buildSymmetryGuideItems() : [];
     if (symmetryItems.length) layers.push({ items: symmetryItems });
+    var gradientGizmoItems = window.buildGradientGizmoItems ? window.buildGradientGizmoItems() : [];
+    if (gradientGizmoItems.length) layers.push({ items: gradientGizmoItems });
     return JSON.stringify({ layers: layers });
   }
 

--- a/src/js/gradient-bridge.js
+++ b/src/js/gradient-bridge.js
@@ -1,82 +1,259 @@
-// ---- GRADIENT FILL (2026-07) ----
-// Applies a 2-stop linear or radial gradient to the CURRENT selection's fill
-// — the Effects panel section's own controls (index.html #effects-sec),
-// only ever active alongside the Select/Subselect tool's selectedPaths
-// (same target `setFillColor` already uses, timeline.js). Stored as
-// `p.data.fillGradient = {kind,from,to,stops}` (world coordinates,
-// serP/desP-persisted, app.js) — a plain data field, not a live Paper.js
-// Gradient object, so every consumer that doesn't yet understand gradients
-// (boolean ops, the eyedropper, thumbnails) still sees a reasonable flat
-// `p.fillColor` fallback (stop 1's color) instead of crashing on an
-// unexpected shape.
+// ---- GRADIENT FILL (2026-07, Illustrator/Rive-style on-canvas control) ----
+// Applies an N-stop linear or radial gradient to the fill of ONE selected
+// shape at a time (Select/Subselect tool) — `p.data.fillGradient =
+// {kind,from,to,stops:[{offset,color},...]}` (world coordinates,
+// serP/desP-persisted, app.js; consumed by engine-bridge.js/geometry-wasm
+// for the live GPU render and export.js's own Paper.js Gradient for
+// export/preview). A plain data field, not a live Paper.js Gradient object,
+// so any consumer that doesn't yet understand gradients (boolean ops, the
+// eyedropper, thumbnails) still sees a flat `p.fillColor` fallback (stop 0's
+// color) instead of breaking.
 //
-// No on-canvas drag-handle gizmo in this first version — direction/size for
-// a linear gradient come from an Angle field (degrees) combined with the
-// selection's own bounding box (from/to computed as the box's half-diagonal
-// projected at that angle through its center); a radial gradient is always
-// centered on the bbox center with a radius of the half-diagonal. A real
-// draggable gizmo (drag the gradient's own start/end handles on the canvas,
-// Illustrator/Figma-style) is a natural follow-up, not built here.
+// Position (both endpoints AND each stop's offset along the line) is edited
+// by DRAGGING an on-canvas gizmo — same overlay + own capture-phase
+// pointerdown/move/up pattern as perspective-bridge.js's vanishing points and
+// symmetry-bridge.js's axis, not a numeric angle field. The Effects panel
+// only edits stop COLORS/count and Linear-vs-Radial, which don't have an
+// obvious canvas gesture of their own.
 (function () {
-  function selectionTargets() {
-    if ((state.tool !== 'select' && state.tool !== 'subselect') || !window.selectedPaths || !selectedPaths.length) return [];
-    return selectedPaths.filter(function (p) { return p instanceof Path || p instanceof CompoundPath; });
+  function engineOn() { return window.SMEngineBridge && window.SMEngineBridge.isEnabled() && !state.playing; }
+  function singleTarget() {
+    if ((state.tool !== 'select' && state.tool !== 'subselect') || !window.selectedPaths || selectedPaths.length !== 1) return null;
+    var p = selectedPaths[0];
+    return (p instanceof Path || p instanceof CompoundPath) ? p : null;
   }
-  function controlRows() { return ['p-grad-controls', 'p-grad-kind-row', 'p-grad-angle-row', 'p-grad-apply-row']; }
-  function setRowsVisible(on) {
-    controlRows().forEach(function (id) { var row = document.getElementById(id); if (row) row.style.display = on ? 'flex' : 'none'; });
+  function sortedStops(grad) {
+    return grad.stops.slice().sort(function (a, b) { return a.offset - b.offset; });
   }
-  function applyGradientToSelection() {
-    var targets = selectionTargets();
-    if (!targets.length) { if (window.showToast) showToast('Sélectionnez une forme d\'abord'); return; }
-    var c1 = document.getElementById('p-grad-c1').value;
-    var c2 = document.getElementById('p-grad-c2').value;
-    var kind = document.getElementById('p-grad-kind').value;
-    var angleDeg = parseFloat(document.getElementById('p-grad-angle').value) || 0;
-    pushUndo();
-    targets.forEach(function (p) {
-      var b = p.bounds;
-      var cx = b.center.x, cy = b.center.y;
-      var halfDiag = Math.hypot(b.width, b.height) / 2 || 1;
-      var from, to;
-      if (kind === 'radial') {
-        from = [cx, cy]; to = [cx + halfDiag, cy];
-      } else {
-        var rad = angleDeg * Math.PI / 180;
-        var dx = Math.cos(rad) * halfDiag, dy = Math.sin(rad) * halfDiag;
-        from = [cx - dx, cy - dy]; to = [cx + dx, cy + dy];
-      }
-      p.data.fillGradient = { kind: kind, from: from, to: to, stops: [{ offset: 0, color: c1 }, { offset: 1, color: c2 }] };
-      // Flat-color fallback (see file header) — keeps every non-gradient-
-      // aware consumer showing a sane approximation instead of nothing.
-      p.fillColor = c1;
-    });
-    saveActiveLayerFrame(); updateUI();
-    if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
-    if (window.showToast) showToast('Dégradé appliqué');
+  function defaultGradientFor(p) {
+    var b = p.bounds;
+    var cx = b.center.x, cy = b.center.y;
+    var halfDiag = Math.hypot(b.width, b.height) / 2 || 100;
+    var c1 = p.fillColor ? colorHex8(p.fillColor) : '#ff0000';
+    return {
+      kind: 'linear',
+      from: [cx - halfDiag, cy],
+      to: [cx + halfDiag, cy],
+      stops: [{ offset: 0, color: c1 }, { offset: 1, color: '#0000ff' }],
+    };
   }
-  function removeGradientFromSelection() {
-    var targets = selectionTargets();
-    if (!targets.length) return;
-    pushUndo();
-    targets.forEach(function (p) { if (p.data && p.data.fillGradient) delete p.data.fillGradient; });
-    saveActiveLayerFrame(); updateUI();
-    if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
-  }
-  function init() {
+
+  // ---- Effects panel: stop list (color/offset/remove), kind, add-stop —
+  // NOT position, which is drag-only (see file header). Rebuilt from
+  // scratch on every call (small N, this app's own convention elsewhere —
+  // e.g. renderElementsList in motion.js does the same) rather than
+  // diffed DOM patching.
+  function renderGradientPanel() {
     var onCb = document.getElementById('p-grad-on');
-    if (!onCb) return; // effects-sec markup not present in this build
-    onCb.addEventListener('change', function () {
-      setRowsVisible(this.checked);
-      if (this.checked) applyGradientToSelection();
-      else removeGradientFromSelection();
+    if (!onCb) return;
+    var kindRow = document.getElementById('p-grad-kind-row');
+    var stopsList = document.getElementById('p-grad-stops-list');
+    var addRow = document.getElementById('p-grad-addstop-row');
+    var hintRow = document.getElementById('p-grad-hint-row');
+    var target = singleTarget();
+    if (!target) {
+      onCb.checked = false; onCb.disabled = true;
+      kindRow.style.display = stopsList.style.display = addRow.style.display = hintRow.style.display = 'none';
+      return;
+    }
+    onCb.disabled = false;
+    var grad = target.data.fillGradient;
+    onCb.checked = !!grad;
+    var show = !!grad ? 'flex' : 'none';
+    kindRow.style.display = show; addRow.style.display = show; hintRow.style.display = grad ? 'block' : 'none';
+    stopsList.style.display = grad ? 'block' : 'none';
+    stopsList.innerHTML = '';
+    if (!grad) return;
+    document.getElementById('p-grad-kind').value = grad.kind;
+    var stops = sortedStops(grad);
+    stops.forEach(function (stop) {
+      var row = document.createElement('div');
+      row.className = 'pr'; row.style.gap = '4px';
+      var colorInp = document.createElement('input');
+      colorInp.type = 'color'; colorInp.value = stop.color.slice(0, 7);
+      colorInp.style.cssText = 'width:24px;height:22px;border:none;cursor:pointer;padding:0;';
+      colorInp.addEventListener('change', function () {
+        pushUndo(); stop.color = this.value;
+        saveActiveLayerFrame(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+      });
+      var offInp = document.createElement('input');
+      offInp.type = 'number'; offInp.className = 'pi'; offInp.min = 0; offInp.max = 100; offInp.step = 1;
+      offInp.style.width = '48px';
+      offInp.value = Math.round(stop.offset * 100);
+      offInp.addEventListener('change', function () {
+        pushUndo(); stop.offset = Math.max(0, Math.min(100, parseFloat(this.value) || 0)) / 100;
+        saveActiveLayerFrame(); renderGradientPanel(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+      });
+      var pct = document.createElement('span'); pct.style.cssText = 'font-size:9px;color:var(--text-dim)'; pct.textContent = '%';
+      var rmBtn = document.createElement('button');
+      rmBtn.className = 'pbtn'; rmBtn.textContent = '×'; rmBtn.style.cssText = 'padding:0 6px;';
+      rmBtn.disabled = grad.stops.length <= 2;
+      rmBtn.addEventListener('click', function () {
+        if (grad.stops.length <= 2) return;
+        pushUndo();
+        var idx = grad.stops.indexOf(stop);
+        if (idx >= 0) grad.stops.splice(idx, 1);
+        saveActiveLayerFrame(); renderGradientPanel(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+      });
+      row.appendChild(colorInp); row.appendChild(offInp); row.appendChild(pct); row.appendChild(rmBtn);
+      stopsList.appendChild(row);
     });
-    document.getElementById('btn-grad-apply').addEventListener('click', applyGradientToSelection);
-    ['p-grad-c1', 'p-grad-c2', 'p-grad-kind', 'p-grad-angle'].forEach(function (id) {
-      document.getElementById(id).addEventListener('input', function () {
-        if (onCb.checked) applyGradientToSelection();
+  }
+  window.renderGradientPanel = renderGradientPanel;
+
+  function toggleGradient(on) {
+    var target = singleTarget();
+    if (!target) return;
+    pushUndo();
+    if (on) {
+      target.data.fillGradient = defaultGradientFor(target);
+      target.fillColor = target.data.fillGradient.stops[0].color;
+    } else {
+      delete target.data.fillGradient;
+    }
+    saveActiveLayerFrame(); updateUI(); renderGradientPanel();
+    if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+  }
+  function addStop() {
+    var target = singleTarget();
+    if (!target || !target.data.fillGradient) return;
+    pushUndo();
+    var grad = target.data.fillGradient;
+    var stops = sortedStops(grad);
+    // Insert at the midpoint of the two stops with the largest gap — a
+    // more useful default than always 0.5 once there are already 3+ stops.
+    var bestGapIdx = 0, bestGap = -1;
+    for (var i = 0; i < stops.length - 1; i++) {
+      var gap = stops[i + 1].offset - stops[i].offset;
+      if (gap > bestGap) { bestGap = gap; bestGapIdx = i; }
+    }
+    var a = stops[bestGapIdx], b = stops[bestGapIdx + 1] || stops[bestGapIdx];
+    var mid = (a.offset + b.offset) / 2;
+    grad.stops.push({ offset: mid, color: a.color });
+    saveActiveLayerFrame(); renderGradientPanel();
+    if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+  }
+
+  // ---- On-canvas gizmo: line + endpoint handles (square=from, circle=to,
+  // Illustrator's own start/end handle convention) + a small diamond per
+  // stop positioned along the line at t=offset (colored to preview that
+  // stop's own color at a glance). Same "extra layer pushed into
+  // buildSceneJson()'s scene, never saved to frame data" convention as
+  // every other overlay in this app.
+  function stopWorldPos(grad, t) {
+    var fx = grad.from[0], fy = grad.from[1], tx = grad.to[0], ty = grad.to[1];
+    return { x: fx + (tx - fx) * t, y: fy + (ty - fy) * t };
+  }
+  function buildGradientGizmoItems() {
+    var target = singleTarget();
+    if (!target || !target.data.fillGradient) return [];
+    var grad = target.data.fillGradient;
+    var items = [];
+    var col = [90, 180, 255, 255];
+    items.push({
+      segments: [{ point: grad.from }, { point: grad.to }],
+      closed: false, fillColor: null, strokeColor: col, strokeWidth: 1.5, strokeCap: 'butt',
+    });
+    // "from" handle — small square.
+    var s = 6, fx = grad.from[0], fy = grad.from[1];
+    items.push({
+      segments: [{ point: [fx - s, fy - s] }, { point: [fx + s, fy - s] }, { point: [fx + s, fy + s] }, { point: [fx - s, fy + s] }],
+      closed: true, fillColor: [255, 255, 255, 255], strokeColor: col, strokeWidth: 1.5,
+    });
+    // "to" handle — small circle (approximated with a 12-gon, consistent
+    // with this file's other overlay builders' style).
+    var tx = grad.to[0], ty = grad.to[1], r = 6, segs = [];
+    for (var i = 0; i < 12; i++) { var a = (i / 12) * Math.PI * 2; segs.push({ point: [tx + Math.cos(a) * r, ty + Math.sin(a) * r] }); }
+    items.push({ segments: segs, closed: true, fillColor: [255, 255, 255, 255], strokeColor: col, strokeWidth: 1.5 });
+    // Stop markers — diamonds, filled with the stop's OWN color so the
+    // gizmo doubles as a live preview of where each color sits.
+    grad.stops.forEach(function (stop) {
+      var p = stopWorldPos(grad, stop.offset);
+      var ds = 5;
+      var h = stop.color.length === 9 ? [parseInt(stop.color.substr(1, 2), 16), parseInt(stop.color.substr(3, 2), 16), parseInt(stop.color.substr(5, 2), 16), parseInt(stop.color.substr(7, 2), 16)]
+        : [parseInt(stop.color.substr(1, 2), 16), parseInt(stop.color.substr(3, 2), 16), parseInt(stop.color.substr(5, 2), 16), 255];
+      items.push({
+        segments: [{ point: [p.x, p.y - ds] }, { point: [p.x + ds, p.y] }, { point: [p.x, p.y + ds] }, { point: [p.x - ds, p.y] }],
+        closed: true, fillColor: h, strokeColor: [30, 30, 30, 255], strokeWidth: 1.2,
       });
     });
+    return items;
+  }
+  window.buildGradientGizmoItems = buildGradientGizmoItems;
+
+  // ---- drag interaction ----
+  var dragging = null; // 'from' | 'to' | {stopIndex} | null
+  function shouldEdit() { return engineOn() && !!singleTarget() && !!singleTarget().data.fillGradient; }
+  function hitPoint(worldPt, wx, wy, tolPx) {
+    var tol = tolPx / view.zoom;
+    return Math.hypot(worldPt.x - wx, worldPt.y - wy) < tol;
+  }
+  function onDown(e) {
+    if (!shouldEdit()) return;
+    var target = singleTarget();
+    var grad = target.data.fillGradient;
+    var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
+    var wp = new Point(w[0], w[1]);
+    if (hitPoint(wp, grad.from[0], grad.from[1], 12)) { dragging = 'from'; }
+    else if (hitPoint(wp, grad.to[0], grad.to[1], 12)) { dragging = 'to'; }
+    else {
+      for (var i = 0; i < grad.stops.length; i++) {
+        var sp = stopWorldPos(grad, grad.stops[i].offset);
+        if (hitPoint(wp, sp.x, sp.y, 9)) { dragging = { stopIndex: i }; break; }
+      }
+    }
+    if (!dragging) return;
+    e.stopImmediatePropagation(); e.preventDefault();
+    pushUndo();
+    window.SMEngineBridge.suspend();
+  }
+  function onMove(e) {
+    if (!dragging || !shouldEdit()) return;
+    e.stopImmediatePropagation(); e.preventDefault();
+    var target = singleTarget();
+    var grad = target.data.fillGradient;
+    var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
+    if (dragging === 'from') grad.from = [w[0], w[1]];
+    else if (dragging === 'to') grad.to = [w[0], w[1]];
+    else {
+      // Project the drag point onto the from→to line, clamped to [0,1] —
+      // dragging a stop off either end just pins it at that end, matching
+      // Illustrator's own gradient-stop clamping.
+      var fx = grad.from[0], fy = grad.from[1], tx = grad.to[0], ty = grad.to[1];
+      var dx = tx - fx, dy = ty - fy, len2 = dx * dx + dy * dy || 1;
+      var t = ((w[0] - fx) * dx + (w[1] - fy) * dy) / len2;
+      grad.stops[dragging.stopIndex].offset = Math.max(0, Math.min(1, t));
+    }
+    window.SMEngineBridge.renderNow();
+  }
+  function onUp(e) {
+    if (!dragging) return;
+    e.stopImmediatePropagation(); e.preventDefault();
+    dragging = null;
+    window.SMEngineBridge.resume();
+    saveActiveLayerFrame(); renderGradientPanel();
+    window.SMEngineBridge.renderNow();
+  }
+
+  function init() {
+    var onCb = document.getElementById('p-grad-on');
+    if (onCb) {
+      onCb.addEventListener('change', function () { toggleGradient(this.checked); });
+      document.getElementById('btn-grad-add-stop').addEventListener('click', addStop);
+      document.getElementById('p-grad-kind').addEventListener('change', function () {
+        var target = singleTarget();
+        if (!target || !target.data.fillGradient) return;
+        pushUndo(); target.data.fillGradient.kind = this.value;
+        saveActiveLayerFrame(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+      });
+    }
+    var target = document.getElementById('canvas-area') || document.getElementById('drawing-canvas');
+    if (target) {
+      target.addEventListener('pointerdown', onDown, { capture: true });
+      target.addEventListener('pointermove', onMove, { capture: true });
+      target.addEventListener('pointerup', onUp, { capture: true });
+      target.addEventListener('pointercancel', onUp, { capture: true });
+    }
   }
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
   else init();

--- a/src/js/labs/labs-float-panel.js
+++ b/src/js/labs/labs-float-panel.js
@@ -51,6 +51,16 @@
         if (state.symmetryEnabled) {
           if (window.ensureSymmetryAxis) window.ensureSymmetryAxis();
           if (window.ensureSymmetryRadialCenter) window.ensureSymmetryRadialCenter();
+          // Feedback: "on ne peut pas changer l'emplacement des points/
+          // guides" — turning the guide on from HERE used to leave
+          // state.tool at whatever it was (almost always Draw/Fillbrush),
+          // so the axis appeared but nothing you clicked on it did
+          // anything: dragging is gated on state.tool==='symmetry' (see
+          // symmetry-bridge.js's shouldEdit). Jumping into that tool the
+          // instant the guide turns on means the very first thing the user
+          // can do is drag it into place, no separate "now click the tiny
+          // toolbar icon" step required.
+          if (window.SM && window.SM.setTool) window.SM.setTool('symmetry');
         }
         var cb = document.getElementById('p-sym-on'); if (cb) cb.checked = state.symmetryEnabled;
         if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
@@ -60,7 +70,11 @@
       isOn: function () { return !!(window.state && state.perspectiveEnabled); },
       toggle: function () {
         state.perspectiveEnabled = !state.perspectiveEnabled;
-        if (state.perspectiveEnabled && window.ensurePerspectiveVPs) window.ensurePerspectiveVPs();
+        if (state.perspectiveEnabled) {
+          if (window.ensurePerspectiveVPs) window.ensurePerspectiveVPs();
+          // Same reasoning as symmetry's toggle above.
+          if (window.SM && window.SM.setTool) window.SM.setTool('perspective');
+        }
         var cb = document.getElementById('p-persp-on'); if (cb) cb.checked = state.perspectiveEnabled;
         if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
       },

--- a/src/js/perspective-bridge.js
+++ b/src/js/perspective-bridge.js
@@ -190,6 +190,58 @@
   }
   window.perspectiveSnapPointMagnetic = nearestGuideProjection;
 
+  // Hard directional lock (2026-07 — feedback: "la contrainte par rapport
+  // aux guides est légère... ça dépend comment on fait notre trait mais il
+  // peut partir dans une autre direction que le guide"). nearestGuideProjection
+  // above is a per-POINT proximity magnet: it only pulls a sample onto a
+  // guide line while that exact sample is within MAGNET_PX, so a stroke that
+  // starts near a ray but then wanders away keeps drawing free-hand instead
+  // of staying on the ray — not how Sketchbook's Perspective Guide actually
+  // behaves once a stroke commits to a vanishing point. These two functions
+  // let draw-bridge.js instead LOCK a whole stroke onto whichever ray is
+  // closest at pointerdown (generous LOCK_TOLERANCE_PX, wider than the
+  // per-point magnet's own, since committing to a direction should be easy
+  // to trigger deliberately) and hard-project every subsequent point onto
+  // that SAME ray for the rest of the gesture, regardless of how far the
+  // hand later strays from it — matching a ruler-against-the-guide feel.
+  // A stroke that starts far from every ray still draws completely free, by
+  // design (not "near the guide" at all is a real, common intent).
+  var LOCK_TOLERANCE_PX = 40;
+  function findGuideRayNear(worldPt) {
+    if (!state.perspectiveEnabled) return null;
+    var vps = ensurePerspectiveVPs();
+    if (!vps.length) return null;
+    var tol = LOCK_TOLERANCE_PX / view.zoom;
+    var best = null, bestDist = tol;
+    function tryLine(px, py, dx, dy) {
+      var vx = worldPt.x - px, vy = worldPt.y - py;
+      var t = vx * dx + vy * dy;
+      var projx = px + dx * t, projy = py + dy * t;
+      var dist = Math.hypot(worldPt.x - projx, worldPt.y - projy);
+      if (dist < bestDist) { bestDist = dist; best = { px: px, py: py, dx: dx, dy: dy }; }
+    }
+    var n = Math.max(4, state.perspectiveDensity | 0);
+    vps.forEach(function (vp) {
+      for (var i = 0; i < n; i++) {
+        var a = (i / n) * Math.PI * 2;
+        tryLine(vp.x, vp.y, Math.cos(a), Math.sin(a));
+      }
+    });
+    if (vps.length >= 2) {
+      var dx = vps[1].x - vps[0].x, dy = vps[1].y - vps[0].y;
+      var len = Math.hypot(dx, dy) || 1;
+      tryLine(vps[0].x, vps[0].y, dx / len, dy / len);
+    }
+    return best;
+  }
+  window.perspectiveFindGuideRayNear = findGuideRayNear;
+  function projectOnRay(worldPt, ray) {
+    var vx = worldPt.x - ray.px, vy = worldPt.y - ray.py;
+    var t = vx * ray.dx + vy * ray.dy;
+    return new Point(ray.px + ray.dx * t, ray.py + ray.dy * t);
+  }
+  window.perspectiveProjectOnRay = projectOnRay;
+
   // ---- Tool interaction: drag a vanishing point, OR drag the horizon line
   // to move the whole guide at once (Sketchbook lets you reposition the
   // entire fan by dragging the eye-level line, not just one VP at a time).

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1363,6 +1363,7 @@ function updatePropsContext(){
   if(blurInp&&state.layers[state.activeLayerIdx]){
     blurInp.value=state.layers[state.activeLayerIdx].blurRadius||0;
   }
+  if(window.renderGradientPanel)window.renderGradientPanel();
   var hdrEl=document.getElementById('props-context-hdr');if(hdrEl)hdrEl.textContent=hdrText;
   Object.keys(show).forEach(function(id){var sec=document.getElementById(id);if(sec)sec.style.display=show[id]?'block':'none';});
   // state.drawMode (Front/Behind) has no effect on Fill Brush — it's always
@@ -4459,7 +4460,7 @@ document.getElementById('p-cbg').addEventListener('input',function(){window.SM.s
 document.getElementById('p-clip').addEventListener('change',function(){window.SM.setCanvasClip(this.checked);});
 document.getElementById('p-safety').addEventListener('change',function(){window.SM.setSafetyZones(this.checked);});
 document.getElementById('p-blur').addEventListener('input',function(){var ld=state.layers[state.activeLayerIdx];if(!ld)return;pushUndo();ld.blurRadius=Math.max(0,parseFloat(this.value)||0);saveActiveLayerFrame();if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
-document.getElementById('p-persp-on').addEventListener('change',function(){state.perspectiveEnabled=this.checked;if(this.checked&&window.ensurePerspectiveVPs)window.ensurePerspectiveVPs();if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
+document.getElementById('p-persp-on').addEventListener('change',function(){state.perspectiveEnabled=this.checked;if(this.checked){if(window.ensurePerspectiveVPs)window.ensurePerspectiveVPs();window.SM.setTool('perspective');}if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
 document.getElementById('p-persp-mode').addEventListener('change',function(){if(window.setPerspectiveMode)window.setPerspectiveMode(this.value);});
 document.getElementById('p-persp-density').addEventListener('input',function(){state.perspectiveDensity=parseInt(this.value)||24;if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
 document.getElementById('p-persp-lock').addEventListener('change',function(){var locked=this.checked;(window.ensurePerspectiveVPs?window.ensurePerspectiveVPs():[]).forEach(function(vp){vp.locked=locked;});if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
@@ -4474,7 +4475,7 @@ window.syncSymmetryPanelVisibility=function(){
   var row=document.getElementById('p-sym-sectors-row');
   if(row)row.style.display=state.symmetryMode==='radial'?'':'none';
 };
-document.getElementById('p-sym-on').addEventListener('change',function(){state.symmetryEnabled=this.checked;if(this.checked&&window.ensureSymmetryAxis)window.ensureSymmetryAxis();if(this.checked&&window.ensureSymmetryRadialCenter)window.ensureSymmetryRadialCenter();if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
+document.getElementById('p-sym-on').addEventListener('change',function(){state.symmetryEnabled=this.checked;if(this.checked){if(window.ensureSymmetryAxis)window.ensureSymmetryAxis();if(window.ensureSymmetryRadialCenter)window.ensureSymmetryRadialCenter();window.SM.setTool('symmetry');}if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
 document.getElementById('p-sym-mode').addEventListener('change',function(){if(window.setSymmetryMode)window.setSymmetryMode(this.value);window.syncSymmetryPanelVisibility();});
 document.getElementById('p-sym-sectors').addEventListener('input',function(){state.symmetryRadialSectors=Math.max(2,Math.min(24,parseInt(this.value)||6));if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
 document.getElementById('p-sym-extend').addEventListener('change',function(){state.symmetryExtend=this.checked;});


### PR DESCRIPTION
## Summary

**Guides déplaçables** — activer Symétrie/Perspective (panel flottant ou checkbox du panel droit) bascule maintenant automatiquement vers l'outil dédié, qui est requis pour glisser les points/l'axe. Avant, on restait sur Pinceau et rien ne se passait au clic — c'était le vrai bug derrière "on ne peut pas changer l'emplacement".

**Contrainte de perspective renforcée** — remplace l'ancien magnétisme point-par-point (qui laissait un trait partir dans une autre direction dès qu'on s'éloignait un peu du guide) par un verrouillage dur : au premier point du geste, si un rayon est assez proche, tout le trait reste collé dessus jusqu'au bout, peu importe où part la main ensuite. Un trait qui démarre loin de tout rayon dessine toujours librement.

**Gizmo de dégradé façon Illustrator/Rive** (j'ai regardé l'éditeur de Rive) — la position (les deux extrémités ET la position de chaque stop) se règle maintenant en glissant directement sur le canevas : ligne + poignée carrée (début) + poignée ronde (fin) + un losange par stop, coloré pour prévisualiser sa couleur. Le panel Effects gère maintenant un nombre quelconque de stops (ajout/suppression/couleur/position), plus seulement 2 fixes avec un champ angle.

## Test plan
- [x] `node --check` sur tous les fichiers touchés
- [x] Testé en direct via de vrais événements pointeur synthétiques :
  - Activer Perspective depuis le panel flottant ET le panel droit → bascule bien vers l'outil `perspective`
  - Trait démarré près d'un rayon puis délibérément dévié loin → reste parfaitement droit sur le rayon (vérifié par calcul exact)
  - Trait démarré loin de tout rayon → dessine librement, non affecté
  - Glisser la poignée "to" du dégradé → coordonnées exactes vérifiées contre `screenToWorld`
  - Glisser un stop intermédiaire → offset mis à jour précisément
  - Glisser un stop qui coïncide avec une extrémité → attrape l'extrémité (précédence correcte)
  - Rendu visuel confirmé (dégradé + gizmo affichés sur le canevas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)