### PR TITLE
Groupes (Cmd+G) + poignées de guide façon Sketchbook + menu de brosses flottant

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -958,6 +958,17 @@ body.mode-motion .lrow.act{box-shadow:inset 3px 0 0 #4E6FF2,inset 0 0 0 1px rgba
 .bp-item-del:hover{background:var(--red);color:#fff;}
 .bp-edit-btn{margin-top:6px;padding:7px;border-radius:4px;border:1px dashed var(--border2);background:transparent;color:var(--text-dim);font-size:10px;cursor:pointer;}
 .bp-edit-btn:hover{color:var(--text);border-color:var(--accent);}
+/* Brush floating menu (2026-07, brush-menu-bridge.js) — reuses .bp-grid/
+   .bp-item/.bp-group-label above verbatim for the thumbnail lists (same
+   visual language, no second style to keep in sync); only new rules are
+   the popover's own wider frame, its Vecteur/Bitmap tab strip, and the
+   condensed parameter footer. */
+.brush-menu-pop{width:300px;max-height:520px;overflow-y:auto;padding:8px;display:flex;flex-direction:column;gap:2px;}
+.brush-menu-tabs{display:flex;gap:2px;margin-bottom:6px;background:var(--panel3);border-radius:5px;padding:2px;}
+.brush-menu-tab{flex:1;background:transparent;border:none;border-radius:4px;padding:6px 0;color:var(--text-dim);font-size:10px;font-weight:600;cursor:pointer;text-transform:uppercase;letter-spacing:.03em;}
+.brush-menu-tab.active{background:var(--accent);color:#fff;}
+.brush-menu-params{border-top:1px solid var(--border2);margin-top:6px;padding-top:6px;display:flex;flex-direction:column;gap:4px;}
+.brush-menu-pop .bp-item canvas{width:130px;height:22px;}
 
 /* BRUSH EDITOR PANEL */
 .bp-editor-pop{width:320px;padding:12px;display:flex;flex-direction:column;gap:6px;}

--- a/src/index.html
+++ b/src/index.html
@@ -1208,7 +1208,9 @@
 <script src="js/abr-import.js"></script>
 <script src="js/bitmap-brush.js"></script>
 <script src="js/bitmap-tip-picker.js"></script>
+<script src="js/brush-menu-bridge.js"></script>
 <script src="js/draw-bridge.js"></script>
+<script src="js/group-bridge.js"></script>
 <script src="js/select-bridge.js"></script>
 <script src="js/subselect-bridge.js"></script>
 <script src="js/shape-bridge.js"></script>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -497,7 +497,10 @@ function serP(p){var isVB=!!(p.data&&p.data.isVectorBrush);var center=isVB&&p.da
   // 'linear'|'radial', from:[x,y], to:[x,y], stops:[{offset,color}]}, world
   // coordinates, plain data so it round-trips through JSON like any other
   // p.data.* field here.
-  fillGradient:(p.data&&p.data.fillGradient)?p.data.fillGradient:undefined};}
+  fillGradient:(p.data&&p.data.fillGradient)?p.data.fillGradient:undefined,
+  // Group membership (2026-07, group-bridge.js's Cmd+G) — a stable id
+  // shared by every member, same pattern as strokeId/brushGroupId above.
+  groupId:(p.data&&p.data.groupId)?p.data.groupId:undefined};}
 // `closed` was missing from this round-trip entirely — every path rebuilt
 // via desP() (onion-skin ghosts, tween/inbetween generation, undo/redo
 // snapshots, project load: everything that goes through serP/desP) silently
