### PR TITLE
Text tool rework: area text, re-edit in place, real persistence

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -950,9 +950,16 @@
 <div id="text-popover" style="display:none;position:absolute;z-index:200;width:230px;background:var(--panel2);border:1px solid var(--border);border-radius:8px;box-shadow:0 8px 24px rgba(0,0,0,.4);padding:8px">
   <textarea id="text-input" rows="2" placeholder="Ton texte..." style="width:100%;resize:vertical;background:var(--bg);border:1px solid var(--border);border-radius:5px;color:var(--text);font-size:12px;padding:5px;box-sizing:border-box"></textarea>
   <div class="pr" style="margin-top:6px;gap:6px">
-    <input type="number" id="text-size" value="48" min="8" max="400" style="width:56px" class="pi" title="Taille (px)">
+    <input type="number" id="text-size" value="48" min="8" max="400" style="width:52px" class="pi" title="Taille (px)">
     <select id="text-font" class="psel" style="flex:1">
       <option value="sans-serif">Sans</option><option value="serif">Serif</option><option value="monospace">Mono</option><option value="Manrope">Manrope</option>
+      <option value="Georgia">Georgia</option><option value="'Times New Roman'">Times</option><option value="'Courier New'">Courier</option><option value="Verdana">Verdana</option>
+    </select>
+    <input type="color" id="text-color" value="#000000" style="width:26px;height:24px;padding:0;border:1px solid var(--border);border-radius:5px;background:none" title="Couleur">
+  </div>
+  <div class="pr" style="margin-top:6px;gap:6px">
+    <select id="text-align" class="psel" style="flex:1" title="Alignement">
+      <option value="left">Gauche</option><option value="center">Centre</option><option value="right">Droite</option>
     </select>
   </div>
   <div class="pr" style="margin-top:6px;gap:6px">

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -682,6 +682,17 @@ function serR(r){
   // Group membership (2026-07, group-bridge.js's Cmd+G) — same stable id
   // as serP's own groupId, so a group can freely mix Path and Raster members.
   if(r.data&&r.data.groupId)d.groupId=r.data.groupId;
+  // Text tool (2026-07 rework) — isText/text/font/size/color/align/fixedWidth
+  // are the ONLY way a re-baked-to-PNG text block stays re-editable (double-
+  // click via openTextPopoverForEdit, timeline.js) instead of degrading into
+  // an indistinguishable plain imported raster after one save/reload — the
+  // exact gap flagged by this session's own text-tool audit. fixedWidth is
+  // world-space (matches x/y/width/height's own units), null for point text.
+  if(r.data&&r.data.isText){
+    d.isText=true;d.text=r.data.text||'';d.font=r.data.font||'sans-serif';
+    d.size=r.data.size||48;d.color=r.data.color||'#000000';d.align=r.data.align||'left';
+    if(r.data.fixedWidth)d.fixedWidth=r.data.fixedWidth;
+  }
   return d;}
 // r.onLoad attached AFTER `new Raster(d.src)` can miss an ALREADY-loaded
 // image (a data: URI, like bitmap-brush.js's baked textures, often decodes
