### PR TITLE
Add Selected Colors panel: manage/recolor colors across selection or project

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -433,6 +433,11 @@ input[type="checkbox"]:disabled{opacity:.4;cursor:not-allowed;}
 .color-eye-toggle:hover{background:rgba(255,255,255,.08);color:var(--text);}
 .color-eye-toggle.off{color:var(--text-dark);}
 .color-eye-toggle svg{width:15px;height:15px;display:block;}
+/* Selected Colors panel (2026-07) — crosshair "select shapes with this
+   color" button, same sizing/hover language as .color-eye-toggle. */
+.color-select-btn{flex:none;cursor:pointer;color:rgba(236,234,231,.5);width:20px;height:20px;display:flex;align-items:center;justify-content:center;border-radius:5px;}
+.color-select-btn:hover{background:rgba(255,255,255,.08);color:var(--text);}
+.color-select-btn svg{display:block;}
 /* Figma-style paired W/H row (Document, 2026-07) — a small link icon
    between the two fields toggles proportion-lock (tools-panel-dock.js
    sibling pattern: JS toggles .on, CSS just reflects it). */

--- a/src/index.html
+++ b/src/index.html
@@ -623,6 +623,25 @@
         <div class="pr" title="Re-smooths the SELECTED stroke's existing geometry — unlike Tool Options' Smooth (which only shapes new strokes as you draw), this is a one-shot action you can apply after the fact, repeatedly, to a stroke already on the canvas. Note: a freshly-drawn stroke is already simplified at draw time (Tool Options' Smooth, 10 by default) — applying THIS at the same or lower value won't visibly change anything since it's already fit that tightly; raise it for a visible extra effect."><span class="pl">Smooth</span><input type="number" class="pi scrub" id="p-poststroke-smooth" value="25" min="0" max="80" data-step="1"><button class="pbtn" id="btn-poststroke-smooth">Apply</button></div>
       </div>
     </div>