@@ -524,7 +527,7 @@ function desP(d,layer,op){var prev=project.activeLayer;layer.activate();var p=ne
   // outline it never had ("un trait blanc apparaît autour du fill après
   // ctrl+Z"). Legacy data predating the field (undefined) keeps the old
   // fallback chain untouched.
-  p.strokeColor=d.hasRealStroke===false?null:(d.strokeColor||((d.isVectorBrush||d.brushTexturePreset||d.bitmapBrushSpec||d.isBrushTextureCopy||dNoStrokeChannel||dIsShadowChannel)?null:'#fff'));p.strokeWidth=d.strokeWidth||3;p.strokeCap=d.strokeCap||'round';p.strokeJoin=d.strokeJoin||'round';if(d.miterLimit!==undefined)p.miterLimit=d.miterLimit;if(d.fillColor)p.fillColor=d.fillColor;else p.fillColor=null;p.opacity=op!==undefined?op:(d.opacity!==undefined?d.opacity:1);if(d.dashArray&&d.dashArray.length)p.dashArray=d.dashArray;if(d.dashOffset!==undefined)p.dashOffset=d.dashOffset;if(d.paintOrder){p.data.paintOrder=d.paintOrder;}if(d.isVectorBrush){p.data.isVectorBrush=true;if(d.centerSegments)p.data.centerSegments=d.centerSegments;if(d.widthProfile)p.data.widthProfile=d.widthProfile;if(d.isFillShape)p.data.isFillShape=true;applyBrushKeyline(p);}if(d.fillSeed){p.data.fillSeed=d.fillSeed;p.data.fillGapPx=d.fillGapPx;}if(d.fillWalls)p.data.fillWalls=d.fillWalls;if(d.strokeId)p.data.strokeId=d.strokeId;if(d.brushGroupId)p.data.brushGroupId=d.brushGroupId;if(d.boxAngle)p.data.boxAngle=d.boxAngle;if(d.xformAnchorKey)p.data.xformAnchorKey=d.xformAnchorKey;if(d.xformAnchorCustom)p.data.xformAnchorCustom=d.xformAnchorCustom;if(d.isBrushTextureCopy)p.data.isBrushTextureCopy=true;if(d.brushTexturePreset)p.data.brushTexturePreset=d.brushTexturePreset;if(d.bitmapBrushSpec)p.data.bitmapBrushSpec=d.bitmapBrushSpec;if(d.bitmapPressureProfile)p.data.bitmapPressureProfile=d.bitmapPressureProfile;if(d.preTextureOpacity!==undefined)p.data.preTextureOpacity=d.preTextureOpacity;if(d.preTextureStroke!==undefined)p.data.preTextureStroke=d.preTextureStroke;if(d.channelTag)p.data.channelTag=d.channelTag;if(d.ownerId)p.data.ownerId=d.ownerId;if(d.ownerName)p.data.ownerName=d.ownerName;if(d.ownerColor)p.data.ownerColor=d.ownerColor;if(d.revisionParentId)p.data.revisionParentId=d.revisionParentId;if(d.isRevisionGhost)p.data.isRevisionGhost=true;if(d.revisionAction)p.data.revisionAction=d.revisionAction;if(d.fillGradient)p.data.fillGradient=d.fillGradient;prev.activate();return p;}
+  p.strokeColor=d.hasRealStroke===false?null:(d.strokeColor||((d.isVectorBrush||d.brushTexturePreset||d.bitmapBrushSpec||d.isBrushTextureCopy||dNoStrokeChannel||dIsShadowChannel)?null:'#fff'));p.strokeWidth=d.strokeWidth||3;p.strokeCap=d.strokeCap||'round';p.strokeJoin=d.strokeJoin||'round';if(d.miterLimit!==undefined)p.miterLimit=d.miterLimit;if(d.fillColor)p.fillColor=d.fillColor;else p.fillColor=null;p.opacity=op!==undefined?op:(d.opacity!==undefined?d.opacity:1);if(d.dashArray&&d.dashArray.length)p.dashArray=d.dashArray;if(d.dashOffset!==undefined)p.dashOffset=d.dashOffset;if(d.paintOrder){p.data.paintOrder=d.paintOrder;}if(d.isVectorBrush){p.data.isVectorBrush=true;if(d.centerSegments)p.data.centerSegments=d.centerSegments;if(d.widthProfile)p.data.widthProfile=d.widthProfile;if(d.isFillShape)p.data.isFillShape=true;applyBrushKeyline(p);}if(d.fillSeed){p.data.fillSeed=d.fillSeed;p.data.fillGapPx=d.fillGapPx;}if(d.fillWalls)p.data.fillWalls=d.fillWalls;if(d.strokeId)p.data.strokeId=d.strokeId;if(d.brushGroupId)p.data.brushGroupId=d.brushGroupId;if(d.boxAngle)p.data.boxAngle=d.boxAngle;if(d.xformAnchorKey)p.data.xformAnchorKey=d.xformAnchorKey;if(d.xformAnchorCustom)p.data.xformAnchorCustom=d.xformAnchorCustom;if(d.isBrushTextureCopy)p.data.isBrushTextureCopy=true;if(d.brushTexturePreset)p.data.brushTexturePreset=d.brushTexturePreset;if(d.bitmapBrushSpec)p.data.bitmapBrushSpec=d.bitmapBrushSpec;if(d.bitmapPressureProfile)p.data.bitmapPressureProfile=d.bitmapPressureProfile;if(d.preTextureOpacity!==undefined)p.data.preTextureOpacity=d.preTextureOpacity;if(d.preTextureStroke!==undefined)p.data.preTextureStroke=d.preTextureStroke;if(d.channelTag)p.data.channelTag=d.channelTag;if(d.ownerId)p.data.ownerId=d.ownerId;if(d.ownerName)p.data.ownerName=d.ownerName;if(d.ownerColor)p.data.ownerColor=d.ownerColor;if(d.revisionParentId)p.data.revisionParentId=d.revisionParentId;if(d.isRevisionGhost)p.data.isRevisionGhost=true;if(d.revisionAction)p.data.revisionAction=d.revisionAction;if(d.fillGradient)p.data.fillGradient=d.fillGradient;if(d.groupId)p.data.groupId=d.groupId;prev.activate();return p;}
 // Phase 2 (async multi-user sync): merges a remote collaborator's exported
 // project JSON into the CURRENT live document at the data level (state.layers
 // serialized strokes — not live Paper objects), so it works the same whether
@@ -676,6 +679,9 @@ function serR(r){
   // from its anchor (independent selection, no group move, no regen).
   if(r.data&&r.data.brushGroupId)d.brushGroupId=r.data.brushGroupId;
   if(r.data&&r.data.isBrushTextureCopy)d.isBrushTextureCopy=true;
+  // Group membership (2026-07, group-bridge.js's Cmd+G) — same stable id
+  // as serP's own groupId, so a group can freely mix Path and Raster members.
+  if(r.data&&r.data.groupId)d.groupId=r.data.groupId;
   return d;}
 // r.onLoad attached AFTER `new Raster(d.src)` can miss an ALREADY-loaded
 // image (a data: URI, like bitmap-brush.js's baked textures, often decodes
