### PR TITLE
Add dockable tools panel (drag to top/right/bottom/left)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -23,7 +23,10 @@ html,body{width:100%;height:100%;overflow:hidden;background:var(--gutter);color:
   white-space:nowrap;word-wrap:normal;direction:ltr;-webkit-font-feature-settings:'liga';
   -webkit-font-smoothing:antialiased;font-variation-settings:'FILL' 0,'wght' 300,'GRAD' 0,'opsz' 20;}
 #app{display:flex;flex-direction:column;height:100vh;box-sizing:border-box;background:var(--gutter);padding:8px;gap:8px;}
-#top-area{flex:1;display:flex;overflow:hidden;min-height:0;gap:8px;}
+/* position:relative — positioning ancestor for the dockable tools panel's
+   top/right/bottom overlay modes (tools-panel-dock.js) and their drop-zone
+   overlay, both anchored with position:absolute against this box. */
+#top-area{flex:1;display:flex;overflow:hidden;min-height:0;gap:8px;position:relative;}
 /* App-wide top bar (2026-07 redesign): burger menu + app-mode segmented
    switcher, full width, above everything (tools panel, canvas, right
    panel alike) — distinct from #project-tabs-bar, which is scoped to the
@@ -127,6 +130,44 @@ body.mac-overlay-titlebar #app{padding-top:28px;}
    indicator is deliberately NOT the whole gap lighting up (too heavy —
    user feedback): a small vertically-centered rounded pill via ::after,
    while the full 8px×full-height div stays the grab/hit area. */
+/* Dockable tools panel (2026-07) — default stays exactly the left-column
+   layout above. Right dock stays fully IN-FLOW (just reordered to the end
+   of #top-area's flex row via `order`) so canvas-col/props-panel naturally
+   share the remaining space with zero overlap. Top/bottom can't do the
+   same trick (they'd need to span perpendicular to #top-area's own row
+   axis, which would mean restructuring canvas-col+props-panel under a
+   shared wrapper) — those float as a position:absolute overlay instead,
+   compensated by matching padding on canvas-col/props-panel (below) so
+   the project-tabs bar and top-of-canvas content never end up hidden
+   underneath it (confirmed live: without the padding, #project-tabs-bar
+   sat exactly under the floated bar, unclickable). */
+.tools-dock-handle{width:100%;height:14px;display:flex;align-items:center;justify-content:center;color:rgba(236,234,231,.3);cursor:grab;font-size:11px;touch-action:none;user-select:none;flex:none;}
+.tools-dock-handle:hover{color:rgba(236,234,231,.6);}
+.tools-dock-handle:active{cursor:grabbing;}
+#tools-panel.tools-dock-right{order:99;}
+#tools-panel.tools-dock-top,#tools-panel.tools-dock-bottom{
+  position:absolute;z-index:20;box-shadow:0 2px 16px rgba(0,0,0,.45);border-radius:8px;
+  top:auto;bottom:auto;left:8px;right:8px;width:auto;height:50px;
+  flex-direction:row;align-items:center;padding:0 10px;overflow-x:auto;overflow-y:hidden;
+}
+#tools-panel.tools-dock-top{top:0;}
+#tools-panel.tools-dock-bottom{bottom:0;}
+#tools-panel.tools-dock-top .tools-dock-handle,#tools-panel.tools-dock-bottom .tools-dock-handle{width:14px;height:100%;}
+#tools-panel.tools-dock-top .tool-sep,#tools-panel.tools-dock-bottom .tool-sep{width:1px;height:24px;margin:0 4px;}
+#tools-panel.tools-dock-top .color-wells,#tools-panel.tools-dock-bottom .color-wells{flex-direction:row;margin-top:0;margin-left:auto;padding-bottom:0;}
+body.tools-dock-top-active #canvas-col,body.tools-dock-top-active #props-panel{padding-top:58px;box-sizing:border-box;}
+body.tools-dock-bottom-active #canvas-col,body.tools-dock-bottom-active #props-panel{padding-bottom:58px;box-sizing:border-box;}
+/* Resize handle only makes sense for the default left dock — hidden the
+   moment the panel floats elsewhere (canvas-col grows into its place). */
+body.tools-docked-away #tools-panel-resize{display:none;}
+/* Drop-zone overlay shown only while actively dragging the handle. */
+#tools-dock-zones{position:absolute;inset:0;z-index:50;pointer-events:none;}
+.tools-dock-zone{position:absolute;background:rgba(63,107,245,.06);border:2px dashed rgba(63,107,245,.25);border-radius:6px;pointer-events:auto;transition:background .1s,border-color .1s;}
+.tools-dock-zone.active{background:var(--accent-dim);border-color:var(--accent);}
+.tools-dock-zone-left{left:4px;top:4px;bottom:4px;width:64px;}
+.tools-dock-zone-right{right:4px;top:4px;bottom:4px;width:64px;}
+.tools-dock-zone-top{left:76px;right:76px;top:4px;height:64px;}
+.tools-dock-zone-bottom{left:76px;right:76px;bottom:4px;height:64px;}
 #tools-panel-resize,#props-panel-resize{width:8px;margin:0 -8px;cursor:ew-resize;background:transparent;flex-shrink:0;z-index:5;position:relative;}
 #tools-panel-resize::after,#props-panel-resize::after{content:'';position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:3px;height:44px;border-radius:99px;background:transparent;transition:background .15s;}
 #tools-panel-resize:hover::after,#tools-panel-resize.active::after,

