### PR TITLE
Fix feedback action-log gaps, live Motion keyframe-drag, stale selection box

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1392,6 +1392,16 @@ function enterSymbol(symId){
   if(state.activeSymbolId){showToast('Composants imbriqués non supportés — fermez le composant courant');return;}
   if(!state.symbols[symId])return;
   saveAllLayerFrames();
+  // "double clic sur un component le bounding box de la selection reste"
+  // (2026-07) — a selection made in the OUTER scene stayed in
+  // `selectedPaths` across this document-context swap; buildTransformBoxItems
+  // (engine-bridge.js) only checks selectedPaths.length, not which document
+  // is active, so it kept drawing a stale box/handles for items that still
+  // exist (just dimmed to opacity 0.25 below) but belong to a scene that's
+  // no longer the active one. Same fix applied on the way back out
+  // (exitToScene) and for StoryBoard's own document swap (enterMontageView/
+  // exitMontageView).
+  if(typeof clearSel==='function')clearSel();
   _sceneSnapshot={layers:state.layers,totalFrames:state.totalFrames,waIn:state.waIn,waOut:state.waOut,activeLayerIdx:state.activeLayerIdx,fps:state.fps,currentFrame:state.currentFrame,userLayers:userLayers,cameraKeys:state.cameraKeys};
   userLayers.forEach(function(l){l.opacity=0.25;});
   var sym=state.symbols[symId];
@@ -1409,6 +1419,7 @@ function enterSymbol(symId){
 function exitToScene(){
   if(!state.activeSymbolId||!_sceneSnapshot)return;
   saveAllLayerFrames();
+  if(typeof clearSel==='function')clearSel(); // see enterSymbol's own comment — same stale-selection risk in reverse
   var symId=state.activeSymbolId;
   // totalFrames/fps are primitives copied into state at enterSymbol() time,
   // not a live binding back to state.symbols[symId] — write them back now
@@ -1461,6 +1472,7 @@ function enterMontageView(montageId){
   var mods=SMStoryboard.chainModsForView(m);
   if(!mods.length){showToast('Montage vide — accrochez des instances contre son bloc d\'abord');return;}
   saveAllLayerFrames();
+  if(typeof clearSel==='function')clearSel(); // see enterSymbol's own comment — same document-swap stale-selection risk
   _montageViewSnapshot={layers:state.layers,totalFrames:state.totalFrames,waIn:state.waIn,waOut:state.waOut,activeLayerIdx:state.activeLayerIdx,fps:state.fps,currentFrame:state.currentFrame,userLayers:userLayers,cameraKeys:state.cameraKeys};
   userLayers.forEach(function(l){l.opacity=0.25;});
   var total=SMStoryboard.montageTotal(m);
@@ -1500,6 +1512,7 @@ function exitMontageView(){
   if(!state.activeMontageViewId||!_montageViewSnapshot)return;
   if(state.activeSymbolId){showToast('Fermez d\'abord le composant en cours d\'édition');return;}
   saveAllLayerFrames();
+  if(typeof clearSel==='function')clearSel(); // see enterSymbol's own comment
   userLayers.forEach(function(l){l.remove();});
   state.layers=_montageViewSnapshot.layers;state.totalFrames=_montageViewSnapshot.totalFrames;state.waIn=_montageViewSnapshot.waIn;state.waOut=_montageViewSnapshot.waOut;
   window._waIn=state.waIn;window._waOut=state.waOut;window._totalF=state.totalFrames;

--- a/src/js/audio-bridge.js
+++ b/src/js/audio-bridge.js
@@ -26,6 +26,14 @@
   }
 
   function tracks() { return state.audioTracks || (state.audioTracks = []); }
+  // Feedback action log (2026-07, "récupère des données exploitable pour
+  // résoudre les soucis") — state.audioTracks isn't part of
+  // layersSnapshotNow()'s undo snapshot, so these mutations can't route
+  // through pushUndoLayers; logging directly is the only way an audio-track
+  // edit shows up in a feedback report's action trail. See feedback-
+  // bridge.js's logAction() doc comment for why an explicit string is
+  // passed instead of relying on state.tool.
+  function logAudio(action) { if (window.SMFeedback) SMFeedback.logAction('audio:' + action); }
 
   // ---- decoding + waveform peaks ----
   function dataURLToArrayBuffer(dataURL) {
@@ -128,6 +136,7 @@
         function up() {
           document.removeEventListener('pointermove', mv);
           document.removeEventListener('pointerup', up);
+          logAudio('offset');
           renderStrip();
         }
         document.addEventListener('pointermove', mv);
@@ -189,6 +198,7 @@
       mute.addEventListener('click', function (e) {
         e.stopPropagation();
         track.muted = !track.muted;
+        logAudio('mute');
         if (state.playing) restartAt(state.currentFrame);
         renderStrip();
       });
@@ -205,7 +215,7 @@
         input.style.cssText = 'width:100%;background:var(--bg);border:1px solid var(--accent);color:var(--text);font-size:11px;border-radius:4px;padding:1px 4px;outline:none;';
         nm.innerHTML = ''; nm.appendChild(input); input.focus(); input.select();
         var done = false;
-        function commit() { if (done) return; done = true; var v = input.value.trim(); if (v) track.name = v; renderStrip(); }
+        function commit() { if (done) return; done = true; var v = input.value.trim(); if (v) { track.name = v; logAudio('rename'); } renderStrip(); }
         input.addEventListener('keydown', function (ev) { ev.stopPropagation(); if (ev.key === 'Enter') commit(); else if (ev.key === 'Escape') { done = true; renderStrip(); } });
         input.addEventListener('blur', commit);
         input.addEventListener('mousedown', function (e2) { e2.stopPropagation(); });
@@ -222,6 +232,7 @@
         track.volume = vol.value / 100;
         if (track._gainNode) track._gainNode.gain.value = track.muted ? 0 : track.volume;
       });
+      vol.addEventListener('change', function () { logAudio('volume'); });
       row.appendChild(vol);
 
       var del = document.createElement('div');
@@ -230,6 +241,7 @@
         e.stopPropagation();
         stopTrack(track);
         tracks().splice(ti, 1);
+        logAudio('deleteTrack');
         renderStrip();
       });
       row.appendChild(del);
@@ -269,6 +281,7 @@
   function addTrackFromDataURL(name, dataURL) {
     var track = { name: name, dataB64: dataURL, offsetFrames: 0, volume: 1, muted: false };
     tracks().push(track);
+    logAudio('import');
     if (dataURL.length > 8 * 1024 * 1024) {
       showToast('Audio volumineux : préférer mp3/ogg (l’autosave navigateur peut ne plus suivre)');
     }

--- a/src/js/camera.js
+++ b/src/js/camera.js
@@ -580,7 +580,7 @@
       ensureState();
       if (!state.cameraLayerOn) {
         state.cameraLayerOn = true;
-        if (!state.cameraKeys.length) setKey(0, defaultRect());
+        if (!state.cameraKeys.length) { pushUndo(); setKey(0, defaultRect()); }
         renderLayerList(); renderTimeline();
       }
       window.SM.setTool(state.tool === 'camera' ? 'select' : 'camera');
@@ -588,8 +588,16 @@
       updateCameraPanel();
       if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
     });