@@ -686,7 +692,7 @@ function serR(r){
 // kept Paper's default natural-pixel dimensions instead of the intended
 // world-space w/h whenever onLoad never fired. Checking `.loaded` first
 // covers both cases.
-function desR(d,layer,op){var prev=project.activeLayer;layer.activate();var r=new Raster(d.src);r.data.src=d.src;if(d.isBitmapBrush)r.data.isBitmapBrush=true;if(d.brushGroupId)r.data.brushGroupId=d.brushGroupId;if(d.isBrushTextureCopy)r.data.isBrushTextureCopy=true;r.position=new Point(d.x,d.y);r.opacity=op!==undefined?op:(d.opacity!==undefined?d.opacity:1);var w=d.width,h=d.height;
+function desR(d,layer,op){var prev=project.activeLayer;layer.activate();var r=new Raster(d.src);r.data.src=d.src;if(d.isBitmapBrush)r.data.isBitmapBrush=true;if(d.brushGroupId)r.data.brushGroupId=d.brushGroupId;if(d.isBrushTextureCopy)r.data.isBrushTextureCopy=true;if(d.groupId)r.data.groupId=d.groupId;r.position=new Point(d.x,d.y);r.opacity=op!==undefined?op:(d.opacity!==undefined?d.opacity:1);var w=d.width,h=d.height;
   // serR()'s mid-decode fallback reads this — see its own comment. Cleared
   // once place() actually applies the real geometry so serR immediately
   // goes back to trusting live r.position/r.bounds afterward (a post-load

--- a/src/js/brush-menu-bridge.js
+++ b/src/js/brush-menu-bridge.js
@@ -1,0 +1,210 @@
+// ---- BRUSH FLOATING MENU (2026-07, Sketchbook-style) ----
+// Feedback: "j'aimerais avoir un menu... dans la barre flottante quand on
+// est sur brush ça ouvre un menu avec toute les brush et des paramètre...
+// 2 onglet vecto et bitmap." A big popover (opened from a new button in
+// the SAME floating strip labs-float-panel.js already shows for the Draw/
+// Fill Brush tools) with two tabs:
+//   - Vecteur: this app's existing vector-approximated brush-texture
+//     presets (state.brushPreset) — reuses brush-preset-picker.js's own
+//     catalog/preview/select logic (BrushPresetPicker.groups/drawPreview/
+//     labelFor/selectPreset) rather than a second copy that could drift.
+//   - Bitmap: the Bitmap Brush tip library (state.bitmapTip) — same reuse
+//     of bitmap-tip-picker.js/SMBitmapBrush's own exposed API.
+// Both grids use the exact `.bp-grid`/`.bp-item`/`.bp-group-label` CSS
+// classes the existing small swatch popovers already use (style.css), so
+// this reads as the SAME visual language, just a bigger surface — not a
+// new picker aesthetic.
+//
+// The parameter footer mirrors a handful of the most relevant existing
+// inputs (Width/Smoothing for Vecteur; Spacing/Scatter/Opacity/Pressure for
+// Bitmap) rather than becoming a second source of truth: each mirrored
+// control writes to the SAME state field the original panel input does
+// (and pushes its new value back into that original DOM element too, so
+// the right panel never goes stale while this popover is open).
+(function () {
+  var popover = null, closeHandlers = null;
+  var currentTab = 'vector';
+
+  function closePopover() {
+    if (!popover) return;
+    popover.remove();
+    popover = null;
+    if (closeHandlers) { closeHandlers(); closeHandlers = null; }
+    if (window.renderLabsFloatPanel) renderLabsFloatPanel();
+  }
+  function isOpen() { return !!popover; }
+
+  // ---- shared param-row builder — a `.pr`/`.pl`/`.pi` row identical in
+  // markup to the ones already in index.html's right panel, so it's
+  // visually indistinguishable from the rest of the app's own controls.
+  function numRow(container, label, value, min, max, step, onChange) {
+    var row = document.createElement('div'); row.className = 'pr';
+    var lbl = document.createElement('span'); lbl.className = 'pl'; lbl.textContent = label;
+    var inp = document.createElement('input');
+    inp.type = 'number'; inp.className = 'pi scrub'; inp.value = value; inp.min = min; inp.max = max; inp.step = step;
+    inp.addEventListener('input', function () { onChange(parseFloat(this.value) || 0); });
+    row.appendChild(lbl); row.appendChild(inp);
+    container.appendChild(row);
+    return inp;
+  }
+  function checkRow(container, label, checked, onChange) {
+    var row = document.createElement('div'); row.className = 'pr';
+    var lbl = document.createElement('label');
+    lbl.style.cssText = 'font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer';
+    var inp = document.createElement('input');
+    inp.type = 'checkbox'; inp.style.accentColor = 'var(--accent)'; inp.checked = checked;
+    inp.addEventListener('change', function () { onChange(this.checked); });
+    lbl.appendChild(inp); lbl.appendChild(document.createTextNode(' ' + label));
+    row.appendChild(lbl);
+    container.appendChild(row);
+    return inp;
+  }
+  // Drives an EXISTING right-panel input by id and fires its real event —
+  // rather than duplicating each input's own state-setting logic here
+  // (risking drift if that logic ever changes), this sets the value/checked
+  // state then dispatches the same event type that input already listens
+  // for, so its own pre-existing handler does the actual work exactly once,
+  // in exactly one place. No-op (and the mirrored control still updates its
+  // own displayed value) if that id isn't present in this build.
+  function driveOriginal(id, value, isCheckbox, eventType) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    if (isCheckbox) el.checked = value; else el.value = value;
+    el.dispatchEvent(new Event(eventType, { bubbles: true }));
+  }
+
+  function buildVectorTab(container) {
+    container.innerHTML = ''; // rebuilt on every selection (to move the .active highlight) — must replace, not append
+    if (!window.BrushPresetPicker || !window.BrushPresetPicker.groups) {
+      container.innerHTML = '<div class="bp-group-label">Indisponible</div>';
+      return;
+    }
+    var current = state.brushPreset || 'none';
+    window.BrushPresetPicker.groups().forEach(function (g) {
+      var label = document.createElement('div'); label.className = 'bp-group-label'; label.textContent = g.label;
+      container.appendChild(label);
+      var grid = document.createElement('div'); grid.className = 'bp-grid';
+      g.keys.forEach(function (k) { grid.appendChild(makeBrushItem(k, k === current, function (key) {
+        window.BrushPresetPicker.selectPreset(key);
+        buildVectorTab(container); // rebuild to move the .active highlight
+      })); });
+      container.appendChild(grid);
+    });
+    var custom = window.BrushPresetPicker.customKeys();
+    if (custom.length) {
+      var clabel = document.createElement('div'); clabel.className = 'bp-group-label'; clabel.textContent = 'Mes brushes';
+      container.appendChild(clabel);
+      var cgrid = document.createElement('div'); cgrid.className = 'bp-grid';
+      custom.forEach(function (k) { cgrid.appendChild(makeBrushItem(k, k === current, function (key) {
+        window.BrushPresetPicker.selectPreset(key);
+        buildVectorTab(container);
+      })); });
+      container.appendChild(cgrid);
+    }
+    var params = document.createElement('div'); params.className = 'brush-menu-params';
+    numRow(params, 'Taille', state.brushSize || 3, 1, 300, 1, function (v) { driveOriginal('p-sw', v, false, 'change'); });
+    numRow(params, 'Lissage', state.smoothing || 0, 0, 60, 1, function (v) { driveOriginal('p-smooth', v, false, 'input'); });
+    container.appendChild(params);
+  }
+  function makeBrushItem(key, active, onSelect) {
+    var btn = document.createElement('button');
+    btn.className = 'bp-item' + (active ? ' active' : '');
+    var canvas = document.createElement('canvas'); canvas.width = 150; canvas.height = 26;
+    var span = document.createElement('span'); span.textContent = window.BrushPresetPicker.labelFor(key);
+    btn.appendChild(canvas); btn.appendChild(span);
+    window.BrushPresetPicker.drawPreview(canvas, key);
+    btn.addEventListener('click', function () { onSelect(key); });
+    return btn;
+  }
+
+  function buildBitmapTab(container) {
+    container.innerHTML = ''; // rebuilt on every selection (to move the .active highlight) — must replace, not append
+    if (!window.SMBitmapBrush || !window.BitmapTipPicker) {
+      container.innerHTML = '<div class="bp-group-label">Bitmap Brush indisponible</div>';
+      return;
+    }
+    checkRow(container, 'Bitmap Brush actif', !!state.bitmapBrushOn, function (v) { driveOriginal('p-bitmapbrush-on', v, true, 'change'); });
+    var current = state.bitmapTip || 'soft';
+    window.SMBitmapBrush.tipGroups().forEach(function (g) {
+      var label = document.createElement('div'); label.className = 'bp-group-label'; label.textContent = g.label;
+      container.appendChild(label);
+      var grid = document.createElement('div'); grid.className = 'bp-grid';
+      g.keys.forEach(function (k) { grid.appendChild(makeTipItem(k, k === current, function (key) {
+        window.BitmapTipPicker.selectTip(key);
+        buildBitmapTab(container);
+      })); });
+      container.appendChild(grid);
+    });
+    var custom = window.SMBitmapBrush.customTipKeys();
+    if (custom.length) {
+      var clabel = document.createElement('div'); clabel.className = 'bp-group-label'; clabel.textContent = 'Mes pointes';
+      container.appendChild(clabel);
+      var cgrid = document.createElement('div'); cgrid.className = 'bp-grid';
+      custom.forEach(function (k) { cgrid.appendChild(makeTipItem(k, k === current, function (key) {
+        window.BitmapTipPicker.selectTip(key);
+        buildBitmapTab(container);
+      })); });
+      container.appendChild(cgrid);
+    }
+    var params = document.createElement('div'); params.className = 'brush-menu-params';
+    numRow(params, 'Taille', state.brushSize || 3, 1, 300, 1, function (v) { driveOriginal('p-sw', v, false, 'change'); });
+    numRow(params, 'Espacement', state.bitmapSpacing !== undefined ? state.bitmapSpacing : 15, 2, 100, 1, function (v) { driveOriginal('p-bitmap-spacing', v, false, 'input'); });
+    numRow(params, 'Dispersion', state.bitmapScatter !== undefined ? state.bitmapScatter : 20, 0, 100, 1, function (v) { driveOriginal('p-bitmap-scatter', v, false, 'input'); });
+    numRow(params, 'Opacité', state.bitmapOpacity !== undefined ? state.bitmapOpacity : 100, 5, 100, 1, function (v) { driveOriginal('p-bitmap-opacity', v, false, 'input'); });
+    checkRow(params, 'Pression (tablette)', state.bitmapPressure !== false, function (v) { driveOriginal('p-bitmap-pressure', v, true, 'change'); });
+    container.appendChild(params);
+  }
+  function makeTipItem(key, active, onSelect) {
+    var btn = document.createElement('button');
+    btn.className = 'bp-item' + (active ? ' active' : '');
+    var canvas = document.createElement('canvas'); canvas.width = 150; canvas.height = 26;
+    var span = document.createElement('span'); span.textContent = window.BitmapTipPicker.labelFor(key);
+    btn.appendChild(canvas); btn.appendChild(span);
+    window.BitmapTipPicker.drawPreview(canvas, key);
+    btn.addEventListener('click', function () { onSelect(key); });
+    return btn;
+  }
+
+  function buildContent(el) {
+    el.innerHTML = '';
+    var tabs = document.createElement('div'); tabs.className = 'brush-menu-tabs';
+    var vecTab = document.createElement('button'); vecTab.className = 'brush-menu-tab' + (currentTab === 'vector' ? ' active' : ''); vecTab.textContent = 'Vecteur';
+    var bmpTab = document.createElement('button'); bmpTab.className = 'brush-menu-tab' + (currentTab === 'bitmap' ? ' active' : ''); bmpTab.textContent = 'Bitmap';
+    vecTab.addEventListener('click', function () { currentTab = 'vector'; buildContent(el); });
+    bmpTab.addEventListener('click', function () { currentTab = 'bitmap'; buildContent(el); });
+    tabs.appendChild(vecTab); tabs.appendChild(bmpTab);
+    el.appendChild(tabs);
+    var body = document.createElement('div');
+    el.appendChild(body);
+    if (currentTab === 'vector') buildVectorTab(body); else buildBitmapTab(body);
+  }
+
+  function toggle(anchorEl) {
+    if (popover) { closePopover(); return; }
+    var el = document.createElement('div');
+    el.className = 'ctx-menu brush-menu-pop';
+    document.body.appendChild(el);
+    popover = el;
+    buildContent(el);
+
+    var ar = anchorEl.getBoundingClientRect();
+    el.style.visibility = 'hidden'; el.style.display = 'block';
+    var ew = el.offsetWidth, eh = el.offsetHeight;
+    var left = Math.min(ar.left, window.innerWidth - ew - 8);
+    var top = Math.min(ar.bottom + 6, window.innerHeight - eh - 8);
+    el.style.left = Math.max(4, left) + 'px'; el.style.top = Math.max(4, top) + 'px';
+    el.style.visibility = '';
+
+    function onOutside(e) { if (!el.contains(e.target) && e.target !== anchorEl) closePopover(); }
+    function onKey(e) { if (e.key === 'Escape') closePopover(); }
+    document.addEventListener('mousedown', onOutside, true);
+    document.addEventListener('keydown', onKey);
+    closeHandlers = function () {
+      document.removeEventListener('mousedown', onOutside, true);
+      document.removeEventListener('keydown', onKey);
+    };
+    if (window.renderLabsFloatPanel) renderLabsFloatPanel();
+  }
+
+  window.BrushMenu = { toggle: toggle, isOpen: isOpen, close: closePopover };
+})();

--- a/src/js/brush-preset-picker.js
+++ b/src/js/brush-preset-picker.js
@@ -212,7 +212,13 @@
     };
   }
 
