### PR TITLE
Fix custom anchor point not following the shape when moved

### DIFF
--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -773,7 +773,24 @@
         if (p.data && p.data.brushCompanions) {
           p.data.brushCompanions.forEach(function (c) { if (!c.removed) c.translate(delta); });
         }
+        // Custom anchor point (2026-07: "on déplace un point d'ancrage avec
+        // alt et l'on bouge l'objet après ... celui-ci ne se déplace pas
+        // avec l'objet") — xformAnchorCustom is stored as an ABSOLUTE
+        // world-space [x,y] (placeAnchorAt, above), not derived from the
+        // shape's bounds like the 9-dot preset anchor is, so it must be
+        // translated explicitly here or it's left stranded at its old
+        // position the moment the shape moves out from under it.
+        if (p.data && p.data.xformAnchorCustom) {
+          p.data.xformAnchorCustom = [p.data.xformAnchorCustom[0] + delta.x, p.data.xformAnchorCustom[1] + delta.y];
+        }
       });
+      // Same fix for the session-level anchor (state.xformAnchorCustom) the
+      // on-canvas crosshair/gizmo actually reads (tools.js's xformAnchorPoint)
+      // — a single global value, translated once per move tick rather than
+      // once per selected path.
+      if (state.xformAnchorCustom) {
+        state.xformAnchorCustom = [state.xformAnchorCustom[0] + delta.x, state.xformAnchorCustom[1] + delta.y];
+      }
       symGestureAccumulate(new Matrix().translate(delta));
     } else if (mode === 'xform-scale') {
       // Geometry-space pointer (NOT reassigning pt — lastPt at the end of


### PR DESCRIPTION
## Summary
- A custom anchor placed via Alt+click/drag is stored as an absolute world-space `[x,y]` (both `state.xformAnchorCustom` and the persisted `p.data.xformAnchorCustom`), unlike the 9-dot preset anchor which is re-derived from the shape's bounds live.
- The plain object-move drag already translates every companion geometry field (segments, centerSegments, linkedFill, brushCompanions) by `delta`, but never touched `xformAnchorCustom` — leaving it stranded at its old position once the shape moved.
- Added the same delta translation for both the per-item and session-level custom anchor. Scale/rotate drags are correctly left untouched since the anchor is their pivot by design.

## Test plan
- [x] Placed a custom anchor at a rectangle's corner, dragged the rectangle — anchor's offset relative to the shape's bounds stayed identical before/after (verified numerically: 9.07/20.88 in both cases) instead of staying at its old absolute position
- [x] `node --check` on changed file
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)