@@ -692,7 +703,9 @@ function serR(r){
 // kept Paper's default natural-pixel dimensions instead of the intended
 // world-space w/h whenever onLoad never fired. Checking `.loaded` first
 // covers both cases.
-function desR(d,layer,op){var prev=project.activeLayer;layer.activate();var r=new Raster(d.src);r.data.src=d.src;if(d.isBitmapBrush)r.data.isBitmapBrush=true;if(d.brushGroupId)r.data.brushGroupId=d.brushGroupId;if(d.isBrushTextureCopy)r.data.isBrushTextureCopy=true;if(d.groupId)r.data.groupId=d.groupId;r.position=new Point(d.x,d.y);r.opacity=op!==undefined?op:(d.opacity!==undefined?d.opacity:1);var w=d.width,h=d.height;
+function desR(d,layer,op){var prev=project.activeLayer;layer.activate();var r=new Raster(d.src);r.data.src=d.src;if(d.isBitmapBrush)r.data.isBitmapBrush=true;if(d.brushGroupId)r.data.brushGroupId=d.brushGroupId;if(d.isBrushTextureCopy)r.data.isBrushTextureCopy=true;if(d.groupId)r.data.groupId=d.groupId;
+  if(d.isText){r.data.isText=true;r.data.text=d.text||'';r.data.font=d.font||'sans-serif';r.data.size=d.size||48;r.data.color=d.color||'#000000';r.data.align=d.align||'left';if(d.fixedWidth)r.data.fixedWidth=d.fixedWidth;}
+  r.position=new Point(d.x,d.y);r.opacity=op!==undefined?op:(d.opacity!==undefined?d.opacity:1);var w=d.width,h=d.height;
   // serR()'s mid-decode fallback reads this — see its own comment. Cleared
   // once place() actually applies the real geometry so serR immediately
   // goes back to trusting live r.position/r.bounds afterward (a post-load

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -3412,47 +3412,134 @@ function initCommentPopover(){
   },true);
 }
 if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',initCommentPopover);else initCommentPopover();
-// ---- Outil texte (v19) ----
+// ---- Outil texte (v20, 2026-07 rework) ----
 // Le moteur Rust ne rasterise pas de glyphes : le texte est rendu une fois
 // dans un canvas offscreen (2x pour la nettete) puis insere comme Raster —
 // le pipeline image existant (serR/desR, registerImagePixels) fait tout le
-// reste (persistance, rendu, selection/deplacement via l'outil V).
-var _textPendingPt=null;
-function openTextPopover(worldPt){
-  _textPendingPt=worldPt.clone();
+// reste (persistance, rendu, selection/deplacement via l'outil V). Ce qui a
+// change (Figma/Illustrator-style) : (1) un simple clic pose du "point text"
+// (largeur auto, inchange), un DRAG pose une boite de largeur fixe ("area
+// text") avec retour a la ligne automatique ; (2) double-clic sur un bloc de
+// texte existant rouvre le popover pre-rempli et RE-BAKE en place (source du
+// Raster remplacee via .source, meme identite d'item, meme position
+// d'ancrage haut-gauche) au lieu de forcer supprimer/retaper ; (3) couleur et
+// alignement sont maintenant des champs du popover, pas figes sur
+// state.strokeColor au moment du clic ; (4) text/font/size/color/align/
+// fixedWidth persistent sur r.data et via serR/desR (app.js) — avant cette
+// session, isText lui-meme ne survivait meme pas a un save/reload.
+var _textPendingPt=null,_textPendingBox=null,_textEditingRaster=null;
+function positionTextPopover(worldPt){
   var pop=document.getElementById('text-popover');if(!pop)return;
   var v=view.projectToView(worldPt);
   var cr=document.getElementById('drawing-canvas').getBoundingClientRect();
   pop.style.display='block';
   pop.style.left=Math.min(window.innerWidth-240,Math.max(4,cr.left+v.x+10))+'px';
-  pop.style.top=Math.min(window.innerHeight-180,Math.max(4,cr.top+v.y+10))+'px';
-  var ta=document.getElementById('text-input');ta.value='';ta.focus();
+  pop.style.top=Math.min(window.innerHeight-220,Math.max(4,cr.top+v.y+10))+'px';
 }
-function closeTextPopover(){var pop=document.getElementById('text-popover');if(pop)pop.style.display='none';_textPendingPt=null;}
+function resetTextPopoverFields(text,size,font,color,align){
+  document.getElementById('text-input').value=text||'';
+  document.getElementById('text-size').value=size||48;
+  document.getElementById('text-font').value=font||'sans-serif';
+  document.getElementById('text-align').value=align||'left';
+  var colorInp=document.getElementById('text-color');if(colorInp)colorInp.value=color||state.strokeColor||'#000000';
+}
+function openTextPopover(worldPt){
+  _textPendingPt=worldPt.clone();_textPendingBox=null;_textEditingRaster=null;
+  resetTextPopoverFields();
+  positionTextPopover(worldPt);
+  document.getElementById('text-input').focus();
+}
+// Drag-to-place area text (Illustrator "type in a box") — widthWorld is in
+// world units (same space as x/y/width/height everywhere else in this
+// codebase), wrapping happens in commitText once the actual font/size are
+// known (they aren't yet at drag time).
+function openTextPopoverForBox(topLeft,widthWorld){
+  _textPendingPt=null;_textPendingBox={topLeft:topLeft.clone(),width:widthWorld};_textEditingRaster=null;
+  resetTextPopoverFields();
+  positionTextPopover(topLeft);
+  document.getElementById('text-input').focus();
+}
+// Re-edit an existing text raster (double-click, onViewDoubleClick in
+// tools.js) — prefills every field from what was persisted on r.data and
+// keeps the box's fixedWidth (if any) so re-wrapping behaves the same way.
+function openTextPopoverForEdit(raster){
+  _textPendingPt=null;_textEditingRaster=raster;
+  _textPendingBox=raster.data.fixedWidth?{topLeft:raster.bounds.topLeft.clone(),width:raster.data.fixedWidth}:null;
+  resetTextPopoverFields(raster.data.text,raster.data.size,raster.data.font,raster.data.color,raster.data.align);
+  positionTextPopover(raster.bounds.topLeft);
+  var ta=document.getElementById('text-input');ta.focus();ta.select();
+}
+function closeTextPopover(){var pop=document.getElementById('text-popover');if(pop)pop.style.display='none';_textPendingPt=null;_textPendingBox=null;_textEditingRaster=null;}
 function commitText(){
   var txt=document.getElementById('text-input').value;
-  if(!txt.trim()||!_textPendingPt){closeTextPopover();return;}
+  if(!txt.trim()||(!_textPendingPt&&!_textPendingBox&&!_textEditingRaster)){closeTextPopover();return;}
   var size=parseInt(document.getElementById('text-size').value,10)||48;
   var font=document.getElementById('text-font').value||'sans-serif';
-  var color=state.strokeColor||'#000';
+  var align=document.getElementById('text-align').value||'left';
+  var colorInp=document.getElementById('text-color');
+  var color=(colorInp&&colorInp.value)||state.strokeColor||'#000000';
+  var fixedWidthWorld=_textPendingBox?_textPendingBox.width:null;
+  var SS=2; // supersample factor for offscreen bake, unchanged from before
   var lines=txt.split('\n');
   var off=document.createElement('canvas');
   var octx=off.getContext('2d');
-  octx.font=size*2+'px '+font;
-  var wMax=1;lines.forEach(function(l){wMax=Math.max(wMax,octx.measureText(l).width);});
-  off.width=Math.ceil(wMax)+8;off.height=lines.length*size*2*1.25+8;
-  octx=off.getContext('2d');
-  octx.font=size*2+'px '+font;octx.fillStyle=color;octx.textBaseline='top';
-  lines.forEach(function(l,i){octx.fillText(l,4,4+i*size*2*1.25);});
+  octx.font=size*SS+'px '+font;
+  var lineH=size*SS*1.25;
+  var fixedWidthPx=fixedWidthWorld?Math.max(20,fixedWidthWorld*SS):null;
+  var wrapped=[];
+  if(fixedWidthPx){
+    // Greedy word-wrap at the fixed pixel width (minus padding) — Figma/
+    // Illustrator area-text behavior. Point text (fixedWidthPx null) keeps
+    // the original one-line-per-input-line, auto-width behavior untouched.
+    lines.forEach(function(l){
+      if(l===''){wrapped.push('');return;}
+      var words=l.split(' ');var cur='';
+      words.forEach(function(w){
+        var test=cur?cur+' '+w:w;
+        if(cur&&octx.measureText(test).width>fixedWidthPx-16){wrapped.push(cur);cur=w;}
+        else cur=test;
+      });
+      wrapped.push(cur);
+    });
+  }else{
+    wrapped=lines;
+  }
+  var wMax=1;
+  if(fixedWidthPx)wMax=fixedWidthPx;
+  else wrapped.forEach(function(l){wMax=Math.max(wMax,octx.measureText(l).width);});
+  off.width=Math.ceil(wMax)+16;off.height=Math.ceil(wrapped.length*lineH)+16;
+  octx=off.getContext('2d'); // resizing the canvas resets its context/state
+  octx.font=size*SS+'px '+font;octx.fillStyle=color;octx.textBaseline='top';
+  wrapped.forEach(function(l,i){
+    var tw=octx.measureText(l).width,x=8;
+    if(align==='center')x=(off.width-tw)/2;else if(align==='right')x=off.width-8-tw;
+    octx.fillText(l,x,8+i*lineH);
+  });
   var url=off.toDataURL('image/png');
   pushUndo();
-  var layer=userLayers[state.activeLayerIdx];
-  var prev=project.activeLayer;layer.activate();
-  var r=new Raster(url);
-  r.data.src=url;r.data.isText=true;
-  var pt=_textPendingPt;
-  r.onLoad=function(){r.size=new Size(off.width/2,off.height/2);r.position=pt;saveActiveLayerFrame();updateUI();if(window.SMEngineBridge){if(r.canvas)SMEngineBridge.registerImagePixels&&0;SMEngineBridge.renderNow();}};
-  prev.activate();
+  var textMeta={text:txt,font:font,size:size,color:color,align:align,fixedWidth:fixedWidthWorld||null};
+  if(_textEditingRaster&&_textEditingRaster.parent){
+    var r=_textEditingRaster;
+    var topLeft=r.bounds.topLeft.clone(); // re-bake keeps its top-left anchor fixed, doesn't re-center on the old click point
+    r.data.isText=true;r.data.src=url;
+    r.data.text=textMeta.text;r.data.font=textMeta.font;r.data.size=textMeta.size;r.data.color=textMeta.color;r.data.align=textMeta.align;r.data.fixedWidth=textMeta.fixedWidth;
+    r.onLoad=function(){r.size=new Size(off.width/SS,off.height/SS);r.position=topLeft.add(new Point(r.size.width/2,r.size.height/2));saveActiveLayerFrame();updateUI();if(window.SMEngineBridge)window.SMEngineBridge.renderNow();};
+    r.source=url; // reassigning .source keeps the same item identity (index/parent/references) — just reloads the bitmap, same pattern as any other Raster edit-in-place in this codebase
+  }else{
+    var layer=userLayers[state.activeLayerIdx];
+    var prev=project.activeLayer;layer.activate();
+    var r2=new Raster(url);
+    r2.data.src=url;r2.data.isText=true;
+    r2.data.text=textMeta.text;r2.data.font=textMeta.font;r2.data.size=textMeta.size;r2.data.color=textMeta.color;r2.data.align=textMeta.align;r2.data.fixedWidth=textMeta.fixedWidth;
+    var pt=_textPendingBox?_textPendingBox.topLeft.clone():_textPendingPt;
+    var isBox=!!_textPendingBox;
+    r2.onLoad=function(){
+      r2.size=new Size(off.width/SS,off.height/SS);
+      r2.position=isBox?pt.add(new Point(r2.size.width/2,r2.size.height/2)):pt;
+      saveActiveLayerFrame();updateUI();if(window.SMEngineBridge)window.SMEngineBridge.renderNow();
+    };
+    prev.activate();
+  }
   closeTextPopover();
 }
 function initTextPopover(){
@@ -3474,6 +3561,8 @@ function initTextPopover(){
 }
 if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',initTextPopover);else initTextPopover();
 window.openTextPopover=openTextPopover;
+window.openTextPopoverForBox=openTextPopoverForBox;
+window.openTextPopoverForEdit=openTextPopoverForEdit;
 function initCycleAndPropagate(){
   var cyc=document.getElementById('btn-cycle');
   if(cyc)cyc.addEventListener('click',function(){

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -1,5 +1,6 @@
 // ---- TOOLS ----
 var currentPath=null,selectedPaths=[],stabQueue=[],shapeStart=null;
+var _textDragStart=null,_textDragRect=null;
 // Shift-constrain helpers for Rectangle/Ellipse/Line (see their onMouseDrag
 // handler) — kept standalone rather than inlined since both the shape and
 // its live drag-preview need the identical constrained endpoint.
@@ -3603,7 +3604,12 @@ function onMouseDown(event){
   }else if(state.tool==='camera'){
     if(window.SMCamera)SMCamera.onDown(event);
   }else if(state.tool==='text'){
-    if(window.openTextPopover)openTextPopover(event.point);
+    // A plain click still opens the point-text popover immediately (see
+    // onMouseUp's companion branch — a click-with-no-drag never enters the
+    // preview-rectangle path below, matching pre-2026-07 behavior exactly).
+    // A drag defines an area-text box instead (Illustrator "type in a box"),
+    // finalized in onMouseUp once the drag distance is known.
+    _textDragStart=event.point.clone();
   }else if(state.tool==='fsselect'){
     _fsSel=fsHitTest(event.point,layer);
     updateUI();
@@ -3871,6 +3877,21 @@ function onMouseDrag(event){
     if(state.tool==='line'){currentPath=new Path.Line({from:shapeStart,to:endPt,strokeColor:state.strokeEnabled?state.strokeColor:null,strokeWidth:state.brushSize,strokeCap:state.strokeCap,fillColor:null,opacity:state.opacity/100});applyStrokeStyle(currentPath);}
     else if(state.tool==='rect')currentPath=new Path.Rectangle({from:shapeStart,to:endPt,strokeColor:state.strokeEnabled?state.strokeColor:null,strokeWidth:state.brushSize,fillColor:state.fillEnabled?state.fillColor:null,opacity:state.opacity/100});
     else{currentPath=new Path.Ellipse({rectangle:new Rectangle(shapeStart,endPt),strokeColor:state.strokeEnabled?state.strokeColor:null,strokeWidth:state.brushSize,fillColor:state.fillEnabled?state.fillColor:null,opacity:state.opacity/100});}
+  }else if(state.tool==='text'&&_textDragStart){
+    // Drag guide rectangle — purely visual (marqueeLayer, never inserted
+    // into real content), same pattern as the subselect marquee just below.
+    // Only x matters for the actual box (wrapping is width-only, no fixed-
+    // height clipping in this implementation); a nominal height is drawn
+    // just so the drag reads as "defining a box" rather than a stray line.
+    if(_textDragRect){_textDragRect.remove();_textDragRect=null;}
+    var twv=Math.abs(event.point.x-_textDragStart.x);
+    if(twv>4/view.zoom){
+      var tx1=Math.min(_textDragStart.x,event.point.x),ty1=Math.min(_textDragStart.y,event.point.y);
+      var tx2=Math.max(_textDragStart.x,event.point.x);
+      var prevTxt=project.activeLayer;marqueeLayer.activate();
+      _textDragRect=new Path.Rectangle({from:new Point(tx1,ty1),to:new Point(tx2,ty1+60/view.zoom),strokeColor:'rgba(255,184,108,.9)',strokeWidth:1/view.zoom,dashArray:[4/view.zoom,3/view.zoom],fillColor:new Color(1,0.72,0.42,0.06),insert:true});
+      prevTxt.activate();
+    }
   }else if(state.tool==='subselect'){
     if(_nmq.active){
       var nx1=Math.min(_nmq.start.x,event.point.x),ny1=Math.min(_nmq.start.y,event.point.y);
@@ -4095,6 +4116,14 @@ function onMouseUp(event){
     _vb.pts=[];_vb.widths=[];currentPath=null;stabQueue=[];saveActiveLayerFrame();updateUI();
   }else if(state.tool==='pen'){
     _pen.draggingHandle=false;
+  }else if(state.tool==='text'&&_textDragStart){
+    if(_textDragRect){_textDragRect.remove();_textDragRect=null;}
+    var textDragWidth=Math.abs(event.point.x-_textDragStart.x);
+    if(textDragWidth>20/view.zoom){
+      var textTopLeft=new Point(Math.min(_textDragStart.x,event.point.x),Math.min(_textDragStart.y,event.point.y));
+      if(window.openTextPopoverForBox)openTextPopoverForBox(textTopLeft,textDragWidth);
+    }else if(window.openTextPopover)openTextPopover(_textDragStart);
+    _textDragStart=null;
   }else if((state.tool==='line'||state.tool==='rect'||state.tool==='ellipse')&&currentPath){
     if(shapeStart&&event.point.getDistance(shapeStart)<2){currentPath.remove();if(state.undoStack.length)state.undoStack.pop();}
     else{
@@ -4203,6 +4232,17 @@ function onMouseMoveTool(event){
 // heuristic: any stroke-only path whose bounds intersect the fill's bounds
 // is assumed to be part of its outline.
 function onViewDoubleClick(event){
+  // Re-edit a placed text block in place (2026-07 rework) — checked before
+  // the select-only guard below since double-clicking with the Text tool
+  // itself active must also work, not just Select.
+  if(state.tool==='select'||state.tool==='text'){
+    var textLayer=userLayers[state.activeLayerIdx];
+    var textHit=textLayer.hitTest(event.point,{fill:true,stroke:true,tolerance:4/view.zoom});
+    if(textHit&&textHit.item instanceof Raster&&textHit.item.data&&textHit.item.data.isText){
+      if(window.openTextPopoverForEdit)openTextPopoverForEdit(textHit.item);
+      return;
+    }
+  }
   if(state.tool!=='select')return;
   var layer=userLayers[state.activeLayerIdx];
   var hit=layer.hitTest(event.point,{fill:true,tolerance:4/view.zoom});


### PR DESCRIPTION
## Summary
- Click = point text (auto-width, unchanged). Drag = area text (fixed-width box, greedy word-wrap), Illustrator/Figma-style.
- Double-click a placed text block re-opens the popover prefilled and re-bakes in place (same item identity, same top-left anchor) instead of forcing delete+retype.
- Color and alignment are now popover fields, not frozen to `state.strokeColor` at click time.
- Fixes the persistence gap this session's audit found: `isText` (and now `text`/`font`/`size`/`color`/`align`/`fixedWidth`) previously vanished on save/reload — a placed text block became an indistinguishable plain raster. Now persisted via `serR`/`desR`.
- A few more system fonts in the picker (Georgia, Times, Courier, Verdana).

Deliberately out of scope for this PR (greenfield, larger follow-ups): true vector glyph rendering, per-character animation, a distinct text layer type.

## Test plan
- [x] `node --check` on all touched files
- [x] Live-tested in browser: point text creation, drag-to-create area text with correct wrap width, double-click re-edit updates the same item in place (index/position preserved), save/reload round-trips all text metadata correctly