### PR TITLE
Redesign Fill/Stroke/Dimensions to a Figma-style compact layout

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -418,6 +418,24 @@ input[type="checkbox"]:disabled{opacity:.4;cursor:not-allowed;}
 .icon-btn.sel{color:#fff;background:var(--accent);}
 .pr .cw-mini{width:24px;height:20px;border:1px solid var(--border2);border-radius:5px;cursor:pointer;position:relative;overflow:hidden;flex-shrink:0;}
 .pr .cw-mini input{position:absolute;inset:0;opacity:0;cursor:pointer;width:100%;height:100%;}
+/* Figma-style color row (Fill/Stroke, 2026-07) — swatch + editable hex +
+   opacity% + eye toggle, one line. */
+.color-row{gap:6px;}
+.color-hex-input{flex:1;min-width:0;text-transform:uppercase;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;letter-spacing:.02em;}
+.color-opacity-input{flex:0 0 40px;width:40px;text-align:right;padding-right:4px;}
+.color-pct{font-size:10px;color:var(--text-dim);flex:none;margin-left:-3px;}
+.color-eye-toggle{flex:none;cursor:pointer;color:rgba(236,234,231,.7);width:20px;height:20px;display:flex;align-items:center;justify-content:center;border-radius:5px;}
+.color-eye-toggle:hover{background:rgba(255,255,255,.08);color:var(--text);}
+.color-eye-toggle.off{color:var(--text-dark);}
+.color-eye-toggle svg{width:15px;height:15px;display:block;}
+/* Figma-style paired W/H row (Document, 2026-07) — a small link icon
+   between the two fields toggles proportion-lock (tools-panel-dock.js
+   sibling pattern: JS toggles .on, CSS just reflects it). */
+.dims-row{gap:5px;}
+.dims-row .pl{min-width:0!important;flex:none;}
+.dims-lock-btn{flex:none;width:22px;height:22px;border:none;background:transparent;color:rgba(236,234,231,.4);cursor:pointer;border-radius:5px;display:flex;align-items:center;justify-content:center;}
+.dims-lock-btn:hover{background:rgba(255,255,255,.08);color:var(--text);}
+.dims-lock-btn.on{color:var(--accent-hover);background:var(--accent-dim);}
 #curve-canvas-wrap{position:relative;display:inline-block;}
 #curve-canvas{width:200px;height:200px;border-radius:4px;cursor:crosshair;background:#111;display:block;}
 #curve-resize-handle{position:absolute;right:-2px;bottom:-2px;width:12px;height:12px;cursor:nwse-resize;background:var(--border2);border-radius:2px 0 4px 0;}

--- a/src/index.html
+++ b/src/index.html
@@ -447,8 +447,17 @@
     <div class="psec" id="canvas-sec">
       <div class="phdr"><span class="ar">☰</span> <span data-i18n="hdrDocument">Document</span></div>
       <div class="pbdy">
-        <div class="pr"><span class="pl">Width</span><input type="number" class="pi scrub" id="p-cw" value="1920" min="1" max="7680" data-step="1"></div>
-        <div class="pr"><span class="pl">Height</span><input type="number" class="pi scrub" id="p-ch" value="1080" min="1" max="4320" data-step="1"></div>
+        <!-- Figma-style paired dimensions row (feedback 2026-07: "des
+             tailles ou position sur une seule ligne") — W/H share one row
+             with a proportion-lock toggle between them (btn-dims-lock,
+             timeline.js) instead of two full rows each with their own
+             text label; locking remembers the W/H ratio at lock-time and
+             keeps it while either field changes. -->
+        <div class="pr dims-row">
+          <span class="pl" style="min-width:14px">W</span><input type="number" class="pi scrub" id="p-cw" value="1920" min="1" max="7680" data-step="1">
+          <button class="dims-lock-btn" id="btn-dims-lock" type="button" title="Lier largeur/hauteur (garder les proportions)"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M9 12a3 3 0 0 0 4.5 2.6L16 12.1a3 3 0 0 0-4.2-4.2"/><path d="M15 12a3 3 0 0 0-4.5-2.6L8 11.9a3 3 0 0 0 4.2 4.2"/></svg></button>
+          <span class="pl" style="min-width:14px">H</span><input type="number" class="pi scrub" id="p-ch" value="1080" min="1" max="4320" data-step="1">
+        </div>
         <div class="pr"><span class="pl">FPS</span><input type="number" class="pi scrub" id="proj-fps" value="12" min="1" max="60" data-step="1"></div>
         <div class="pr"><span class="pl">Frames</span><input type="number" class="pi scrub" id="proj-frames" value="24" min="1" max="999" data-step="1"></div>
         <div class="pr"><span class="pl">BG</span><input type="color" id="p-cbg" value="#ffffff" style="width:28px;height:22px;border:none;cursor:pointer;padding:0;"></div>
@@ -460,17 +469,56 @@
     <div class="psec" id="fill-sec">
       <div class="phdr"><span class="ar">☰</span> <span data-i18n="hdrFill">Fill</span></div>
       <div class="pbdy">
-        <div class="pr"><span class="pl">Color</span><div class="cw-mini" id="pm-fill" style="background:transparent" title="Click to pick a color, double-click to toggle fill on/off"><input type="color" id="pm-fill-c" value="#ff0000"></div><input type="checkbox" id="p-fill-on" style="display:none"></div>
-        <div class="pr"><span class="pl">Opacity</span><input type="number" class="pi scrub" id="p-opacity" value="100" min="5" max="100" data-step="1"></div>
+        <!-- Figma-style single-line color row (feedback 2026-07: "les
+             couleurs ça peut être un système comme [Figma]") — swatch,
+             editable hex text, opacity, and an eye toggle to
+             enable/disable, all on one row instead of two stacked rows
+             with full-word labels. #p-fill-hex is a NEW plain-text field
+             (wireColorHexField, timeline.js) — editable independently of
+             the swatch's own popover, exactly like Figma's own hex box.
+             #fill-enable-toggle is a NEW inline eye (setFillEnabled
+             already had a guarded slot for this id, unused until now — see
+             its own comment). No "remove" icon like Figma's paint list:
+             Nemo has exactly one fill per shape, not a stack, so eye-off
+             already covers "no fill" — a remove button would have nothing
+             real to do. -->
+        <div class="pr color-row">
+          <div class="cw-mini" id="pm-fill" style="background:transparent" title="Click to pick a color, double-click to toggle fill on/off"><input type="color" id="pm-fill-c" value="#ff0000"></div>
+          <input type="checkbox" id="p-fill-on" style="display:none">
+          <input type="text" class="pi color-hex-input" id="p-fill-hex" value="FF0000" maxlength="9" spellcheck="false" title="Code hex — tape pour changer">
+          <input type="number" class="pi color-opacity-input" id="p-opacity" value="100" min="5" max="100" data-step="1">
+          <span class="color-pct">%</span>
+          <div class="lico color-eye-toggle" id="fill-enable-toggle" title="Enable/disable fill"></div>
+        </div>
         <div class="pr"><button class="pbtn" id="btn-propagate-color" style="flex:1;font-size:10px" title="Applique la couleur du trait/fill selectionne a toutes ses occurrences sur toutes les frames (ink &amp; paint)">Propager la couleur a toutes les frames</button></div>
       </div>
     </div>
     <div class="psec" id="stroke-sec">
       <div class="phdr"><span class="ar">☰</span> <span data-i18n="hdrStroke">Stroke</span></div>
       <div class="pbdy">
-        <div class="pr"><span class="pl">Color</span><div class="cw-mini" id="pm-stroke" style="background:#000"><input type="color" id="pm-stroke-c" value="#000000"></div></div>
-        <div class="pr"><span class="pl">Width</span><input type="number" class="pi scrub" id="p-sw" value="3" min="1" max="300" data-step="1" title="Stroke width (px) — pilote aussi la taille des dabs du Bitmap Brush"><span style="font-size:9px;color:var(--text-dim)">px</span></div>
-        <div class="pr"><span class="pl">Style</span><select class="psel" id="p-strokestyle"><option value="solid">Solid</option><option value="dashed">Dashed</option><option value="dotted">Dotted</option></select></div>
+        <!-- Same color-row pattern as Fill above. Stroke has no separate
+             per-object "opacity" field the way Fill does — the closest
+             equivalent Figma concept (paint opacity, distinct from a
+             layer's own Opacity) maps onto the stroke COLOR's own alpha
+             byte here (#p-stroke-alpha, NEW — reads/writes the hex8 alpha
+             channel via the SAME .dataset.hex8 convention CLAUDE.md §2
+             documents for every other alpha color in this codebase). -->
+        <div class="pr color-row">
+          <div class="cw-mini" id="pm-stroke" style="background:#000"><input type="color" id="pm-stroke-c" value="#000000"></div>
+          <input type="text" class="pi color-hex-input" id="p-stroke-hex" value="000000" maxlength="9" spellcheck="false" title="Code hex — tape pour changer">
+          <input type="number" class="pi color-opacity-input" id="p-stroke-alpha" value="100" min="0" max="100" data-step="1" title="Opacité du trait (alpha de la couleur)">
+          <span class="color-pct">%</span>
+          <div class="lico color-eye-toggle" id="stroke-enable-toggle" title="Enable/disable stroke"></div>
+        </div>
+        <!-- Width+Style paired on one row (feedback: "des tailles ou
+             position sur une seule ligne") — Cap/Join stay on their own
+             rows below: each is already a 3-button icon group, and this
+             panel is only 280px wide — cramming two of those plus two
+             labels onto one row would just look cluttered, not cleaner. -->
+        <div class="pr">
+          <span class="pl">Width</span><input type="number" class="pi scrub" id="p-sw" value="3" min="1" max="300" data-step="1" title="Stroke width (px) — pilote aussi la taille des dabs du Bitmap Brush" style="flex:0 0 56px">
+          <select class="psel" id="p-strokestyle" style="flex:1"><option value="solid">Solid</option><option value="dashed">Dashed</option><option value="dotted">Dotted</option></select>
+        </div>
         <div class="pr"><span class="pl">Cap</span><div class="icon-grp" id="p-cap-grp" data-value="round">
           <button class="icon-btn" data-value="round" title="Round"><svg viewBox="0 0 24 10"><line x1="4" y1="5" x2="20" y2="5" stroke="currentColor" stroke-width="6" stroke-linecap="round"/></svg></button>
           <button class="icon-btn" data-value="butt" title="Butt"><svg viewBox="0 0 24 10"><line x1="4" y1="5" x2="20" y2="5" stroke="currentColor" stroke-width="6" stroke-linecap="butt"/></svg></button>

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -356,6 +356,12 @@ window.SM={
     }},
   setStrokeColor:function(v){state.strokeColor=v;document.getElementById('stroke-well').style.background=v;document.getElementById('pm-stroke').style.background=v;
     ['color-stroke','pm-stroke-c'].forEach(function(id){var el=document.getElementById(id);el.value=v;el.dataset.hex8=v;});
+    // Figma-style inline hex/alpha fields (2026-07) — see setFillColor's
+    // own comment; alphaPctFromHex reads the hex8 alpha byte (defaults to
+    // 100 when absent/opaque, same "#rrggbb == fully opaque" convention
+    // color-picker.js's hexToAlpha already uses).
+    var shex=document.getElementById('p-stroke-hex');if(shex&&document.activeElement!==shex)shex.value=hexDisplayValue(v);
+    var salpha=document.getElementById('p-stroke-alpha');if(salpha&&document.activeElement!==salpha)salpha.value=alphaPctFromHex(v);
     if((state.tool==='select'||state.tool==='subselect')&&selectedPaths.length){pushUndo();selectedPaths.forEach(function(p){if(p.data&&p.data.isVectorBrush)p.fillColor=v;else if(p.strokeColor)p.strokeColor=v;});saveActiveLayerFrame();updateUI();}
     // Fill/Stroke Select tool: recolor ONLY the clicked aspect — a 'stroke'
     // selection here means strokeColor, never touches fillColor even on a
@@ -367,10 +373,14 @@ window.SM={
     // the .none overlay (red diagonal) is what actually communicates "off".
     document.getElementById('fill-well').style.background=v;document.getElementById('pm-fill').style.background=v;
     ['color-fill','pm-fill-c'].forEach(function(id){var el=document.getElementById(id);el.value=v;el.dataset.hex8=v;});
+    // Figma-style inline hex field (2026-07) — kept in sync with every
+    // other write path to this color (popover, eyedropper, project load),
+    // not just this function's own callers.
+    var fhex=document.getElementById('p-fill-hex');if(fhex&&document.activeElement!==fhex)fhex.value=hexDisplayValue(v);
     if((state.tool==='select'||state.tool==='subselect')&&selectedPaths.length){pushUndo();selectedPaths.forEach(function(p){if(p.fillColor)p.fillColor=v;});saveActiveLayerFrame();updateUI();}
     else if(state.tool==='fsselect'&&_fsSel&&(_fsSel.kind==='fill'||_fsSel.kind==='fillregion')){pushUndo();if(_fsSel.kind==='fillregion')_fsSel=fsRealizeFillRegion(_fsSel,userLayers[state.activeLayerIdx]);_fsSel.path.fillColor=v;saveActiveLayerFrame();updateUI();}},
   setFillEnabled:function(v){state.fillEnabled=v;var fw=document.getElementById('fill-well'),pf=document.getElementById('pm-fill');fw.classList.toggle('none',!v);pf.classList.toggle('none',!v);document.getElementById('p-fill-on').checked=v;
-    var ft=document.getElementById('fill-enable-toggle');if(ft)ft.classList.toggle('off',!v);
+    var ft=document.getElementById('fill-enable-toggle');if(ft){ft.classList.toggle('off',!v);ft.innerHTML=v?ICO_EYE:ICO_EYE_CLOSED;}
     var ftlp=document.getElementById('fill-enable-toggle-lp');if(ftlp){ftlp.classList.toggle('off',!v);ftlp.innerHTML=v?ICO_EYE:ICO_EYE_CLOSED;}
     if((state.tool==='select'||state.tool==='subselect')&&selectedPaths.length){pushUndo();selectedPaths.forEach(function(p){if(p.data&&p.data.isVectorBrush)return;p.fillColor=v?state.fillColor:null;});saveActiveLayerFrame();updateUI();}
     else if(state.tool==='fsselect'&&_fsSel&&(_fsSel.kind==='fill'||_fsSel.kind==='fillregion')){pushUndo();if(_fsSel.kind==='fillregion')_fsSel=fsRealizeFillRegion(_fsSel,userLayers[state.activeLayerIdx]);_fsSel.path.fillColor=v?state.fillColor:null;if(!v){fsUnlinkFillRegen(_fsSel.path);if(!_fsSel.path.strokeColor){_fsSel.path.remove();fsClearSel();}}saveActiveLayerFrame();updateUI();}},
@@ -379,7 +389,7 @@ window.SM={
   // the quick phdr toggle button since disabling stroke without it required
   // opening the color popover and hunting for "None".
   setStrokeEnabled:function(v){state.strokeEnabled=v;
-    var st=document.getElementById('stroke-enable-toggle');if(st)st.classList.toggle('off',!v);
+    var st=document.getElementById('stroke-enable-toggle');if(st){st.classList.toggle('off',!v);st.innerHTML=v?ICO_EYE:ICO_EYE_CLOSED;}
     var stlp=document.getElementById('stroke-enable-toggle-lp');if(stlp){stlp.classList.toggle('off',!v);stlp.innerHTML=v?ICO_EYE:ICO_EYE_CLOSED;}
     if((state.tool==='select'||state.tool==='subselect')&&selectedPaths.length){pushUndo();selectedPaths.forEach(function(p){if(p.data&&p.data.isVectorBrush)return;p.strokeColor=v?state.strokeColor:null;});saveActiveLayerFrame();updateUI();}
     // fsselect's 'stroke' selection can be just a bounded segment (between
@@ -4692,6 +4702,88 @@ document.getElementById('fill-enable-toggle-lp').addEventListener('click',functi
 document.getElementById('stroke-enable-toggle-lp').addEventListener('click',function(){window.SM.setStrokeEnabled(!state.strokeEnabled);});
 document.getElementById('color-stroke').addEventListener('input',function(){window.SM.setStrokeColor(this.dataset.hex8||this.value);if(!state.strokeEnabled)window.SM.setStrokeEnabled(true);});
 document.getElementById('pm-stroke-c').addEventListener('input',function(){var v=this.dataset.hex8||this.value;window.SM.setStrokeColor(v);document.getElementById('color-stroke').value=v;document.getElementById('color-stroke').dataset.hex8=v;if(!state.strokeEnabled)window.SM.setStrokeEnabled(true);});
+// Figma-style color row (2026-07, "les couleurs ça peut être un système
+// comme [Figma]") — inline eye toggles + editable hex/alpha text fields
+// right in the Fill/Stroke rows, alongside the existing swatch popover.
+document.getElementById('fill-enable-toggle').addEventListener('click',function(){window.SM.setFillEnabled(!state.fillEnabled);});
+document.getElementById('stroke-enable-toggle').addEventListener('click',function(){window.SM.setStrokeEnabled(!state.strokeEnabled);});
+// Formats a color for the inline hex text field: no '#', uppercase, and
+// the alpha byte dropped when it's just FF (fully opaque) — showing
+// "FF0000FF" for a plain opaque red would read as broken/unexpected to
+// anyone not already thinking in hex8.
+function hexDisplayValue(hex){
+  var h=(hex||'#000000').replace('#','');
+  if(h.length===8&&h.slice(6).toUpperCase()==='FF')h=h.slice(0,6);
+  return h.toUpperCase();
+}
+// Reads the alpha byte (if present) as a 0-100 percentage, same "#rrggbb
+// == fully opaque" convention color-picker.js's own hexToAlpha uses.
+function alphaPctFromHex(hex){
+  var h=(hex||'').replace('#','');
+  if(h.length!==8)return 100;
+  return Math.round((parseInt(h.slice(6,8),16)||0)/255*100);
+}
+// Parses a typed hex string (with or without '#', 3/6/8 digits) into a
+// normalized '#rrggbb'/'#rrggbbaa' string, or null if it's not valid yet
+// (mid-typing) — shared by both hex fields below.
+function parseHexInput(raw){
+  var h=(raw||'').trim().replace(/^#/,'');
+  if(/^[0-9a-fA-F]{3}$/.test(h))return '#'+h.split('').map(function(c){return c+c;}).join('').toUpperCase();
+  if(/^[0-9a-fA-F]{6}$/.test(h)||/^[0-9a-fA-F]{8}$/.test(h))return '#'+h.toUpperCase();
+  return null;
+}
+document.getElementById('p-fill-hex').addEventListener('change',function(){
+  var hex=parseHexInput(this.value);
+  if(!hex){this.value=hexDisplayValue(state.fillColor);return;}
+  window.SM.setFillColor(hex);
+  if(!state.fillEnabled)window.SM.setFillEnabled(true);
+});
+document.getElementById('p-stroke-hex').addEventListener('change',function(){
+  var hex=parseHexInput(this.value);
+  if(!hex){this.value=hexDisplayValue(state.strokeColor);return;}
+  window.SM.setStrokeColor(hex);
+  if(!state.strokeEnabled)window.SM.setStrokeEnabled(true);
+});
+// Stroke's own alpha (2026-07) — Stroke has no separate per-object
+// "opacity" field the way Fill does (#p-opacity), so its Figma-style
+// opacity% box writes straight into the stroke COLOR's own hex8 alpha
+// byte instead, keeping RGB untouched.
+document.getElementById('p-stroke-alpha').addEventListener('input',function(){
+  var pct=Math.max(0,Math.min(100,parseInt(this.value)||0));
+  var rgb=(state.strokeColor||'#000000').replace('#','').slice(0,6);
+  var a=Math.round(pct/100*255).toString(16).padStart(2,'0').toUpperCase();
+  window.SM.setStrokeColor('#'+rgb+(pct<100?a:''));
+  if(!state.strokeEnabled)window.SM.setStrokeEnabled(true);
+});
+['p-fill-hex','p-stroke-hex'].forEach(function(id){
+  var el=document.getElementById(id);
+  el.addEventListener('keydown',function(e){if(e.key==='Enter')this.blur();});
+});
+// Document Dimensions proportion-lock (2026-07, "des tailles ou position
+// sur une seule ligne") — remembers the W/H ratio at the moment it's
+// switched ON; while locked, editing either field scales the other to
+// preserve that ratio. Off by default (matches the pre-existing behavior
+// of W/H being fully independent).
+var _dimsLockRatio=null;
+document.getElementById('btn-dims-lock').addEventListener('click',function(){
+  var on=!this.classList.contains('on');
+  this.classList.toggle('on',on);
+  _dimsLockRatio=on?(state.canvasW/state.canvasH):null;
+});
+document.getElementById('p-cw').addEventListener('input',function(){
+  if(_dimsLockRatio){
+    var h=Math.max(1,Math.round(parseFloat(this.value)/_dimsLockRatio));
+    document.getElementById('p-ch').value=h;
+    window.SM.setCanvasSize(parseInt(this.value)||1,h);
+  }
+});
+document.getElementById('p-ch').addEventListener('input',function(){
+  if(_dimsLockRatio){
+    var w=Math.max(1,Math.round(parseFloat(this.value)*_dimsLockRatio));
+    document.getElementById('p-cw').value=w;
+    window.SM.setCanvasSize(w,parseInt(this.value)||1);
+  }
+});
 // Paint the panel's fill swatch from the actual starting state.fillColor/
 // fillEnabled on load — without this it sits at whatever background the
 // static HTML happened to have (transparent) until the user touches it.


### PR DESCRIPTION
## Summary
Scoped to the highest-leverage reusable patterns rather than a full app-wide redesign:
- Fill/Stroke color rows: swatch + editable hex + opacity% + eye toggle, one line (matches the Figma reference screenshots).
- Stroke's opacity% writes into the stroke color's own alpha byte (no separate object-opacity field exists for stroke, unlike Fill).
- Stroke Width+Style paired on one row; Cap/Join kept on separate rows (each is a 3-button icon group — cramming both onto one row in a 280px panel would look cluttered).
- Document Width/Height paired on one row with a working proportion-lock toggle (remembers ratio at lock time, scales the other field live).

## Test plan
- [x] Verified in browser: Fill/Stroke rows render swatch+hex+opacity+eye on one line, closely matching the reference screenshots.
- [x] Toggled fill/stroke via the new eye icons — swatch and left-toolbar mirror both update correctly.
- [x] Edited the hex field directly (typed `00FF00`) — color updates everywhere.
- [x] Edited stroke alpha (50%) — color becomes `#00000080`, swatch shows transparency.
- [x] Tested Dimensions lock: locked at 1920×1080, changed W to 960 → H auto-scaled to 540 (correct 16:9 ratio preserved).
- [x] No console errors.
- [x] `node --check` on the modified JS file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)