### PR TITLE
Fix 3 follow-ups: Comment button, Perspective/Symmetry buttons, right dock

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -34,6 +34,15 @@ html,body{width:100%;height:100%;overflow:hidden;background:var(--gutter);color:
 #app-topbar{flex:none;height:34px;display:flex;align-items:center;gap:10px;padding:0 10px;background:var(--panel2);border-radius:8px;}
 #app-menu-btn{flex:none;width:26px;height:26px;border-radius:6px;background:transparent;border:none;color:var(--text-dim);cursor:pointer;display:flex;align-items:center;justify-content:center;}
 #app-menu-btn:hover{background:var(--panel3);color:var(--text);}
+/* Comment tool button, relocated from the left tools panel into the top
+   bar (feedback 2026-07) — same .tool-btn/.active styling elsewhere still
+   applies (so it still highlights while the Comment tool is selected),
+   just sized down to match its new compact neighbors (avatar/help/
+   settings) instead of the left panel's larger 34px icons. The shortcut
+   badge (.sk, a small "C") only makes sense against the left panel's
+   taller buttons — dropped here, the title tooltip already says "(C)". */
+#topbar-comment-btn{width:26px;height:26px;flex:none;}
+#topbar-comment-btn .sk{display:none;}
 #app-mode-switch{display:flex;align-items:center;gap:2px;background:var(--bg);border-radius:7px;padding:2px;}
 .app-mode-btn{flex:none;border:none;background:transparent;color:var(--text-dim);font-size:11px;font-weight:500;padding:5px 12px;border-radius:5px;cursor:pointer;}
 .app-mode-btn:hover:not(:disabled){color:var(--text);}
@@ -144,7 +153,6 @@ body.mac-overlay-titlebar #app{padding-top:28px;}
 .tools-dock-handle{width:100%;height:14px;display:flex;align-items:center;justify-content:center;color:rgba(236,234,231,.3);cursor:grab;font-size:11px;touch-action:none;user-select:none;flex:none;}
 .tools-dock-handle:hover{color:rgba(236,234,231,.6);}
 .tools-dock-handle:active{cursor:grabbing;}
-#tools-panel.tools-dock-right{order:99;}
 #tools-panel.tools-dock-top,#tools-panel.tools-dock-bottom{
   position:absolute;z-index:20;box-shadow:0 2px 16px rgba(0,0,0,.45);border-radius:8px;
   top:auto;bottom:auto;left:8px;right:8px;width:auto;height:50px;

--- a/src/index.html
+++ b/src/index.html
@@ -122,6 +122,12 @@
   <!-- Feedback avatars + settings gear stay pinned to the top bar (their
        pre-redesign position) instead of following the project tabs down
        into the canvas column. -->
+  <!-- Comment tool, moved here from the left tools panel (feedback
+       2026-07: "réorganisation des boutons dans le panel gauche" — right
+       next to the feedback avatars it already pins comments alongside).
+       Same .tool-btn class, same data-tool wiring — the click handler is a
+       global querySelectorAll('.tool-btn'), location-independent. -->
+  <button class="tool-btn" id="topbar-comment-btn" data-tool="comment" data-i18n-title="toolComment" title="Comment — click the canvas to pin a note (C)"><svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M20 2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h4l4 4 4-4h4a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2z"/></svg><span class="sk">C</span></button>
   <div id="fb-avatars" title="Feedback comments sur ce projet"></div>
   <div id="fb-avatars-pop"></div>
   <button id="btn-open-tutorial-topbar" title="Découvrir Nemo — tutoriel interactif"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg></button>
@@ -163,16 +169,22 @@
     <button class="tool-btn" data-tool="fill" data-i18n-title="toolFill" title="Paint bucket — click an enclosed area to fill it (G)"><span class="material-symbols-rounded">&#xe23a;</span><span class="sk">G</span></button>
     <button class="tool-btn" data-tool="eyedropper" data-i18n-title="toolEyedropper" title="Eyedropper (I)"><span class="material-symbols-rounded">&#xe3b8;</span><span class="sk">I</span></button>
     <div class="tool-sep"></div>
-    <button class="tool-btn" data-tool="comment" data-i18n-title="toolComment" title="Comment — click the canvas to pin a note (C)"><svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M20 2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h4l4 4 4-4h4a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2z"/></svg><span class="sk">C</span></button>
+    <!-- Comment moved to #app-topbar (feedback 2026-07 — "réorganisation
+         des boutons dans le panel gauche") — .tool-btn click wiring is a
+         global document.querySelectorAll('.tool-btn'), location-
+         independent, so the same element works unchanged wherever it
+         lives; see #app-topbar below for its new home near the avatar. -->
     <button class="tool-btn" data-tool="hand" data-i18n-title="toolHand" title="Hand — pan the canvas (H or Space)"><svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M20.5 5A1.5 1.5 0 0 0 19 6.5V11h-1V4.5a1.5 1.5 0 0 0-3 0V11h-1V3.5a1.5 1.5 0 0 0-3 0V11h-1V5.5a1.5 1.5 0 0 0-3 0v10.81l-2.22-3.6a1.504 1.504 0 1 0-2.56 1.58l3.31 5.34A5 5 0 0 0 9.78 22H17a5 5 0 0 0 5-5V6.5A1.5 1.5 0 0 0 20.5 5Z"/></svg><span class="sk">H</span></button>
     <button class="tool-btn" data-tool="zoom" data-i18n-title="toolZoom" title="Zoom — click to zoom in, Alt+click to zoom out (Z)"><svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="6"/><path d="M20 20l-4.35-4.35" stroke-linecap="round"/></svg><span class="sk">Z</span></button>
     <button class="tool-btn" data-tool="rotate" data-i18n-title="toolRotate" title="Rotate canvas — drag to spin the stage around its center. Also works as Alt+drag from any other tool."><span style="font-size:15px;line-height:1">&#x21bb;</span></button>
-    <!-- Vanishing-point icon (horizon + converging rays) instead of the old
-         abstract ◇, which read as nothing in particular (feedback #21). -->
-    <button class="tool-btn" data-tool="perspective" data-i18n-title="toolPerspective" title="Perspective guide — drag vanishing points to place them. Once enabled, the Line tool snaps toward them from any tool."><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><path d="M2 6h20"/><circle cx="12" cy="6" r="1.7" fill="currentColor" stroke="none"/><path d="M12 6 4 20M12 6l8 14M12 6v14"/></svg></button>
-    <!-- Symmetry guide icon: a mirrored pair of shapes split by an axis
-         line, distinct from perspective's fan-of-rays icon just above. -->
-    <button class="tool-btn" data-tool="symmetry" data-i18n-title="toolSymmetry" title="Symmetry guide — Y/X/free-angle mirror or radial mandala. Drag the axis (its endpoints in Free mode, or the center in Radial mode) to reposition it. Draw with any tool once enabled."><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M12 2v20" stroke-dasharray="2.5 2.5"/><path d="M12 5 5 8v8l7 3" stroke-linejoin="round"/><path d="M12 5l7 3v8l-7 3" stroke-linejoin="round"/></svg></button>
+    <!-- Perspective/Symmetry tool buttons removed (feedback 2026-07: "tu
+         n'as pas enlevé les boutons de perspective et symétrie dans la
+         barre gauche" — a follow-up to the right-panel section removal
+         earlier) — both tools stay fully functional, entered exclusively
+         via the Labs floating panel's toggle (REAL_FEATURES.toggle already
+         calls window.SM.setTool('perspective'/'symmetry') the moment its
+         guide turns on), matching "les options doivent être gérées au
+         niveau du panneau flottant". -->
     <div class="tool-sep"></div>
     <!-- v10 (mockup redesign): stroke swatch (colored ring) stacked ABOVE
          the fill swatch (solid rounded square), each with its own round

--- a/src/js/tools-panel-dock.js
+++ b/src/js/tools-panel-dock.js
@@ -9,9 +9,22 @@
 
   function applyDock(pos) {
     var panel = document.getElementById('tools-panel');
-    if (!panel) return;
+    var area = document.getElementById('top-area');
+    if (!panel || !area) return;
     DOCKS.forEach(function (d) { panel.classList.remove('tools-dock-' + d); });
     if (pos !== 'left') panel.classList.add('tools-dock-' + pos);
+    // Right dock stays fully in-flow (no CSS order trick — that landed the
+    // panel PAST #props-panel, at the outer screen edge, when the actual
+    // ask was "entre le canvas et le menu droite": tucked between
+    // #canvas-col and #props-panel, same spot a real docking app like
+    // Krita/Photoshop would put it). Always reset to the natural default
+    // (first child) before deciding where it really belongs, so this stays
+    // idempotent regardless of which dock we're coming from.
+    if (area.firstChild !== panel) area.insertBefore(panel, area.firstChild);
+    if (pos === 'right') {
+      var propsResize = document.getElementById('props-panel-resize');
+      if (propsResize) area.insertBefore(panel, propsResize);
+    }
     // Hides #tools-panel-resize (only meaningful for the left dock) and
     // lets #canvas-col/#props-panel reclaim the space the panel isn't
     // occupying in the flex flow anymore once docked elsewhere.


### PR DESCRIPTION
## Summary
- Comment tool button moved from the left tools panel into the top bar, next to the feedback avatars.
- Perspective/Symmetry tool buttons removed from the left toolbar (still fully functional via the Labs floating panel toggle).
- Dockable panel's "right" position fixed: now sits between the canvas and the right panel (via DOM reordering) instead of past the right panel via CSS `order`.

## Test plan
- [x] Verified in browser: Comment button in top bar activates the Comment tool correctly (status bar confirms).
- [x] Left toolbar no longer shows Perspective/Symmetry icons.
- [x] Right dock measured: canvas-col right edge (724) → tools-panel (732-782) → props-panel (790+), zero overlap, correct order.
- [x] No console errors.
- [x] `node --check` on the modified JS file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)