### PR TITLE
Perspective guide: angle-based freehand snap, not proximity-to-line

### DIFF
--- a/src/js/draw-bridge.js
+++ b/src/js/draw-bridge.js
@@ -37,6 +37,17 @@
   // this replaced a pure per-point magnet). Set once at pointerdown, held
   // for the whole gesture, cleared at pointerup.
   var lockedGuideRay = null;
+  // Angle-based lock (2026-07 — feedback: "dans sketchbook tu fais tes
+  // traits n'importe où ils vont suivre la perspective"): unlike the
+  // proximity lock above (decided instantly at pointerdown, since distance-
+  // to-a-drawn-line is already known from a single point), the ANGLE lock
+  // needs a couple of pixels of real drag before a direction even exists to
+  // compare against a vanishing point — guideStartPt is the gesture's true
+  // (unconstrained) first point, guideLockDecided flips true the moment
+  // EITHER kind of lock has been resolved (found a ray, or confirmed none
+  // applies), so the angle check only ever runs once per gesture, not on
+  // every subsequent sample.
+  var guideStartPt = null, guideLockDecided = false;
   var lastMoveT = 0, lastWorldPt = null;
   var lastPenPressure = null; // held across a real-pen gesture, see pressureOf()
   // state.stabilizer (position-averaging while drawing) used to only exist
@@ -190,7 +201,22 @@
   // magnetSnap when nothing was close enough to lock at the start (so a
   // stroke drawn nowhere near the guide still behaves exactly as before).
   function guideConstrain(w, isStart) {
-    if (isStart) lockedGuideRay = window.perspectiveFindGuideRayNear ? window.perspectiveFindGuideRayNear(new Point(w[0], w[1])) : null;
+    if (isStart) {
+      guideStartPt = new Point(w[0], w[1]);
+      // Proximity lock still applies IMMEDIATELY when the stroke starts
+      // right on a drawn ray (or the horizon) — a single point is already
+      // enough distance-to-line info, no need to wait for a direction.
+      lockedGuideRay = window.perspectiveFindGuideRayNear ? window.perspectiveFindGuideRayNear(guideStartPt) : null;
+      guideLockDecided = !!lockedGuideRay;
+    } else if (!guideLockDecided && guideStartPt) {
+      var curPt = new Point(w[0], w[1]);
+      // Needs real direction before the angle check means anything — same
+      // 4px-of-drag floor snapToVP itself uses (perspective-bridge.js).
+      if (curPt.getDistance(guideStartPt) >= 4) {
+        lockedGuideRay = window.perspectiveFindVPRayByAngle ? window.perspectiveFindVPRayByAngle(guideStartPt, curPt) : null;
+        guideLockDecided = true; // decided either way — never re-checked again this gesture, so a stroke that isn't aimed at any VP just draws free for its whole length, not just its first few px
+      }
+    }
     if (lockedGuideRay && window.perspectiveProjectOnRay) {
       var p = window.perspectiveProjectOnRay(new Point(w[0], w[1]), lockedGuideRay);
       return [p.x, p.y];
@@ -430,7 +456,7 @@
     // catch-up behavior Photoshop/Clip Studio's stabilized brushes use.
     var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
     w = guideConstrain(w, false);
-    lockedGuideRay = null; // stroke over — next pointerdown re-evaluates from scratch
+    lockedGuideRay = null; guideStartPt = null; guideLockDecided = false; // stroke over — next pointerdown re-evaluates from scratch
     var pressure = smoothPressure(wantsPressure() ? pressureOf(e, w) : 1);
     if (modeler) {
       // The modeler's own end-of-stroke catch-up (physics iterated until

--- a/src/js/perspective-bridge.js
+++ b/src/js/perspective-bridge.js
@@ -243,6 +243,37 @@
     return best;
   }
   window.perspectiveFindGuideRayNear = findGuideRayNear;
+  // Angle-based freehand lock (2026-07 — feedback: "dans sketchbook tu fais
+  // tes traits n'importe où ils vont suivre la perspective" — the PROXIMITY
+  // lock above (findGuideRayNear) only fires when the stroke STARTS within
+  // LOCK_TOLERANCE_PX of an already-drawn guide ray, which is exactly the
+  // opposite of Sketchbook's own behavior: there, the guide's ANGLE from a
+  // vanishing point is what matters, not the stroke's distance from any
+  // drawn line — you can start a stroke anywhere on the canvas and, once
+  // its direction reads as "aimed at a VP," it locks onto that VP's ray.
+  // Mirrors snapToVP's angle math above (same SNAP_DEG, same "closest VP
+  // direction wins" logic) but returns a {px,py,dx,dy} ray struct usable by
+  // projectOnRay/draw-bridge.js's guideConstrain, instead of a single
+  // projected point — draw-bridge.js calls this once dragLen has crossed a
+  // few pixels (see its own guideLockDecided comment for why the decision
+  // can't happen at pointerdown, before any direction is known at all).
+  function findVPRayByAngle(start, currentPt) {
+    if (!state.perspectiveEnabled) return null;
+    var dx = currentPt.x - start.x, dy = currentPt.y - start.y;
+    var dragAngle = Math.atan2(dy, dx);
+    var vps = ensurePerspectiveVPs();
+    var best = null, bestDiff = SNAP_DEG * Math.PI / 180;
+    vps.forEach(function (vp) {
+      var vx = vp.x - start.x, vy = vp.y - start.y;
+      var vlen = Math.hypot(vx, vy);
+      if (vlen < 1) return; // start point sits ON the VP — no meaningful direction to compare against
+      var vAngle = Math.atan2(vy, vx);
+      var diff = Math.abs(Math.atan2(Math.sin(dragAngle - vAngle), Math.cos(dragAngle - vAngle)));
+      if (diff < bestDiff) { bestDiff = diff; best = { px: start.x, py: start.y, dx: vx / vlen, dy: vy / vlen }; }
+    });
+    return best;
+  }
+  window.perspectiveFindVPRayByAngle = findVPRayByAngle;
   function projectOnRay(worldPt, ray) {
     var vx = worldPt.x - ray.px, vy = worldPt.y - ray.py;
     var t = vx * ray.dx + vy * ray.dy;


### PR DESCRIPTION
## Summary
- "dans sketchbook tu fais tes traits n'importe où ils vont suivre la perspective" — freehand Draw/Fillbrush strokes only locked onto a guide ray when the stroke STARTED within 40px of an already-drawn ray (pure distance-to-line-segment search). Sketchbook's own behavior is angle-based: the stroke's DIRECTION relative to a vanishing point is what matters, not its distance from any drawn line.
- New `perspectiveFindVPRayByAngle` mirrors the Line tool's own `snapToVP` angle math (same 6° tolerance) — compares the stroke's actual drawn angle to the direction from its start point toward each VP, locking regardless of how far the start is from any drawn ray.
- `draw-bridge.js`'s `guideConstrain` defers this decision to the first move sample with real direction (~4px of drag), falls back to the immediate proximity lock at pointerdown for a stroke starting right on a line, and never re-checks once decided — so a stroke not aimed at any VP still draws completely free.

## Test plan
- [x] `node --check` on both touched files
- [x] Live-tested in browser: a stroke starting far from every guide ray (proximity check correctly returns null) now locks via angle when aimed at a VP within tolerance; a stroke aimed away from every VP correctly stays unlocked