-  window.BrushPresetPicker = { open: open, paintButton: paintButton, drawPreview: drawPreview, labelFor: labelFor, selectPreset: selectPreset };
+  window.BrushPresetPicker = {
+    open: open, paintButton: paintButton, drawPreview: drawPreview, labelFor: labelFor, selectPreset: selectPreset,
+    // Exposed for brush-menu-bridge.js's own big two-tab picker (2026-07) —
+    // reuses this file's exact catalog/preview/select logic rather than
+    // keeping a second copy that could drift out of sync.
+    groups: builtinGroups, customKeys: customKeys,
+  };
 
   function init() {
     var btn = document.getElementById('p-brushpreset-btn');

--- a/src/js/group-bridge.js
+++ b/src/js/group-bridge.js
@@ -1,0 +1,58 @@
+// ---- GROUPS (2026-07, Cmd+G) ----
+// Feedback: "mettre en place les groupes, avec command+g, select les
+// éléments et ça permet d'avoir un avec une seul boite de transformation."
+//
+// Deliberately NOT a Paper.js `Group` (a real wrapper item that would
+// become a THIRD kind of `strokes`/`layer.children` entry alongside Path/
+// Raster) — select-bridge.js's transform box already computes one shared
+// box + shared pivot/delta for however many items are in `selectedPaths`
+// today (xformSelBounds/orientedSelBox, tools.js), with zero Group needed
+// for the "one transform box" mechanic itself. The only thing actually
+// missing was PERSISTENCE: `selectedPaths` is rebuilt from scratch on every
+// click/marquee, so a multi-selection never survived a deselect, a save/
+// reload, or a frame navigation.
+//
+// So a group here is just a shared `data.groupId` tag (same stable-id
+// pattern as `data.strokeId`/`data.brushGroupId` elsewhere in this file)
+// on each member Path/Raster — they stay perfectly ordinary flat items to
+// every existing consumer (buildSceneJson, tween matching, export.js,
+// serP/desP...), which is exactly why this is safe: none of those loops
+// need to change at all, unlike introducing a real new item type would
+// require (see CLAUDE.md §1's "famille de bug n°1"). select-bridge.js's
+// click-select is the ONE place that needs to know about groupId — it
+// expands a click on any one member into the whole group via membersOf()
+// below, and from there the EXISTING shared-transform-box code just works
+// unmodified on whatever `selectedPaths` now contains.
+(function () {
+  function groupSelection() {
+    if ((state.tool !== 'select' && state.tool !== 'subselect') || !window.selectedPaths || selectedPaths.length < 2) {
+      if (window.showToast) showToast('Sélectionnez au moins 2 éléments pour créer un groupe');
+      return;
+    }
+    pushUndo();
+    var gid = 'grp_' + Date.now().toString(36) + '_' + Math.floor(Math.random() * 1e6);
+    selectedPaths.forEach(function (p) { if (!p.data) p.data = {}; p.data.groupId = gid; });
+    saveActiveLayerFrame(); updateUI();
+    if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+    if (window.showToast) showToast('Groupe créé (' + selectedPaths.length + ' éléments)');
+  }
+  function ungroupSelection() {
+    if (!window.selectedPaths || !selectedPaths.length) return;
+    var hasGroup = selectedPaths.some(function (p) { return p.data && p.data.groupId; });
+    if (!hasGroup) return;
+    pushUndo();
+    selectedPaths.forEach(function (p) { if (p.data) delete p.data.groupId; });
+    saveActiveLayerFrame(); updateUI();
+    if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+    if (window.showToast) showToast('Groupe dissocié');
+  }
+  // Every sibling in `layer` sharing `p`'s groupId, INCLUDING `p` itself —
+  // `[p]` (a one-item "group") when `p` has no groupId, so every caller can
+  // unconditionally use this instead of branching on "is this grouped".
+  function membersOf(p, layer) {
+    var gid = p.data && p.data.groupId;
+    if (!gid || !layer) return [p];
+    return layer.children.filter(function (c) { return c.data && c.data.groupId === gid; });
+  }
+  window.SMGroup = { groupSelection: groupSelection, ungroupSelection: ungroupSelection, membersOf: membersOf };
+})();

--- a/src/js/labs/labs-float-panel.js
+++ b/src/js/labs/labs-float-panel.js
@@ -26,8 +26,8 @@
     // are real `state.*`-backed features, not Labs prototypes — see
     // REAL_FEATURES below for how this panel treats them as first-class
     // entries alongside the localStorage-flag-based Labs ones.
-    draw: ['symmetry', 'perspective', 'predictive-stroke', 'multiframe-draw', 'canvas-grid', 'view-filter'],
-    fillbrush: ['symmetry', 'perspective', 'canvas-grid', 'view-filter'],
+    draw: ['brush-menu', 'symmetry', 'perspective', 'predictive-stroke', 'multiframe-draw', 'canvas-grid', 'view-filter'],
+    fillbrush: ['brush-menu', 'symmetry', 'perspective', 'canvas-grid', 'view-filter'],
     pen: ['symmetry', 'perspective', 'french-curve', 'canvas-grid', 'view-filter'],
     line: ['symmetry', 'perspective', 'french-curve', 'canvas-grid'],
     rect: ['symmetry', 'canvas-grid', 'view-filter'],
@@ -80,6 +80,19 @@
       },
     },
   };
