### PR TITLE
Route raster export through the WGPU engine when effects are active

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -1453,6 +1453,61 @@
     lastSceneVersion = window._sceneVersion;
   }
 
+  // ---- Effects-aware frame export (2026-07) ----
+  // Ordinary export (exportFrameDataURL, export.js) rasterizes straight
+  // from Paper.js's own vector data — correct and fast, but bypasses the
+  // WGPU effect stack entirely, so a project using any effect (blur/
+  // vignette/glow/ground shadow/contour/threshold/halftone/...) never saw
+  // them in its exported PNG/video (feedback 2026-07: "vérifie que le
+  // rendu temps réel marche bien avec les effets" surfaced this — the live
+  // preview worked fine, but effects turned out to be preview-only).
+  //
+  // This renders ONE frame through the SAME engine + buildSceneJson the
+  // live preview already uses (reusing loadFrame/buildSceneJson keeps this
+  // a single source of truth for scene content — no second parallel
+  // per-stroke-transform implementation to drift out of sync with, the
+  // exact family-of-bug-#1 risk this codebase explicitly warns against),
+  // at the document's own resolution and zoom=1 — NOT whatever the
+  // on-screen viewport happens to be sized/zoomed to, since effect pixel
+  // params are now zoom-scaled (see run_one_effect, engine.rs) and must
+  // match the true document size to look right in the export.
+  //
+  // Scope limitation: unlike exportFrameDataURL, this path doesn't support
+  // a supersampling `scale` factor — export.js only takes it for scale=1
+  // when routing through here. Revisit if higher-res effect exports are
+  // ever needed.
+  var _fxExportSavedFrame = null, _fxExportSavedEngineW = 0, _fxExportSavedEngineH = 0;
+  function beginEffectsExport() {
+    if (!engine) return false;
+    suspended = true; // same gate suspend() sets — see tick()'s own check
+    _fxExportSavedFrame = state.currentFrame;
+    _fxExportSavedEngineW = engineW; _fxExportSavedEngineH = engineH;
+    return true;
+  }
+  async function renderFrameToPixelsPNG(frameIdx) {
+    var cw = state.canvasW, ch = state.canvasH;
+    engine.resize(cw, ch);
+    engine.set_viewport(0, 0, 1, 0, cw / 2, ch / 2);
+    loadFrame(frameIdx);
+    var json = buildSceneJson(true);
+    var bytes = await engine.render_to_pixels(json);
+    var imgData = new ImageData(new Uint8ClampedArray(bytes.buffer, bytes.byteOffset, bytes.byteLength), cw, ch);
+    var off = document.createElement('canvas'); off.width = cw; off.height = ch;
+    off.getContext('2d').putImageData(imgData, 0, 0);
+    return off.toDataURL('image/png');
+  }
+  function endEffectsExport() {
+    if (_fxExportSavedFrame === null) return;
+    loadFrame(_fxExportSavedFrame);
+    if (_fxExportSavedEngineW && _fxExportSavedEngineH) engine.resize(_fxExportSavedEngineW, _fxExportSavedEngineH);
+    syncViewport();
+    lastSceneJson = ''; // force a full re-render at the restored size/viewport
+    suspended = false;
+    invalidateOverlayBase();
+    renderNow();
+    _fxExportSavedFrame = null;
+  }
+
   window.SMEngineBridge = {
     setEnabled: setEnabled,
     isEnabled: function () { return enabled; },
@@ -1480,6 +1535,13 @@
       invalidateOverlayBase();
       if (overlayRafId) { cancelAnimationFrame(overlayRafId); overlayRafId = 0; pendingOverlayItem = null; }
     },
+    // Effects-aware frame export (2026-07) — see the functions' own
+    // comments above. beginEffectsExport/endEffectsExport bracket a whole
+    // export run (called once each); renderFrameToPixelsPNG is called once
+    // per exported frame in between.
+    beginEffectsExport: beginEffectsExport,
+    renderFrameToPixelsPNG: renderFrameToPixelsPNG,
+    endEffectsExport: endEffectsExport,
   };
 
   // Rust/vello is now the default renderer (no more opt-in checkbox) — per