+    // pushUndo() here (2026-07: "récupère des données exploitable pour
+    // résoudre les soucis" — the feedback action log/undo stack was
+    // silently skipping this button entirely, unlike a camera keyframe
+    // added/removed by DRAGGING, which already calls pushUndo() via
+    // onDown further down this file) — cameraKeys IS part of
+    // layersSnapshotNow()'s undo snapshot, so this was a real gap, not a
+    // structural exclusion like StoryBoard/audio below.
     var addKey = document.getElementById('btn-cam-addkey');
     if (addKey) addKey.addEventListener('click', function () {
+      pushUndo();
       var f = state.currentFrame;
       if (keyAt(f)) removeKey(f);
       else setKey(f, cameraAtFrame(f) || defaultRect());

--- a/src/js/feedback-bridge.js
+++ b/src/js/feedback-bridge.js
@@ -27,11 +27,25 @@
   // before every meaningful mutation) — consecutive same-tool/same-frame
   // calls collapse into one entry with a running count, so a long freehand
   // drag or a burst of clicks doesn't flood the trail with duplicates.
-  function logAction() {
+  //
+  // Optional `explicitTool` (2026-07, "récupère des données exploitable
+  // pour résoudre les soucis"): StoryBoard (storyboard.js) and audio
+  // tracks (audio-bridge.js) mutate state that ISN'T part of
+  // layersSnapshotNow()'s undo snapshot (state.storyboard/state.audioTracks
+  // aren't captured there), so they can't route through pushUndoLayers —
+  // there'd be nothing real for undo to restore. Rather than leave those
+  // two subsystems invisible to the log entirely, their own call sites log
+  // directly with a descriptive string ("storyboard:addInstance",
+  // "audio:deleteTrack", ...) instead of falling back to state.tool, which
+  // would otherwise record whatever DRAWING tool happened to be selected —
+  // misleading, not just uninformative, for an action that has nothing to
+  // do with it. Every pre-existing call site (via pushUndoLayers) keeps
+  // passing nothing and gets state.tool exactly as before.
+  function logAction(explicitTool) {
     if (!state.actionLog) state.actionLog = [];
     var ld = state.layers[state.activeLayerIdx];
     var last = state.actionLog[state.actionLog.length - 1];
-    var tool = state.tool, frame = state.currentFrame, layerName = ld ? ld.name : null;
+    var tool = explicitTool || state.tool, frame = state.currentFrame, layerName = ld ? ld.name : null;
     if (last && last.tool === tool && last.frame === frame && last.layer === layerName) {
       last.count = (last.count || 1) + 1;
       last.t = Date.now();

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -2564,6 +2564,14 @@
       });
       touched.forEach(sortKeys);
       renderTimeline();
+      // Live stage feedback (2026-07: "un component ne bouge pas en temps
+      // réel quand on drag" — the timeline diamond tracked the cursor via
+      // renderTimeline() above, but the interpolated value AT THE CURRENT
+      // PLAYHEAD only changed on mouseup, since nothing re-rendered the
+      // stage until onDragUp's own renderNow(). Every sibling drag
+      // (onDrag's canvas gizmo, layer-inout.js's bar drag) already
+      // re-renders on every move — this was the one gap.
+      if (window.SMEngineBridge) SMEngineBridge.renderNow();
       return;
     }
     var d = window._motionKeyDrag; if (!d) return;
@@ -2585,6 +2593,7 @@
       d.keys.forEach(function (s) { s.key.frame += deltaFrames; sortKeys(s.holder.motion[s.prop]); });
       d.startX = e.clientX; // re-baseline so the next move is a fresh delta from here
       renderTimeline();
+      if (window.SMEngineBridge) SMEngineBridge.renderNow(); // live stage feedback — see skew-drag branch's own comment above
       return;
     }
     var nf = Math.max(0, Math.min(state.totalFrames - 1, d.startFrame + deltaFrames));
@@ -2593,6 +2602,7 @@
     if (keyAt(track, nf)) return; // don't stomp an existing key
     d.key.frame = nf; sortKeys(track);
     renderTimeline();
+    if (window.SMEngineBridge) SMEngineBridge.renderNow(); // live stage feedback — see skew-drag branch's own comment above
   }
   function onDragUp() {
     endMarquee();

--- a/src/js/storyboard.js
+++ b/src/js/storyboard.js
@@ -551,6 +551,7 @@
           function up() {
             document.removeEventListener('pointermove', mv);
             document.removeEventListener('pointerup', up);
+            logSb(stretch ? 'stretch' : 'trim');
             render(); updatePreview();
           }
           document.addEventListener('pointermove', mv);
@@ -846,6 +847,7 @@
         // snap-join: instance → chain row; sound → under-chain audio lane;
         // montage blocks never join anything.
         var joined = tryJoinChain(m, 0, 0) || tryJoinAudio(m);
+        logSb('moveModule');
         render();
         if (joined) updatePreview();
       }