+  // Non-toggle entries — a plain action button (opens a popover) rather
+  // than an on/off switch, so `registered[n]`/`addBtn` below treat it
+  // differently: `isActive` decides the `.active` highlight (whether the
+  // popover happens to be open right now) and `onClick` just runs the
+  // action instead of flipping a boolean. Currently only the Brush menu
+  // (brush-menu-bridge.js, 2026-07 — "un menu... avec toute les brush et
+  // des paramètre... 2 onglet vecto et bitmap").
+  var ACTIONS = {
+    'brush-menu': {
+      isActive: function () { return !!(window.BrushMenu && window.BrushMenu.isOpen()); },
+      onClick: function (btn) { if (window.BrushMenu) window.BrushMenu.toggle(btn); },
+    },
+  };
   // Tools armed by a held key regardless of the active tool (flip-roll=R,
   // mirror-check=M, lagoon-menu=Q) — always available, shown after a
   // divider so they read as a separate "always on hand" group rather than
@@ -87,6 +100,7 @@
   var ALWAYS = ['flip-roll', 'mirror-check', 'lagoon-menu'];
 
   var SHORT_NAME = {
+    'brush-menu': 'Brosses (vecteur/bitmap)',
     'symmetry': 'Guide de symétrie / mandala',
     'perspective': 'Guide de perspective',
     'predictive-stroke': 'Trait prédictif',
@@ -108,6 +122,7 @@
   // stroke-based line art, which read as a different, thinner icon
   // language. Rebuilt every icon as a solid silhouette to match.
   var ICONS = {
+    'brush-menu': '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M19.4 2.6c.8.8.8 2 0 2.8L9.5 15.3l-4-4L15.4 1.4c.8-.8 2-.8 2.8 0z" opacity=".85"/><path d="M8.3 12.4l3.3 3.3-1.4 1.4c-1.8 1.8-6.4 2-6.4 2s.2-4.6 2-6.4z"/></svg>',
     // Same "split by an axis" language as the toolbar button (index.html),
     // simplified/solid-filled to match this strip's icon set.
     'symmetry': '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><rect x="11" y="2" width="2" height="20" rx="1"/><path d="M9 6L3 12L9 18Z"/><path d="M15 6L21 12L15 18Z"/></svg>',
@@ -146,11 +161,11 @@
   }
 
   // A name is "available" (gets a button at all) if it's either a
-  // registered Labs prototype OR one of the real state-backed
-  // REAL_FEATURES above — the two are otherwise treated identically by
-  // everything below (same button, same active-state highlight).
+  // registered Labs prototype, one of the real state-backed REAL_FEATURES,
+  // or a plain ACTIONS entry — all three are otherwise treated identically
+  // by everything below (same button, same active-state highlight).
   function buildGroup(names, registered) {
-    return names.filter(function (n) { return registered.hasOwnProperty(n) || REAL_FEATURES.hasOwnProperty(n); });
+    return names.filter(function (n) { return registered.hasOwnProperty(n) || REAL_FEATURES.hasOwnProperty(n) || ACTIONS.hasOwnProperty(n); });
   }
   var SYM_MODES = ['y', 'x', 'free', 'radial'];
   var SYM_MODE_LABEL = { y: 'Y', x: 'X', free: 'Libre', radial: 'Radial' };
@@ -166,6 +181,7 @@
     // their own live state check — done here, once, rather than special-
     // casing every reader below.
     Object.keys(REAL_FEATURES).forEach(function (n) { registered[n] = REAL_FEATURES[n].isOn(); });
+    Object.keys(ACTIONS).forEach(function (n) { registered[n] = ACTIONS[n].isActive(); });
     var ctx = buildGroup(TOOL_CONTEXT[state.tool] || [], registered);
     var always = buildGroup(ALWAYS.filter(function (n) { return ctx.indexOf(n) < 0; }), registered);
     if (!ctx.length && !always.length) { panel.style.display = 'none'; return; }
@@ -178,6 +194,12 @@
       btn.title = SHORT_NAME[n] || n;
       btn.innerHTML = ICONS[n] || '';
       btn.addEventListener('click', function () {
+        // ACTIONS entries manage their own re-render (BrushMenu.toggle
+        // calls renderLabsFloatPanel itself once the popover's open/closed
+        // state is settled) — skip the generic renderLabsFloatPanel() call
+        // below for those so a just-opened popover's own button doesn't
+        // get redrawn (and re-bound) out from under an in-flight click.
+        if (ACTIONS[n]) { ACTIONS[n].onClick(btn); return; }
         if (REAL_FEATURES[n]) REAL_FEATURES[n].toggle();
         else window.SMLabs.toggle(n);
         renderLabsFloatPanel();

--- a/src/js/perspective-bridge.js
+++ b/src/js/perspective-bridge.js
@@ -104,17 +104,25 @@
         closed: false, fillColor: null, strokeColor: [255, 200, 80, 130], strokeWidth: 1.4, strokeCap: 'butt',
       });
     }
