### PR TITLE
Fix Motion mode: expression buttons buried far down the right panel

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -2597,6 +2597,12 @@
         mpHdr.classList.remove('closed');
       }
     }
+    // The 2D-tool sections (Fill/Stroke/Tool Options/Effects/Document) stay
+    // visible via updatePropsContext()'s own inline display:block unless
+    // re-run right now — without this, switching into Motion still shows
+    // whatever tool context was active in 2D mode, burying the section
+    // above (which contains the expression buttons) far down the panel.
+    if (window.updatePropsContext) window.updatePropsContext();
     renderLayerList(); renderTimeline();
     if (window.renderSymbolTabs) renderSymbolTabs();
     if (window.SMEngineBridge) window.SMEngineBridge.renderNow();

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1395,6 +1395,21 @@ function updatePropsContext(){
   }
   if(window.renderGradientPanel)window.renderGradientPanel();
   var hdrEl=document.getElementById('props-context-hdr');if(hdrEl)hdrEl.textContent=hdrText;
+  // Motion mode: none of these 2D-drawing-tool sections apply (no active
+  // Fill/Stroke/Draw tool, no canvas marquee selection in the Animation 2D
+  // sense) — they were rendering unconditionally via this same inline
+  // display:block regardless of state.appMode, which is what buried
+  // #motion-props-sec (the ONLY section actually relevant in Motion mode,
+  // and the one containing the ƒx expression buttons) ~1375px down the
+  // right panel behind Fill/Stroke/Tool Options/etc. Reported as "toujours
+  // pas d'endroit où mettre les expressions" even after the local
+  // scroll-into-view fix (PR #48) — that fix only handled scrolling WITHIN
+  // an already-visible section, not this much bigger burial problem.
+  // layer-sec (Blend/Matte/Flou) is spared: those are genuine per-layer
+  // properties still meaningful while animating, not a drawing-tool panel.
+  if(state.appMode==='motion'){
+    show['sel-props-sec']=show['fill-sec']=show['stroke-sec']=show['tool-opts-sec']=show['effects-sec']=show['canvas-sec']=false;
+  }
   Object.keys(show).forEach(function(id){var sec=document.getElementById(id);if(sec)sec.style.display=show[id]?'block':'none';});
   // state.drawMode (Front/Behind) has no effect on Fill Brush — it's always
   // inserted at the back regardless (see draw-bridge.js/tools.js commit) —


### PR DESCRIPTION
## Summary
- Root cause of "toujours pas d'endroit où mettre les expressions" (still no place to put expressions), reported even after PR #48's local scroll-into-view fix.
- `updatePropsContext()` shows/hides Fill/Stroke/Tool Options/Effects/Document/Selection panel sections based on the active 2D tool, with zero awareness of `state.appMode` — so switching into Motion mode left all of those 2D-only sections visible, stacking above `#motion-props-sec` (the Transform mirror panel containing the ƒx expression buttons) and pushing it ~1375px down the right panel.
- Fix: force those 2D-only sections closed while in Motion mode, and have `setAppMode('motion')` re-run `updatePropsContext()` immediately so the Transform panel lands near the top on switch.

## Test plan
- [x] Verified in browser: before the fix, `#motion-props-sec` measured `top: 1375` in the right panel's scroll flow.
- [x] After the fix, switching to Motion mode puts it at `top: 261` (then `top: 17` once scrolled/expanded) — immediately visible, no long scroll needed.
- [x] Confirmed the 5 `.motion-expr-btn` (ƒx) buttons render correctly inside, screenshot-verified.
- [x] `node --check` on both modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)