### PR TITLE
Remove right-panel Projet section, fold into burger menu

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -687,52 +687,32 @@
     <div class="psec" id="onion-sec">
       <div class="phdr" style="cursor:pointer" title="Clic : activer/désactiver l'onion skin (O). Options détaillées : clic-droit sur le bouton onion de la timeline."><span class="ar">☰</span> <span>Onion Skin</span> <span id="os-st-panel" style="margin-left:auto;margin-right:6px;font-size:9px;color:var(--green)">ON</span></div>
     </div>
-    <div class="psec">
-      <div class="phdr" id="phdr-project"><span class="ar">☰</span> <span data-i18n="hdrProject">Project</span></div>
-      <div class="pbdy">
-        <div class="pr" id="proj-current" style="font-size:9px;color:var(--text-dim)" title="Currently open project">Untitled (not saved)</div>
-        <div class="pr" style="gap:4px">
-          <button class="pbtn ac" id="btn-save" style="flex:1" title="Save (⌘S) — writes to the current file, or Save As if none yet"><span class="material-symbols-rounded" style="font-size:14px;vertical-align:middle">&#xe161;</span> Save</button>
-          <button class="pbtn" id="btn-saveas" title="Save As…"><span class="material-symbols-rounded" style="font-size:14px;vertical-align:middle">&#xe161;</span></button>
-        </div>
-        <div class="pr" style="gap:4px">
-          <button class="pbtn" id="btn-open" style="flex:1"><span class="material-symbols-rounded" style="font-size:14px;vertical-align:middle">&#xe2c8;</span> Open…</button>
-          <button class="pbtn" id="btn-new" style="flex:1"><span class="material-symbols-rounded" style="font-size:14px;vertical-align:middle">&#xe145;</span> New…</button>
-        </div>
-        <div class="pr" style="gap:4px">
-          <button class="pbtn" id="btn-kitsu-open" style="flex:1" title="Ouvrir un shot depuis la production Kitsu"><span class="material-symbols-rounded" style="font-size:14px;vertical-align:middle">&#xe80b;</span> Depuis Kitsu…</button>
-        </div>
-        <div class="pr" style="gap:4px">
-          <button class="pbtn" id="btn-history" style="flex:1" title="Historique des versions — un instantané automatique toutes les 30s, récupérable même après un crash"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:middle"><circle cx="12" cy="13" r="8"/><path d="M12 9v4l3 2"/><path d="M5 3 2 6"/><path d="M2 6h4"/></svg> Historique…</button>
-          <button class="pbtn" id="btn-settings" title="Réglages — raccourcis clavier"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:middle"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/></svg></button>
-        </div>
-        <div class="pr" id="kitsu-shot-row" style="font-size:9px;color:var(--text-dim);display:none"></div>
-        <div class="pr" id="kitsu-publish-row" style="gap:4px;display:none">
-          <button class="pbtn ac" id="btn-kitsu-publish" style="flex:1" title="Rend un MP4, l'envoie sur la tâche du shot et passe le statut en révision">Publier vers Kitsu</button>
-        </div>
-        <input type="file" id="file-input" accept=".json" style="display:none">
-        <div class="pr" style="gap:4px"><button class="pbtn" id="btn-export" style="flex:1"><span class="material-symbols-rounded" style="font-size:14px;vertical-align:middle">&#xe2c6;</span> Export…</button></div>
-        <!-- Document (Width/Height/FPS/Frames) fusionné dans la section
-             "Document" du panel (canvas-sec, en haut) — feedback audit
-             2026-07-17 : deux jeux de champs séparés pour la même taille de
-             canvas, resynchronisés seulement par le tick de rendu. FPS/Frames
-             gardent leurs ids proj-fps/proj-frames (juste déplacés). -->
-        <div class="phdr" style="padding-top:10px;font-size:9px;color:var(--text-dim)">Import</div>
-        <div class="pr" style="gap:4px"><button class="pbtn" id="btn-import-img" style="flex:1" title="Import bitmap image(s) — a numbered sequence (frame001.png, frame002.png…) auto-detects into a new animated layer, one image per frame"><span class="material-symbols-rounded" style="font-size:14px;vertical-align:middle">&#xe410;</span> Import Image(s)…</button></div>
-        <input type="file" id="image-input" accept="image/*" multiple style="display:none">
-        <!-- v14: video import decodes to a per-frame image sequence and
-             lands on a normal layer via the same isRaster pipeline as
-             Import Image(s) above — real layer, transformable/scalable/
-             opacity like anything else, no separate "video layer" concept. -->
-        <div class="pr" style="gap:4px"><button class="pbtn" id="btn-import-video" style="flex:1" title="Import a video — decoded to one image per frame at the project's fps and dropped onto a new animated layer, same as an image sequence"><svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" style="vertical-align:middle"><rect x="2" y="6" width="14" height="12" rx="2"/><path d="M17 10.5l4-2.5v8l-4-2.5z"/></svg> Import Video…</button></div>
-        <input type="file" id="video-input" accept="video/*" style="display:none">
-        <!-- PSD import (2026-07, audit gap "pas d'import/export PSD") — read-
-             only import, one Nemo layer per PSD layer (flat top-level layers
-             only, see psd-import-bridge.js's own scope note re: groups/text/
-             smart objects). No PSD export/write-back. -->
-        <div class="pr" style="gap:4px"><button class="pbtn" id="btn-import-psd" style="flex:1" title="Importe un fichier Photoshop .psd — un calque Nemo par calque PSD (image aplatie), les groupes sont aplatis en calques individuels"><span class="material-symbols-rounded" style="font-size:14px;vertical-align:middle">&#xe2c8;</span> Import PSD (calques)…</button></div>
-        <input type="file" id="psd-input" accept=".psd" style="display:none">
-      </div>
+    <!-- Ex-section "Projet" du panel de droite, supprimee (feedback 2026-07:
+         "l'onglet projet n'est plus utile on retrouve tous ces elements dans
+         le burger menu") -- tout ce qu'elle contenait est maintenant dans le
+         menu burger (#app-menu-btn, initAppMenu dans timeline.js), y compris
+         Depuis Kitsu/Historique/Import PSD qui n'y etaient pas encore. Les
+         boutons/inputs reels restent ici, caches : le menu leur envoie un
+         vrai .click() (clickEl(id)) plutot que de dupliquer leur logique, et
+         les modules tutoriel 'history'/'export' cliquent maintenant le menu
+         burger reel au lieu de cette section (voir tutorial.js). -->
+    <div id="legacy-project-actions" style="display:none">
+      <button id="btn-save"></button>
+      <button id="btn-saveas"></button>
+      <button id="btn-open"></button>
+      <button id="btn-new"></button>
+      <button id="btn-kitsu-open"></button>
+      <button id="btn-history"></button>
+      <button id="btn-settings"></button>
+      <button id="btn-kitsu-publish"></button>
+      <input type="file" id="file-input" accept=".json">
+      <button id="btn-export"></button>
+      <button id="btn-import-img"></button>
+      <input type="file" id="image-input" accept="image/*" multiple>
+      <button id="btn-import-video"></button>
+      <input type="file" id="video-input" accept="video/*">
+      <button id="btn-import-psd"></button>
+      <input type="file" id="psd-input" accept=".psd">
     </div>
   </div>
 </div>

--- a/src/js/project.js
+++ b/src/js/project.js
@@ -25,6 +25,12 @@
     el.textContent=currentPath?(currentName+' — '+currentPath):(currentName+' (not saved)');
     el.title=currentPath||'';
   }
+  // Used by the burger menu (timeline.js initAppMenu) now that the old
+  // right-panel "Projet" section (and its #proj-current row) is gone —
+  // same text updateCurrentLabel used to write there.
+  function getCurrentLabel(){
+    return currentPath?(currentName+' — '+currentPath):(currentName+' (not saved)');
+  }
 
   function baseName(path){
     var parts=path.split(/[\\/]/);var f=parts[parts.length-1]||path;
@@ -342,7 +348,7 @@
     // feedback-bridge.js's local + shared feedback storage keys off, so a
     // feedback thread and this project's own history/sync folders always
     // agree on which project they belong to without re-deriving the logic.
-    getProjectKey:historyKey,profileDir:profileDir,isDirty:isDirty,markSaved:function(){try{markSaved(window.SM.exportJSON());}catch(e){}}};
+    getProjectKey:historyKey,profileDir:profileDir,isDirty:isDirty,markSaved:function(){try{markSaved(window.SM.exportJSON());}catch(e){}},getCurrentLabel:getCurrentLabel};
 
   // ---- Close-with-unsaved-work guard ----
   // Cmd+Q / window-close with unsaved changes asked NOTHING before this —

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -3927,15 +3927,25 @@ function initAppMenu(){
   btn.addEventListener('click',function(e){
     e.stopPropagation();
     var r=btn.getBoundingClientRect();
-    window.showContextMenu(r.left,r.bottom+4,[
+    var items=[
+      // Live current-project label (feedback 2026-07: the right-panel
+      // "Projet" section was pure duplication of this menu — everything
+      // in it either already had an entry here or is added below. This
+      // disabled row replaces its old #proj-current text readout, the one
+      // thing in that section with no action of its own.
+      {label:(window.SMProject&&window.SMProject.getCurrentLabel)?window.SMProject.getCurrentLabel():'Untitled (not saved)',disabled:true},
+      {sep:true},
       {label:'Nouveau projet',shortcut:'⌘N',action:function(){clickEl('project-tab-add');}},
       {label:'Ouvrir…',shortcut:'⌘O',action:function(){if(window.SMProject)window.SMProject.open();}},
       {label:'Enregistrer',shortcut:'⌘S',action:function(){if(window.SMProject)window.SMProject.save();}},
       {label:'Enregistrer sous…',shortcut:'⇧⌘S',action:function(){if(window.SMProject)window.SMProject.saveAs();}},
+      {label:'Depuis Kitsu…',id:'ctx-kitsu-open',action:function(){clickEl('btn-kitsu-open');}},
+      {label:'Historique des versions…',id:'ctx-history',action:function(){clickEl('btn-history');}},
       {sep:true},
       {label:'Importer image(s)…',action:function(){clickEl('btn-import-img');}},
       {label:'Importer vidéo…',action:function(){clickEl('btn-import-video');}},
-      {label:'Exporter…',action:function(){clickEl('btn-export');}},
+      {label:'Importer PSD (calques)…',id:'ctx-import-psd',action:function(){clickEl('btn-import-psd');}},
+      {label:'Exporter…',id:'ctx-export',action:function(){clickEl('btn-export');}},
       {sep:true},
       {label:'Réglages',action:function(){clickEl('btn-settings');}},
       {label:'Raccourcis clavier',action:function(){
@@ -3948,7 +3958,17 @@ function initAppMenu(){
         var t=document.querySelector('#settings-tabs .settings-tab[data-tab="updates"]');
         if(t)t.click();
       }}
-    ]);
+    ];
+    // Kitsu publish only makes sense once a shot is actually open — mirrors
+    // the old kitsu-shot-row/kitsu-publish-row's own show/hide condition
+    // (kitsu.js's updateKitsuShotUI), just decided fresh at menu-open time
+    // instead of a persistent DOM row kept in sync.
+    var ks=window.SMKitsu&&window.SMKitsu.getCurrentShot&&window.SMKitsu.getCurrentShot();
+    if(ks){
+      items.splice(1,0,{label:'Kitsu: '+ks.projectName+(ks.sequenceName?' / '+ks.sequenceName:'')+' / '+ks.shotName+(ks.taskName?' ('+ks.taskName+')':''),disabled:true});
+      items.splice(2,0,{label:'Publier vers Kitsu',id:'ctx-kitsu-publish',action:function(){clickEl('btn-kitsu-publish');}});
+    }
+    window.showContextMenu(r.left,r.bottom+4,items);
   });
 }
 if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',initAppMenu);else initAppMenu();

--- a/src/js/tutorial.js
+++ b/src/js/tutorial.js
@@ -254,15 +254,16 @@
     ["Clic-droit sur une pastille propose \"Remplacer dans le calque…\" — pratique pour recolorer tous les traits d'une teinte en une fois. Le \"+\" au-dessus des palettes en crée une nouvelle.", "Right-clicking a swatch offers \"Replace in layer…\" — handy for recoloring every stroke of one shade at once. The \"+\" above the palettes creates a new one.", "Clic derecho en una muestra ofrece \"Reemplazar en la capa…\" — práctico para recolorear todos los trazos de un tono a la vez. El \"+\" encima de las paletas crea una nueva.", "スウォッチを右クリックすると「レイヤー内で置換…」が表示されます — 同じ色のすべての線を一括で塗り替えるのに便利です。パレット上部の「+」で新しいパレットを作成できます。"],
     ["Clique \"Apply\" (ou Ctrl/Cmd+Entrée) pour poser le texte sur le canevas.", "Click \"Apply\" (or Ctrl/Cmd+Enter) to place the text on the canvas.", "Haz clic en \"Apply\" (o Ctrl/Cmd+Intro) para colocar el texto en el lienzo.", "「Apply」（またはCtrl/Cmd+Enter）をクリックしてテキストをキャンバスに配置します。"],
     ["Clique \"Choisir…\" pour voir comment on désigne un dossier partagé (nécessite l'app desktop — un simple message s'affiche ici en preview navigateur).", "Click \"Choose…\" to see how a shared folder is designated (requires the desktop app — just a message shows here in the browser preview).", "Haz clic en \"Elegir…\" para ver cómo se designa una carpeta compartida (requiere la app de escritorio — aquí en la vista previa del navegador solo se muestra un mensaje).", "「選択…」をクリックして共有フォルダの指定方法を確認します（デスクトップアプリが必要 — このブラウザプレビューでは単純なメッセージが表示されるだけです）。"],
-    ["Clique \"Export…\" dans le panneau de droite (section Projet).", "Click \"Export…\" in the right panel (Project section).", "Haz clic en \"Export…\" en el panel derecho (sección Proyecto).", "右パネルの「Export…」をクリック（Projetセクション内）。"],
+    ["Clique \"Exporter…\" dans le menu.", "Click \"Export…\" in the menu.", "Haz clic en \"Exportar…\" en el menú.", "メニューの「Exporter…」をクリックします。"],
     ["Clique \"Frame suivante\" 2 ou 3 fois pour te placer plus loin dans la timeline.", "Click \"Next frame\" 2 or 3 times to move further along the timeline.", "Haz clic en \"Siguiente fotograma\" 2 o 3 veces para avanzar en la línea de tiempo.", "「次のフレーム」を2〜3回クリックして、タイムラインの先へ進みます。"],
     ["Clique \"Frame suivante\" plusieurs fois (ou glisse le curseur) pour te placer 5 à 10 frames plus loin.", "Click \"Next frame\" several times (or drag the playhead) to move 5 to 10 frames further.", "Haz clic en \"Siguiente fotograma\" varias veces (o arrastra el cursor) para avanzar de 5 a 10 fotogramas.", "「次のフレーム」を何度かクリック（またはカーソルをドラッグ）して5〜10フレーム先へ進みます。"],
     ["Clique \"Frame suivante\" plusieurs fois pour te placer plus loin.", "Click \"Next frame\" several times to move further along.", "Haz clic en \"Siguiente fotograma\" varias veces para avanzar.", "「次のフレーム」を何度かクリックして先へ進みます。"],
     ["Clique \"Frame suivante\" pour voir les frames voisines apparaître en fantôme.", "Click \"Next frame\" to see the neighboring frames appear as ghosts.", "Haz clic en \"Siguiente fotograma\" para ver los fotogramas vecinos aparecer como fantasmas.", "「次のフレーム」をクリックすると、前後のフレームが半透明の残像として表示されます。"],
-    ["Clique \"Historique…\" dans le panneau de droite (section Projet).", "Click \"History…\" in the right panel (Project section).", "Haz clic en \"Historial…\" en el panel derecho (sección Proyecto).", "右パネルの「Historique…」をクリック（Projetセクション内）。"],
+    ["Clique \"Historique des versions…\" dans le menu.", "Click \"Version history…\" in the menu.", "Haz clic en \"Historial de versiones…\" en el menú.", "メニューの「Historique des versions…」をクリックします。"],
     ["Clique l'en-tête \"Perspective Guide\" dans le panneau de droite pour la déplier, si besoin.", "Click the \"Perspective Guide\" header in the right panel to expand it, if needed.", "Haz clic en el encabezado \"Perspective Guide\" del panel derecho para desplegarlo, si es necesario.", "必要であれば、右パネルの「Perspective Guide」見出しをクリックして開きます。"],
     ["Clique l'en-tête \"Project\" dans le panneau de droite pour la déplier.", "Click the \"Project\" header in the right panel to expand it.", "Haz clic en el encabezado \"Project\" del panel derecho para desplegarlo.", "右パネルの「Project」見出しをクリックして開きます。"],
     ["Clique l'en-tête \"Projet\" dans le panneau de droite pour la déplier, si besoin.", "Click the \"Project\" header in the right panel to expand it, if needed.", "Haz clic en el encabezado \"Proyecto\" del panel derecho para desplegarlo, si es necesario.", "必要であれば、右パネルの「Projet」見出しをクリックして開きます。"],
+    ["Clique l'icône ☰ en haut à gauche.", "Click the ☰ icon at the top left.", "Haz clic en el icono ☰ en la parte superior izquierda.", "左上の☰アイコンをクリックします。"],
     ["Clique l'icône en forme de roue crantée en haut de l'écran.", "Click the gear icon at the top of the screen.", "Haz clic en el icono de engranaje en la parte superior de la pantalla.", "画面上部の歯車アイコンをクリックします。"],
     ["Clique l'onglet \"Animation 2D\" en haut de l'écran.", "Click the \"Animation 2D\" tab at the top of the screen.", "Haz clic en la pestaña \"Animation 2D\" en la parte superior de la pantalla.", "画面上部の「Animation 2D」タブをクリックします。"],
     ["Clique l'onglet \"Collaboration\" en haut de la fenêtre de Réglages.", "Click the \"Collaboration\" tab at the top of the Settings window.", "Haz clic en la pestaña \"Collaboration\" en la parte superior de la ventana de Ajustes.", "設定ウィンドウ上部の「Collaboration」タブをクリックします。"],
@@ -1001,13 +1002,11 @@
       time: '1 min',
       steps: [
         { type: 'info', title: 'Remonter dans le temps', body: 'Nemo prend un instantané automatique toutes les 30 secondes — récupérable même après un crash, pas seulement la dernière session.' },
-        // The "Project" section (right panel) starts COLLAPSED by default
-        // (.pbdy has the .hid class on load) — #btn-history is 0x0 and
-        // unclickable until its header is opened. Found live: the spotlight
-        // highlighted nothing, because getBoundingClientRect() on a
-        // display:none descendant is legitimately zero.
-        { type: 'click', target: '#phdr-project', title: 'Ouvre la section "Project"', body: 'Clique l\'en-tête "Project" dans le panneau de droite pour la déplier.' },
-        { type: 'click', target: '#btn-history', title: 'Ouvre l\'historique', body: 'Clique "Historique…" dans le panneau de droite (section Projet).' },
+        // The old "Project" right-panel section is gone (feedback 2026-07 —
+        // duplicated the burger menu) — #btn-history now lives hidden in
+        // #legacy-project-actions, only reachable through the real menu.
+        { type: 'click', target: '#app-menu-btn', title: 'Ouvre le menu', body: 'Clique l\'icône ☰ en haut à gauche.' },
+        { type: 'click', target: '#ctx-history', title: 'Ouvre l\'historique', body: 'Clique "Historique des versions…" dans le menu.' },
         { type: 'info', title: 'Bien joué !', body: 'Restaurer un ancien instantané prend d\'abord un instantané de l\'état actuel — l\'opération reste donc elle-même annulable.' }
       ]
     },