-    // VP markers themselves — small diamonds, filled if locked (matches
-    // Sketchbook's locked/unlocked visual distinction) so it's obvious at a
-    // glance which points can still be dragged.
+    // VP markers themselves — draggable-point handles, Sketchbook-style
+    // (feedback: "dans sketchbook on a des points que l'on peut
+    // déplacer... regarde bien sketchbook" — a ring + filled center dot
+    // reads unambiguously as "grab me", replacing the small diamond this
+    // used to be). Locked VPs swap the center dot for a solid fill of the
+    // ring itself, keeping Sketchbook's own locked/unlocked distinction.
     vps.forEach(function (vp) {
-      var s = 6;
+      var r = 9, innerR = r * 0.4, outer = [], inner = [];
+      for (var i = 0; i < 16; i++) {
+        var a = (i / 16) * Math.PI * 2;
+        outer.push({ point: [vp.x + Math.cos(a) * r, vp.y + Math.sin(a) * r] });
+        inner.push({ point: [vp.x + Math.cos(a) * innerR, vp.y + Math.sin(a) * innerR] });
+      }
       items.push({
-        segments: [{ point: [vp.x, vp.y - s] }, { point: [vp.x + s, vp.y] }, { point: [vp.x, vp.y + s] }, { point: [vp.x - s, vp.y] }],
-        closed: true,
-        fillColor: vp.locked ? [255, 120, 80, 220] : null,
-        strokeColor: [255, 150, 100, 255], strokeWidth: 1.5,
+        segments: outer, closed: true,
+        fillColor: vp.locked ? [255, 120, 80, 200] : [15, 20, 30, 160],
+        strokeColor: [255, 150, 100, 255], strokeWidth: 2,
       });
+      items.push({ segments: inner, closed: true, fillColor: [255, 150, 100, 255], strokeColor: null });
     });
     return items;
   }

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -560,9 +560,15 @@
       // selects the real anchor, not the companion; moving/deleting a
       // companion alone would silently desync it from its group.
       var p = resolveBrushAnchor(hit.item, userLayers[state.activeLayerIdx]);
