### PR TITLE
Fix: expression editor opened off-screen, looked like nothing happened

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -1612,7 +1612,22 @@
         e.stopPropagation();
         var already = window._exprEditorOpen && window._exprEditorOpen.holder === holder && window._exprEditorOpen.prop === prop;
         window._exprEditorOpen = already ? null : { holder: holder, prop: prop };
+        // Bug found live (2026-07 — "pas compris où est ce qu'elle sont
+        // écrite"): both containers this row can render into (#layer-list's
+        // bottom Transform group, #motion-props-body's right-panel mirror)
+        // are small fixed-height scrolling panels with no visible scrollbar
+        // affordance — clicking ƒx opened the editor exactly as designed,
+        // but the newly-inserted textarea routinely landed BELOW the
+        // already-scrolled viewport of that panel, reading as "nothing
+        // happened". Scroll the container the user actually clicked in (not
+        // its sibling mirror, which may not even be visible) so the editor
+        // is guaranteed on-screen the instant it opens.
+        var container = exprBtn.closest('#layer-list, #motion-props-body');
         renderLayerList(); renderTimeline();
+        if (container && !already) {
+          var editorRow = container.querySelector('.motion-expr-editor');
+          if (editorRow) editorRow.scrollIntoView({ block: 'nearest' });
+        }
       });
       pr.appendChild(sw); pr.appendChild(exprBtn); pr.appendChild(pnm);
       var vals = isAnimated(holder, prop) ? valueAtFrame(holder, prop, state.currentFrame) : staticValue(holder, prop);


### PR DESCRIPTION
## Summary
"pour les expression pas compris où est ce qu'elle sont écrite" — traced this to a real UX bug, not just unfamiliarity: clicking the ƒx button on a Motion property row does open the inline expression editor, but both containers it renders into (`#layer-list`'s bottom Transform group, `#motion-props-body`'s right-panel mirror) are small fixed-height scrolling panels with no scrollbar affordance. The new textarea routinely landed below the panel's current scroll position, so it looked like the click did nothing.

Scrolls the editor into view in whichever container was actually clicked, the instant it opens.

## Test plan
- [x] `node --check`
- [x] Live-tested in browser: confirmed the editor was genuinely rendering off-screen before the fix (`getBoundingClientRect` outside the panel's visible bounds), confirmed it's fully visible immediately after the fix in both the bottom Transform group and the right-panel mirror