@@ -876,12 +878,12 @@
           } else {
             menu.push({ label: 'Scinder (placez le lecteur dans ce clip)', disabled: true, action: function () {} });
           }
-          menu.push({ label: 'Réinitialiser le retiming', action: function () { m.trimIn = 0; m.trimOut = symbolDuration(m.symbolId) - 1; m.duration = m.trimOut + 1; render(); updatePreview(); } });
-          menu.push({ label: 'Détacher du montage', action: function () { leaveAnyChain(m); m.y += 110; render(); updatePreview(); } });
+          menu.push({ label: 'Réinitialiser le retiming', action: function () { logSb('resetRetime'); m.trimIn = 0; m.trimOut = symbolDuration(m.symbolId) - 1; m.duration = m.trimOut + 1; render(); updatePreview(); } });
+          menu.push({ label: 'Détacher du montage', action: function () { logSb('detach'); leaveAnyChain(m); m.y += 110; render(); updatePreview(); } });
         }
       }
       if (m.type === 'montage') {
-        menu.push({ label: 'Renommer', action: function () { var v = prompt('Nom du montage', m.name); if (v) { m.name = v; render(); } } });
+        menu.push({ label: 'Renommer', action: function () { var v = prompt('Nom du montage', m.name); if (v) { logSb('rename'); m.name = v; render(); } } });
         // The link between the three modes: a montage becomes a LAYER in
         // Animation 2D/Motion (spec: "apparaîtra comme un layer dans les
         // autres timelines"). The montage stays the source of truth —
@@ -890,9 +892,9 @@
         menu.push({ label: 'Placer comme calque dans Animation 2D', action: function () { placeMontageAsLayer(m); } });
       }
       if (m.type === 'sound' && audioHostOf(m)) {
-        menu.push({ label: 'Détacher du montage', action: function () { leaveAnyChain(m); m.y += 60; render(); } });
+        menu.push({ label: 'Détacher du montage', action: function () { logSb('detach'); leaveAnyChain(m); m.y += 60; render(); } });
       }