+      // Group (group-bridge.js, 2026-07): clicking any ONE member selects
+      // every sibling sharing its groupId — membersOf returns `[p]`
+      // unchanged when it isn't grouped, so this is a no-op widening for
+      // the (overwhelmingly common) ungrouped case.
+      var clickedSet = window.SMGroup ? SMGroup.membersOf(p, userLayers[state.activeLayerIdx]) : [p];
       var idx2 = selectedPaths.indexOf(p);
       if (e.shiftKey) {
-        if (idx2 >= 0) selectedPaths.splice(idx2, 1); else selectedPaths.push(p);
+        if (idx2 >= 0) clickedSet.forEach(function (m) { var mi = selectedPaths.indexOf(m); if (mi >= 0) selectedPaths.splice(mi, 1); });
+        else clickedSet.forEach(function (m) { if (selectedPaths.indexOf(m) < 0) selectedPaths.push(m); });
       } else if (idx2 < 0) {
         // Clicking a NEW item without shift replaces the selection — but
         // clicking one already part of a multi-selection must NOT clear the
@@ -572,7 +578,7 @@
         // reported "transform works but moving several selected elements
         // doesn't".
         clearSel();
-        selectedPaths.push(p);
+        clickedSet.forEach(function (m) { selectedPaths.push(m); });
       }
       state.selectedStrokeIndices = selectedPaths.map(getSI).filter(function (i2) { return i2 >= 0; });
       mode = selectedPaths.length ? 'move' : null;
@@ -1107,7 +1113,8 @@
     // anything else replaces it with just that item, same as a plain click.
     if (clickedPath && selectedPaths.indexOf(clickedPath) < 0) {
       clearSel();
-      selectedPaths.push(clickedPath);
+      var rcSet = window.SMGroup ? SMGroup.membersOf(clickedPath, layer) : [clickedPath];
+      rcSet.forEach(function (m) { selectedPaths.push(m); });
       state.selectedStrokeIndices = selectedPaths.map(getSI).filter(function (i) { return i >= 0; });
       renderArcs(); updateUI(); window.SMEngineBridge.renderNow();
     }
@@ -1117,10 +1124,17 @@
     var p0 = selectedPaths[0];
     var isDeleteGhost = !multi && p0.data && p0.data.isRevisionGhost && p0.data.revisionAction === 'delete';
     var isActiveRevision = !multi && p0.data && p0.data.revisionParentId && !p0.data.isRevisionGhost;
+    var isGrouped = !multi && p0.data && p0.data.groupId;
     var items = [
       { label: 'Dupliquer', shortcut: '⌘D', action: function () { duplicateSelection(); } },
       { label: multi ? 'Supprimer la sélection' : 'Supprimer', shortcut: 'Suppr', action: function () { window.SM.deleteSelStrokes(); } },
       { sep: true },
+    ];
+    if (multi || isGrouped) {
+      items.push({ label: isGrouped ? 'Dissocier' : 'Grouper', shortcut: isGrouped ? '⇧⌘G' : '⌘G', action: function () { if (window.SMGroup) { if (isGrouped) SMGroup.ungroupSelection(); else SMGroup.groupSelection(); } } });
+      items.push({ sep: true });
+    }
+    items = items.concat([
       {
         label: 'Premier plan', action: function () {
           pushUndo();
@@ -1153,7 +1167,7 @@
           updateUI(); window.SMEngineBridge.renderNow();
         }
       },
-    ];
+    ]);
     if (isActiveRevision || isDeleteGhost) {
       // Same actions as the Properties-panel Accept/Reject buttons
       // (timeline.js updateRevisionPanel) — surfacing them here too so a

--- a/src/js/symmetry-bridge.js
+++ b/src/js/symmetry-bridge.js
@@ -127,11 +127,21 @@
     var reach = Math.max(state.canvasW, state.canvasH) * 4;
     var col = [230, 90, 200, 130];
     var handleCol = [230, 120, 210, 255];
-    function diamond(x, y, s, filled) {
-      items.push({
-        segments: [{ point: [x, y - s] }, { point: [x + s, y] }, { point: [x, y + s] }, { point: [x - s, y] }],
-        closed: true, fillColor: filled ? handleCol : null, strokeColor: handleCol, strokeWidth: 1.5,
-      });
+    // Draggable-point handle, Sketchbook-style (feedback: "dans sketchbook
+    // on a des points que l'on peut déplacer... regarde bien sketchbook") —
+    // a ring + filled center dot, not the small diamond this used to be.
+    // Bigger and rounder reads unambiguously as "a grabbable point", the
+    // exact same visual language Sketchbook's own guide handles use.
+    function ringHandle(x, y, r) {
+      var outer = [], inner = [];
+      var innerR = r * 0.4;
+      for (var i = 0; i < 16; i++) {
+        var a = (i / 16) * Math.PI * 2;
+        outer.push({ point: [x + Math.cos(a) * r, y + Math.sin(a) * r] });
+        inner.push({ point: [x + Math.cos(a) * innerR, y + Math.sin(a) * innerR] });
+      }
+      items.push({ segments: outer, closed: true, fillColor: [15, 20, 30, 160], strokeColor: handleCol, strokeWidth: 2 });
+      items.push({ segments: inner, closed: true, fillColor: handleCol, strokeColor: null });
     }
     if (state.symmetryMode === 'radial') {
       var c = ensureSymmetryRadialCenter();
@@ -143,7 +153,7 @@
           closed: false, fillColor: null, strokeColor: col, strokeWidth: 1, strokeCap: 'butt',
         });
       }
