### PR TITLE
StoryBoard: enter a montage as a combined timeline view

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -168,6 +168,7 @@ var state={
   refMedia:null, // rotoscopy reference {type:'video'|'imageseq'|'image',...} — reference-bridge.js
   mediaLibrary:[], // {id,name,kind:'image'|'video',thumb,layerName} — browsable catalog of imports, media-library.js
   symbols:{},activeSymbolId:null,openSymbolTabs:[],
+  activeMontageViewId:null, // StoryBoard montage currently entered (enterMontageView) — see app.js
   // Layer folders: purely organizational metadata, not a real tree — each
   // layer optionally carries ld.folderId pointing into this map. Keeping
   // state.layers/userLayers as the same flat, 1:1-indexed arrays every
@@ -834,7 +835,20 @@ function resolveSymbolFrameIdx(sym,layer,mainFrameIdx){
   var elapsed=Math.max(0,(mainFrameIdx-(layer.symPlacedAt||0)))*(layer.symSpeed||1);
   var total=Math.max(1,sym.totalFrames);
   if(layer.symPlayMode==='single')return Math.min(total-1,Math.max(0,Math.floor(layer.symSingleFrame||0)));
-  if(layer.symPlayMode==='once')return Math.min(total-1,Math.floor(elapsed));
+  if(layer.symPlayMode==='once'){
+    // symTrimIn/symTrimOut are optional (default: play the WHOLE symbol
+    // from frame 0, unchanged behavior for every pre-existing Component-
+    // instance layer) — only enterMontageView (app.js) sets them, so a
+    // montage segment plays back exactly the source range the StoryBoard
+    // chain member was trimmed to (storyboard.js's own montageStrokesAt
+    // formula: trimIn + floor(local*srcLen/duration), reproduced here via
+    // symSpeed=srcLen/duration + symPlacedAt=that member's montage-local
+    // start frame), holding at trimOut instead of rolling into unrelated
+    // symbol frames beyond the trimmed range.
+    var trimIn=layer.symTrimIn||0;
+    var trimOut=(layer.symTrimOut!=null)?layer.symTrimOut:total-1;
+    return Math.min(trimOut,trimIn+Math.floor(elapsed));
+  }
   if(layer.symPlayMode==='pingpong'){
     if(total<2)return 0;
     var cycle=(total-1)*2;
@@ -1056,6 +1070,7 @@ function getEffectiveStrokes(layerIdx,frameIdx){
   return [];
 }
 var _symbolPaperLayers={},_sceneSnapshot=null;
+var _montageViewSnapshot=null; // enterMontageView/exitMontageView — see below
 function ensureSymbolPaperLayers(symId){
   if(_symbolPaperLayers[symId])return _symbolPaperLayers[symId];
   var sym=state.symbols[symId];var arr=[];
@@ -1410,6 +1425,83 @@ function closeSymbolTab(symId){
   if(state.activeSymbolId===symId)exitToScene();
   var idx=state.openSymbolTabs.indexOf(symId);if(idx>=0)state.openSymbolTabs.splice(idx,1);
   if(window.renderSymbolTabs)renderSymbolTabs();
+}
+// StoryBoard "entrer dans le montage" (2026-07: "si on rentre dans montage
+// cela affiche les layers de component avec le bon montage de layer afin
+// de le modifier"). Builds a temporary scene made of real Component-
+// instance layers — one per chain member, in chain order — so the montage
+// view is a normal Motion/Animation2D timeline the user already knows how
+// to read (segments = layer bars), with zero new rendering path: each
+// segment IS a real `ld.symbolId` layer, so Motion's existing "double-click
+// a Component layer enters it" (enterComponentLayer/enterSymbol) works on
+// a segment completely unmodified — no nested-nesting special-casing
+// needed, since entering a REAL symbol from here just treats "the montage
+// view's synthetic layers" as the scene to snapshot/restore, exactly like
+// it would any other scene.
+//
+// Each segment's symPlacedAt/symSpeed reproduce storyboard.js's own
+// montageStrokesAt formula exactly (symPlacedAt = that member's montage-
+// local start frame, symSpeed = srcLen/duration), and symTrimIn/symTrimOut
+// (resolveSymbolFrameIdx above) carry the member's own trim range so a
+// mid-clip trim shows correctly instead of always starting the symbol's
+// own frame 0.
+function enterMontageView(montageId){
+  if(state.activeSymbolId){showToast('Fermez d\'abord le composant en cours d\'édition');return;}
+  if(state.activeMontageViewId===montageId)return;
+  if(state.activeMontageViewId){showToast('Fermez d\'abord le montage en cours d\'édition');return;}
+  if(!window.SMStoryboard)return;
+  var m=SMStoryboard.montageById(montageId);if(!m)return;
+  var mods=SMStoryboard.chainModsForView(m);
+  if(!mods.length){showToast('Montage vide — accrochez des instances contre son bloc d\'abord');return;}
+  saveAllLayerFrames();
+  _montageViewSnapshot={layers:state.layers,totalFrames:state.totalFrames,waIn:state.waIn,waOut:state.waOut,activeLayerIdx:state.activeLayerIdx,fps:state.fps,currentFrame:state.currentFrame,userLayers:userLayers,cameraKeys:state.cameraKeys};
+  userLayers.forEach(function(l){l.opacity=0.25;});
+  var total=SMStoryboard.montageTotal(m);
+  var newLayers=[],newUls=[],acc=0;
+  arcLayer.activate();
+  mods.forEach(function(mod){
+    var sym=state.symbols[mod.symbolId];
+    var srcLen=mod.trimOut-mod.trimIn+1;
+    var frames=[];for(var i=0;i<total;i++)frames.push({strokes:[],isKeyframe:i===0,isInterpolated:false});
+    newLayers.push({
+      name:(sym?sym.name:'Composant')+' — montage',
+      symbolId:mod.symbolId,locked:true,visible:true,
+      symPlayMode:'once',symSpeed:srcLen/mod.duration,symPlacedAt:acc,
+      symTrimIn:mod.trimIn,symTrimOut:mod.trimOut,symSingleFrame:0,
+      // Explicit in/out so Motion's layer bar shows this segment's own
+      // [acc, acc+duration) span instead of defaulting to the full
+      // combined timeline (layerOutPoint's auto-detect skips symbolId
+      // layers entirely, so leaving these unset would draw every segment
+      // as one full-width bar) — this also makes getEffectiveStrokes hide
+      // the layer outside its own window for free (same inPoint/outPoint
+      // early-return every other layer already goes through).
+      inPoint:acc,outPoint:acc+mod.duration-1,
+      frames:frames,
+    });
+    newUls.push(new Layer({name:'montageview-'+montageId+'-'+newUls.length}));
+    acc+=mod.duration;
+  });
+  state.layers=newLayers;state.totalFrames=total;state.waIn=0;state.waOut=total-1;
+  window._waIn=0;window._waOut=state.waOut;window._totalF=state.totalFrames;
+  state.activeLayerIdx=0;state.currentFrame=0;
+  userLayers=newUls;
+  userLayers.forEach(function(l){l.insertBelow(arcLayer);l.visible=true;});
+  state.activeMontageViewId=montageId;
+  activateUL(0);drawStage();loadFrame(0);renderOS();renderArcs();updateUI();if(window.renderSymbolTabs)renderSymbolTabs();
+}
+function exitMontageView(){
+  if(!state.activeMontageViewId||!_montageViewSnapshot)return;
+  if(state.activeSymbolId){showToast('Fermez d\'abord le composant en cours d\'édition');return;}
+  saveAllLayerFrames();
+  userLayers.forEach(function(l){l.remove();});
+  state.layers=_montageViewSnapshot.layers;state.totalFrames=_montageViewSnapshot.totalFrames;state.waIn=_montageViewSnapshot.waIn;state.waOut=_montageViewSnapshot.waOut;
+  window._waIn=state.waIn;window._waOut=state.waOut;window._totalF=state.totalFrames;
+  state.activeLayerIdx=_montageViewSnapshot.activeLayerIdx;state.currentFrame=_montageViewSnapshot.currentFrame;state.fps=_montageViewSnapshot.fps;
+  userLayers=_montageViewSnapshot.userLayers;
+  state.cameraKeys=_montageViewSnapshot.cameraKeys;
+  userLayers.forEach(function(l){l.opacity=1;});
+  state.activeMontageViewId=null;_montageViewSnapshot=null;
+  activateUL(state.activeLayerIdx);drawStage();loadFrame(state.currentFrame);renderOS();renderArcs();updateUI();if(window.renderSymbolTabs)renderSymbolTabs();
 }
 
 // Cheap "did anything change" signal for engine-bridge.js's tick() loop,

--- a/src/js/storyboard.js
+++ b/src/js/storyboard.js
@@ -569,7 +569,11 @@
   function renderMontageBlock(m) {
     var el = document.createElement('div');
     el.className = 'sb-module sb-montageblock' + (sb().activeMontageId === m.id ? ' active' : '');
-    el.title = m.name + ' — glissez des instances contre son bord droit pour monter';
+    el.title = m.name + ' — glissez des instances contre son bord droit pour monter (double-clic: entrer dans le montage)';
+    // "Entrer" (2026-07): opens a combined Motion/Animation 2D timeline made
+    // of the chain's real components in sequence, so their layers can be
+    // modified directly — see enterMontageView (app.js).
+    el.addEventListener('dblclick', function (e) { e.stopPropagation(); if (window.SM && window.SM.enterMontageView) window.SM.enterMontageView(m.id); });
     el.innerHTML = '<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M7 5v14M17 5v14M3 10h4M3 14h4M17 10h4M17 14h4"/></svg>';
     var play = document.createElement('span');
     play.className = 'sb-play sb-block-play';
@@ -1197,6 +1201,11 @@
     montageStrokesAt: montageStrokesAt,
     montageTotal: montageTotal,
     montageById: montageById,
+    // Ordered chain members with retiming resolved (ensureRetime already
+    // called) — exposed for enterMontageView (app.js) to build one
+    // Component-instance layer per member without duplicating the chain-
+    // walk/retiming logic montageStrokesAt already owns.
+    chainModsForView: function (m) { return chainMods(m).map(function (mod) { ensureRetime(mod); return mod; }); },
     invalidateThumb: invalidateThumb,
     thumbDataUrl: thumbDataUrl, // exposed for debug/tests as well as internal reuse
   };

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -657,6 +657,8 @@ window.SM={
   splitLayerIntoElementsCore:function(li,opts){return splitLayerIntoElementsCore(li,opts);},
   exitToScene:function(){exitToScene();},
   closeSymbolTab:function(symId){closeSymbolTab(symId);},
+  enterMontageView:function(montageId){enterMontageView(montageId);},
+  exitMontageView:function(){exitMontageView();},
   setSymbolPlayMode:function(v){var ld=state.layers[state.activeLayerIdx];if(!ld||!ld.symbolId)return;ld.symPlayMode=v;loadFrame(state.currentFrame);renderOS();updateUI();},
   setSymbolSpeed:function(v){var ld=state.layers[state.activeLayerIdx];if(!ld||!ld.symbolId)return;ld.symSpeed=Math.max(0.1,parseFloat(v)||1);loadFrame(state.currentFrame);renderOS();updateUI();},
   setSymbolSingleFrame:function(v){var ld=state.layers[state.activeLayerIdx];if(!ld||!ld.symbolId)return;ld.symSingleFrame=Math.max(0,parseInt(v)||0);loadFrame(state.currentFrame);renderOS();updateUI();},
@@ -946,13 +948,27 @@ window.SM={
     // state.layers IS the symbol's own layers array (shared reference), so
     // saveAllLayerFrames keeps state.symbols current, and the scene's real
     // layers are read from the snapshot taken by enterSymbol.
+    //
+    // Same problem, same fix, for a StoryBoard montage view (2026-07,
+    // enterMontageView/app.js): while active, state.layers is a SYNTHETIC
+    // per-segment scene built for editing, not the real top-level document
+    // — saving it wholesale would silently overwrite the real scene's own
+    // layer arrangement with the montage's segments the moment autosave's
+    // 30s tick fires while a montage is open. Checked BEFORE activeSymbolId
+    // deliberately: entering a component FROM WITHIN a montage view (a
+    // supported nested case) leaves both flags set, and _sceneSnapshot in
+    // that case only unwinds one level (back to the montage view's own
+    // synthetic scene) — _montageViewSnapshot is the one that actually
+    // holds the real document.
     saveAllLayerFrames();
-    var inSym=!!(state.activeSymbolId&&_sceneSnapshot);
-    var sceneLayers=inSym?_sceneSnapshot.layers:state.layers;
-    var sceneTotal=inSym?_sceneSnapshot.totalFrames:state.totalFrames;
-    var sceneFps=inSym?_sceneSnapshot.fps:state.fps;
-    var sceneWaIn=inSym?_sceneSnapshot.waIn:state.waIn;
-    var sceneWaOut=inSym?_sceneSnapshot.waOut:state.waOut;
+    var inMontage=!!(state.activeMontageViewId&&_montageViewSnapshot);
+    var inSym=!inMontage&&!!(state.activeSymbolId&&_sceneSnapshot);
+    var srcSnap=inMontage?_montageViewSnapshot:(inSym?_sceneSnapshot:null);
+    var sceneLayers=srcSnap?srcSnap.layers:state.layers;
+    var sceneTotal=srcSnap?srcSnap.totalFrames:state.totalFrames;
+    var sceneFps=srcSnap?srcSnap.fps:state.fps;
+    var sceneWaIn=srcSnap?srcSnap.waIn:state.waIn;
+    var sceneWaOut=srcSnap?srcSnap.waOut:state.waOut;
     return JSON.stringify({version:13,totalFrames:sceneTotal,fps:sceneFps,canvasW:state.canvasW,canvasH:state.canvasH,canvasBg:state.canvasBg,waIn:sceneWaIn,waOut:sceneWaOut,
       layers:sceneLayers.map(function(l){return{name:l.name,visible:l.visible,locked:l.locked,frames:l.frames,symbolId:l.symbolId,symPlayMode:l.symPlayMode,symSpeed:l.symSpeed,symPlacedAt:l.symPlacedAt,symSingleFrame:l.symSingleFrame,symMatrix:l.symMatrix,lfsGroup:l.lfsGroup,lfsIds:l.lfsIds,lfsSettings:l.lfsSettings,blendMode:l.blendMode,folderId:l.folderId,channel:l.channel,linkGroupId:l.linkGroupId,color:l.color,motion:l.motion,motionStatic:l.motionStatic,elementMotion:l.elementMotion,inPoint:l.inPoint,outPoint:l.outPoint,nativeVideo:l.nativeVideo,matteMode:l.matteMode,montageId:l.montageId,expressions:l.expressions,isTextLayer:l.isTextLayer,isNullLayer:l.isNullLayer,isEffectLayer:l.isEffectLayer,effects:l.effects};}),
       layerFolders:state.layerFolders,layerLinkGroups:state.layerLinkGroups,
@@ -3134,9 +3150,26 @@ window.addEventListener('mouseup',function(){
 });
 function renderSymbolTabs(){
   var bar=document.getElementById('symbol-tabs');if(!bar)return;bar.innerHTML='';
-  var scene=document.createElement('div');scene.className='sym-tab'+(state.activeSymbolId?'':' act');scene.textContent='Scene';
-  scene.addEventListener('click',function(){if(state.activeSymbolId)window.SM.exitToScene();});
+  var scene=document.createElement('div');scene.className='sym-tab'+((state.activeSymbolId||state.activeMontageViewId)?'':' act');scene.textContent='Scene';
+  scene.addEventListener('click',function(){
+    if(state.activeSymbolId)window.SM.exitToScene();
+    else if(state.activeMontageViewId)window.SM.exitMontageView();
+  });
   bar.appendChild(scene);
+  // StoryBoard "entrer dans le montage" (2026-07) — a montage view sits
+  // BETWEEN Scene and any real component entered from within it (breadcrumb:
+  // Scene > Montage > Composant). Not part of openSymbolTabs — at most one
+  // montage view is active at a time, no multi-tab list needed.
+  if(state.activeMontageViewId){
+    var mtg=window.SMStoryboard&&window.SMStoryboard.montageById(state.activeMontageViewId);
+    var mtab=document.createElement('div');mtab.className='sym-tab'+(state.activeSymbolId?'':' act');
+    var mlabel=document.createElement('span');mlabel.textContent=(mtg?mtg.name:'Montage')+' (montage)';
+    var mx=document.createElement('span');mx.className='sym-tab-x';mx.textContent='×';
+    mtab.appendChild(mlabel);mtab.appendChild(mx);
+    mtab.addEventListener('click',function(e){if(e.target===mx)return;if(state.activeSymbolId)window.SM.exitToScene();});
+    mx.addEventListener('click',function(e){e.stopPropagation();if(state.activeSymbolId)window.SM.exitToScene();window.SM.exitMontageView();});
+    bar.appendChild(mtab);
+  }
   state.openSymbolTabs.forEach(function(symId){
     var sym=state.symbols[symId];if(!sym)return;
     var tab=document.createElement('div');tab.className='sym-tab'+(state.activeSymbolId===symId?' act':'');


### PR DESCRIPTION
## Summary
- Double-clicking a montage block in StoryBoard now enters a combined Motion/Animation 2D timeline made of the chain's real components, placed back-to-back as segments — double-clicking a segment drills into that component's own real layers to edit it (design confirmed with the user over the flat-merged-layers alternative).
- `enterMontageView`/`exitMontageView` (app.js) build this via real `ld.symbolId` Component-instance layers with `symPlacedAt`/`symSpeed` reproducing the montage's own retiming, plus new optional `symTrimIn`/`symTrimOut` fields so trimmed chain members play their correct source range.
- Explicit `inPoint`/`outPoint` per segment so Motion's layer bar shows the correct span instead of the full combined length.
- `renderSymbolTabs` shows a breadcrumb tab (Scene → Montage → Component) matching the existing symbol-tab UX.
- **Autosave-safety fix**: `exportJSON` now protects `activeMontageViewId` the same way it already protects `activeSymbolId` — without this, the 30s autosave tick would silently overwrite the real document's layer arrangement with the montage view's synthetic one. Found and fixed during testing.

## Test plan
- [x] Built a 2-component montage via console, entered the view: verified segmented layer bars (0–119, 120–239) and correct canvas content per segment
- [x] Double-clicked a segment: verified it enters the real component's own layers (breadcrumb Scene → Montage → Component)
- [x] Exited back to Scene: verified original 2-layer scene fully restored
- [x] Called `exportJSON()` directly while inside the montage view: confirmed it saves the original scene, not the synthetic one
- [x] `node --check` on all changed files
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)