--- a/src/index.html
+++ b/src/index.html
@@ -132,7 +132,14 @@
      the outgoing tab and imports the incoming one via the same JSON
      export/import already used for file save/open. -->
 <div id="top-area">
+  <!-- Dockable tools panel (2026-07, "ajoute la possibilité en drag du
+       panel de réorganiser la position du panel gauche en haut/à droite/
+       en bas") — dragging #tools-panel-handle over one of the 4 edge drop
+       zones (tools-panel-dock.js) re-docks the whole panel there, choice
+       persisted to localStorage. Same drag-handle idiom as the Labs
+       floating panel's own #labs-float-handle. -->
   <div id="tools-panel">
+    <div id="tools-panel-handle" class="tools-dock-handle" title="Glisser pour déplacer le panneau d'outils">⠿</div>
     <button class="tool-btn" data-tool="select" data-i18n-title="toolSelect" title="Selection / Transform (V)"><svg viewBox="0 0 24 24" width="17" height="17"><rect x="2.5" y="2.5" width="12" height="12" rx="0.5" fill="none" stroke="currentColor" stroke-width="1.3" stroke-dasharray="2.4 2"/><rect x="1.3" y="1.3" width="2.4" height="2.4" fill="currentColor"/><rect x="12.3" y="1.3" width="2.4" height="2.4" fill="currentColor"/><rect x="1.3" y="12.3" width="2.4" height="2.4" fill="currentColor"/><rect x="12.3" y="12.3" width="2.4" height="2.4" fill="currentColor"/><path d="M11 9l8.5 5.2-4.3 0.9L13.2 19z" fill="currentColor"/></svg><span class="sk">V</span></button>
     <button class="tool-btn" data-tool="subselect" data-i18n-title="toolSubselect" title="Subselection — points &amp; tangents (A)"><svg viewBox="0 0 24 24" width="17" height="17" fill="currentColor"><path d="M5 3l14 8-6 1.3L11 20z"/></svg><span class="sk">A</span></button>
     <!-- v18: independent fill/stroke selection, Animate merge-drawing style —
@@ -1188,6 +1195,7 @@
 <script src="js/labs/timeline-zoom.js"></script>
 <script src="js/labs/labs-panel.js"></script>
 <script src="js/labs/labs-float-panel.js"></script>
+<script src="js/tools-panel-dock.js"></script>
 <script src="js/lottie-preview.js"></script>
 <script src="js/timeline.js"></script>
 <script src="js/i18n.js"></script>

--- a/src/js/tools-panel-dock.js
+++ b/src/js/tools-panel-dock.js
@@ -1,0 +1,97 @@
+// ---- Dockable tools panel (2026-07) ----
+// "Ajoute la possibilité en drag du panel de réorganiser la position du
+// panel gauche en haut/à droite/en bas" — dragging #tools-panel-handle
+// shows 4 edge drop zones over #top-area; dropping on one re-docks the
+// whole panel there. Persisted to localStorage so it survives reload.
+(function () {
+  var DOCK_KEY = 'nemo-tools-dock';
+  var DOCKS = ['top', 'right', 'bottom']; // 'left' is the default, no class needed
+
+  function applyDock(pos) {
+    var panel = document.getElementById('tools-panel');
+    if (!panel) return;
+    DOCKS.forEach(function (d) { panel.classList.remove('tools-dock-' + d); });
+    if (pos !== 'left') panel.classList.add('tools-dock-' + pos);
+    // Hides #tools-panel-resize (only meaningful for the left dock) and
+    // lets #canvas-col/#props-panel reclaim the space the panel isn't
+    // occupying in the flex flow anymore once docked elsewhere.
+    document.body.classList.toggle('tools-docked-away', pos !== 'left');
+    // Top/bottom float as an overlay (position:absolute — see the CSS
+    // comment) rather than staying in-flow like left/right, so their
+    // siblings need compensating padding or the project-tabs bar (top) /
+    // bottom of the canvas (bottom) ends up hidden underneath it.
+    document.body.classList.toggle('tools-dock-top-active', pos === 'top');
+    document.body.classList.toggle('tools-dock-bottom-active', pos === 'bottom');
+    try { localStorage.setItem(DOCK_KEY, pos); } catch (e) {}
+  }
+  function currentDock() {
+    try {
+      var v = localStorage.getItem(DOCK_KEY);
+      return (v === 'left' || DOCKS.indexOf(v) >= 0) ? v : 'left';
+    } catch (e) { return 'left'; }
+  }
+  // Applied immediately (not waiting for DOMContentLoaded) so there's no
+  // visible flash of the default left position before the saved one kicks
+  // in — #tools-panel already exists in the initial HTML parse by the time
+  // this script tag runs (it's placed after the body markup).
+  applyDock(currentDock());
+
+  var zonesEl = null, dragging = false;
+  function buildZones() {
+    var area = document.getElementById('top-area');
+    if (!area) return null;
+    var wrap = document.createElement('div');
+    wrap.id = 'tools-dock-zones';
+    ['left', 'top', 'right', 'bottom'].forEach(function (d) {
+      var z = document.createElement('div');
+      z.className = 'tools-dock-zone tools-dock-zone-' + d;
+      z.dataset.dock = d;
+      wrap.appendChild(z);
+    });
+    area.appendChild(wrap);
+    return wrap;
+  }
+  function zoneAt(x, y) {
+    if (!zonesEl) return null;
+    var els = zonesEl.querySelectorAll('.tools-dock-zone');
+    for (var i = 0; i < els.length; i++) {
+      var r = els[i].getBoundingClientRect();
+      if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) return els[i];
+    }
+    return null;
+  }
+  function onMove(e) {
+    if (!dragging) return;
+    var hit = zoneAt(e.clientX, e.clientY);
+    var els = zonesEl.querySelectorAll('.tools-dock-zone');
+    for (var i = 0; i < els.length; i++) els[i].classList.toggle('active', els[i] === hit);
+  }
+  function endDrag(e) {
+    if (!dragging) return;
+    dragging = false;
+    var hit = e ? zoneAt(e.clientX, e.clientY) : null;
+    if (hit) applyDock(hit.dataset.dock);
+    if (zonesEl) { zonesEl.remove(); zonesEl = null; }
+    document.removeEventListener('pointermove', onMove);
+    document.removeEventListener('pointerup', endDrag);
+    document.removeEventListener('pointercancel', endDrag);
+  }
+  function initHandle() {
+    // One delegated listener on #top-area rather than re-binding to the
+    // handle every time it moves between docks — the handle element
+    // itself is never recreated (applyDock only toggles classes), so a
+    // direct binding would work too, but delegation is one less thing to
+    // keep in sync if that ever changes.
+    document.addEventListener('pointerdown', function (e) {
+      if (!e.target.closest || !e.target.closest('#tools-panel-handle')) return;
+      e.preventDefault();
+      dragging = true;
+      zonesEl = buildZones();
+      document.addEventListener('pointermove', onMove);
+      document.addEventListener('pointerup', endDrag);
+      document.addEventListener('pointercancel', endDrag);
+    });
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initHandle);
+  else initHandle();
+})();


### PR DESCRIPTION
## Summary
- Dragging the new #tools-panel-handle grip shows 4 highlighted edge drop-zones over the canvas area; dropping on one re-docks the whole tools panel there, persisted to localStorage.
- Right dock uses CSS `order` (in-flow, zero overlap with the right panel). Top/bottom float as a compensated overlay (padding added to canvas-col/props-panel so nothing ends up hidden underneath, confirmed via a real bug found in testing — the project-tabs bar was initially unclickable under the floated top bar).
- Icons reflow to a horizontal row when docked top/bottom; the left-only resize handle hides when docked elsewhere.

## Test plan
- [x] Verified in browser (real pointer-event drag simulation) for all 4 positions: Top, Right, Bottom, back to Left.
- [x] Confirmed zero overlap in Right dock (props-panel and tools-panel measured with an 8px gap).
- [x] Confirmed project-tabs bar and canvas/timeline stay fully usable in Top/Bottom dock after the padding fix.
- [x] Confirmed persistence: dock choice survives a full page reload.
- [x] No console errors.
- [x] `node --check` on the new JS file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)