-      diamond(c.x, c.y, 6, true);
+      ringHandle(c.x, c.y, 9);
     } else {
       var axis = ensureSymmetryAxis();
       var d = axisDir(axis);
@@ -152,8 +162,17 @@
         segments: [{ point: [mx - d.ux * reach, my - d.uy * reach] }, { point: [mx + d.ux * reach, my + d.uy * reach] }],
         closed: false, fillColor: null, strokeColor: col, strokeWidth: 1.4, strokeCap: 'butt',
       });
-      diamond(axis.x1, axis.y1, 6, false);
-      diamond(axis.x2, axis.y2, 6, false);
+      // One handle per draggable point: both endpoints in Free mode (each
+      // independently grabbable), but Y/X only really has ONE meaningful
+      // drag point — the whole-axis translate — so a single handle at the
+      // visible midpoint reads more like Sketchbook's own Y/X guide (one
+      // ring on the line, not two at its off-screen-reaching ends).
+      if (state.symmetryMode === 'free') {
+        ringHandle(axis.x1, axis.y1, 7);
+        ringHandle(axis.x2, axis.y2, 7);
+      } else {
+        ringHandle(mx, my, 9);
+      }
     }
     return items;
   }

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -4051,6 +4051,29 @@ function onKeyDown(event){
     duplicateSelection();
     return;
   }
+  // Ctrl/Cmd+G "group selected CANVAS objects" (2026-07, feedback: "mettre
+  // en place les groupes, avec command+g, select les éléments et ça permet
+  // d'avoir... une seule boite de transformation") — takes priority over
+  // the PRE-EXISTING layer-panel "group into folder" binding just below
+  // when there's an actual canvas selection, since Select-tool grouping is
+  // the more central/expected meaning of Cmd+G. Falls through to the
+  // folder-grouping behavior unchanged when there's no canvas selection
+  // (e.g. 2+ layers selected in the layer list instead) — group-bridge.js's
+  // own groupSelection() already no-ops+toasts on <2 selectedPaths, so this
+  // guard just decides which of the two "group" actions gets first refusal.
+  if((event.metaKey||event.ctrlKey)&&(event.key==='g'||event.key==='G')&&!event.shiftKey&&window.selectedPaths&&selectedPaths.length>=2){
+    event.preventDefault();
+    if(window.SMGroup)SMGroup.groupSelection();
+    return;
+  }
+  // Ctrl/Cmd+Shift+G "ungroup" — free shortcut (unused elsewhere), only
+  // acts when the current canvas selection actually has grouped members;
+  // otherwise falls through (currently nothing else claims this combo).
+  if((event.metaKey||event.ctrlKey)&&(event.key==='g'||event.key==='G')&&event.shiftKey&&window.selectedPaths&&selectedPaths.length){
+    event.preventDefault();
+    if(window.SMGroup)SMGroup.ungroupSelection();
+    return;
+  }
   // Ctrl/Cmd+G "group into folder" — the action already existed
   // (groupSelectionIntoFolder, right-click menu only) but every other
   // grouping-adjacent action in this app has a keyboard path; this one


### PR DESCRIPTION
## Summary

**Groupes (Cmd+G)** — pas un vrai `Group` Paper.js (un 3ᵉ type d'item dans `layer.children`, exactement le genre de changement que CLAUDE.md §1 signale comme dangereux). La recherche a confirmé que la boîte de transformation de l'outil Sélection traite DÉJÀ toute multi-sélection comme une seule unité (pivot/delta partagés) — il ne manquait que la PERSISTANCE, puisque `selectedPaths` est reconstruit à chaque clic. Un groupe est donc juste un `data.groupId` partagé (même principe que `strokeId`), persisté via serP/desP/serR/desR. Cliquer un membre du groupe re-sélectionne tout le groupe automatiquement — tout le reste (boîte de transform, déplacement, undo) fonctionne déjà sans modification.

**Poignées de guide façon Sketchbook** — remplacé les petits losanges des points de fuite (Perspective) et de l'axe/centre (Symétrie) par un anneau + point central rempli, plus gros et sans ambiguïté "on peut m'attraper".

**Menu de brosses flottant** — nouveau bouton dans la barre flottante qui ouvre un popover à 2 onglets (Vecteur/Bitmap), réutilisant les catalogues/aperçus/sélecteurs déjà existants (brush-preset-picker.js, bitmap-tip-picker.js) — même style visuel `.bp-grid`/`.bp-item` que les petits popovers existants, plus un pied de page de paramètres condensé qui pilote les VRAIS champs du panel droit (au lieu de dupliquer leur logique).

## Test plan
- [x] `node --check` sur tous les fichiers touchés
- [x] Testé en direct (événements réels) :
  - Grouper 2 rectangles → même `groupId` ; cliquer l'un re-sélectionne les deux ; glisser déplace les deux du même delta exact ; round-trip serP/desP préserve le groupId ; Cmd+Shift+G dissocie, après quoi cliquer un seul ne sélectionne que lui
  - Guides : overlay ring+dot vérifié (16-gone + dot, formes correctes)
  - Menu brosses : onglets Vecteur (27 items)/Bitmap (10 items), sélection met à jour `state.brushPreset`/`state.bitmapTip` et le highlight `.active` (bug de duplication trouvé et corrigé en cours de test), paramètres mirroir vérifiés (Spacing → state + panel droit synchronisés)

🤖 Generated with [Claude Code](https://claude.com/claude-code)