### PR TITLE
Clarify Smooth vs Stabilizer are two independent smoothing controls

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -510,8 +510,18 @@
     <div class="psec" id="tool-opts-sec">
       <div class="phdr"><span class="ar">☰</span> <span data-i18n="hdrToolOptions">Tool Options</span></div>
       <div class="pbdy">
-        <div class="pr"><span class="pl">Smooth</span><input type="number" class="pi scrub" id="p-smooth" value="10" min="0" max="60" data-step="1"></div>
-        <div class="pr"><span class="pl">Stabilizer</span><select class="psel" id="p-stab" title="Off/Low/Medium/High : moyenne glissante classique. Plume : modèle physique ressort-amortisseur (Google ink-stroke-modeler, comme rnote) — lisse le flux d’entrée en direct sans détruire la géométrie, rattrape la pointe au relâcher"><option value="0">Off</option><option value="1">Low</option><option value="2" selected>Medium</option><option value="3">High</option><option value="4">Plume — légère</option><option value="5">Plume — moyenne</option><option value="6">Plume — forte</option></select></div>
+        <!-- Ordre volontairement calé sur le pipeline réel (Stabilizer agit
+             EN DIRECT pendant le tracé, Smooth simplifie la courbe APRÈS
+             coup) — étaient dans l'ordre inverse, ce qui + les deux mots
+             "lissage" a fait croire que Smooth=0 devait suffire à obtenir
+             un trait 100% brut ("le smooth de la brush à 0 smooth
+             toujours"). Ce ne sont PAS deux réglages du même lissage : à
+             Smooth=0 + Stabilizer sur autre chose que Off, le tracé reste
+             visiblement adouci — vérifié: un zigzag identique perd ~1/3 de
+             son amplitude avec Stabilizer=Medium même à Smooth=0. Pour un
+             trait vraiment brut, Stabilizer doit AUSSI être sur "Off". -->
+        <div class="pr"><span class="pl">Stabilizer</span><select class="psel" id="p-stab" title="Lisse la POSITION en direct pendant que tu dessines (corrige le tremblement de la main) — agit AVANT que le trait soit posé, indépendamment de Smooth ci-dessous. Off/Low/Medium/High : moyenne glissante classique. Plume : modèle physique ressort-amortisseur (Google ink-stroke-modeler, comme rnote), rattrape la pointe au relâcher. Mets ça sur Off si tu veux un tracé qui suit ta main au pixel près."><option value="0">Off</option><option value="1">Low</option><option value="2" selected>Medium</option><option value="3">High</option><option value="4">Plume — légère</option><option value="5">Plume — moyenne</option><option value="6">Plume — forte</option></select></div>
+        <div class="pr"><span class="pl">Smooth</span><input type="number" class="pi scrub" id="p-smooth" value="10" min="0" max="60" data-step="1" title="Simplifie la courbe APRÈS coup (moins de points, tracé plus économe) — n'a aucun effet sur le tremblement pendant le dessin, c'est le Stabilizer ci-dessus qui s'en charge. À 0 : le nombre de points n'est pas réduit, mais le trait peut rester visiblement adouci si le Stabilizer est activé."></div>
         <div class="pr" id="p-drawmode-row"><span class="pl">Draw mode</span><select class="psel" id="p-drawmode" title="Front = new strokes on top, Behind = new strokes under existing artwork"><option value="front">Front</option><option value="behind">Behind</option></select></div>
         <div class="pr" id="p-fillbrushmode-row" style="display:none"><span class="pl">Placement</span><div class="icon-grp" id="p-fillbrushmode-grp" data-value="above">
           <button class="icon-btn" data-value="above" title="Above — on top of existing fills"><svg viewBox="0 0 20 20"><rect x="7" y="2" width="11" height="11" rx="2" fill="currentColor" opacity=".35"/><rect x="2" y="6" width="11" height="11" rx="2" fill="none" stroke="currentColor" stroke-width="1.6"/></svg></button>

--- a/src/js/brush-menu-bridge.js
+++ b/src/js/brush-menu-bridge.js
@@ -37,8 +37,8 @@
   // ---- shared param-row builder — a `.pr`/`.pl`/`.pi` row identical in
   // markup to the ones already in index.html's right panel, so it's
   // visually indistinguishable from the rest of the app's own controls.
-  function numRow(container, label, value, min, max, step, onChange) {
-    var row = document.createElement('div'); row.className = 'pr';
+  function numRow(container, label, value, min, max, step, onChange, title) {
+    var row = document.createElement('div'); row.className = 'pr'; if (title) row.title = title;
     var lbl = document.createElement('span'); lbl.className = 'pl'; lbl.textContent = label;
     var inp = document.createElement('input');
     inp.type = 'number'; inp.className = 'pi scrub'; inp.value = value; inp.min = min; inp.max = max; inp.step = step;
@@ -59,8 +59,8 @@
     container.appendChild(row);
     return inp;
   }
-  function selectRow(container, label, value, options, onChange) {
-    var row = document.createElement('div'); row.className = 'pr';
+  function selectRow(container, label, value, options, onChange, title) {
+    var row = document.createElement('div'); row.className = 'pr'; if (title) row.title = title;
     var lbl = document.createElement('span'); lbl.className = 'pl'; lbl.textContent = label;
     var sel = document.createElement('select'); sel.className = 'psel';
     options.forEach(function (o) {
@@ -100,13 +100,23 @@
   // Also answers "y a t'il pas plus d'option ?" — Stabilizer, Pressure
   // brush, and Taper ends are the most relevant "brush feel" settings that
   // existed elsewhere in the right panel but were never mirrored here.
+  // Ordre/tooltips alignés sur index.html (Tool Options) — feedback "le
+  // smooth de la brush à 0 smooth toujours" : Stabilisateur (lisse la
+  // POSITION en direct, agit AVANT que le trait soit posé) et Lissage
+  // (simplifie la courbe APRÈS coup) sont deux mécanismes indépendants qui
+  // se ressemblent trop par leur nom seul — mesuré : un zigzag à Lissage=0
+  // perd encore ~1/3 de son amplitude si Stabilisateur=Medium. D'où
+  // Stabilisateur en premier (ordre du pipeline réel) + tooltips explicites
+  // ici aussi, ce panneau dupliquant les mêmes contrôles.
+  var STAB_TITLE = 'Lisse la POSITION en direct pendant que tu dessines (corrige le tremblement de la main) — agit AVANT que le trait soit posé, indépendamment de Lissage ci-dessous. Mets ça sur Off si tu veux un tracé qui suit ta main au pixel près.';
+  var SMOOTH_TITLE = 'Simplifie la courbe APRÈS coup (moins de points) — n\'a aucun effet sur le tremblement pendant le dessin, c\'est le Stabilisateur ci-dessus qui s\'en charge. À 0, le trait peut rester visiblement adouci si le Stabilisateur est activé.';
   function buildVectorParams(params) {
     numRow(params, 'Taille', state.brushSize || 3, 1, 300, 1, function (v) { driveOriginal('p-sw', v, false, 'change'); });
-    numRow(params, 'Lissage', state.smoothing || 0, 0, 60, 1, function (v) { driveOriginal('p-smooth', v, false, 'input'); });
     selectRow(params, 'Stabilisateur', state.stabilizer !== undefined ? state.stabilizer : 2, [
       { value: 0, label: 'Off' }, { value: 1, label: 'Low' }, { value: 2, label: 'Medium' }, { value: 3, label: 'High' },
       { value: 4, label: 'Plume — légère' }, { value: 5, label: 'Plume — moyenne' }, { value: 6, label: 'Plume — forte' },
-    ], function (v) { driveOriginal('p-stab', v, false, 'change'); });
+    ], function (v) { driveOriginal('p-stab', v, false, 'change'); }, STAB_TITLE);
+    numRow(params, 'Lissage', state.smoothing || 0, 0, 60, 1, function (v) { driveOriginal('p-smooth', v, false, 'input'); }, SMOOTH_TITLE);
     checkRow(params, 'Pressure brush', !!state.vectorBrush, function (v) { driveOriginal('p-vecbrush', v, true, 'change'); });
     checkRow(params, 'Taper ends', !!state.taperEnds, function (v) { driveOriginal('p-taper', v, true, 'change'); });
   }
@@ -120,7 +130,7 @@
     selectRow(params, 'Stabilisateur', state.stabilizer !== undefined ? state.stabilizer : 2, [
       { value: 0, label: 'Off' }, { value: 1, label: 'Low' }, { value: 2, label: 'Medium' }, { value: 3, label: 'High' },
       { value: 4, label: 'Plume — légère' }, { value: 5, label: 'Plume — moyenne' }, { value: 6, label: 'Plume — forte' },
-    ], function (v) { driveOriginal('p-stab', v, false, 'change'); });
+    ], function (v) { driveOriginal('p-stab', v, false, 'change'); }, STAB_TITLE);
   }
   function buildVectorGrid(container) {
     container.innerHTML = ''; // rebuilt on every selection (to move the .active highlight) — must replace, not append


### PR DESCRIPTION
## Summary
- Reported: "le smooth de la brush à 0 smooth toujours alors qu'il faudrait pas smooth si 0".
- Root cause investigation (real pointer-event stroke simulation, zigzag path): Smooth (Lissage) is not broken — at 0 it correctly skips `path.simplify()`, segments stay raw/straight. The residual smoothing comes from **Stabilizer**, a separate control (default "Medium") that averages the live drawn position while the pointer moves, entirely independent of Smooth. Measured: an identical zigzag loses ~1/3 of its amplitude at Stabilizer=Medium even with Smooth=0.
- Since the two controls are legitimately independent (live input smoothing vs. post-hoc path simplification), fixed via clarity rather than merging them:
  - Reordered Tool Options + the brush floating menu to put Stabilizer before Smooth (matches the real pipeline order).
  - Added explicit tooltips on both controls, in both places, explaining what each does and that a fully raw stroke needs Stabilizer OFF too.

## Test plan
- [x] Verified via synthetic pointer-event zigzag test: Smooth=0 + Stabilizer=Off → segments preserve full zigzag amplitude exactly.
- [x] Same test with Stabilizer=Medium (default) + Smooth=0 → amplitude flattened by ~1/3, confirming Stabilizer as the actual source.
- [x] Screenshot-confirmed new order + tooltips in both Tool Options panel and the brush floating menu.
- [x] `node --check` on both modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)