### PR TITLE
UI polish batch: separator, scrub fields, clearer icons, EN/onion defaults

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -387,6 +387,11 @@ input[type="checkbox"]:disabled{opacity:.4;cursor:not-allowed;}
 #blend-pop .blend-opt:hover,#matte-pop .blend-opt:hover{background:var(--accent-dim);color:var(--accent-hover);}
 #blend-pop .blend-opt.sel,#matte-pop .blend-opt.sel{background:var(--panel3);font-weight:600;}
 .pbtn{background:var(--panel3);border:none;color:rgba(236,234,231,.75);border-radius:6px;padding:6px 8px;font-size:12px;font-weight:600;cursor:pointer;transition:background .15s,color .15s;}
+/* Icon-only .pbtn variant (2026-07) — square instead of text-padded, icon
+   centered; the title tooltip carries the label, same as every .tool-btn
+   in the left toolbar. */
+.icon-only-btn{width:30px;height:30px;padding:0;display:flex;align-items:center;justify-content:center;flex:none;}
+.icon-only-btn svg{display:block;}
 .pbtn:hover{background:#2c2a31;color:var(--text);}
 .pbtn.ac{background:var(--accent);border-color:var(--accent);color:#fff;}
 .pbtn.ac:hover{background:#5254d9;}

--- a/src/index.html
+++ b/src/index.html
@@ -157,6 +157,11 @@
     <button class="tool-btn active" data-tool="draw" data-i18n-title="toolDraw" title="Brush (B)"><svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M7 14c-1.66 0-3 1.34-3 3 0 1.31-1.16 2-2 2 .92 1.22 2.49 2 4 2 2.21 0 4-1.79 4-4 0-1.66-1.34-3-3-3z"/><path d="M20.71 4.63l-1.34-1.34a1 1 0 00-1.41 0L9 12.25 11.75 15l8.96-8.96a1 1 0 000-1.41z"/></svg><span class="sk">B</span></button>
     <button class="tool-btn" data-tool="pen" data-i18n-title="toolPen" title="Pen — click to place points, drag for curves (P)"><svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="m4.93 21.482 5.845-5.846a2 2 0 1 0-1.414-1.414l-5.846 5.846-1.06-1.06c2.827-3.3 3.888-6.954 5.302-13.082l6.364-.707 5.657 5.657-.707 6.364c-6.128 1.414-9.782 2.475-13.08 5.303l-1.062-1.06v-.001ZM16.595 2.037l6.347 6.346a.5.5 0 0 1-.277.848l-1.474.23-5.656-5.656.212-1.485a.5.5 0 0 1 .848-.283Z"/></svg><span class="sk">P</span></button>
     <button class="tool-btn" data-tool="fillbrush" data-i18n-title="toolFillbrush" title="Fill brush — paint a freehand filled shape, pressure-sensitive (N)"><span style="font-size:14px;line-height:1">&#x25CF;</span><span class="sk">N</span></button>
+    <!-- Missing separator (feedback 2026-07) — freehand painting tools
+         (Draw/Pen/Fill brush) and geometric shape tools (Line/Rect/
+         Ellipse) read as one undifferentiated group without this; Text
+         keeps its own separator right after Ellipse below. -->
+    <div class="tool-sep"></div>
     <button class="tool-btn" data-tool="line" data-i18n-title="toolLine" title="Line (U)"><span class="material-symbols-rounded">&#xf755;</span><span class="sk">U</span></button>
     <button class="tool-btn" data-tool="rect" data-i18n-title="toolRect" title="Rectangle (R)"><span class="material-symbols-rounded">&#xe3c6;</span><span class="sk">R</span></button>
     <button class="tool-btn" data-tool="ellipse" data-i18n-title="toolEllipse" title="Ellipse (L)"><span class="material-symbols-rounded">&#xef4a;</span><span class="sk">L</span></button>
@@ -440,7 +445,15 @@
         </div>
         <div class="pr" style="font-size:9px;color:var(--text-dim)" id="p-ref-name">Aucune référence</div>
         <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer"><input type="checkbox" id="p-ref-on"> Visible</label></div>
-        <div class="pr"><span class="pl">Opacity</span><input type="range" id="p-ref-opacity" min="5" max="100" value="50" style="flex:1"></div>
+        <!-- Scrub field, not a native range slider (feedback 2026-07: "tout
+             ce qui est slider doit être changer en valeur à slider comme
+             les autres propriétés du genre") — matches every other opacity/
+             numeric field in this panel (.pi.scrub, drag-to-change or
+             click-to-type, wired generically in ui.js — no per-field JS
+             needed, reference-bridge.js's existing 'input' listener on
+             #p-ref-opacity already reads .value the same way either type
+             produces it). -->
+        <div class="pr"><span class="pl">Opacity</span><input type="number" class="pi scrub" id="p-ref-opacity" min="5" max="100" value="50" data-step="1"></div>
         <div class="pr"><span class="pl">Offset</span><input type="number" class="pi scrub" id="p-ref-offset" value="0" data-step="1" title="Frame de la timeline où la référence démarre"></div>
       </div>
     </div>
@@ -461,7 +474,16 @@
         <div class="pr"><span class="pl">FPS</span><input type="number" class="pi scrub" id="proj-fps" value="12" min="1" max="60" data-step="1"></div>
         <div class="pr"><span class="pl">Frames</span><input type="number" class="pi scrub" id="proj-frames" value="24" min="1" max="999" data-step="1"></div>
         <div class="pr"><span class="pl">BG</span><input type="color" id="p-cbg" value="#ffffff" style="width:28px;height:22px;border:none;cursor:pointer;padding:0;"></div>
-        <div class="pr" style="gap:4px"><button class="pbtn" id="btn-fit">Fit</button><button class="pbtn" id="btn-resetv">Reset View</button></div>
+        <!-- Icon buttons instead of text (feedback 2026-07: "les boutons
+             avec un texte est-ce qu'ils peuvent avoir un bouton icon
+             plutôt que texte") — tooltip (title) carries the label, same
+             convention as every .tool-btn in the left toolbar (icon-only,
+             no visible text, ui.js's shared instant-tooltip system covers
+             discoverability). -->
+        <div class="pr" style="gap:4px">
+          <button class="pbtn icon-only-btn" id="btn-fit" title="Fit — fit the canvas to the viewport"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M21 16v3a2 2 0 0 1-2 2h-3M3 16v3a2 2 0 0 0 2 2h3"/></svg></button>
+          <button class="pbtn icon-only-btn" id="btn-resetv" title="Reset View — restore zoom/pan/rotation to default"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 1 3 6.7"/><path d="M3 21v-5h5"/></svg></button>
+        </div>
         <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer" title="Hide artwork outside the canvas bounds — off by default, so you can see and work with content that spills over the edge"><input type="checkbox" id="p-clip" style="accent-color:var(--accent)"> Clip to canvas</label></div>
         <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer" title="Broadcast-safe overlay guides: 90% action-safe / 80% title-safe margins, standard TV/film safe areas"><input type="checkbox" id="p-safety" style="accent-color:var(--accent)"> Safety zones</label></div>
       </div>
@@ -655,17 +677,23 @@
       <div class="pbdy">
         <div id="palette-tabs" class="palette-tabs"></div>
         <div class="pr" style="gap:4px">
-          <button class="pbtn" id="btn-palette-new" title="Créer une nouvelle palette">+ Palette</button>
+          <button class="pbtn icon-only-btn" id="btn-palette-new" title="Créer une nouvelle palette"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg></button>
         </div>
         <div class="pr" style="font-size:9px;color:var(--text-dim)">Clic: fill · Maj+clic: stroke · Glisser: réordonner · Double-clic onglet: renommer</div>
         <div id="palette-grid" class="palette-grid"></div>
+        <!-- Icon buttons instead of text (feedback 2026-07) — filled
+             droplet = add Fill, outlined droplet = add Stroke, keeping the
+             existing +Fill/+Stroke distinction readable at a glance
+             without text; the small "+" badge marks "add to palette" on
+             both, and swap becomes a real SVG (crisper than the ⇄
+             character glyph it replaces, same meaning). -->
         <div class="pr" style="gap:4px">
-          <button class="pbtn" id="btn-palette-add-fill" title="Ajouter la couleur de Fill actuelle à la palette">+ Fill</button>
-          <button class="pbtn" id="btn-palette-add-stroke" title="Ajouter la couleur de Stroke actuelle à la palette">+ Stroke</button>
-          <button class="pbtn" id="btn-palette-swap" title="Échanger Fill ↔ Stroke">⇄</button>
+          <button class="pbtn icon-only-btn" id="btn-palette-add-fill" title="Ajouter la couleur de Fill actuelle à la palette"><svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M12 2C8 7 5 10.5 5 14a7 7 0 0 0 14 0c0-3.5-3-7-7-12z"/><path d="M15 4v4M13 6h4" stroke="var(--panel3)" stroke-width="1.6" stroke-linecap="round" fill="none"/></svg></button>
+          <button class="pbtn icon-only-btn" id="btn-palette-add-stroke" title="Ajouter la couleur de Stroke actuelle à la palette"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.6"><path d="M12 2C8 7 5 10.5 5 14a7 7 0 0 0 14 0c0-3.5-3-7-7-12z"/><path d="M15 4v4M13 6h4" stroke-linecap="round"/></svg></button>
+          <button class="pbtn icon-only-btn" id="btn-palette-swap" title="Échanger Fill ↔ Stroke"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3l4 4-4 4M21 7H9M7 13l-4 4 4 4M3 17h12"/></svg></button>
         </div>
         <div class="pr" style="gap:4px">
-          <button class="pbtn" id="btn-palette-replace" title="Remplacer une couleur dans le calque actif : clic sur la source, puis sur la cible" style="flex:1">🔁 Remplacer dans le calque</button>
+          <button class="pbtn icon-only-btn" id="btn-palette-replace" title="Remplacer une couleur dans le calque actif : clic sur la source, puis sur la cible"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M17 2l4 4-4 4"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><path d="M7 22l-4-4 4-4"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></svg></button>
         </div>
       </div>
     </div>
@@ -1125,7 +1153,7 @@
       <span style="margin-left:6px">Frames</span><input type="number" id="tl-total" value="24" min="1" max="999">
     </div>
     <span style="width:1px;height:20px;background:var(--border2);flex:none"></span>
-    <button class="tb active" id="btn-os" title="Onion skin on/off (O)"><span class="material-symbols-rounded" style="font-size:16px">&#xe53b;</span></button>
+    <button class="tb" id="btn-os" title="Onion skin on/off (O)"><span class="material-symbols-rounded" style="font-size:16px">&#xe53b;</span></button>
     <button class="tb" id="btn-os-outline" title="Onion skin outlines only"><span style="font-size:13px;line-height:1">&#x25ad;</span></button>
     <button class="tb" id="btn-os-range" title="Modify onion markers"><span style="font-size:11px;line-height:1">&#x25be;</span></button>
     <button class="tb" id="btn-ghost-all" title="Ghost all keyframes — shows every keyframe of the active layer at once" style="margin-left:4px"><span style="font-size:13px;line-height:1">&#x2637;</span></button>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -79,7 +79,10 @@ var state={
   totalFrames:24,currentFrame:0,fps:12,playing:false,loopPlayback:true,pingPongPlayback:false,playDir:1,
   tool:'draw',
   appMode:'anim2d', // 'anim2d' | 'motion' | 'storyboard' — see #app-mode-switch (index.html) / motion.js
-  onionSkin:true,onionPrevOpacity:30,onionNextOpacity:30,onionMode:'tinted',
+  // Off by default (feedback 2026-07: "désactive l'onion skin par default")
+  // — #btn-os's own static HTML class updated to match (index.html), so
+  // there's no flash of an "active" toolbar icon before this state loads.
+  onionSkin:false,onionPrevOpacity:30,onionNextOpacity:30,onionMode:'tinted',
   onionIn:0,onionOut:23,
   brushSize:3,fillBrushSize:40,strokeColor:'#000000',fillColor:'#ff0000',fillEnabled:true,strokeEnabled:true,shadowMode:false,brushPreset:'none',
   smoothing:10,stabilizer:2,strokeCap:'round',strokeJoin:'round',opacity:100,

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -156,7 +156,11 @@
   function initLanguage(){
     var saved=null;
     try{saved=localStorage.getItem('nemo-lang');}catch(e){}
-    state.language=(saved&&LANGS.indexOf(saved)>=0)?saved:(state.language||'fr');
+    // Default language is English (feedback 2026-07: "met l'app en anglais
+    // par default") — a saved localStorage choice (any language, French
+    // included) still always wins; this only changes what a brand-new
+    // install/browser profile sees before ever touching Réglages.
+    state.language=(saved&&LANGS.indexOf(saved)>=0)?saved:(state.language||'en');
     applyI18n();
     var sel=document.getElementById('settings-language');
     if(sel)sel.addEventListener('change',function(){setLanguage(this.value);});

--- a/src/js/labs/labs-float-panel.js
+++ b/src/js/labs/labs-float-panel.js
@@ -122,11 +122,21 @@
   // stroke-based line art, which read as a different, thinner icon
   // language. Rebuilt every icon as a solid silhouette to match.
   var ICONS = {
-    'brush-menu': '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M19.4 2.6c.8.8.8 2 0 2.8L9.5 15.3l-4-4L15.4 1.4c.8-.8 2-.8 2.8 0z" opacity=".85"/><path d="M8.3 12.4l3.3 3.3-1.4 1.4c-1.8 1.8-6.4 2-6.4 2s.2-4.6 2-6.4z"/></svg>',
-    // Same "split by an axis" language as the toolbar button (index.html),
-    // simplified/solid-filled to match this strip's icon set.
-    'symmetry': '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><rect x="11" y="2" width="2" height="20" rx="1"/><path d="M9 6L3 12L9 18Z"/><path d="M15 6L21 12L15 18Z"/></svg>',
-    'perspective': '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><circle cx="12" cy="6" r="2"/><path d="M12 6L2 22h4L12 10l6 12h4Z"/><path d="M2 22L12 6l10 16" fill="none" stroke="currentColor" stroke-width="1.4" opacity=".5"/></svg>',
+    // Reuses the EXACT same glyph as the main Brush/Draw tool button in the
+    // left toolbar (index.html, data-tool="draw") — feedback 2026-07:
+    // "certaines icônes comme les guides ou brush du panneau flottant ne
+    // sont pas très claires". Same concept, same icon, so it reads as
+    // recognizable on sight instead of a new abstract shape to learn.
+    'brush-menu': '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M7 14c-1.66 0-3 1.34-3 3 0 1.31-1.16 2-2 2 .92 1.22 2.49 2 4 2 2.21 0 4-1.79 4-4 0-1.66-1.34-3-3-3z"/><path d="M20.71 4.63l-1.34-1.34a1 1 0 00-1.41 0L9 12.25 11.75 15l8.96-8.96a1 1 0 000-1.41z"/></svg>',
+    // Redrawn (2026-07, same "not very clear" feedback) as two solid
+    // mirrored blocks either side of the axis instead of two thin
+    // triangles — reads unambiguously as "mirror" even at 15px, where the
+    // old triangle pair tended to blur into a single arrow-like shape.
+    'symmetry': '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><rect x="11" y="2" width="2" height="20" rx="1" opacity=".45"/><path d="M9 4H4a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h5z"/><path d="M15 4h5a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1h-5z" opacity=".55"/></svg>',
+    // Redrawn as a square frame with diagonals converging on a center
+    // vanishing point — the standard "perspective grid" glyph used by
+    // most design tools, clearer than the old horizon-line-plus-rays shape.
+    'perspective': '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="1"/><path d="M3 3l8.5 8.5M21 3l-8.5 8.5M3 21l8.5-8.5M21 21l-8.5-8.5"/><circle cx="12" cy="12" r="1.3" fill="currentColor" stroke="none"/></svg>',
     'predictive-stroke': '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M12 2l1.2 3.8L17 7l-3.8 1.2L12 12l-1.2-3.8L7 7l3.8-1.2L12 2z"/><path d="M19 13l.6 1.9L21.5 15.5l-1.9.6L19 18l-.6-1.9L16.5 15.5l1.9-.6L19 13z"/><path d="M5 15l.5 1.5L7 17l-1.5.5L5 19l-.5-1.5L3 17l1.5-.5L5 15z"/></svg>',
     'multiframe-draw': '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M12 2L22 7L12 12L2 7Z"/><path d="M2 12L12 17L22 12L22 14L12 19L2 14Z" opacity=".55"/></svg>',
     'canvas-grid': '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>',

--- a/src/js/tutorial.js
+++ b/src/js/tutorial.js
@@ -1233,7 +1233,7 @@
           check: function (win) { var el = win.document.getElementById('btn-ref-import'); return !!(el && el.getBoundingClientRect().height > 0); }
         },
         { type: 'click', target: '#btn-ref-import', title: 'Regarde le bouton "Importer…"', body: 'Clique "Importer…" pour voir le sélecteur de fichier s\'ouvrir (vidéo, séquence d\'images, ou image seule).' },
-        { type: 'click', target: '#p-ref-opacity', title: 'Repère le réglage Opacity', body: 'Ce curseur règle la transparence de la référence une fois importée, pour qu\'elle ne gêne pas ton dessin par-dessus.' },
+        { type: 'click', target: '#p-ref-opacity', title: 'Repère le réglage Opacity', body: 'Ce champ (glisse pour changer, ou clique pour taper une valeur) règle la transparence de la référence une fois importée, pour qu\'elle ne gêne pas ton dessin par-dessus.' },
         { type: 'info', title: 'Bien joué !', body: '"Offset" décale la frame de départ de la référence par rapport à la timeline — utile si ta vidéo ne commence pas au même instant que ton animation.' }
       ]
     },


### PR DESCRIPTION
## Summary
- Added missing tool-sep between Fill Brush and Line (separates freehand-painting tools from geometric-shape tools).
- Reference (roto) Opacity slider → scrub field, matching every other numeric property.
- Redrew 3 Labs floating panel icons (brush-menu, symmetry, perspective) for clarity.
- Converted Document's Fit/Reset View and Swatches' +Palette/+Fill/+Stroke/swap/replace buttons from text to icon-only with tooltips.
- Default language → English (saved choice still wins).
- Onion skin → off by default.

## Test plan
- [x] Verified in browser: default language is English with no saved override; onion skin off; toolbar separator in the right spot; icon buttons render and are clickable with correct tooltips.
- [x] No console errors.
- [x] `node --check` on all modified JS files.

## Note
Two items from the original feedback are NOT in this PR, flagged separately:
- "Text buttons → icons" was scoped to a representative pass (Document + Swatches) rather than every text button app-wide — a much larger sweep if wanted.
- The Tauri multi-window "pop panels out like After Effects" question is a substantial feature (needs a separate render entry point + cross-window state sync via Tauri IPC, not just the existing in-window floating drag) — discussed with the user rather than attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)