### PR TITLE
Hide layer panel unless reached via explicit timeline click

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -604,6 +604,7 @@ window.SM={
     if(src.elementMotion)state.layers[ni].elementMotion=JSON.parse(JSON.stringify(src.elementMotion));
     if(src.inPoint!=null)state.layers[ni].inPoint=src.inPoint;if(src.outPoint!=null)state.layers[ni].outPoint=src.outPoint;activateUL(ni);loadFrame(state.currentFrame);updateUI();},
   setActiveLayer:function(idx){if(idx<0||idx>=state.layers.length)return;saveAllLayerFrames();activateUL(idx);clearSel();
+    window._layerActiveExplicit=true; // see clearSel()'s own comment — an explicit timeline row click, not a canvas deselect
     // The camera row is a synthetic pseudo-layer (not a real state.layers
     // entry — see camera.js's renderPanelRow) selected by switching TO the
     // camera tool, never by an activeLayerIdx change; picking a real layer
@@ -1399,13 +1400,17 @@ function updatePropsContext(){
   }else{
     ctx='document';
     show['canvas-sec']=true;
-    // Nothing selected on canvas — the right panel falls back to Document,
-    // which is also the natural place to surface the clicked layer's own
-    // properties (Blend Mode). state.activeLayerIdx is already whatever
-    // layer was last clicked in the layer list (setActiveLayer runs on
-    // every row click), so this needs no separate "layer panel selection"
-    // tracking of its own.
-    show['layer-sec']=!!(state.layers[state.activeLayerIdx]);
+    // Nothing selected on canvas — the right panel falls back to Document.
+    // Layer-sec (Blend Mode etc.) only joins it if the CURRENT activeLayerIdx
+    // was reached by an explicit click on a layer row in the timeline
+    // (window._layerActiveExplicit, set by setActiveLayer/cleared by
+    // clearSel() — tools.js) — 2026-07: "si on clic dans le canvas sans
+    // rien sélectionner il ne faut pas afficher les options de calque, ce
+    // n'est que si on sélectionne des calques dans la timeline". Before
+    // this flag, activeLayerIdx being ALWAYS a valid index (never "none")
+    // meant this branch showed the last-active layer's properties even
+    // right after deselecting everything on canvas.
+    show['layer-sec']=!!window._layerActiveExplicit&&!!(state.layers[state.activeLayerIdx]);
     hdrText='Document';
   }
   // p-blendmode sync moved OUT of the 'document' branch above: it only ran

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -715,7 +715,18 @@ function rotateCenterSegments(segs,angleDeg,cx,cy){
 // selection it was built from, so it's cleared here too — nodeLayer
 // (the Paper-fallback's actual visual dots) already gets wiped by the
 // next real renderNodeHandles() call, no need to touch it here.
-function clearSel(){selectedPaths=[];state.selectedStrokeIndices=[];_nodeSel=[];state.xformAnchorCustom=null;state.xformAnchorHovered=false;state.xformRingHovered=false;if(typeof nodeHandles!=='undefined')nodeHandles=[];}
+function clearSel(){selectedPaths=[];state.selectedStrokeIndices=[];_nodeSel=[];state.xformAnchorCustom=null;state.xformAnchorHovered=false;state.xformRingHovered=false;if(typeof nodeHandles!=='undefined')nodeHandles=[];
+  // 2026-07 ("si on clic dans le canvas sans rien sélectionner il ne faut
+  // pas afficher les options de calque, ce n'est que si on sélectionne des
+  // calques dans la timeline"): drop the "an explicit timeline layer click
+  // is why layer-sec is showing" flag every time selection resets — clicking
+  // empty canvas (which routes through here, select-bridge.js) falls back
+  // to the fallback 'document' context in updatePropsContext(), which
+  // should then hide layer-sec instead of defaulting to the last-active
+  // layer. setActiveLayer (timeline.js) sets the flag back to true right
+  // after ITS OWN clearSel() call, so clicking a layer row still works.
+  if(typeof window!=='undefined')window._layerActiveExplicit=false;
+}
 function getSI(path){var ch=userLayers[state.activeLayerIdx].children;for(var i=0;i<ch.length;i++){if(ch[i]===path)return i;}return -1;}
 // UI/UX audit (2026-07): the statusbar footer has claimed "⌘/Ctrl+D
 // Dupliquer" for as long as an object selection exists, but NOTHING wired


### PR DESCRIPTION
## Summary
- Clicking empty canvas with nothing selected previously left the Layer/Blend/Matte panel (`#layer-sec`) visible, falling back to `state.activeLayerIdx` even though no explicit layer action happened.
- Now gated behind a new `window._layerActiveExplicit` flag: set true only by `setActiveLayer` (an explicit timeline row click), cleared by `clearSel()` (canvas deselect and any other selection reset).

## Test plan
- [x] Click a layer row in the timeline → Layer section appears.
- [x] Click empty canvas → Layer section disappears.
- [x] Click the layer row again → Layer section reappears.
- [x] `node --check` on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)