### PR TITLE
Fix effects panel UX: Add Effect flyout, collapse chevron, ground-shadow defaults

### DIFF
--- a/geometry-wasm/src/engine.rs
+++ b/geometry-wasm/src/engine.rs
@@ -2111,11 +2111,15 @@ impl VelloEngine {
                 };
                 let default_p2 = match eff.effect_type.as_str() {
                     "scanlines" => 0.5,
-                    "groundShadow" => 0.75,
+                    // kept in sync with EFFECT_DEFAULTS.groundShadow in
+                    // effects-panel.js — ground=75%/length=1 left the
+                    // shadow's reachable source band far from a typical
+                    // centered shape, making it look broken by default.
+                    "groundShadow" => 0.62,
                     _ => 0.0,
                 };
-                let default_p3 = if eff.effect_type == "groundShadow" { 1.0 } else { 0.0 };
-                let default_p4 = if eff.effect_type == "groundShadow" { 0.5 } else { 0.0 };
+                let default_p3 = if eff.effect_type == "groundShadow" { 0.6 } else { 0.0 };
+                let default_p4 = if eff.effect_type == "groundShadow" { 0.65 } else { 0.0 };
                 simple_fx_pass(
                     &self.device, &self.queue, &self.simple_fx_pipeline, &self.simple_fx_bind_group_layout, &self.simple_fx_sampler, &self.simple_fx_uniform_buf,
                     source, effect_id,

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -442,10 +442,14 @@ input[type="checkbox"]:disabled{opacity:.4;cursor:not-allowed;}
    calque... et voir les paramètre de ces effets un peu comme ici ci on
    clic sur l'effet") — a click-to-expand effect list matching the shared
    reference mockup's own "Risograph"-style panel, built by effects-
-   panel.js from ld.effects. Replaces the old visual-preview-tile grid. */
+   panel.js from ld.effects. */
 .fx-row{display:flex;align-items:center;gap:6px;padding:5px 2px;border-radius:5px;cursor:pointer;}
 .fx-row:hover{background:rgba(255,255,255,.04);}
 .fx-row.expanded{background:rgba(255,255,255,.06);}
+.fx-row-chevron{flex:none;width:12px;height:16px;display:flex;align-items:center;justify-content:center;color:rgba(236,234,231,.4);cursor:pointer;transition:transform .12s ease;}
+.fx-row-chevron:hover{color:var(--text);}
+.fx-row-chevron svg{display:block;}
+.fx-row.expanded .fx-row-chevron{transform:rotate(90deg);}
 .fx-row-eye{flex:none;width:16px;height:16px;display:flex;align-items:center;justify-content:center;color:rgba(236,234,231,.5);cursor:pointer;}
 .fx-row-eye:hover{color:var(--text);}
 .fx-row-eye svg{display:block;}
@@ -456,6 +460,47 @@ input[type="checkbox"]:disabled{opacity:.4;cursor:not-allowed;}
 .fx-row-params{padding:2px 2px 8px 22px;display:flex;flex-direction:column;gap:4px;}
 .fx-row-param{display:flex;align-items:center;gap:6px;}
 .fx-row-param .pl{width:70px;flex:none;}
+/* Add Effect flyout (2026-07, feedback: "on a pas de préviz vignette et
+   de sous menu. Pense bien l'architecture ui qui marcherait le mieux") —
+   a two-level category → preview-tile submenu, position:fixed + appended
+   to <body> (built by effects-panel.js's openAddMenu/openSubmenu) so it
+   escapes the right panel's own overflow/stacking context, same pattern
+   as showContextMenu's .ctx-menu elsewhere in this app. */
+.fx-addmenu,.fx-submenu{position:fixed;z-index:300;background:var(--panel2);border:1px solid var(--border2);border-radius:8px;box-shadow:0 8px 28px rgba(0,0,0,.45);padding:4px;min-width:150px;}
+.fx-addmenu-cat{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:6px 8px;border-radius:5px;cursor:pointer;font-size:11.5px;color:var(--text);}
+.fx-addmenu-cat:hover{background:rgba(255,255,255,.06);}
+.fx-addmenu-arrow{color:var(--text-dim);font-size:12px;}
+.fx-submenu{max-height:70vh;overflow-y:auto;}
+.fx-submenu-item{display:flex;align-items:center;gap:8px;padding:5px 8px;border-radius:5px;cursor:pointer;font-size:11.5px;color:var(--text);white-space:nowrap;}
+.fx-submenu-item:hover{background:rgba(255,255,255,.06);}
+/* Preview thumbnails — small CSS-filter/gradient approximations of each
+   WGSL effect (not a live GPU render — cheap, always in sync, good enough
+   as a visual identifier at menu size). Same base swatch + per-type trick
+   as the effect-library PR's original tile grid. */
+.fx-prev{flex:none;width:26px;height:19px;border-radius:3px;overflow:hidden;position:relative;background:linear-gradient(135deg,#ff6b57 0%,#f4c542 45%,#5b8dfc 100%);}
+.fx-prev-generic{background:var(--panel3);display:flex;align-items:center;justify-content:center;}
+.fx-prev-generic::after{content:'{ }';font-size:8px;color:var(--text-dim);}
+.fx-prev-blur{filter:blur(1.4px);}
+.fx-prev-colorAdjust{filter:contrast(1.35) brightness(1.1);}
+.fx-prev-vignette{box-shadow:inset 0 0 7px 3px rgba(0,0,0,.75);}
+.fx-prev-glow{filter:saturate(1.6) brightness(1.15) blur(.3px);box-shadow:0 0 4px 1px rgba(255,220,150,.6) inset;}
+.fx-prev-sepia{filter:sepia(1) saturate(1.4);}
+.fx-prev-invert{filter:invert(1);}
+.fx-prev-grayscale{filter:grayscale(1);}
+.fx-prev-posterize{filter:contrast(1.6) saturate(1.8) brightness(1.05);}
+.fx-prev-pixelate{background-size:400% 400%;image-rendering:pixelated;filter:contrast(1.1);}
+.fx-prev-chromaticAberration{background:linear-gradient(135deg,#ff3b3b 0%,#f4c542 45%,#3ba0ff 100%);}
+.fx-prev-chromaticAberration::after{content:'';position:absolute;inset:0;background:linear-gradient(135deg,rgba(255,0,60,.5),transparent 55%,rgba(0,180,255,.5));mix-blend-mode:screen;transform:translateX(1.5px);}
+.fx-prev-scanlines::after{content:'';position:absolute;inset:0;background:repeating-linear-gradient(to bottom,rgba(0,0,0,.55) 0,rgba(0,0,0,.55) 1px,transparent 1px,transparent 3px);}
+.fx-prev-grain{filter:contrast(1.1) brightness(.95);}
+.fx-prev-grain::after{content:'';position:absolute;inset:0;opacity:.5;background-image:radial-gradient(rgba(255,255,255,.9) .5px,transparent .5px),radial-gradient(rgba(0,0,0,.9) .5px,transparent .5px);background-size:3px 3px,4px 4px;}
+.fx-prev-sharpen{filter:contrast(1.5) saturate(1.3);}
+.fx-prev-sharpen::after{content:'';position:absolute;inset:0;box-shadow:inset 0 0 0 1px rgba(255,255,255,.4);}
+.fx-prev-edgeDetect{background:#0a0a0a;}
+.fx-prev-edgeDetect::after{content:'';position:absolute;inset:12% 22%;border:1.2px solid #eee;border-radius:2px;opacity:.85;}
+.fx-prev-groundShadow{background:linear-gradient(to bottom,#dfe6f0 0%,#dfe6f0 62%,#aab4c4 62%,#aab4c4 100%);}
+.fx-prev-groundShadow::after{content:'';position:absolute;left:30%;top:14%;width:22%;height:38%;background:#556;border-radius:3px 3px 0 0;}
+.fx-prev-groundShadow::before{content:'';position:absolute;left:38%;top:58%;width:46%;height:16%;background:rgba(0,0,0,.45);border-radius:50%;filter:blur(1px);transform:skewX(-25deg);}
 /* Figma-style paired W/H row (Document, 2026-07) — a small link icon
    between the two fields toggles proportion-lock (tools-panel-dock.js
    sibling pattern: JS toggles .on, CSS just reflects it). */

--- a/src/index.html
+++ b/src/index.html
@@ -405,9 +405,13 @@
       <div class="pbdy">
         <div class="pr" id="effects-adj-hint" style="font-size:10px;color:var(--text-dim);display:none" data-i18n="effectLayerDesc">Appliqué à tout ce qui est en dessous de ce calque dans la pile (comme un Adjustment Layer After Effects).</div>
         <div id="effects-list"></div>
-        <div class="pr">
-          <select class="psel" id="p-add-effect"><option value="">+ Add Effect…</option></select>
-        </div>
+        <!-- Categorized flyout with preview thumbnails (feedback 2026-07:
+             "on a pas de préviz vignette et de sous menu. Pense bien
+             l'architecture ui qui marcherait le mieux") — replaces the
+             plain <select>+<optgroup>; built entirely by effects-panel.js
+             (buildAddEffectMenu) so no per-category/per-effect markup
+             lives in this file. -->
+        <div class="pr"><button class="pbtn" id="p-add-effect-btn" style="flex:1">+ Add Effect…</button></div>
       </div>
     </div>
     <div class="psec" id="camera-sec" style="display:none">

--- a/src/js/effects-panel.js
+++ b/src/js/effects-panel.js
@@ -49,7 +49,15 @@
     edgeDetect: [{ key: 'p1', label: 'Intensité', min: 0, max: 20, step: 1, scale: 1, unit: '' }],
     groundShadow: [
       { key: 'p1', label: 'Inclinaison', min: -3, max: 3, step: 0.05, scale: 1, unit: '' },
-      { key: 'p2', label: 'Sol (Y)', min: 0, max: 100, step: 1, scale: 100, unit: '%' },
+      // max capped at 90 (not 100) — feedback: "l'effet ombre au sol ne
+      // marche pas j'ai l'impression". At 100% the ground line sits
+      // exactly on the canvas' last row, leaving ZERO room below it for
+      // the shadow to render into (the math is correct — y is never >
+      // ground_y when ground_y is the frame's own bottom edge — but it
+      // LOOKS broken: the slider still moves, nothing ever appears).
+      // Capping at 90 guarantees at least a sliver of canvas is always
+      // available for the shadow, regardless of Longueur.
+      { key: 'p2', label: 'Sol (Y)', min: 0, max: 90, step: 1, scale: 100, unit: '%' },
       { key: 'p3', label: 'Longueur', min: 0.1, max: 4, step: 0.05, scale: 1, unit: '×' },
       { key: 'p4', label: 'Opacité', min: 0, max: 100, step: 1, scale: 100, unit: '%' },
     ],
@@ -58,7 +66,16 @@
     blur: [8, 0, 0, 0], colorAdjust: [0, 0, 0, 0], vignette: [0.5, 0.4, 0, 0], glow: [16, 0, 0, 0],
     sepia: [0, 0, 0, 0], invert: [0, 0, 0, 0], grayscale: [0, 0, 0, 0], posterize: [6, 0, 0, 0],
     pixelate: [16, 0, 0, 0], chromaticAberration: [4, 0, 0, 0], scanlines: [240, 0.5, 0, 0],
-    grain: [0.08, 0, 0, 0], sharpen: [0.5, 0, 0, 0], edgeDetect: [4, 0, 0, 0], groundShadow: [0, 0.75, 1, 0.5],
+    grain: [0.08, 0, 0, 0], sharpen: [0.5, 0, 0, 0], edgeDetect: [4, 0, 0, 0],
+    // groundShadow default was [0, 0.75, 1, 0.5] — at ground=75%/length=1 the
+    // shader's inverse-mapped source row only reaches sy≈ground-(1-ground)
+    // ≈49.7% of canvas height, right at the edge of most centered shapes'
+    // own bottom edge: the shadow existed but was a near-invisible sliver
+    // (root cause of "l'effet ombre au sol ne marche pas j'ai l'impression").
+    // Lower ground + shorter length reach much further up the source
+    // regardless of exact shape position, so the effect is visible the
+    // moment it's added instead of requiring manual tuning to find it.
+    groundShadow: [0, 0.62, 0.6, 0.65],
   };
   // Also read by renderLayerList's FX badge (timeline.js) via window.EFFECT_LABELS.
   var EFFECT_LABELS = {
@@ -109,35 +126,89 @@
     return EFFECT_DEFAULTS[type] || [0, 0, 0, 0];
   }
 
-  function renderAddMenu(isAdjustment) {
-    var sel = document.getElementById('p-add-effect');
-    if (!sel) return;
-    sel.innerHTML = '<option value="">+ Add Effect…</option>';
+  // Categorized flyout menu with preview thumbnails (2026-07 rewrite —
+  // feedback: "on a pas de préviz vignette et de sous menu. Pense bien
+  // l'architecture ui qui marcherait le mieux"). Replaces the plain
+  // <select>+<optgroup> (functional but no visual preview and no real
+  // nested-menu structure) with a two-level flyout matching how AE/most
+  // desktop apps present a categorized "Add Effect" menu: a category list
+  // that opens a submenu of preview tiles (small CSS-approximation
+  // thumbnail + label) to the side. Built FRESH every time it's opened
+  // (not cached) since which categories/custom effects are available can
+  // change between opens (adjustment vs ordinary layer, a shader just
+  // authored, etc).
+  var addMenuEl = null, subMenuEl = null;
+  function closeAddMenu() {
+    if (addMenuEl) { addMenuEl.remove(); addMenuEl = null; }
+    if (subMenuEl) { subMenuEl.remove(); subMenuEl = null; }
+  }
+  function openSubmenu(anchorEl, items) {
+    if (subMenuEl) { subMenuEl.remove(); subMenuEl = null; }
+    var sub = document.createElement('div');
+    sub.className = 'fx-submenu';
+    items.forEach(function (item) {
+      var row = document.createElement('div');
+      row.className = 'fx-submenu-item';
+      var prev = document.createElement('div');
+      prev.className = 'fx-prev' + (item.preview ? ' fx-prev-' + item.preview : ' fx-prev-generic');
+      var lbl = document.createElement('span'); lbl.textContent = item.label;
+      row.appendChild(prev); row.appendChild(lbl);
+      row.addEventListener('click', function (e) { e.stopPropagation(); closeAddMenu(); item.action(); });
+      sub.appendChild(row);
+    });
+    document.body.appendChild(sub);
+    var r = anchorEl.getBoundingClientRect();
+    var sw = sub.offsetWidth, sh = sub.offsetHeight;
+    var left = r.right + 2;
+    if (left + sw > window.innerWidth - 4) left = r.left - sw - 2;
+    var top = Math.min(r.top, window.innerHeight - sh - 4);
+    sub.style.left = left + 'px'; sub.style.top = top + 'px';
+    subMenuEl = sub;
+  }
+  function openAddMenu(anchorEl, isAdjustment) {
+    closeAddMenu();
+    var menu = document.createElement('div');
+    menu.className = 'fx-addmenu';
     EFFECT_CATEGORIES.forEach(function (cat) {
       if (isAdjustment && cat.layerOnly) return;
-      var group = document.createElement('optgroup');
-      group.label = cat.label;
-      cat.types.forEach(function (type) {
-        var opt = document.createElement('option');
-        opt.value = type; opt.textContent = EFFECT_LABELS[type] || type;
-        group.appendChild(opt);
-      });
-      sel.appendChild(group);
+      var row = document.createElement('div');
+      row.className = 'fx-addmenu-cat';
+      row.innerHTML = '<span>' + cat.label + '</span><span class="fx-addmenu-arrow">›</span>';
+      var open = function () {
+        openSubmenu(row, cat.types.map(function (type) {
+          return { label: EFFECT_LABELS[type] || type, preview: type, action: function () { addEffect(type); } };
+        }));
+      };
+      row.addEventListener('mouseenter', open);
+      row.addEventListener('click', function (e) { e.stopPropagation(); open(); });
+      menu.appendChild(row);
     });
     // Custom shaders (2026-07) — user-authored effects saved in
     // state.customEffects, plus a fixed entry to open the authoring modal.
-    var customGroup = document.createElement('optgroup');
-    customGroup.label = 'Custom';
-    (state.customEffects || []).forEach(function (c) {
-      var opt = document.createElement('option');
-      opt.value = 'custom:' + c.id; opt.textContent = c.name;
-      customGroup.appendChild(opt);
-    });
-    var newOpt = document.createElement('option');
-    newOpt.value = '__new_custom__'; newOpt.textContent = '+ New custom shader…';
-    customGroup.appendChild(newOpt);
-    sel.appendChild(customGroup);
+    var customRow = document.createElement('div');
+    customRow.className = 'fx-addmenu-cat';
+    customRow.innerHTML = '<span>Custom</span><span class="fx-addmenu-arrow">›</span>';
+    var openCustom = function () {
+      var items = (state.customEffects || []).map(function (c) {
+        return { label: c.name, preview: null, action: function () { addEffect('custom:' + c.id); } };
+      });
+      items.push({ label: '+ New custom shader…', preview: null, action: function () { if (window.openCustomEffectEditor) window.openCustomEffectEditor(null); } });
+      openSubmenu(customRow, items);
+    };
+    customRow.addEventListener('mouseenter', openCustom);
+    customRow.addEventListener('click', function (e) { e.stopPropagation(); openCustom(); });
+    menu.appendChild(customRow);
+    document.body.appendChild(menu);
+    var r = anchorEl.getBoundingClientRect();
+    var mw = menu.offsetWidth, mh = menu.offsetHeight;
+    menu.style.left = Math.min(r.left, window.innerWidth - mw - 4) + 'px';
+    menu.style.top = Math.min(r.bottom + 2, window.innerHeight - mh - 4) + 'px';
+    addMenuEl = menu;
   }
+  document.addEventListener('pointerdown', function (e) {
+    if (addMenuEl && !addMenuEl.contains(e.target) && (!subMenuEl || !subMenuEl.contains(e.target)) && e.target.id !== 'p-add-effect-btn') closeAddMenu();
+  }, true);
+  window.addEventListener('keydown', function (e) { if (e.key === 'Escape') closeAddMenu(); });
 
   function addEffect(type) {
     var ld = activeLayer(); if (!ld) return;
@@ -207,13 +278,23 @@
     effects.forEach(function (eff, idx) {
       var row = document.createElement('div');
       row.className = 'fx-row' + (eff.enabled ? '' : ' disabled') + (expandedIdx === idx ? ' expanded' : '');
+      // Explicit disclosure chevron (feedback: "faudrait pouvoir déplier
+      // ou replier les paramètre de l'effet") — the whole row already
+      // toggled its own param panel on click, but with no visual cue that
+      // it's expandable/collapsible at all. Own click handler (not just
+      // relying on the row's) so it works even where the row's own
+      // listener might be intercepted, and rotates via CSS to show state.
+      var chevron = document.createElement('div'); chevron.className = 'fx-row-chevron';
+      chevron.innerHTML = '<svg viewBox="0 0 24 24" width="10" height="10" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M9 6l6 6-6 6"/></svg>';
+      chevron.title = expandedIdx === idx ? 'Replier' : 'Déplier';
+      chevron.addEventListener('click', function (e) { e.stopPropagation(); expandedIdx = expandedIdx === idx ? -1 : idx; renderEffectsList(); });
       var eye = document.createElement('div'); eye.className = 'fx-row-eye';
       eye.innerHTML = eff.enabled ? ICON_EYE : ICON_EYE_OFF;
       eye.title = eff.enabled ? 'Désactiver' : 'Activer';
       eye.addEventListener('click', function (e) { e.stopPropagation(); toggleEnabled(idx); });
       var name = document.createElement('span'); name.className = 'fx-row-name';
       name.textContent = labelFor(eff.type);
-      row.appendChild(eye); row.appendChild(name);
+      row.appendChild(chevron); row.appendChild(eye); row.appendChild(name);
       // Edit the shader source (custom effects only — built-ins have no
       // source to edit, just params, already reachable by expanding the row).
       if (isCustomEffect(eff.type)) {
@@ -249,7 +330,6 @@
     if (!applicable) return;
     var hint = document.getElementById('effects-adj-hint');
     if (hint) hint.style.display = ld.isEffectLayer ? '' : 'none';
-    renderAddMenu(!!ld.isEffectLayer);
     renderEffectsList();
   }
   window.updateEffectsPanel = renderEffectsSection;
@@ -257,11 +337,11 @@
   function init() {
     var sec = document.getElementById('effects-stack-sec');
     if (!sec) return;
-    var addSel = document.getElementById('p-add-effect');
-    if (addSel) addSel.addEventListener('change', function () {
-      var type = this.value; this.value = '';
-      if (type === '__new_custom__') { if (window.openCustomEffectEditor) window.openCustomEffectEditor(null); return; }
-      if (type) addEffect(type);
+    var addBtn = document.getElementById('p-add-effect-btn');
+    if (addBtn) addBtn.addEventListener('click', function (e) {
+      e.stopPropagation();
+      var ld = activeLayer();
+      openAddMenu(addBtn, !!(ld && ld.isEffectLayer));
     });
   }
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();


### PR DESCRIPTION
## Summary
- Replaces the plain `<select>+<optgroup>` Add Effect menu with a categorized flyout (category list → hover/click → submenu with a preview swatch per effect).
- Adds an explicit disclosure chevron to each effect row so expand/collapse has a visible affordance.
- Fixes ground shadow appearing broken: root cause was the default parameters (ground=75%, length=1) placing the reachable shadow band right at the edge of invisibility for a typically-centered shape. Capped Sol (Y) UI max at 90% (100% left zero room below the ground line) and retuned defaults (ground=62%, length=0.6, opacity=65%) so the effect is visible immediately on add. Synced matching fallback defaults in `engine.rs`.

## Test plan
- [x] Verified in-browser: Add Effect button opens category flyout with preview swatches; clicking an item adds the effect
- [x] Verified chevron toggles expand/collapse with rotation + tooltip
- [x] Verified ground shadow renders visibly with new defaults via pixel-probe + screenshot on a test shape
- [x] Verified previous 100%→90% cap fix still avoids the zero-shadow-room case
- [x] `node --check` on changed JS
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)