### PR TITLE
Unify checkbox design, remove 3 redundant right-panel sections

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -246,6 +246,12 @@ body.mac-overlay-titlebar #app{padding-top:28px;}
 .labs-float-stepper .lfs-btn{width:20px;height:22px;border:none;background:transparent;color:rgba(236,234,231,.75);font-size:13px;line-height:1;cursor:pointer;display:flex;align-items:center;justify-content:center;}
 .labs-float-stepper .lfs-btn:hover{background:rgba(255,255,255,.09);color:var(--text);}
 .labs-float-stepper .lfs-val{min-width:26px;text-align:center;font-size:10.5px;font-weight:600;color:var(--text);padding:0 2px;}
+/* Wide toggle/action pills (Extend/Lock/Reset, moved here from the removed
+   right-panel Perspective/Symmetry sections) — same stepper pill shell,
+   just one full-width button instead of −/value/+. .on marks a toggle
+   (Extend/Lock) as currently active; a plain action (Reset) never gets it. */
+.labs-float-stepper .lfs-btn.wide{width:auto;padding:0 9px;font-size:10px;font-weight:600;color:var(--text-dim);}
+.labs-float-stepper .lfs-btn.wide.on{background:var(--accent-dim);color:var(--accent-hover);}
 #zoom-scrub:focus{color:var(--text);outline:none;}
 #zoom-scrub.scrubbing{color:var(--accent-hover);}
 
@@ -290,6 +296,21 @@ body.mac-overlay-titlebar #app{padding-top:28px;}
 .pi{flex:1;background:var(--panel3);border:none;color:var(--text);border-radius:6px;padding:5px 8px;font-size:12.5px;font-weight:600;outline:none;box-shadow:inset 0 0 0 1px transparent;transition:box-shadow .15s;}
 .pi:focus{box-shadow:inset 0 0 0 1px var(--accent);}
 .pi[type="range"]{padding:0;border:none;background:transparent;accent-color:var(--accent);}