+    <!-- Selected Colors (2026-07, "un nouvel onglet de gestion des couleurs
+         en fonction de ce que l'on sélectionne ou si on sélectionne rien on
+         voit toutes les couleurs dans le projet") — always visible, driven
+         by color-manager.js. Selection non-empty: colors used by the
+         current selection. Nothing selected: every distinct color used
+         anywhere in the project (scanned from the persisted frame data,
+         not live Paper.js objects — see color-manager.js's own header
+         comment). Editing a row's hex/opacity batch-recolors every
+         instance of that exact color (selection-scoped if there IS a
+         selection, project-wide otherwise); the crosshair icon selects
+         the matching shapes on the CURRENT layer/frame (cross-frame/
+         cross-layer selection isn't a thing this app's selection model
+         supports elsewhere either). -->
+    <div class="psec" id="selected-colors-sec">
+      <div class="phdr"><span class="ar">☰</span> <span id="selected-colors-hdr">Selected Colors</span></div>
+      <div class="pbdy" id="selected-colors-body">
+        <div class="pr" style="font-size:9px;color:var(--text-dim)" id="selected-colors-empty">Aucune couleur</div>
+      </div>
+    </div>
     <div class="psec" id="tool-opts-sec">
       <div class="phdr"><span class="ar">☰</span> <span data-i18n="hdrToolOptions">Tool Options</span></div>
       <div class="pbdy">
@@ -1312,6 +1331,7 @@
 <script src="js/storyboard.js"></script>
 <script src="js/drop-import.js"></script>
 <script src="js/palette-panel.js"></script>
+<script src="js/color-manager.js"></script>
 <script src="js/project.js"></script>
 <script src="js/feedback-bridge.js"></script>
 <script src="js/updater-bridge.js"></script>

--- a/src/js/color-manager.js
+++ b/src/js/color-manager.js
@@ -1,0 +1,211 @@
+// ---- Selected Colors panel (2026-07) ----
+// "Un nouvel onglet de gestion des couleurs en fonction de ce que l'on
+// sélectionne ou si on sélectionne rien on voit toutes les couleurs dans le
+// projet, et ça nous permet de les changer sur des ensembles" — a color-
+// management panel, always visible (#selected-colors-sec, index.html):
+//   - Selection non-empty: every distinct fill/stroke color used by the
+//     selected shapes.
+//   - Nothing selected: every distinct color used ANYWHERE in the project —
+//     scanned from state.layers[i].frames[j].strokes[k], which already
+//     stores fillColor/strokeColor as plain hex STRINGS (serP(), app.js) —
+//     no need to touch live Paper.js objects or walk every frame's actual
+//     geometry, just the persisted data, so this stays cheap even on a
+//     project with many frames.
+// Editing a row's hex/opacity batch-recolors every exact match (selection-
+// scoped if there IS a selection, project-wide otherwise, mirroring the
+// same "current selection redefines the scope" convention every other
+// color control in this app already follows — e.g. Fill/Stroke's own
+// setFillColor/setStrokeColor). The crosshair icon selects the matching
+// shapes on the CURRENT layer/frame — cross-frame/cross-layer selection
+// isn't something this app's selection model supports anywhere else
+// either (state.selectedStrokeIndices is keyed to the active layer only),
+// so this doesn't invent a new capability, just scopes honestly to what
+// selection already means here.
+(function () {
+  var ICON_CROSSHAIR = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.6"><circle cx="12" cy="12" r="7"/><path d="M12 2v4M12 18v4M2 12h4M18 12h4"/></svg>';
+
+  // Groups by normalized hex (case-insensitive), keeping the first-seen
+  // casing/alpha form as the canonical value for that group — good enough
+  // since colorHex8/serP already normalize to lowercase hex on write.
+  function addColor(map, hex) {
+    if (!hex) return;
+    var key = hex.toUpperCase();
+    if (!map[key]) map[key] = { hex: hex, count: 0 };
+    map[key].count++;
+  }
+
+  function computeUsedColors() {
+    var map = {};
+    if (window.selectedPaths && selectedPaths.length) {
+      selectedPaths.forEach(function (p) {
+        if (p.fillColor) addColor(map, colorHex8(p.fillColor));
+        if (p.strokeColor) addColor(map, colorHex8(p.strokeColor));
+      });
+    } else {
+      (state.layers || []).forEach(function (ld) {
+        (ld.frames || []).forEach(function (fr) {
+          (fr.strokes || []).forEach(function (sd) {
+            if (sd.fillColor) addColor(map, sd.fillColor);
+            // serP() (app.js) writes strokeColor:'#ffffff' as a legacy
+            // fallback even when the shape has NO real stroke — hasRealStroke
+            // is the authoritative flag (CLAUDE.md §1's own documented
+            // gotcha). Without this check, every plain filled-only shape
+            // added a phantom white "stroke color" to the list.
+            var hasStroke = sd.hasRealStroke !== undefined ? sd.hasRealStroke : !!sd.strokeColor;
+            if (hasStroke && sd.strokeColor) addColor(map, sd.strokeColor);
+          });
+        });
+      });
+    }
+    return Object.keys(map).map(function (k) { return map[k]; }).sort(function (a, b) { return b.count - a.count; });
+  }
+
+  // Batch recolor — same scope rule as the scan above: within the current
+  // selection if one exists, project-wide (persisted data + every live
+  // on-canvas layer) otherwise.
+  function recolorColor(oldHex, newHex) {
+    pushUndo();
+    var oldNorm = oldHex.toUpperCase();
+    if (window.selectedPaths && selectedPaths.length) {
+      selectedPaths.forEach(function (p) {
+        if (p.fillColor && colorHex8(p.fillColor).toUpperCase() === oldNorm) p.fillColor = newHex;
+        if (p.strokeColor && colorHex8(p.strokeColor).toUpperCase() === oldNorm) p.strokeColor = newHex;
+      });
+      saveActiveLayerFrame();
+    } else {
+      state.layers.forEach(function (ld) {
+        (ld.frames || []).forEach(function (fr) {
+          (fr.strokes || []).forEach(function (sd) {
+            if (sd.fillColor && sd.fillColor.toUpperCase() === oldNorm) sd.fillColor = newHex;
+            // Same hasRealStroke guard as computeUsedColors above — without
+            // it, recoloring away from the fallback white would WRITE a
+            // brand new visible strokeColor onto shapes that never had one
+            // (hasRealStroke would still read false, but strokeColor would
+            // no longer be the recognizable '#ffffff' sentinel either),
+            // corrupting persisted data on next load.
+            var hasStroke = sd.hasRealStroke !== undefined ? sd.hasRealStroke : !!sd.strokeColor;
+            if (hasStroke && sd.strokeColor && sd.strokeColor.toUpperCase() === oldNorm) sd.strokeColor = newHex;
+          });
+        });
+      });
+      // Persisted data alone wouldn't show up until the frame reloads —
+      // also patch every currently-live canvas layer so the change is
+      // visible immediately, same reasoning as Propager la couleur's own
+      // "live objects need their own pass, persisted data isn't enough".
+      (window.userLayers || []).forEach(function (layer) {
+        layer.children.forEach(function (item) {
+          if (item.fillColor && colorHex8(item.fillColor).toUpperCase() === oldNorm) item.fillColor = newHex;
+          if (item.strokeColor && colorHex8(item.strokeColor).toUpperCase() === oldNorm) item.strokeColor = newHex;
+        });
+      });
+    }
+    updateUI();
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+  }
+
+  // Selects every shape on the ACTIVE layer's CURRENT frame whose fill OR
+  // stroke matches `hex` — same 4-step "set selection" recipe every other
+  // select-these-paths feature in this codebase uses (selectGhostAll,
+  // timeline.js:1637; select-bridge.js's own marquee/click-select).
+  function selectPathsWithColor(hex) {
+    var norm = hex.toUpperCase();
+    window.SM.setTool('select');
+    var layer = userLayers[state.activeLayerIdx];
+    if (!layer) return;
+    selectedPaths = layer.children.filter(function (c) {
+      if (!(c instanceof Path) || !isSelectablePathChild(c)) return false;
+      var fm = c.fillColor && colorHex8(c.fillColor).toUpperCase() === norm;
+      var sm = c.strokeColor && colorHex8(c.strokeColor).toUpperCase() === norm;
+      return fm || sm;
+    });
+    state.selectedStrokeIndices = selectedPaths.map(getSI).filter(function (i) { return i >= 0; });
+    if (window.renderArcs) renderArcs();
+    updateUI();
+    if (!selectedPaths.length && window.showToast) showToast('Aucune forme avec cette couleur sur ce calque/cette frame');
+  }
+
+  function renderSelectedColorsPanel() {
+    var body = document.getElementById('selected-colors-body');
+    var hdr = document.getElementById('selected-colors-hdr');
+    if (!body) return;
+    var hasSel = !!(window.selectedPaths && selectedPaths.length);
+    if (hdr) hdr.textContent = hasSel ? 'Selected Colors' : 'All Project Colors';
+    var list = computeUsedColors();
+    body.innerHTML = '';
+    if (!list.length) {
+      var empty = document.createElement('div');
+      empty.className = 'pr'; empty.style.cssText = 'font-size:9px;color:var(--text-dim)';
+      empty.textContent = 'Aucune couleur';
+      body.appendChild(empty);
+      return;
+    }
+    // No silent cap on real project sizes worth flagging — most projects
+    // land well under 100 distinct colors; this is a diagnostics/recolor
+    // tool, not a performance-critical hot path, so no truncation here.
+    list.forEach(function (entry) {
+      var row = document.createElement('div'); row.className = 'pr color-row';
+      var sw = document.createElement('div'); sw.className = 'cw-mini'; sw.style.background = entry.hex; sw.style.flexShrink = '0';
+      var hexInput = document.createElement('input');
+      hexInput.type = 'text'; hexInput.className = 'pi color-hex-input'; hexInput.spellcheck = false; hexInput.maxLength = 9;
+      hexInput.value = hexDisplayValue(entry.hex);
+      var opacityInput = document.createElement('input');
+      opacityInput.type = 'number'; opacityInput.className = 'pi color-opacity-input'; opacityInput.min = 0; opacityInput.max = 100;
+      opacityInput.value = alphaPctFromHex(entry.hex);
+      var pct = document.createElement('span'); pct.className = 'color-pct'; pct.textContent = '%';
+      var selBtn = document.createElement('div'); selBtn.className = 'lico color-select-btn'; selBtn.title = 'Sélectionner les formes de cette couleur (calque/frame actifs)';
+      selBtn.innerHTML = ICON_CROSSHAIR;
+
+      hexInput.addEventListener('change', function () {
+        var parsed = window.parseHexInput ? parseHexInput(this.value) : null;
+        if (!parsed) { this.value = hexDisplayValue(entry.hex); return; }
+        recolorColor(entry.hex, parsed);
+      });
+      hexInput.addEventListener('keydown', function (e) { if (e.key === 'Enter') this.blur(); });
+      opacityInput.addEventListener('input', function () {
+        var p = Math.max(0, Math.min(100, parseInt(this.value) || 0));
+        var rgb = entry.hex.replace('#', '').slice(0, 6);
+        var a = Math.round(p / 100 * 255).toString(16).padStart(2, '0');
+        recolorColor(entry.hex, '#' + rgb + (p < 100 ? a : ''));
+      });
+      selBtn.addEventListener('click', function () { selectPathsWithColor(entry.hex); });
+
+      row.appendChild(sw); row.appendChild(hexInput); row.appendChild(opacityInput); row.appendChild(pct); row.appendChild(selBtn);
+      body.appendChild(row);
+    });
+  }
+
+  // Cheap early-return so this doesn't cost anything while the section is
+  // collapsed (the common case) — only the header's own click handler
+  // below forces a render right when it actually expands.
+  function updateSelectedColorsPanelIfVisible() {
+    var body = document.getElementById('selected-colors-body');
+    if (!body || body.classList.contains('hid')) return;
+    renderSelectedColorsPanel();
+  }
+  window.updateSelectedColorsPanel = updateSelectedColorsPanelIfVisible;
+
+  function init() {
+    var sec = document.getElementById('selected-colors-sec');
+    if (!sec) return;
+    var hdr = sec.querySelector('.phdr');
+    // ui.js's own generic .phdr delegated listener toggles the collapsed
+    // class first (it's bound earlier, at DOMContentLoaded, so it always
+    // runs before this one) — this one just renders once expansion lands,
+    // since the generic toggle has no idea this section needs a render.
+    if (hdr) hdr.addEventListener('click', function () { renderSelectedColorsPanel(); });
+    // Hooks into the app's one central "everything may have changed"
+    // choke point (selection, edits, frame navigation all funnel through
+    // updateUI already) rather than threading a call into every individual
+    // selection/edit code path — same reasoning as this file's own cheap
+    // visibility gate: near-zero cost when the section is collapsed.
+    var origUpdateUI = window.updateUI;
+    if (typeof origUpdateUI === 'function') {
+      window.updateUI = function () {
+        origUpdateUI.apply(this, arguments);
+        updateSelectedColorsPanelIfVisible();
+      };
+    }
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();


### PR DESCRIPTION
## Summary
- New always-visible right-panel section listing every distinct fill/stroke color used by the current selection, or every color used in the project when nothing is selected.
- Each color row: swatch, editable hex, editable opacity %, and a crosshair button that selects matching shapes on the active layer/frame.
- Editing hex/opacity batch-recolors every exact match (selection-scoped if selecting, project-wide otherwise — persisted data + live canvas layers).
- Fixed a bug found during testing: the `hasRealStroke` sentinel (`strokeColor:'#ffffff'` fallback for shapes with no real stroke) wasn't checked, causing a phantom white entry and a risk of writing a fake stroke color onto shapes that never had one.

## Test plan
- [x] `node --check src/js/color-manager.js`
- [x] Create 3 shapes (2 red fill, 1 green fill, no real strokes) — panel shows correct 2-color project list (no phantom white)
- [x] Crosshair on red row selects exactly the 2 red shapes, excludes green
- [x] Edit red row hex to blue — both selected shapes recolor live on canvas
- [x] Deselect — panel reverts to "All Project Colors" showing updated color set, confirming persisted data was updated too
- [x] Console clean throughout

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>