--- a/src/js/export.js
+++ b/src/js/export.js
@@ -211,13 +211,36 @@ async function exportRunFfmpeg(args,onProgress){
   }
 }
 
+// Any layer with an enabled effect anywhere in the project — mirrors
+// engine.rs's own has_effects_stack check (composite_scene). Cheap: no
+// layer in the overwhelming common case (no effects used) short-circuits
+// on the very first layer.
+function exportHasActiveEffects(){
+  return state.layers.some(function(ld){return ld.effects&&ld.effects.some(function(e){return e.enabled;});});
+}
 // ---- PNG sequence rendering to a working directory (shared by raster exports) ----
 async function exportRenderPNGsToDir(dir,start,end,scale,onProgress,alpha){
-  for(var f=start,i=1;f<=end;f++,i++){
-    var url=exportFrameDataURL(f,scale,alpha);
-    var bytes=exportDataURLToBytes(url);
-    await exportWriteBytes(dir+'/frame_'+pad4(i)+'.png',bytes);
-    if(onProgress)onProgress(i,end-start+1);
+  // Effects (blur/vignette/glow/ground shadow/...) only ever rendered in
+  // the live GPU preview — exportFrameDataURL rasterizes straight from
+  // Paper.js's vector data, with no route through the WGPU effect stack at
+  // all (feedback 2026-07: "vérifie que le rendu temps réel marche bien
+  // avec les effets" surfaced this gap). When the project actually uses an
+  // effect, route every frame through the engine instead so the export
+  // matches what the user sees on screen — see engine-bridge.js's
+  // beginEffectsExport/renderFrameToPixelsPNG/endEffectsExport.
+  // Scale>1 (supersampled export) isn't supported on this path yet, so it
+  // only kicks in at the default scale — see renderFrameToPixelsPNG's own
+  // comment for why.
+  var useFx=(scale===1||!scale)&&exportHasActiveEffects()&&window.SMEngineBridge&&window.SMEngineBridge.beginEffectsExport();
+  try{
+    for(var f=start,i=1;f<=end;f++,i++){
+      var url=useFx?await SMEngineBridge.renderFrameToPixelsPNG(f):exportFrameDataURL(f,scale,alpha);
+      var bytes=exportDataURLToBytes(url);
+      await exportWriteBytes(dir+'/frame_'+pad4(i)+'.png',bytes);
+      if(onProgress)onProgress(i,end-start+1);
+    }
+  }finally{
+    if(useFx)SMEngineBridge.endEffectsExport();
   }
 }
 


### PR DESCRIPTION
## Summary
- Found: `exportFrameDataURL` (used by every raster export — PNG sequence, MP4, TIFF, ProRes, GIF) rasterizes straight from Paper.js's vector data, completely bypassing the WGPU effect stack. Every effect was preview-only.
- `engine-bridge.js`: new `beginEffectsExport`/`renderFrameToPixelsPNG`/`endEffectsExport` bracket an export run — reuses `loadFrame`+`buildSceneJson` (same scene path the live preview uses) + `render_to_pixels`, at the document's native resolution/zoom=1. Suspends the live rAF tick for the duration and fully restores frame/engine-size/viewport afterward.
- `export.js`: `exportRenderPNGsToDir` now checks `exportHasActiveEffects()` once and routes through the engine path when true. Scoped to scale=1 (no supersampling support yet on this path).

## Test plan
- [x] Called the new functions directly: exported PNG matches document resolution (1920x1080) exactly
- [x] Confirmed the blur effect is visibly present in the exported frame (bbox widened well beyond the shape's own bounds vs. no-blur baseline)
- [x] 3-frame sequential export produced 3 valid PNGs
- [x] Live preview and `state.currentFrame` correctly restored after export
- [x] `node --check` on changed files
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)