@@ -1071,21 +1070,14 @@
       // reste donc volontairement au niveau "ouvrir/configurer" : chaque
       // étape est un vrai clic/changement réel sur la vraie fenêtre
       // d'export, sans jamais cliquer "Exporter" pour de vrai.
-      // #btn-export vit dans le panneau de droite, section "Projet" —
-      // COLLAPSÉE par défaut (même piège que #btn-history, voir module
-      // 'history' plus haut). Étape tolérante façon 'perspective' : si la
-      // section est déjà ouverte (ex. module Historique fait juste avant
-      // dans la même session), un re-clic sur son en-tête la refermerait —
-      // on attend juste que le bouton devienne visible, qu'il ait fallu
-      // cliquer ou non.
+      // #btn-export vit désormais caché dans #legacy-project-actions
+      // (l'ancienne section "Projet" du panel de droite a été supprimée,
+      // feedback 2026-07 — dupliquait le menu burger) — seul accès réel :
+      // le menu burger, comme le module 'history' juste au-dessus.
       steps: [
         { type: 'info', title: 'Sortir ton animation', body: 'Nemo exporte en PNG/TIFF/GIF/MP4/ProRes, en SVG, en Lottie (JSON animé) ou en projet Rive/After Effects — un seul bouton, plusieurs formats.' },
-        {
-          type: 'state', target: '#phdr-project', title: 'Ouvre la section "Projet"', body: 'Clique l\'en-tête "Projet" dans le panneau de droite pour la déplier, si besoin.',
-          hint: 'En attente…',
-          check: function (win) { var el = win.document.getElementById('btn-export'); return !!(el && el.getBoundingClientRect().height > 0); }
-        },
-        { type: 'click', target: '#btn-export', title: 'Ouvre la fenêtre d\'export', body: 'Clique "Export…" dans le panneau de droite (section Projet).' },
+        { type: 'click', target: '#app-menu-btn', title: 'Ouvre le menu', body: 'Clique l\'icône ☰ en haut à gauche.' },
+        { type: 'click', target: '#ctx-export', title: 'Ouvre la fenêtre d\'export', body: 'Clique "Exporter…" dans le menu.' },
         stateChangedStep({
           target: '#exp-format', title: 'Choisis un format', body: 'Ouvre le menu déroulant "Format" et choisis "Lottie" pour voir la fenêtre s\'adapter (les options d\'échelle disparaissent, un aperçu scrubbable s\'ouvrira après export).',
           hint: 'En attente de ton choix…', measure: function (win) { var el = win.document.getElementById('exp-format'); return el ? el.value : ''; }

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -812,6 +812,7 @@
     items.forEach(function(it){
       if(it.sep){var s=document.createElement('div');s.className='ctx-sep';m.appendChild(s);return;}
       var row=document.createElement('div');row.className='ctx-item'+(it.disabled?' disabled':'');
+      if(it.id)row.id=it.id;
       var lbl=document.createElement('span');lbl.textContent=it.label;row.appendChild(lbl);
       if(it.shortcut){var sc=document.createElement('span');sc.className='ctx-sc';sc.textContent=it.shortcut;row.appendChild(sc);}
       if(!it.disabled)row.addEventListener('click',function(e){e.stopPropagation();closeCtxMenu();it.action();});


### PR DESCRIPTION
## Summary
- Feedback: "l'onglet projet n'est plus utile on retrouve tous ces éléments dans le burger menu" — the right-panel "Projet" section duplicated the existing burger menu (New/Open/Save/Save As/Import/Export/Settings) or was missing a few real entry points from it (Depuis Kitsu, Historique des versions, Import PSD, the current-project label, Kitsu publish).
- Added the missing entries to the burger menu (`initAppMenu`, timeline.js), including a live current-project label and a Kitsu status/publish pair shown only when a shot is open.
- Removed the visible section from index.html; its real buttons/inputs stay in the DOM (hidden) so every existing id-based listener keeps working — the menu just sends them a real `.click()`.
- Updated the 2 tutorial modules ('history', 'export') that used to click those buttons directly inside the now-removed section — they now open the burger menu first, matching the real path a user takes.

## Test plan
- [x] Verified in browser: right panel no longer shows "Projet"; burger menu shows the live "Untitled (not saved)" label, Nouveau projet/Ouvrir/Enregistrer/Enregistrer sous, Depuis Kitsu, Historique des versions, Importer image(s)/vidéo/PSD, Exporter, Réglages/Raccourcis/À propos.
- [x] `node --check` on all modified JS files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)