### PR TITLE
Stroke panel: Smooth applies live (no Apply button), moved below Width

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -572,6 +572,11 @@
           <span class="pl" data-i18n="fieldWidth2">Width</span><input type="number" class="pi scrub" id="p-sw" value="3" min="1" max="300" data-step="1" data-i18n-title="strokeWidthTitle" title="Stroke width (px) — pilote aussi la taille des dabs du Bitmap Brush" style="flex:0 0 56px">
           <select class="psel" id="p-strokestyle" style="flex:1"><option value="solid" data-i18n="styleSolid">Solid</option><option value="dashed" data-i18n="styleDashed">Dashed</option><option value="dotted" data-i18n="styleDotted">Dotted</option></select>
         </div>
+        <!-- Smooth moved right below Width (feedback 2026-07: "le smooth
+             doit aller en dessous de Width") — was much further down, past
+             Brush/Bitmap Brush. No more Apply button either (see its own
+             input's comment / timeline.js) — applies live on change. -->
+        <div class="pr" data-i18n-title="poststrokeSmoothTitle" title="Re-smooths the SELECTED stroke's existing geometry — unlike Tool Options' Smooth (which only shapes new strokes as you draw), this is a one-shot action you can apply after the fact, repeatedly, to a stroke already on the canvas. Note: a freshly-drawn stroke is already simplified at draw time (Tool Options' Smooth, 10 by default) — applying THIS at the same or lower value won't visibly change anything since it's already fit that tightly; raise it for a visible extra effect."><span class="pl" data-i18n="fieldSmooth">Smooth</span><input type="number" class="pi scrub" id="p-poststroke-smooth" value="25" min="0" max="80" data-step="1"></div>
         <div class="pr"><span class="pl" data-i18n="fieldCap">Cap</span><div class="icon-grp" id="p-cap-grp" data-value="round">
           <button class="icon-btn" data-value="round" data-i18n-title="capRound" title="Round"><svg viewBox="0 0 24 10"><line x1="4" y1="5" x2="20" y2="5" stroke="currentColor" stroke-width="6" stroke-linecap="round"/></svg></button>
           <button class="icon-btn" data-value="butt" data-i18n-title="capButt" title="Butt"><svg viewBox="0 0 24 10"><line x1="4" y1="5" x2="20" y2="5" stroke="currentColor" stroke-width="6" stroke-linecap="butt"/></svg></button>
@@ -647,7 +652,6 @@
         <div class="pr" data-i18n-title="bitmapApplyTitle" title="Re-stamps every selected Bitmap Brush stroke (or converts a selected vector-textured/plain stroke) with the settings above"><span class="pl"></span><button class="pbtn" id="btn-bitmap-apply" style="flex:1;font-size:10px" type="button" data-i18n="btnApplySelection">Apply to selection</button></div>
         <div class="pr" data-i18n-title="bitmapRemoveTitle" title="Strips the bitmap texture off every selected stroke, restoring its plain stroke/fill"><span class="pl"></span><button class="pbtn" id="btn-bitmap-remove" style="flex:1;font-size:10px" type="button" data-i18n="btnRemoveSelection">Remove from selection</button></div>
         </div>
-        <div class="pr" data-i18n-title="poststrokeSmoothTitle" title="Re-smooths the SELECTED stroke's existing geometry — unlike Tool Options' Smooth (which only shapes new strokes as you draw), this is a one-shot action you can apply after the fact, repeatedly, to a stroke already on the canvas. Note: a freshly-drawn stroke is already simplified at draw time (Tool Options' Smooth, 10 by default) — applying THIS at the same or lower value won't visibly change anything since it's already fit that tightly; raise it for a visible extra effect."><span class="pl" data-i18n="fieldSmooth">Smooth</span><input type="number" class="pi scrub" id="p-poststroke-smooth" value="25" min="0" max="80" data-step="1"><button class="pbtn" id="btn-poststroke-smooth" data-i18n="btnApply">Apply</button></div>
       </div>
     </div>
     <!-- Selected Colors (2026-07, "un nouvel onglet de gestion des couleurs

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -461,7 +461,18 @@ window.SM={
   smoothSelectedStroke:function(amount){
     if(!((state.tool==='select'||state.tool==='subselect')&&selectedPaths.length))return;
     amount=Math.max(0,parseFloat(amount)||0);
-    pushUndo();
+    // No Apply button anymore (2026-07: "plus besoin du bouton apply pour
+    // smooth, il le fait directement quand on change de valeur") — wired to
+    // the field's own 'change' event instead, which the scrub mechanism
+    // (ui.js) ALSO dispatches repeatedly WHILE dragging (coalesced per
+    // frame, not just at release) — its OWN pushUndo() already fires once
+    // at the start of that drag (ui.js's pointermove handler), so calling
+    // pushUndo() again here on every one of those live ticks would spam
+    // the undo stack with one throwaway entry per frame instead of a
+    // single "before Smooth" snapshot. Skip ONLY this call's own snapshot
+    // while a scrub is live; a plain typed value + Enter/blur (no scrub
+    // involved, flag never set) still gets its own real undo step here.
+    if(!window._scrubLiveActive)pushUndo();
     selectedPaths.forEach(function(p){
       if(p.data&&p.data.isVectorBrush&&p.data.centerSegments&&p.data.centerSegments.length>1){
         var raw=p.data.centerSegments.map(function(s){return new Point(s.point[0],s.point[1]);});
@@ -4820,7 +4831,13 @@ document.getElementById('p-stab').addEventListener('change',function(){window.SM
 document.getElementById('p-strokestyle').addEventListener('change',function(){window.SM.setStrokeStyle(this.value);});
 document.getElementById('p-miterlimit').addEventListener('change',function(){window.SM.setMiterLimit(this.value);});
 document.getElementById('p-dashoffset').addEventListener('change',function(){window.SM.setDashOffset(this.value);});
-document.getElementById('btn-poststroke-smooth').addEventListener('click',function(){window.SM.smoothSelectedStroke(document.getElementById('p-poststroke-smooth').value);});
+// "Apply" button removed (2026-07: "plus besoin du bouton apply pour
+// smooth, il le fait directement quand on change de valeur") — the field
+// applies live on its own 'change' (fires on type+Enter/blur, and on the
+// scrub drag's own coalesced/final dispatches — see smoothSelectedStroke's
+// own comment for why its internal pushUndo() is skipped during a live
+// scrub instead of double-snapshotting).
+document.getElementById('p-poststroke-smooth').addEventListener('change',function(){window.SM.smoothSelectedStroke(this.value);});
 // Icon-button groups (Cap/Join/Paint Order) — clicking a button selects it
 // (single-choice, like a radio group) and calls the matching SM setter.
 // `data-value` on the wrapper always mirrors the currently-selected


### PR DESCRIPTION
## Summary
- `#p-poststroke-smooth` now applies on its own 'change' event instead of a separate "Apply" button (button removed).
- Guarded `smoothSelectedStroke`'s own `pushUndo()` to skip while a scrub drag is live — the scrub mechanism already snapshots once at drag-start; without this, every scrub-dispatched change during a drag would push a redundant undo entry.
- Moved the Smooth row from its old position (past Brush/Bitmap Brush) to directly below Width.

## Test plan
- [x] Verified: dragging Smooth updates the value live with no Apply click needed
- [x] Verified: exactly one undo entry per full scrub drag (not one per tick)
- [x] `node --check` on changed JS
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)