+/* Unified checkbox design (feedback 2026-07: "tous les checkbox qui
+   apparraissent dans l'app devrait avoir cette apparence") — a single
+   global rule on the type selector, not a class, so every existing
+   `<input type="checkbox">` across the app (right panel toggles, brush
+   menu, Labs float panel, dynamically-built rows) picks it up automatically
+   with zero HTML changes. Custom-drawn (appearance:none) rather than
+   relying on accent-color alone — native checkbox rendering still varies
+   subtly across browsers/OSes even with accent-color set, which read as
+   "inconsistent" across the app's own controls. */
+input[type="checkbox"]{-webkit-appearance:none;appearance:none;width:14px;height:14px;flex:none;margin:0;border:1px solid var(--border2);border-radius:3px;background:var(--panel3);cursor:pointer;position:relative;transition:background .12s,border-color .12s;}
+input[type="checkbox"]:hover{border-color:rgba(255,255,255,.3);}
+input[type="checkbox"]:focus-visible{box-shadow:0 0 0 2px var(--accent-dim);}
+input[type="checkbox"]:checked{background:var(--accent);border-color:var(--accent);}
+input[type="checkbox"]:checked::after{content:'';position:absolute;left:4px;top:1px;width:4px;height:8px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg);}
+input[type="checkbox"]:disabled{opacity:.4;cursor:not-allowed;}
 /* min-width:0 — with flex:1 these grow, but the default min-width:auto kept
    them from ever shrinking below width+padding (~70px); in rows that also
    carry a fixed-width widget (Position/Size/Rotate + the 9-dot anchor grid)

--- a/src/index.html
+++ b/src/index.html
@@ -400,6 +400,24 @@
              "plain per-layer field" convention as Blend/Matte above.
              0 = off (the vast majority of layers), no GPU cost. -->
         <div class="pr"><span class="pl">Flou</span><input type="number" class="pi scrub" id="p-blur" value="0" min="0" max="100" data-step="1" title="Flou gaussien (approx.) appliqué à tout le calque, en pixels"><span style="font-size:9px;color:var(--text-dim)">px</span></div>
+        <!-- Référence (roto) — déplacée ici depuis sa propre section
+             toujours-visible (feedback 2026-07: "référence (roto) onglet
+             n'a plus lieu d'être doit être géré par le panneau calque en
+             fonction de la sélection de l'élément") : reste une référence
+             GLOBALE au projet (state.refMedia, reference-bridge.js — un
+             seul clip de roto, pas par-calque), mais son contrôle ne
+             s'affiche plus que dans le contexte du panneau Layer,
+             c'est-à-dire quand un calque est sélectionné, via la même
+             condition que Blend/Matte/Flou ci-dessus. -->
+        <div class="pr" style="gap:4px;margin-top:6px">
+          <button class="pbtn" id="btn-ref-import" title="Importer une vidéo, une séquence d'images (sélection multiple) ou une image seule comme référence de rotoscopie">Référence…</button>
+          <button class="pbtn" id="btn-ref-remove" disabled>Retirer</button>
+          <input type="file" id="ref-file-input" accept="video/*,image/*" multiple style="display:none">
+        </div>
+        <div class="pr" style="font-size:9px;color:var(--text-dim)" id="p-ref-name">Aucune référence</div>
+        <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer"><input type="checkbox" id="p-ref-on"> Visible</label></div>
+        <div class="pr"><span class="pl">Opacity</span><input type="range" id="p-ref-opacity" min="5" max="100" value="50" style="flex:1"></div>
+        <div class="pr"><span class="pl">Offset</span><input type="number" class="pi scrub" id="p-ref-offset" value="0" data-step="1" title="Frame de la timeline où la référence démarre"></div>
       </div>
     </div>
     <div class="psec" id="canvas-sec">
@@ -579,43 +597,16 @@
         </div>
       </div>
     </div>
-    <div class="psec">
-      <div class="phdr" id="phdr-perspective"><span class="ar">☰</span> <span data-i18n="hdrPerspective">Perspective Guide</span></div>
-      <div class="pbdy">
-        <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer" title="Shows the vanishing-point grid and snaps the Line tool toward it, from any tool"><input type="checkbox" id="p-persp-on" style="accent-color:var(--accent)"> Enabled</label></div>
-        <div class="pr"><span class="pl">Mode</span><select class="psel" id="p-persp-mode"><option value="1pt">1 point</option><option value="2pt" selected>2 points</option><option value="3pt">3 points</option><option value="fisheye">Fisheye</option></select></div>
-        <div class="pr"><span class="pl">Density</span><input type="number" class="pi scrub" id="p-persp-density" value="24" min="4" max="72" data-step="2"></div>
-        <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer" title="Prevents dragging any vanishing point with the Perspective tool"><input type="checkbox" id="p-persp-lock" style="accent-color:var(--accent)"> Lock vanishing points</label></div>
-        <div class="pr" style="gap:4px"><button class="pbtn" id="btn-persp-reset">Reset positions</button></div>
-        <div class="pr" style="font-size:9px;color:var(--text-dim)">Select the ◇ tool to drag vanishing points. Draw a Line roughly toward one to snap onto it.</div>
-      </div>
-    </div>
-    <div class="psec">
-      <div class="phdr" id="phdr-symmetry"><span class="ar">☰</span> <span data-i18n="hdrSymmetry">Symmetry Guide</span></div>
-      <div class="pbdy">
-        <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer" title="Mirrors (or rotates, in Radial mode) every stroke drawn with any tool"><input type="checkbox" id="p-sym-on" style="accent-color:var(--accent)"> Enabled</label></div>
-        <div class="pr"><span class="pl">Mode</span><select class="psel" id="p-sym-mode"><option value="y" selected>Vertical (Y)</option><option value="x">Horizontal (X)</option><option value="free">Free angle</option><option value="radial">Radial (mandala)</option></select></div>
-        <div class="pr" id="p-sym-sectors-row" style="display:none"><span class="pl">Sectors</span><input type="number" class="pi scrub" id="p-sym-sectors" value="6" min="2" max="24" data-step="1"></div>
-        <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer" title="Off: a stroke crossing the axis is cut right at it, so it and its mirror never overlap at the fold"><input type="checkbox" id="p-sym-extend" checked style="accent-color:var(--accent)"> Extend strokes across the axis</label></div>
-        <div class="pr" style="gap:4px"><button class="pbtn" id="btn-sym-reset">Reset position</button></div>
-        <div class="pr" style="font-size:9px;color:var(--text-dim)">Select the ⧗ tool to drag the axis (its ends in Free mode, or the center in Radial mode). Draw with any tool once enabled.</div>
-      </div>
-    </div>
-    <div class="psec" id="ref-sec">
-      <div class="phdr" id="phdr-reference"><span class="ar">☰</span> <span data-i18n="hdrReference">Référence (roto)</span></div>
-      <div class="pbdy">
-        <div class="pr" style="gap:4px">
-          <button class="pbtn" id="btn-ref-import" title="Importer une vidéo, une séquence d'images (sélection multiple) ou une image seule comme référence de rotoscopie">Importer…</button>
-          <button class="pbtn" id="btn-ref-remove" disabled>Retirer</button>
-          <input type="file" id="ref-file-input" accept="video/*,image/*" multiple style="display:none">
-        </div>
-        <div class="pr" style="font-size:9px;color:var(--text-dim)" id="p-ref-name">Aucune référence</div>
-        <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer"><input type="checkbox" id="p-ref-on" style="accent-color:var(--accent)"> Visible</label></div>
-        <div class="pr"><span class="pl">Opacity</span><input type="range" id="p-ref-opacity" min="5" max="100" value="50" style="flex:1"></div>
-        <div class="pr"><span class="pl">Offset</span><input type="number" class="pi scrub" id="p-ref-offset" value="0" data-step="1" title="Frame de la timeline où la référence démarre"></div>
-        <div class="pr" style="font-size:9px;color:var(--text-dim)">S'affiche sous le dessin, suit la frame courante (vidéo/séquence). Jamais exportée.</div>
-      </div>
-    </div>
+    <!-- Perspective/Symmetry Guide sections removed (feedback 2026-07:
+         "on en a plus besoin ici car ils sont dans le menu flottant") --
+         every control (on/off, mode, density/sectors, lock/extend, reset)
+         now lives in the Labs floating panel (labs-float-panel.js), which
+         already mirrored on/off + mode before this and gained the rest
+         (Density/Lock/Reset, Extend/Reset) alongside this removal so
+         nothing was lost, just relocated. -->
+    <!-- Reference (roto) section removed — its controls moved into
+         #layer-sec above (feedback 2026-07: "doit être géré par le
+         panneau calque en fonction de la sélection de l'élément"). -->
     <!-- Motion mode only (hidden otherwise via body:not(.mode-motion),
          style.css) — the active layer's Transform properties mirrored into
          the right panel, populated by motion.js renderMotionPropsPanel(). -->
@@ -678,15 +669,12 @@
         <div class="pr"><button class="pbtn" id="btn-comp-detach" style="flex:1" title="Bake the component's animation back into a normal layer">Décomposer en calque</button></div>
       </div>
     </div>
-    <!-- Onion Skin en section du panel (mockup 2026-07-17) : header +
-         badge ON/OFF. Clic sur le header = toggle (même action que le
-         bouton timeline #btn-os / touche O) ; les OPTIONS détaillées
-         restent dans le popover #onion-pop (clic-droit sur #btn-os).
-         Le badge est un id distinct de #os-st (celui du popover) —
-         toggleOnion (timeline.js) met à jour les deux. -->
-    <div class="psec" id="onion-sec">
-      <div class="phdr" style="cursor:pointer" title="Clic : activer/désactiver l'onion skin (O). Options détaillées : clic-droit sur le bouton onion de la timeline."><span class="ar">☰</span> <span>Onion Skin</span> <span id="os-st-panel" style="margin-left:auto;margin-right:6px;font-size:9px;color:var(--green)">ON</span></div>
-    </div>
+    <!-- Onion Skin right-panel section removed (feedback 2026-07: "plus
+         besoin de l'onglet onion skin dans le panneau droit tout se fait
+         sur le bouton de la timeline") — it was purely a redundant toggle
+         mirror of #btn-os anyway (mockup 2026-07-17's own comment already
+         said as much); the toolbar button + its right-click popover
+         (#onion-pop) remain the one real entry point. -->
     <!-- Ex-section "Projet" du panel de droite, supprimee (feedback 2026-07:
          "l'onglet projet n'est plus utile on retrouve tous ces elements dans
          le burger menu") -- tout ce qu'elle contenait est maintenant dans le

--- a/src/js/labs/labs-float-panel.js
+++ b/src/js/labs/labs-float-panel.js
@@ -168,6 +168,8 @@
     return names.filter(function (n) { return registered.hasOwnProperty(n) || REAL_FEATURES.hasOwnProperty(n) || ACTIONS.hasOwnProperty(n); });
   }
   var SYM_MODES = ['y', 'x', 'free', 'radial'];
+  var PERSP_MODES = ['1pt', '2pt', '3pt', 'fisheye'];
+  var PERSP_MODE_LABEL = { '1pt': '1pt', '2pt': '2pt', '3pt': '3pt', fisheye: 'Fisheye' };
   var SYM_MODE_LABEL = { y: 'Y', x: 'X', free: 'Libre', radial: 'Radial' };
 
   function renderLabsFloatPanel() {
@@ -263,6 +265,82 @@
         secPill.appendChild(secLbl); secPill.appendChild(secMinus); secPill.appendChild(secVal); secPill.appendChild(secPlus);
         paramsWrap.appendChild(secPill);
       }
+      // Extend/Reset (2026-07): moved here from the now-removed right-panel
+      // "Symmetry Guide" section (feedback: "les onglet guide symétrie et
+      // perspective n'ont plus lieu d'être, les options doivent être gérées
+      // au niveau du panneau flottant") — same wide-toggle-pill/action-pill
+      // shape as Perspective's own Lock/Reset just below.
+      var extPill = document.createElement('div'); extPill.className = 'labs-float-stepper';
+      var extBtn = document.createElement('button'); extBtn.className = 'lfs-btn wide' + (state.symmetryExtend ? ' on' : '');
+      extBtn.textContent = 'Extend'; extBtn.title = "Off: a stroke crossing the axis is cut right at it, so it and its mirror never overlap at the fold";
+      extBtn.addEventListener('click', function () {
+        state.symmetryExtend = !state.symmetryExtend;
+        extBtn.classList.toggle('on', state.symmetryExtend);
+      });
+      extPill.appendChild(extBtn);
+      paramsWrap.appendChild(extPill);
+      var symResetPill = document.createElement('div'); symResetPill.className = 'labs-float-stepper';
+      var symResetBtn = document.createElement('button'); symResetBtn.className = 'lfs-btn wide';
+      symResetBtn.textContent = 'Reset'; symResetBtn.title = 'Reset position';
+      symResetBtn.addEventListener('click', function () { if (window.resetSymmetryGuide) window.resetSymmetryGuide(); });
+      symResetPill.appendChild(symResetBtn);
+      paramsWrap.appendChild(symResetPill);
+    }
+    if (registered.perspective) {
+      // Mode/Density/Lock/Reset (2026-07): moved here from the removed
+      // right-panel "Perspective Guide" section (same feedback as
+      // Symmetry's Extend/Reset above) — only on/off was mirrored here
+      // before, so this panel had no Mode control at all yet either.
+      anyParams = true;
+      var pModePill = document.createElement('div'); pModePill.className = 'labs-float-stepper';
+      var pModeLbl = document.createElement('span'); pModeLbl.className = 'lfs-label'; pModeLbl.textContent = 'Mode';
+      var pModePrev = document.createElement('button'); pModePrev.className = 'lfs-btn'; pModePrev.textContent = '−';
+      var pModeVal = document.createElement('span'); pModeVal.className = 'lfs-val';
+      var pModeNext = document.createElement('button'); pModeNext.className = 'lfs-btn'; pModeNext.textContent = '+';
+      function cyclePerspMode(dir) {
+        var i = PERSP_MODES.indexOf(state.perspectiveMode);
+        var next = PERSP_MODES[(i + dir + PERSP_MODES.length) % PERSP_MODES.length];
+        if (window.setPerspectiveMode) window.setPerspectiveMode(next);
+        pModeVal.textContent = PERSP_MODE_LABEL[next];
+      }
+      pModeVal.textContent = PERSP_MODE_LABEL[state.perspectiveMode] || state.perspectiveMode;
+      pModePrev.addEventListener('click', function () { cyclePerspMode(-1); });
+      pModeNext.addEventListener('click', function () { cyclePerspMode(1); });
+      pModePill.appendChild(pModeLbl); pModePill.appendChild(pModePrev); pModePill.appendChild(pModeVal); pModePill.appendChild(pModeNext);
+      paramsWrap.appendChild(pModePill);
+      var densPill = document.createElement('div'); densPill.className = 'labs-float-stepper';
+      var densLbl = document.createElement('span'); densLbl.className = 'lfs-label'; densLbl.textContent = 'Densité';
+      var densMinus = document.createElement('button'); densMinus.className = 'lfs-btn'; densMinus.textContent = '−';
+      var densVal = document.createElement('span'); densVal.className = 'lfs-val'; densVal.textContent = state.perspectiveDensity;
+      var densPlus = document.createElement('button'); densPlus.className = 'lfs-btn'; densPlus.textContent = '+';
+      function setDensity(v) {
+        state.perspectiveDensity = Math.max(4, Math.min(72, v));
+        densVal.textContent = state.perspectiveDensity;
+        if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+      }
+      densMinus.addEventListener('click', function () { setDensity(state.perspectiveDensity - 2); });
+      densPlus.addEventListener('click', function () { setDensity(state.perspectiveDensity + 2); });
+      densPill.appendChild(densLbl); densPill.appendChild(densMinus); densPill.appendChild(densVal); densPill.appendChild(densPlus);
+      paramsWrap.appendChild(densPill);
+      var lockPill = document.createElement('div'); lockPill.className = 'labs-float-stepper';
+      var lockBtn = document.createElement('button'); lockBtn.className = 'lfs-btn wide';
+      lockBtn.textContent = 'Lock'; lockBtn.title = 'Prevents dragging any vanishing point with the Perspective tool';
+      var vpsNow = window.ensurePerspectiveVPs ? window.ensurePerspectiveVPs() : [];
+      lockBtn.classList.toggle('on', !!(vpsNow.length && vpsNow.every(function (vp) { return vp.locked; })));
+      lockBtn.addEventListener('click', function () {
+        var locked = !lockBtn.classList.contains('on');
+        (window.ensurePerspectiveVPs ? window.ensurePerspectiveVPs() : []).forEach(function (vp) { vp.locked = locked; });
+        lockBtn.classList.toggle('on', locked);
+        if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+      });
+      lockPill.appendChild(lockBtn);
+      paramsWrap.appendChild(lockPill);
+      var perspResetPill = document.createElement('div'); perspResetPill.className = 'labs-float-stepper';
+      var perspResetBtn = document.createElement('button'); perspResetBtn.className = 'lfs-btn wide';
+      perspResetBtn.textContent = 'Reset'; perspResetBtn.title = 'Reset positions';
+      perspResetBtn.addEventListener('click', function () { if (window.resetPerspectiveVPs) window.resetPerspectiveVPs(); });
+      perspResetPill.appendChild(perspResetBtn);
+      paramsWrap.appendChild(perspResetPill);
     }
     shown.forEach(function (n) {
       if (!registered[n] || !PARAMS[n]) return;

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1111,15 +1111,7 @@ window.SM={
     state.mediaLibrary=d.mediaLibrary||[];
     if(window.SMMediaLibrary)SMMediaLibrary.reload();
     state.perspectiveEnabled=d.perspectiveEnabled||false;state.perspectiveMode=d.perspectiveMode||'2pt';state.perspectiveDensity=d.perspectiveDensity||24;state.perspectiveVPs=d.perspectiveVPs||null;
-    var perspOnCb=document.getElementById('p-persp-on');if(perspOnCb)perspOnCb.checked=state.perspectiveEnabled;
-    var perspModeSel=document.getElementById('p-persp-mode');if(perspModeSel)perspModeSel.value=state.perspectiveMode;
-    var perspDensityInp=document.getElementById('p-persp-density');if(perspDensityInp)perspDensityInp.value=state.perspectiveDensity;
     state.symmetryEnabled=d.symmetryEnabled||false;state.symmetryMode=d.symmetryMode||'y';state.symmetryAxis=d.symmetryAxis||null;state.symmetryRadialCenter=d.symmetryRadialCenter||null;state.symmetryRadialSectors=d.symmetryRadialSectors||6;state.symmetryExtend=d.symmetryExtend!==undefined?d.symmetryExtend:true;
-    var symOnCb=document.getElementById('p-sym-on');if(symOnCb)symOnCb.checked=state.symmetryEnabled;
-    var symModeSel=document.getElementById('p-sym-mode');if(symModeSel)symModeSel.value=state.symmetryMode;
-    var symSectorsInp=document.getElementById('p-sym-sectors');if(symSectorsInp)symSectorsInp.value=state.symmetryRadialSectors;
-    var symExtendCb=document.getElementById('p-sym-extend');if(symExtendCb)symExtendCb.checked=state.symmetryExtend;
-    if(window.syncSymmetryPanelVisibility)window.syncSymmetryPanelVisibility();
     if(window.renderPaletteGrid)window.renderPaletteGrid();
     if(d.resamplePts)state.resamplePts=d.resamplePts;if(d.tweenStep)state.tweenStep=d.tweenStep;
     state.currentFrame=0;state.activeLayerIdx=0;activateUL(0);drawStage();loadFrame(0);renderOS();renderArcs();updateUI();renderSymbolTabs();
@@ -4870,27 +4862,15 @@ document.getElementById('p-effect-brightness').addEventListener('input',function
 document.getElementById('p-effect-contrast').addEventListener('input',function(){var ld=state.layers[state.activeLayerIdx];if(!ld||!ld.isEffectLayer)return;pushUndo();ld.effectP2=(parseFloat(this.value)||0)/100;saveActiveLayerFrame();if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
 document.getElementById('p-effect-vig-strength').addEventListener('input',function(){var ld=state.layers[state.activeLayerIdx];if(!ld||!ld.isEffectLayer)return;pushUndo();ld.effectP1=Math.max(0,Math.min(1,(parseFloat(this.value)||0)/100));saveActiveLayerFrame();if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
 document.getElementById('p-effect-vig-radius').addEventListener('input',function(){var ld=state.layers[state.activeLayerIdx];if(!ld||!ld.isEffectLayer)return;pushUndo();ld.effectP2=Math.max(0,Math.min(0.95,(parseFloat(this.value)||0)/100));saveActiveLayerFrame();if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
-document.getElementById('p-persp-on').addEventListener('change',function(){state.perspectiveEnabled=this.checked;if(this.checked){if(window.ensurePerspectiveVPs)window.ensurePerspectiveVPs();window.SM.setTool('perspective');}if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
-document.getElementById('p-persp-mode').addEventListener('change',function(){if(window.setPerspectiveMode)window.setPerspectiveMode(this.value);});
-document.getElementById('p-persp-density').addEventListener('input',function(){state.perspectiveDensity=parseInt(this.value)||24;if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
-document.getElementById('p-persp-lock').addEventListener('change',function(){var locked=this.checked;(window.ensurePerspectiveVPs?window.ensurePerspectiveVPs():[]).forEach(function(vp){vp.locked=locked;});if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
-document.getElementById('btn-persp-reset').addEventListener('click',function(){if(window.resetPerspectiveVPs)window.resetPerspectiveVPs();});
-// Symmetry guide (symmetry-bridge.js) — same wiring shape as the Perspective
-// block just above. Sectors row only makes sense in Radial mode, hence the
-// visibility toggle — kept as its own named function (not inline) so
-// timeline.js's own loadProject() can call it too after restoring
-// state.symmetryMode from a save, otherwise a project saved mid-Radial-mode
-// would reopen with the field hidden until the user touched the dropdown.
-window.syncSymmetryPanelVisibility=function(){
-  var row=document.getElementById('p-sym-sectors-row');
-  if(row)row.style.display=state.symmetryMode==='radial'?'':'none';
-};
-document.getElementById('p-sym-on').addEventListener('change',function(){state.symmetryEnabled=this.checked;if(this.checked){if(window.ensureSymmetryAxis)window.ensureSymmetryAxis();if(window.ensureSymmetryRadialCenter)window.ensureSymmetryRadialCenter();window.SM.setTool('symmetry');}if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
-document.getElementById('p-sym-mode').addEventListener('change',function(){if(window.setSymmetryMode)window.setSymmetryMode(this.value);window.syncSymmetryPanelVisibility();});
-document.getElementById('p-sym-sectors').addEventListener('input',function(){state.symmetryRadialSectors=Math.max(2,Math.min(24,parseInt(this.value)||6));if(window.SMEngineBridge)window.SMEngineBridge.renderNow();});
-document.getElementById('p-sym-extend').addEventListener('change',function(){state.symmetryExtend=this.checked;});
-document.getElementById('btn-sym-reset').addEventListener('click',function(){if(window.resetSymmetryGuide)window.resetSymmetryGuide();});
-window.syncSymmetryPanelVisibility();
+// Perspective/Symmetry Guide (feedback 2026-07: "les onglet guide symétrie
+// et perspective n'ont plus lieu d'être, les options doivent être gérées au
+// niveau du panneau flottant") — the right-panel section these ids used to
+// live in is gone; every control (on/off, mode, density/sectors, lock/
+// extend, reset) now lives in the Labs floating panel (labs-float-panel.js)
+// instead, reading/writing the same state.* fields directly. Kept as a
+// no-op stub (rather than deleted outright) since labs-float-panel.js's
+// cycleMode still calls it after a Symmetry mode change.
+window.syncSymmetryPanelVisibility=function(){};
 // Custom blend-mode dropdown (feedback #17): hovering an option in the open
 // list applies that blend mode to the active layer IMMEDIATELY as a live
 // canvas preview; clicking commits it (with undo), while closing any other

--- a/src/js/tutorial.js
+++ b/src/js/tutorial.js
@@ -1019,17 +1019,19 @@
       time: '1 min',
       steps: [
         { type: 'info', title: 'Dessiner en perspective', body: 'Le guide de perspective affiche une grille de points de fuite et aimante l\'outil Ligne dessus, depuis n\'importe quel outil.' },
-        { type: 'click', target: '.tool-btn[data-tool="perspective"]', title: 'Choisis l\'outil Perspective', body: 'Clique sur l\'outil Perspective dans la barre de gauche.' },
-        {
-          type: 'state', target: '#phdr-perspective', title: 'Ouvre la section "Perspective Guide"', body: 'Clique l\'en-tête "Perspective Guide" dans le panneau de droite pour la déplier, si besoin.',
-          hint: 'En attente…',
-          check: function (win) { var el = win.document.getElementById('p-persp-on'); return !!(el && el.getBoundingClientRect().height > 0); }
-        },
+        // Perspective/Symmetry n'ont plus leur propre section droite
+        // (feedback 2026-07: "les onglet guide symétrie et perspective
+        // n'ont plus lieu d'être, les options doivent être gérées au
+        // niveau du panneau flottant") — leur toggle vit maintenant dans
+        // le panneau flottant Labs, qui n'apparaît QUE pour certains
+        // outils (pas l'outil Perspective/Symmetry lui-même — voir
+        // TOOL_CONTEXT, labs-float-panel.js). L'outil Ligne l'affiche.
+        { type: 'click', target: '.tool-btn[data-tool="line"]', title: 'Choisis la Ligne', body: 'Clique sur l\'outil Ligne (raccourci U) — le panneau flottant au-dessus du canevas propose alors le guide de Perspective.' },
         stateChangedStep({
-          target: '#p-persp-on', title: 'Active le guide', body: 'Coche "Enabled" pour afficher la grille de points de fuite sur le canevas.', hint: 'En attente…',
-          measure: function (win) { var el = win.document.getElementById('p-persp-on'); return el ? el.checked : false; }
+          target: '.labs-float-btn[title="Guide de perspective"]', title: 'Active le guide', body: 'Clique l\'icône Perspective dans le panneau flottant pour afficher la grille de points de fuite.', hint: 'En attente…',
+          measure: function (win) { return !!(win.state && win.state.perspectiveEnabled); }
         }),
-        { type: 'click', target: '.tool-btn[data-tool="line"]', title: 'Choisis la Ligne', body: 'Clique sur l\'outil Ligne (raccourci U) — il va s\'aimanter aux points de fuite.' },
+        { type: 'click', target: '.tool-btn[data-tool="line"]', title: 'Reviens à la Ligne', body: 'Activer le guide t\'a basculé sur l\'outil Perspective (pour placer les points de fuite) — reclique Ligne pour tracer un trait qui s\'y aimante.' },
         stateIncreaseStep({
           target: '#drawing-canvas', title: 'Trace une ligne', body: 'Clique-glisse sur le canevas — la ligne s\'oriente vers un point de fuite.',
           hint: 'En attente de ton trait…', measure: measureStrokeCount
@@ -1096,16 +1098,16 @@
       time: '1 min',
       steps: [
         { type: 'info', title: 'Dessiner en miroir', illustration: ILLUS.symmetry, body: 'Le guide de symétrie duplique chaque trait dessiné (avec n\'importe quel outil de dessin libre) en miroir — vertical, horizontal, à un angle libre, ou en rosace radiale façon mandala.' },
-        {
-          type: 'state', target: '#phdr-symmetry', title: 'Ouvre la section "Symmetry Guide"', body: 'Clique l\'en-tête "Symmetry Guide" dans le panneau de droite pour la déplier, si besoin.',
-          hint: 'En attente…',
-          check: function (win) { var el = win.document.getElementById('p-sym-on'); return !!(el && el.getBoundingClientRect().height > 0); }
-        },
+        // Symmetry/Perspective n'ont plus leur propre section droite
+        // (feedback 2026-07, voir le module 'perspective' juste au-dessus)
+        // — leur toggle vit dans le panneau flottant Labs, qui apparaît
+        // pour l'outil Pinceau.
+        { type: 'click', target: '.tool-btn[data-tool="draw"]', title: 'Choisis le Pinceau', body: 'Clique sur l\'outil Pinceau — le panneau flottant au-dessus du canevas propose alors le guide de Symétrie. La symétrie ne duplique que le dessin libre, pas les formes (Rectangle, Ellipse…).' },
         stateChangedStep({
-          target: '#p-sym-on', title: 'Active la symétrie', body: 'Coche "Enabled" pour activer le guide.', hint: 'En attente…',
-          measure: function (win) { var el = win.document.getElementById('p-sym-on'); return el ? el.checked : false; }
+          target: '.labs-float-btn[title="Guide de symétrie / mandala"]', title: 'Active la symétrie', body: 'Clique l\'icône Symétrie dans le panneau flottant pour activer le guide.', hint: 'En attente…',
+          measure: function (win) { return !!(win.state && win.state.symmetryEnabled); }
         }),
-        { type: 'click', target: '.tool-btn[data-tool="draw"]', title: 'Choisis le Pinceau', body: 'Clique sur l\'outil Pinceau — la symétrie ne duplique que le dessin libre, pas les formes (Rectangle, Ellipse…).' },
+        { type: 'click', target: '.tool-btn[data-tool="draw"]', title: 'Reviens au Pinceau', body: 'Activer le guide t\'a basculé sur l\'outil Symétrie (pour placer l\'axe) — reclique Pinceau pour dessiner.' },
         // onStrokeCommitted() (symmetry-bridge.js) insère le clone miroir
         // directement dans le calque, comme un second Path indépendant —
         // un seul trait dessiné doit donc faire +2 sur measureStrokeCount
@@ -1219,10 +1221,14 @@
       // niveau navigation réelle — ouvrir la section, voir le bouton
       // d'import, voir les réglages une fois qu'une référence existe —
       // sans jamais prétendre valider un import qui n'a pas lieu.
+      // La Référence n'a plus sa propre section (feedback 2026-07: "doit
+      // être géré par le panneau calque en fonction de la sélection de
+      // l'élément") — ses contrôles vivent maintenant dans #layer-sec
+      // (Blend/Matte/Flou), visible dès qu'un calque est actif.
       steps: [
         { type: 'info', title: 'Dessiner par-dessus une référence', body: 'La Référence affiche une vidéo, une séquence d\'images ou une image fixe SOUS ton dessin, pour la rotoscopie — elle suit la frame courante et n\'est jamais exportée.' },
         {
-          type: 'state', target: '#phdr-reference', title: 'Ouvre la section "Référence (roto)"', body: 'Clique l\'en-tête "Référence (roto)" dans le panneau de droite pour la déplier, si besoin.',
+          type: 'state', target: '#layer-sec .phdr', title: 'Ouvre la section "Layer"', body: 'Clique l\'en-tête "Layer" dans le panneau de droite pour la déplier, si besoin.',
           hint: 'En attente…',
           check: function (win) { var el = win.document.getElementById('btn-ref-import'); return !!(el && el.getBoundingClientRect().height > 0); }
         },


### PR DESCRIPTION
## Summary
- Global custom checkbox styling (appearance:none + checkmark) applied via a single CSS rule — every checkbox app-wide now looks consistent, matching the requested design.
- Removed right-panel "Perspective Guide" / "Symmetry Guide" sections — their controls now live entirely in the Labs floating panel (added Density/Lock/Reset and Extend/Reset there, which weren't mirrored before, so nothing was lost).
- Removed the right-panel "Onion Skin" section (pure duplicate of the timeline's onion button).
- Removed the standalone "Référence (roto)" section; folded into the Layer panel section (Blend/Matte/Flou), contextual on the active layer.
- Updated the 3 affected tutorial modules to follow the real new UI path, and removed now-dead event listeners that would have crashed on boot after the DOM elements were deleted.

## Test plan
- [x] Verified in browser: checkboxes render with the new styled checkmark design; toggling one visually confirms checked/unchecked states.
- [x] Right panel no longer shows Perspective Guide/Symmetry Guide/Onion Skin/Référence as standalone sections.
- [x] Layer section (canvas selection context) now shows Référence controls contextually.
- [x] Floating panel (Draw/Line tool) shows Symmetry's Mode/Extend/Reset and Perspective's Mode/Densité/Lock/Reset pills; toggling them actually shows the guide on canvas.
- [x] No console errors on boot.
- [x] `node --check` on all modified JS files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)