-      menu.push({ label: 'Supprimer le module', action: function () { leaveAnyChain(m); var s = sb(); s.modules.splice(s.modules.indexOf(m), 1); if (s.activeMontageId === m.id) s.activeMontageId = null; render(); } });
+      menu.push({ label: 'Supprimer le module', action: function () { logSb('deleteModule'); leaveAnyChain(m); var s = sb(); s.modules.splice(s.modules.indexOf(m), 1); if (s.activeMontageId === m.id) s.activeMontageId = null; render(); } });
       window.showContextMenu(e.clientX, e.clientY, menu);
     });
   }
@@ -937,8 +939,19 @@
     });
   }
 
+  // Feedback action log (2026-07, "récupère des données exploitable pour
+  // résoudre les soucis") — state.storyboard isn't part of
+  // layersSnapshotNow()'s undo snapshot, so these mutations can't route
+  // through pushUndoLayers (nothing for undo to actually restore); logging
+  // directly here is the only way a StoryBoard edit shows up in a feedback
+  // report's action trail at all. See feedback-bridge.js's logAction() doc
+  // comment for why this passes an explicit string instead of relying on
+  // state.tool (StoryBoard mode has no meaningful "drawing tool" active).
+  function logSb(action) { if (window.SMFeedback) SMFeedback.logAction('storyboard:' + action); }
+
   function addInstance(symbolId, x, y) {
     sb().modules.push({ id: newId(), type: 'instance', symbolId: symbolId, x: Math.round(x), y: Math.round(y) });
+    logSb('addInstance');
     render();
   }
   // "Synchroniser l'affichage des éléments dans StoryBoard pour tout
@@ -960,6 +973,7 @@
     var m = { id: newId(), type: 'montage', name: 'Montage ' + (s.modules.filter(function (x2) { return x2.type === 'montage'; }).length + 1), x: Math.round(x), y: Math.round(y), chain: [], audio: [], playhead: 0 };
     s.modules.push(m);
     s.activeMontageId = m.id;
+    logSb('addMontage');
     render();
     return m;
   }
@@ -1103,8 +1117,8 @@
       } else {
         menu.push({ label: 'Scinder (cliquer la forme d’onde pour placer le point)', disabled: true, action: function () {} });
       }
-      if (audioHostOf(m)) menu.push({ label: 'Détacher du montage', action: function () { leaveAnyChain(m); m.y += 60; render(); } });
-      menu.push({ label: 'Supprimer le module', action: function () { leaveAnyChain(m); var s = sb(); s.modules.splice(s.modules.indexOf(m), 1); render(); } });
+      if (audioHostOf(m)) menu.push({ label: 'Détacher du montage', action: function () { logSb('detach'); leaveAnyChain(m); m.y += 60; render(); } });
+      menu.push({ label: 'Supprimer le module', action: function () { logSb('deleteModule'); leaveAnyChain(m); var s = sb(); s.modules.splice(s.modules.indexOf(m), 1); render(); } });
       window.showContextMenu(e.clientX, e.clientY, menu);
     });
     return el;
@@ -1116,6 +1130,7 @@
     m.cursorSec = null;
     if (_audioBuffers[m.id]) _audioBuffers[right.id] = _audioBuffers[m.id];
     s.modules.push(right);
+    logSb('splitSound');
     render();
   }
 
@@ -1162,6 +1177,7 @@
     mod.duration = local;
     sb().modules.push(newMod);
     host.chain.splice(host.chain.indexOf(mod.id) + 1, 0, newMod.id);
+    logSb('splitChainClip');
     render(); updatePreview();
   }
 


### PR DESCRIPTION
## Summary
Three fixes from this session's audit and bug reports:

1. **Feedback action log gaps** — `state.actionLog` only fires via `pushUndoLayers()`, but StoryBoard and audio-track edits mutate state that isn't part of the undo snapshot, so they never reached it. `logAction()` now accepts an explicit label; `storyboard.js`/`audio-bridge.js` log directly at every real mutation. Also fixed the camera add/remove-keyframe button, which never called `pushUndo()` unlike dragging a camera key.
2. **Motion keyframe drag not live** — `onDragMove`'s keyframe-retime branches updated the timeline DOM every mousemove but only called `SMEngineBridge.renderNow()` on mouseup, so the stage snapped to the new position only on release.
3. **Stale selection box after entering a Component** — `enterSymbol`/`exitToScene`/`enterMontageView`/`exitMontageView` never cleared `selectedPaths` across a document-context swap, so a selection made in the outer scene kept drawing its box over newly-entered content.

## Test plan
- [x] StoryBoard/audio actions now appear in `state.actionLog` with descriptive labels (verified via console)
- [x] Camera add-key button now grows the undo stack
- [x] Double-clicking a 3-shape Component (previously selected as a whole) now shows a correctly-sized box around just the entered layer, not the stale outer selection (verified visually)
- [x] `node --check` on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)