### PR TITLE
Harmonize Stroke panel brush controls into the floating Brush panel

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -622,36 +622,20 @@
             </optgroup>
           </select>
         </div>
-        <div class="pr" id="p-brushpreset-apply-row" style="display:none"><span class="pl"></span><button class="pbtn" id="btn-brushpreset-apply" data-i18n="btnApplySelection">Apply to selection</button></div>
-        <!-- Bitmap Brush, unified into Stroke (2026-07, "que tous soit dans
-             trait unifier... pour plus de cohérence") — was its own separate
-             psec; now sits right below the vector Brush row above, same
-             swatch-button-opens-a-preview-grid pattern (bitmap-tip-picker.js
-             mirrors brush-preset-picker.js exactly) instead of a plain
-             <select>, so choosing a tip finally shows what it looks like
-             before picking it, same as the vector presets already do. -->
-        <div class="pr" data-i18n-title="bitmapBrushRowTitle" title="Renders this stroke as a stamped raster texture (real bitmap grain) instead of the vector Brush above — the geometry Draw captures stays the same, only the OUTPUT becomes an image layer. The vector presets above are untouched (kept for exports like Rive that need real vector dabs) — this is a parallel category, not a replacement."><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer"><input type="checkbox" id="p-bitmapbrush-on" style="accent-color:var(--accent)"> <span data-i18n="bitmapBrushLabel">Bitmap Brush (Draw tool)</span></label></div>
-        <!-- Sous-rangées Bitmap Brush repliées derrière la checkbox
-             ci-dessus (audit panel droit 2026-07-17) : 8 lignes de réglages
-             n'ont de sens que si Bitmap Brush est activé — masquées par
-             défaut (checkbox off), togglées par toggleBitmapBrushRows() en
-             plus de son ancien rôle purement fonctionnel (ui.js). -->
-        <div id="p-bitmapbrush-rows" style="display:none">
-        <div class="pr" id="p-bitmaptip-row">
-          <span class="pl" data-i18n="fieldTip">Tip</span>
-          <button class="bp-swatch-btn" id="p-bitmaptip-btn" type="button"><canvas id="p-bitmaptip-preview" width="120" height="20"></canvas><span id="p-bitmaptip-label" data-i18n="tipSoftRound">Soft Round</span></button>
-        </div>
-        <!-- La row "Size" du Bitmap Brush a été retirée (2026-07-17) : la
-             taille des dabs est unifiée avec le Width du Trait (p-sw) —
-             un seul champ pilote l'épaisseur, vecto comme bitmap. -->
-        <div class="pr" data-i18n-title="bitmapSpacingTitle" title="Distance between stamps along the stroke, as a % of tip size — lower = denser/smoother coverage, higher = visible individual dabs"><span class="pl" data-i18n="fieldSpacing">Spacing</span><input type="number" class="pi scrub" id="p-bitmap-spacing" value="15" min="2" max="100" data-step="1"><span style="font-size:9px;color:var(--text-dim)">%</span></div>
-        <div class="pr" data-i18n-title="bitmapScatterTitle" title="Random position/size jitter per stamp — 0 = perfectly even, mechanical dabbing"><span class="pl" data-i18n="fieldScatter">Scatter</span><input type="number" class="pi scrub" id="p-bitmap-scatter" value="20" min="0" max="100" data-step="1"><span style="font-size:9px;color:var(--text-dim)">%</span></div>
-        <div class="pr"><span class="pl" data-i18n="fieldOpacity">Opacity</span><input type="number" class="pi scrub" id="p-bitmap-opacity" value="100" min="5" max="100" data-step="1"><span style="font-size:9px;color:var(--text-dim)">%</span></div>
-        <div class="pr" data-i18n-title="bitmapPressureTitle" title="Modulates stamp size by real tablet pen pressure, captured while drawing — Draw tool only, ignored for shapes/other tools"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer"><input type="checkbox" id="p-bitmap-pressure" style="accent-color:var(--accent)" checked> <span data-i18n="bitmapPressureLabel">Pressure (tablet)</span></label></div>
-        <div class="pr" data-i18n-title="bitmapImportAbrTitle" title="Import a Photoshop .abr brush file — its tip shape(s) become selectable Tip presets above, alongside the procedural ones"><span class="pl"></span><button class="pbtn" id="btn-bitmap-import-abr" style="flex:1;font-size:10px" type="button" data-i18n="bitmapImportAbrBtn">Import .abr tip…</button><input type="file" id="bitmap-abr-file" accept=".abr" style="display:none"></div>
-        <div class="pr" data-i18n-title="bitmapApplyTitle" title="Re-stamps every selected Bitmap Brush stroke (or converts a selected vector-textured/plain stroke) with the settings above"><span class="pl"></span><button class="pbtn" id="btn-bitmap-apply" style="flex:1;font-size:10px" type="button" data-i18n="btnApplySelection">Apply to selection</button></div>
-        <div class="pr" data-i18n-title="bitmapRemoveTitle" title="Strips the bitmap texture off every selected stroke, restoring its plain stroke/fill"><span class="pl"></span><button class="pbtn" id="btn-bitmap-remove" style="flex:1;font-size:10px" type="button" data-i18n="btnRemoveSelection">Remove from selection</button></div>
-        </div>
+        <!-- "Apply to selection" button and the whole Bitmap Brush section
+             (checkbox + Tip/Spacing/Scatter/Opacity/Pressure/Import .abr/
+             Apply/Remove rows) moved OUT of Stroke (2026-07, harmonization
+             pass — "que tous soit dans le panneau flottant Brush, la
+             checkbox Bitmap Brush entièrement"): the floating Brush panel
+             (brush-menu-bridge.js, opened from the Draw/Fill-Brush tools'
+             own floating strip) already mirrors every one of these controls
+             in its Bitmap tab, so this row and the whole bitmap block below
+             were pure duplication once that panel existed. Picking a preset/
+             tip there now auto-applies to the current selection directly
+             (window.SM.applyVectorBrushToSelection/applyBitmapBrushToSelection,
+             timeline.js/bitmap-brush.js) instead of needing a separate
+             button click here — the floating panel is the sole source of
+             truth for both vector and bitmap brush settings now. -->
       </div>
     </div>
     <!-- Selected Colors (2026-07, "un nouvel onglet de gestion des couleurs

--- a/src/js/bitmap-brush.js
+++ b/src/js/bitmap-brush.js
@@ -686,51 +686,111 @@
   // specKey is the corresponding data.bitmapBrushSpec property name;
   // toSpec converts the panel's displayed value into the units the spec
   // actually stores (opacity is 0-100 in the UI, 0-1 in the spec).
-  function bindNum(id, key, def, specKey, toSpec) {
-    var el = document.getElementById(id); if (!el) return;
-    state[key] = def;
-    function apply() {
-      var v = parseFloat(this.value) || def;
-      state[key] = v;
-      if (!specKey) return;
-      if (!(state.tool === 'select' || state.tool === 'subselect') || !selectedPaths.length) return;
-      var targets = selectedPaths.filter(function (p) { return p.data && p.data.bitmapBrushSpec; });
-      if (!targets.length) return;
-      pushUndo();
-      var specVal = toSpec ? toSpec(v) : v;
-      var layer = userLayers[state.activeLayerIdx];
-      targets.forEach(function (p) { p.data.bitmapBrushSpec[specKey] = specVal; regenerate(p, layer); });
-      saveActiveLayerFrame();
-      if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
-    }
-    el.addEventListener('change', apply);
-    el.addEventListener('input', apply);
+  // Pure state+live-selection setter (no DOM dependency) — was the guts of
+  // an element's 'change'/'input' handler; the Stroke panel's own
+  // #p-bitmap-spacing/-scatter/-opacity/-pressure inputs are gone (2026-07
+  // harmonization, moved to the floating Brush panel), so this is now
+  // called directly by that panel's own mirrored number inputs
+  // (brush-menu-bridge.js) instead of via bindNum's removed element.
+  function setBitmapNumericState(key, v, specKey, toSpec) {
+    state[key] = v;
+    if (!specKey) return;
+    if (!(state.tool === 'select' || state.tool === 'subselect') || !selectedPaths.length) return;
+    var targets = selectedPaths.filter(function (p) { return p.data && p.data.bitmapBrushSpec; });
+    if (!targets.length) return;
+    pushUndo();
+    var specVal = toSpec ? toSpec(v) : v;
+    var layer = userLayers[state.activeLayerIdx];
+    targets.forEach(function (p) { p.data.bitmapBrushSpec[specKey] = specVal; regenerate(p, layer); });
+    saveActiveLayerFrame();
+    if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
   }
-  function init() {
-    var onEl = document.getElementById('p-bitmapbrush-on');
-    if (onEl) {
-      state.bitmapBrushOn = false;
-      // Sous-rangées (Tip/Spacing/Scatter/Opacity/Pressure/Import/Apply/
-      // Remove) repliées derrière cette checkbox — audit panel droit
-      // 2026-07-17, elles n'ont de sens que si Bitmap Brush est activé.
-      var rowsEl = document.getElementById('p-bitmapbrush-rows');
-      if (rowsEl) rowsEl.style.display = onEl.checked ? 'block' : 'none';
-      onEl.addEventListener('change', function () {
-        state.bitmapBrushOn = this.checked;
-        if (rowsEl) rowsEl.style.display = this.checked ? 'block' : 'none';
-        // Select/Subselect with a live selection (2026-07-17, "on peut pas
-        // switch avec un stroke vecto") : the checkbox now doubles as the
-        // switch this panel already had buttons for — btn-bitmap-apply/
-        // -remove below — so toggling it with something selected converts
-        // that selection immediately instead of only affecting the NEXT
-        // stroke drawn. Empty selection (or Draw tool active): unchanged,
-        // draw-tool-default-only behavior.
-        if ((state.tool === 'select' || state.tool === 'subselect') && selectedPaths.length) {
-          var btn = document.getElementById(this.checked ? 'btn-bitmap-apply' : 'btn-bitmap-remove');
-          if (btn) btn.click();
-        }
-      });
+  // Kept for any element that might still exist in some other build/layout
+  // — a no-op today (id never resolves), but harmless, and it's what seeds
+  // state[key]'s default now that the Stroke-panel elements are gone.
+  function bindNum(id, key, def, specKey, toSpec) {
+    state[key] = def;
+    var el = document.getElementById(id); if (!el) return;
+    el.addEventListener('change', function () { setBitmapNumericState(key, parseFloat(this.value) || def, specKey, toSpec); });
+    el.addEventListener('input', function () { setBitmapNumericState(key, parseFloat(this.value) || def, specKey, toSpec); });
+  }
+  window.SM.setBitmapSpacing = function (v) { setBitmapNumericState('bitmapSpacing', v, 'spacing'); };
+  window.SM.setBitmapScatter = function (v) { setBitmapNumericState('bitmapScatter', v, 'scatter'); };
+  window.SM.setBitmapOpacity = function (v) { setBitmapNumericState('bitmapOpacity', v, 'opacity', function (x) { return x / 100; }); };
+  // Same "also patch the current selection" pattern as setBitmapNumericState
+  // above — pressure toggling a stroke's own spec needs a full re-stamp (a
+  // stroke baked with pressure=false has no bitmapPressureProfile shaping to
+  // fall back on, so toggling it back on regenerates flat-width dabs until
+  // the stroke is redrawn — an acceptable, pre-existing limitation of the
+  // profile itself, not something this introduces).
+  function setBitmapPressure(checked) {
+    state.bitmapPressure = checked;
+    if (!(state.tool === 'select' || state.tool === 'subselect') || !selectedPaths.length) return;
+    var targets = selectedPaths.filter(function (p) { return p.data && p.data.bitmapBrushSpec; });
+    if (!targets.length) return;
+    pushUndo();
+    var layer = userLayers[state.activeLayerIdx];
+    targets.forEach(function (p) { p.data.bitmapBrushSpec.pressure = checked; regenerate(p, layer); });
+    saveActiveLayerFrame();
+    if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+  }
+  window.SM.setBitmapPressure = setBitmapPressure;
+  // Toggles Bitmap Brush on/off — was the Stroke panel's #p-bitmapbrush-on
+  // checkbox's own change handler; that checkbox (and its whole sub-row
+  // section) is gone (2026-07 harmonization, moved out to the floating
+  // Brush panel's Bitmap tab, which already mirrored every one of these
+  // controls) — this is now a plain function the floating panel
+  // (brush-menu-bridge.js) calls directly, since there's no longer a DOM
+  // checkbox here to own the change event at all.
+  // Apply / Remove to selection ("changer taille, type de brush et autre
+  // paramètre une fois appliqué et dessiné" + "passer d'un brush vecto à
+  // texturé et inversement") — mirrors applyVectorBrushToSelection
+  // (timeline.js) exactly, including reuse of the SAME shared
+  // stripAnyBrushTexture (app.js) so converting either direction, or just
+  // re-editing a bitmap stroke's own tip/size/spacing/scatter in place, all
+  // go through one clean path. Were the Stroke panel's own
+  // #btn-bitmap-apply/-remove click handlers; now plain functions the
+  // floating Brush panel (brush-menu-bridge.js) and setBitmapBrushOn below
+  // both call directly, since there's no longer a button here at all.
+  function applyBitmapBrushToSelection() {
+    var eligible = selectedPaths.filter(function (p) { return p instanceof Path && !(p.data && (p.data.isVectorBrush || p.data.isFillShape)) && (p.strokeColor || p.fillColor || (p.data && (p.data.brushTexturePreset || p.data.bitmapBrushSpec))); });
+    if (!eligible.length) { if (window.showToast) showToast('Sélectionne au moins un trait'); return; }
+    pushUndo();
+    eligible.forEach(function (p) {
+      stripAnyBrushTexture(p);
+      applyBitmapBrushTexture(p);
+    });
+    saveActiveLayerFrame(); updateUI();
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+    if (window.showToast) showToast('Bitmap Brush appliqué à la sélection');
+  }
+  function removeBitmapBrushFromSelection() {
+    var eligible = selectedPaths.filter(function (p) { return p instanceof Path && p.data && (p.data.bitmapBrushSpec || p.data.brushTexturePreset); });
+    if (!eligible.length) { if (window.showToast) showToast('Aucun trait texturé sélectionné'); return; }
+    pushUndo();
+    eligible.forEach(function (p) { stripAnyBrushTexture(p); });
+    saveActiveLayerFrame(); updateUI();
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+    if (window.showToast) showToast('Texture retirée');
+  }
+  window.SM.applyBitmapBrushToSelection = applyBitmapBrushToSelection;
+  window.SM.removeBitmapBrushFromSelection = removeBitmapBrushFromSelection;
+  function setBitmapBrushOn(on) {
+    state.bitmapBrushOn = !!on;
+    // Select/Subselect with a live selection (2026-07-17, "on peut pas
+    // switch avec un stroke vecto") : toggling doubles as the switch
+    // applyBitmapBrushToSelection/removeBitmapBrushFromSelection below
+    // provide — so toggling it with something selected converts that
+    // selection immediately instead of only affecting the NEXT stroke
+    // drawn. Empty selection (or Draw tool active): unchanged, draw-tool-
+    // default-only behavior.
+    if ((state.tool === 'select' || state.tool === 'subselect') && selectedPaths.length) {
+      if (on) applyBitmapBrushToSelection(); else removeBitmapBrushFromSelection();
     }
+  }
+  window.SM.setBitmapBrushOn = setBitmapBrushOn;
+  function init() {
+    state.bitmapBrushOn = false;
     // Tip is now picked via bitmap-tip-picker.js's swatch popover (panel
     // reorg pass) — state.bitmapTip's default lives here since this file
     // still owns that state field, the picker only ever writes to it.
@@ -741,90 +801,40 @@
     bindNum('p-bitmap-spacing', 'bitmapSpacing', 15, 'spacing');
     bindNum('p-bitmap-scatter', 'bitmapScatter', 20, 'scatter');
     bindNum('p-bitmap-opacity', 'bitmapOpacity', 100, 'opacity', function (v) { return v / 100; });
+    state.bitmapPressure = true;
     var pressEl = document.getElementById('p-bitmap-pressure');
-    if (pressEl) {
-      state.bitmapPressure = pressEl.checked;
-      pressEl.addEventListener('change', function () {
-        state.bitmapPressure = this.checked;
-        // Same "also patch the current selection" fix as spacing/scatter/
-        // opacity above — pressure toggling a stroke's own spec needs a
-        // full re-stamp (a stroke baked with pressure=false has no
-        // bitmapPressureProfile shaping to fall back on, so toggling it
-        // back on regenerates flat-width dabs until the stroke is redrawn —
-        // an acceptable, pre-existing limitation of the profile itself,
-        // not something this fix introduces).
-        if (!(state.tool === 'select' || state.tool === 'subselect') || !selectedPaths.length) return;
-        var targets = selectedPaths.filter(function (p) { return p.data && p.data.bitmapBrushSpec; });
-        if (!targets.length) return;
-        pushUndo();
-        var layer = userLayers[state.activeLayerIdx];
-        targets.forEach(function (p) { p.data.bitmapBrushSpec.pressure = state.bitmapPressure; regenerate(p, layer); });
-        saveActiveLayerFrame();
-        if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
-      });
-    }
-
-    // ---- Apply / Remove to selection ("changer taille, type de brush et
-    // autre paramètre une fois appliqué et dessiné" + "passer d'un brush
-    // vecto à texturé et inversement") — mirrors the vector preset panel's
-    // own "Apply to selection" button (timeline.js) exactly, including
-    // reuse of the SAME shared stripAnyBrushTexture (app.js) so converting
-    // either direction, or just re-editing a bitmap stroke's own
-    // tip/size/spacing/scatter in place, all go through one clean path. ----
-    var applyBtn = document.getElementById('btn-bitmap-apply');
-    if (applyBtn) applyBtn.addEventListener('click', function () {
-      var eligible = selectedPaths.filter(function (p) { return p instanceof Path && !(p.data && (p.data.isVectorBrush || p.data.isFillShape)) && (p.strokeColor || p.fillColor || (p.data && (p.data.brushTexturePreset || p.data.bitmapBrushSpec))); });
-      if (!eligible.length) { if (window.showToast) showToast('Sélectionne au moins un trait'); return; }
-      pushUndo();
-      eligible.forEach(function (p) {
-        stripAnyBrushTexture(p);
-        applyBitmapBrushTexture(p);
-      });
-      saveActiveLayerFrame(); updateUI();
-      if (window.SMEngineBridge) SMEngineBridge.renderNow();
-      if (window.showToast) showToast('Bitmap Brush appliqué à la sélection');
-    });
-    var removeBtn = document.getElementById('btn-bitmap-remove');
-    if (removeBtn) removeBtn.addEventListener('click', function () {
-      var eligible = selectedPaths.filter(function (p) { return p instanceof Path && p.data && (p.data.bitmapBrushSpec || p.data.brushTexturePreset); });
-      if (!eligible.length) { if (window.showToast) showToast('Aucun trait texturé sélectionné'); return; }
-      pushUndo();
-      eligible.forEach(function (p) { stripAnyBrushTexture(p); });
-      saveActiveLayerFrame(); updateUI();
-      if (window.SMEngineBridge) SMEngineBridge.renderNow();
-      if (window.showToast) showToast('Texture retirée');
-    });
+    if (pressEl) { state.bitmapPressure = pressEl.checked; pressEl.addEventListener('change', function () { setBitmapPressure(this.checked); }); }
 
     // ---- ABR import ----
-    var abrBtn = document.getElementById('btn-bitmap-import-abr');
-    var abrFile = document.getElementById('bitmap-abr-file');
-    if (abrBtn && abrFile) {
-      abrBtn.addEventListener('click', function () { abrFile.click(); });
-      abrFile.addEventListener('change', function () {
-        var file = this.files && this.files[0];
-        this.value = ''; // allow re-importing the same file name later
-        if (!file || !window.SMAbrImport) return;
-        var reader = new FileReader();
-        reader.onload = function () {
-          var tipsFound;
-          try { tipsFound = window.SMAbrImport.readAbrArrayBuffer(reader.result); }
-          catch (e) { if (window.showToast) showToast('Import .abr échoué : ' + e.message); return; }
-          var lastId = null;
-          tipsFound.forEach(function (t, i) {
-            var id = 'abr_' + Date.now().toString(36) + '_' + i;
-            customTips[id] = { name: t.name, canvas: t.canvas };
-            lastId = id;
-          });
-          // Picker swatch (bitmap-tip-picker.js) owns the visible label/
-          // preview now — select the just-imported tip and repaint it.
-          if (lastId) { state.bitmapTip = lastId; if (window.BitmapTipPicker) window.BitmapTipPicker.paintButton(lastId); }
-          if (window.showToast) showToast(tipsFound.length + ' tip(s) importé(s) depuis ' + file.name);
-        };
-        reader.onerror = function () { if (window.showToast) showToast('Lecture du fichier .abr échouée'); };
-        reader.readAsArrayBuffer(file);
-      });
-    }
+    // The Stroke panel's own #btn-bitmap-import-abr button + hidden
+    // #bitmap-abr-file input are gone (2026-07 harmonization) — the actual
+    // import logic is now importAbrFile() below (module scope, takes a
+    // File directly, no dependency on a specific <input> element), exposed
+    // via window.SM so the floating Brush panel (brush-menu-bridge.js) can
+    // create its own button + file input and call it.
   }
+  function importAbrFile(file) {
+    if (!file || !window.SMAbrImport) return;
+    var reader = new FileReader();
+    reader.onload = function () {
+      var tipsFound;
+      try { tipsFound = window.SMAbrImport.readAbrArrayBuffer(reader.result); }
+      catch (e) { if (window.showToast) showToast('Import .abr échoué : ' + e.message); return; }
+      var lastId = null;
+      tipsFound.forEach(function (t, i) {
+        var id = 'abr_' + Date.now().toString(36) + '_' + i;
+        customTips[id] = { name: t.name, canvas: t.canvas };
+        lastId = id;
+      });
+      // Picker swatch (bitmap-tip-picker.js) owns the visible label/
+      // preview now — select the just-imported tip and repaint it.
+      if (lastId) { state.bitmapTip = lastId; if (window.BitmapTipPicker) window.BitmapTipPicker.paintButton(lastId); }
+      if (window.showToast) showToast(tipsFound.length + ' tip(s) importé(s) depuis ' + file.name);
+    };
+    reader.onerror = function () { if (window.showToast) showToast('Lecture du fichier .abr échouée'); };
+    reader.readAsArrayBuffer(file);
+  }
+  window.SM.importAbrFile = importAbrFile;
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
 
   window.SMBitmapBrush = {

--- a/src/js/brush-menu-bridge.js
+++ b/src/js/brush-menu-bridge.js
@@ -27,12 +27,91 @@
 
   function closePopover() {
     if (!popover) return;
+    // A live hover-preview (see below) must never survive the popover
+    // closing some OTHER way than a plain mouseleave (outside click,
+    // Escape, re-toggle) — none of those fire the swatch's own mouseleave,
+    // so without this an uncommitted preview (no pushUndo, no
+    // saveActiveLayerFrame) could linger applied to the live Paper objects.
+    revertBrushPreview();
     popover.remove();
     popover = null;
     if (closeHandlers) { closeHandlers(); closeHandlers = null; }
     if (window.renderLabsFloatPanel) renderLabsFloatPanel();
   }
   function isOpen() { return !!popover; }
+
+  // ---- Hover-preview (2026-07, "un hover en preview sur le canvas comme
+  // pour le blend-mode des calques") — mirrors initBlendDropdown's own
+  // applyPreview/revert pattern (timeline.js): apply live on mouseenter, no
+  // undo/save; revert to the pre-hover snapshot on mouseleave. Unlike a
+  // blend-mode string, a brush/tip is a STRUCTURAL edit (creates/removes
+  // companion dab objects via stripAnyBrushTexture/applyBrushTexture), so
+  // "revert" means re-running that same strip+apply pair against a snapshot
+  // of each path's ORIGINAL texture (preset key or full bitmapSpec object),
+  // not just restoring a scalar.
+  var _previewSnapshot = null;
+  function eligiblePathsForPreview() {
+    if (!(state.tool === 'select' || state.tool === 'subselect') || !selectedPaths.length) return [];
+    return selectedPaths.filter(function (p) { return p instanceof Path && !(p.data && (p.data.isVectorBrush || p.data.isFillShape)); });
+  }
+  function beginBrushPreview() {
+    if (_previewSnapshot) return;
+    _previewSnapshot = eligiblePathsForPreview().map(function (p) {
+      return {
+        p: p,
+        preset: (p.data && p.data.brushTexturePreset) || null,
+        bitmapSpec: (p.data && p.data.bitmapBrushSpec) ? JSON.parse(JSON.stringify(p.data.bitmapBrushSpec)) : null,
+      };
+    });
+  }
+  function previewVectorBrush(key) {
+    beginBrushPreview();
+    if (!_previewSnapshot.length) return;
+    _previewSnapshot.forEach(function (rec) {
+      stripAnyBrushTexture(rec.p);
+      if (key && key !== 'none') applyBrushTexture(rec.p, key);
+    });
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+  }
+  // Explicit spec (not the current-selection default applyBitmapBrushTexture
+  // would otherwise fall back to) so hovering TIP B while TIP A is actually
+  // selected previews B, not a no-op re-application of A — mirrors that
+  // function's own default-spec shape (bitmap-brush.js) intentionally.
+  function previewBitmapBrush(tipKey) {
+    beginBrushPreview();
+    if (!_previewSnapshot.length) return;
+    _previewSnapshot.forEach(function (rec) {
+      var p = rec.p;
+      var spec = {
+        tip: tipKey,
+        size: state.brushSize || 40,
+        spacing: state.bitmapSpacing != null ? state.bitmapSpacing : 15,
+        scatter: state.bitmapScatter != null ? state.bitmapScatter : 20,
+        opacity: (state.bitmapOpacity != null ? state.bitmapOpacity : 100) / 100,
+        color: p.strokeColor ? colorHex8(p.strokeColor) : ((p.data && p.data.preTextureStroke) || state.strokeColor || '#000000'),
+        pressure: !!state.bitmapPressure,
+        seed: Math.floor(Math.random() * 0xffffffff),
+      };
+      stripAnyBrushTexture(p);
+      applyBitmapBrushTexture(p, spec);
+    });
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+  }
+  function revertBrushPreview() {
+    if (!_previewSnapshot) return;
+    _previewSnapshot.forEach(function (rec) {
+      stripAnyBrushTexture(rec.p);
+      if (rec.bitmapSpec) applyBitmapBrushTexture(rec.p, rec.bitmapSpec);
+      else if (rec.preset) applyBrushTexture(rec.p, rec.preset);
+    });
+    _previewSnapshot = null;
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+  }
+  // Called right before a REAL commit (a swatch click) — the preview must
+  // be undone first so the commit's own pushUndo() snapshots the true
+  // pre-hover state, not the already-mutated preview (else Ctrl+Z would
+  // restore to the hovered-but-not-chosen brush instead of the original).
+  function commitBrushPreview() { revertBrushPreview(); }
 
   // ---- shared param-row builder — a `.pr`/`.pl`/`.pi` row identical in
   // markup to the ones already in index.html's right panel, so it's
@@ -121,16 +200,42 @@
     checkRow(params, 'Taper ends', !!state.taperEnds, function (v) { driveOriginal('p-taper', v, true, 'change'); });
   }
   function buildBitmapParams(params) {
-    checkRow(params, 'Bitmap Brush actif', !!state.bitmapBrushOn, function (v) { driveOriginal('p-bitmapbrush-on', v, true, 'change'); });
+    // The Stroke panel's #p-bitmapbrush-on checkbox is gone (2026-07
+    // harmonization — this floating panel is the sole owner of
+    // state.bitmapBrushOn now), so this calls window.SM.setBitmapBrushOn
+    // directly instead of driving a hidden original element that no longer
+    // exists.
+    checkRow(params, 'Bitmap Brush actif', !!state.bitmapBrushOn, function (v) { if (window.SM && window.SM.setBitmapBrushOn) window.SM.setBitmapBrushOn(v); });
     numRow(params, 'Taille', state.brushSize || 3, 1, 300, 1, function (v) { driveOriginal('p-sw', v, false, 'change'); });
-    numRow(params, 'Espacement', state.bitmapSpacing !== undefined ? state.bitmapSpacing : 15, 2, 100, 1, function (v) { driveOriginal('p-bitmap-spacing', v, false, 'input'); });
-    numRow(params, 'Dispersion', state.bitmapScatter !== undefined ? state.bitmapScatter : 20, 0, 100, 1, function (v) { driveOriginal('p-bitmap-scatter', v, false, 'input'); });
-    numRow(params, 'Opacité', state.bitmapOpacity !== undefined ? state.bitmapOpacity : 100, 5, 100, 1, function (v) { driveOriginal('p-bitmap-opacity', v, false, 'input'); });
-    checkRow(params, 'Pression (tablette)', state.bitmapPressure !== false, function (v) { driveOriginal('p-bitmap-pressure', v, true, 'change'); });
+    // Spacing/Scatter/Opacity/Pressure no longer have a Stroke-panel element
+    // to drive at all (removed, 2026-07 harmonization) — call
+    // bitmap-brush.js's own state+live-selection setters directly instead of
+    // routing through driveOriginal (which would now silently no-op).
+    numRow(params, 'Espacement', state.bitmapSpacing !== undefined ? state.bitmapSpacing : 15, 2, 100, 1, function (v) { if (window.SM && window.SM.setBitmapSpacing) window.SM.setBitmapSpacing(v); });
+    numRow(params, 'Dispersion', state.bitmapScatter !== undefined ? state.bitmapScatter : 20, 0, 100, 1, function (v) { if (window.SM && window.SM.setBitmapScatter) window.SM.setBitmapScatter(v); });
+    numRow(params, 'Opacité', state.bitmapOpacity !== undefined ? state.bitmapOpacity : 100, 5, 100, 1, function (v) { if (window.SM && window.SM.setBitmapOpacity) window.SM.setBitmapOpacity(v); });
+    checkRow(params, 'Pression (tablette)', state.bitmapPressure !== false, function (v) { if (window.SM && window.SM.setBitmapPressure) window.SM.setBitmapPressure(v); });
     selectRow(params, 'Stabilisateur', state.stabilizer !== undefined ? state.stabilizer : 2, [
       { value: 0, label: 'Off' }, { value: 1, label: 'Low' }, { value: 2, label: 'Medium' }, { value: 3, label: 'High' },
       { value: 4, label: 'Plume — légère' }, { value: 5, label: 'Plume — moyenne' }, { value: 6, label: 'Plume — forte' },
     ], function (v) { driveOriginal('p-stab', v, false, 'change'); }, STAB_TITLE);
+    // Import .abr — was the Stroke panel's own button + hidden file input
+    // (2026-07 harmonization, removed along with the rest of that section);
+    // the actual parsing logic lives in bitmap-brush.js's importAbrFile
+    // (exposed via window.SM), this just needs its own button+input pair
+    // since there's nowhere else left to click it from.
+    var abrRow = document.createElement('div'); abrRow.className = 'pr';
+    var abrLbl = document.createElement('span'); abrLbl.className = 'pl';
+    var abrBtn = document.createElement('button'); abrBtn.className = 'pbtn'; abrBtn.style.cssText = 'flex:1;font-size:10px'; abrBtn.type = 'button'; abrBtn.textContent = 'Import .abr tip…';
+    var abrFile = document.createElement('input'); abrFile.type = 'file'; abrFile.accept = '.abr'; abrFile.style.display = 'none';
+    abrBtn.addEventListener('click', function () { abrFile.click(); });
+    abrFile.addEventListener('change', function () {
+      var file = this.files && this.files[0];
+      this.value = ''; // allow re-importing the same file name later
+      if (window.SM && window.SM.importAbrFile) window.SM.importAbrFile(file);
+    });
+    abrRow.appendChild(abrLbl); abrRow.appendChild(abrBtn); abrRow.appendChild(abrFile);
+    params.appendChild(abrRow);
   }
   function buildVectorGrid(container) {
     container.innerHTML = ''; // rebuilt on every selection (to move the .active highlight) — must replace, not append
@@ -144,6 +249,13 @@
       container.appendChild(label);
       var grid = document.createElement('div'); grid.className = 'bp-grid';
       g.keys.forEach(function (k) { grid.appendChild(makeBrushItem(k, k === current, function (key) {
+        commitBrushPreview();
+        // NOT window.SM.applyVectorBrushToSelection(key) too — selectPreset
+        // (brush-preset-picker.js) already retroactively re-textures the
+        // current selection itself (its own pushUndo included); calling
+        // both double-applies (two undo entries for one click, redundant
+        // re-stamp with a fresh random seed each time — caught via a live
+        // undoStack-length check, not just visually).
         window.BrushPresetPicker.selectPreset(key);
         buildVectorGrid(container); // rebuild the GRID only (to move the .active highlight) — the params header above is untouched
       })); });
@@ -155,6 +267,13 @@
       container.appendChild(clabel);
       var cgrid = document.createElement('div'); cgrid.className = 'bp-grid';
       custom.forEach(function (k) { cgrid.appendChild(makeBrushItem(k, k === current, function (key) {
+        commitBrushPreview();
+        // NOT window.SM.applyVectorBrushToSelection(key) too — selectPreset
+        // (brush-preset-picker.js) already retroactively re-textures the
+        // current selection itself (its own pushUndo included); calling
+        // both double-applies (two undo entries for one click, redundant
+        // re-stamp with a fresh random seed each time — caught via a live
+        // undoStack-length check, not just visually).
         window.BrushPresetPicker.selectPreset(key);
         buildVectorGrid(container);
       })); });
@@ -169,6 +288,8 @@
     btn.appendChild(canvas); btn.appendChild(span);
     window.BrushPresetPicker.drawPreview(canvas, key);
     btn.addEventListener('click', function () { onSelect(key); });
+    btn.addEventListener('mouseenter', function () { previewVectorBrush(key); });
+    btn.addEventListener('mouseleave', function () { revertBrushPreview(); });
     return btn;
   }
 
@@ -184,7 +305,9 @@
       container.appendChild(label);
       var grid = document.createElement('div'); grid.className = 'bp-grid';
       g.keys.forEach(function (k) { grid.appendChild(makeTipItem(k, k === current, function (key) {
+        commitBrushPreview();
         window.BitmapTipPicker.selectTip(key);
+        if (window.SM && window.SM.applyBitmapBrushToSelection) window.SM.applyBitmapBrushToSelection();
         buildBitmapGrid(container);
       })); });
       container.appendChild(grid);
@@ -195,7 +318,9 @@
       container.appendChild(clabel);
       var cgrid = document.createElement('div'); cgrid.className = 'bp-grid';
       custom.forEach(function (k) { cgrid.appendChild(makeTipItem(k, k === current, function (key) {
+        commitBrushPreview();
         window.BitmapTipPicker.selectTip(key);
+        if (window.SM && window.SM.applyBitmapBrushToSelection) window.SM.applyBitmapBrushToSelection();
         buildBitmapGrid(container);
       })); });
       container.appendChild(cgrid);
@@ -209,6 +334,8 @@
     btn.appendChild(canvas); btn.appendChild(span);
     window.BitmapTipPicker.drawPreview(canvas, key);
     btn.addEventListener('click', function () { onSelect(key); });
+    btn.addEventListener('mouseenter', function () { previewBitmapBrush(key); });
+    btn.addEventListener('mouseleave', function () { revertBrushPreview(); });
     return btn;
   }
 

--- a/src/js/brush-preset-picker.js
+++ b/src/js/brush-preset-picker.js
@@ -113,33 +113,21 @@
   // existed. The <select> still exists in the DOM for anything that reads
   // its markup, but is no longer the source of truth.
   function selectPreset(key) {
+    // setBrushPreset (timeline.js, SM.setBrushPreset) ALREADY retroactively
+    // re-textures the current selection itself (own pushUndo/
+    // stripAnyBrushTexture+applyBrushTexture/saveActiveLayerFrame, added
+    // 2026-07-17 — "les changement de brush dynamique ne s'applique pas au
+    // stroke de la selection") — this function used to ALSO do its own,
+    // essentially identical, retroactive-apply block on top of that,
+    // silently double-applying (two undo entries, two re-stamps with a
+    // fresh random seed each) every time a preset was picked from this
+    // popover with an eligible selection active. Found via the floating
+    // Brush panel's own preset grid (brush-menu-bridge.js, 2026-07
+    // harmonization pass) calling this same function — caught by checking
+    // state.undoStack.length after a single click, not just eyeballing the
+    // result, which is why it went unnoticed this long.
     if (window.SM) window.SM.setBrushPreset(key);
     paintButton(key);
-    // Also retroactively re-texture whatever's currently selected (feedback:
-    // "impossible d'appliquer une brush preset à postériori") — plain
-    // constant-width strokes AND pressure (isVectorBrush) ribbons now that
-    // applyBrushTexture can size dabs off a widthProfile instead of one
-    // fixed strokeWidth. isFillShape/isBrushTextureCopy items still have no
-    // applicable dab-placement model and stay excluded.
-    if (typeof selectedPaths !== 'undefined' && selectedPaths.length && typeof applyOrChangeBrushTexture === 'function') {
-      var layer = window.userLayers && window.userLayers[state.activeLayerIdx];
-      if (layer) {
-        var touched = 0;
-        if (typeof pushUndo === 'function') pushUndo();
-        selectedPaths.forEach(function (p) {
-          var isPressureRibbon = !!(p.data && p.data.isVectorBrush && p.data.centerSegments && p.data.widthProfile);
-          if (!isPressureRibbon && !p.strokeColor && !(p.data && p.data.preTextureStroke !== undefined) && !(p.data && p.data.preTextureOpacity !== undefined)) return;
-          if (p.data && (p.data.isFillShape || p.data.isBrushTextureCopy)) return;
-          applyOrChangeBrushTexture(p, layer, key);
-          touched++;
-        });
-        if (touched) {
-          if (typeof saveActiveLayerFrame === 'function') saveActiveLayerFrame();
-          if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
-          if (typeof showToast === 'function') showToast(touched + ' trait(s) retexturé(s)');
-        }
-      }
-    }
   }
 
   function open(anchorEl, currentKey, onSelect) {

--- a/src/js/labs/labs-float-panel.js
+++ b/src/js/labs/labs-float-panel.js
@@ -33,8 +33,16 @@
     rect: ['symmetry', 'canvas-grid', 'view-filter'],
     ellipse: ['symmetry', 'french-curve', 'canvas-grid'],
     eraser: ['out-of-pegs', 'canvas-grid'],
-    select: ['vector-sculpt', 'canvas-grid'],
-    subselect: ['vector-sculpt'],
+    // 'brush-menu' added here (2026-07, Stroke-panel brush harmonization):
+    // applying/converting a vector or bitmap brush texture on an EXISTING
+    // selection (Select/Subselect tool, nothing being drawn) used to go
+    // through the Stroke panel's own "Apply to selection" button/Bitmap
+    // Brush checkbox — both removed in favor of the floating Brush panel
+    // auto-applying on preset click (see brush-menu-bridge.js). Without an
+    // entry here that panel's button never appears outside Draw/Fillbrush,
+    // making that whole apply-to-selection path unreachable.
+    select: ['brush-menu', 'vector-sculpt', 'canvas-grid'],
+    subselect: ['brush-menu', 'vector-sculpt'],
     hand: ['canvas-grid'],
   };
   // Real `state.*`-backed features (NOT Labs prototypes — no localStorage

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1486,8 +1486,6 @@ function updatePropsContext(){
   var eligibleSel=hasSel&&selectedPaths.every(function(p){return p instanceof Path&&p.strokeColor&&!(p.data&&(p.data.isVectorBrush||p.data.isFillShape));});
   var brushPresetRow=document.getElementById('p-brushpreset-row');
   if(brushPresetRow)brushPresetRow.style.display=(state.tool==='draw'||eligibleSel)?'flex':'none';
-  var brushApplyRow=document.getElementById('p-brushpreset-apply-row');
-  if(brushApplyRow)brushApplyRow.style.display=eligibleSel?'flex':'none';
   // Only auto-(re)expand sections on an actual context CHANGE — every
   // updateUI() tick calls this, and forcing every visible section back open
   // on each call would fight a user who deliberately collapsed one while
@@ -1612,20 +1610,21 @@ function updateSelPropsPanel(){
       // Apply/Remove-to-selection (btn-bitmap-apply/-remove, already wired
       // for exactly this — see bitmap-brush.js) looked broken because the
       // checkbox never confirmed which state you were in or landed in.
+      // Bitmap Brush controls moved OUT of the Stroke panel entirely
+      // (2026-07 harmonization — see index.html's own comment where that
+      // section used to live): the state.* writes below no longer have a
+      // Stroke-panel checkbox/fields to also mirror into, but they still
+      // need to run unconditionally — the floating Brush panel
+      // (brush-menu-bridge.js) reads these same state fields fresh every
+      // time it's opened, so keeping them in sync with the actual selection
+      // is still exactly as necessary as before, just with no DOM element
+      // here to gate on.
       var bmSpec=ref.data&&ref.data.bitmapBrushSpec;
-      var bmChk=document.getElementById('p-bitmapbrush-on');
-      if(bmChk){
-        bmChk.checked=!!bmSpec;state.bitmapBrushOn=!!bmSpec;
-        if(bmSpec){
-          state.bitmapTip=bmSpec.tip;state.bitmapSpacing=bmSpec.spacing;
-          state.bitmapScatter=bmSpec.scatter;state.bitmapOpacity=Math.round(bmSpec.opacity*100);
-          state.bitmapPressure=!!bmSpec.pressure;
-          var spEl=document.getElementById('p-bitmap-spacing');if(spEl)spEl.value=bmSpec.spacing;
-          var scEl=document.getElementById('p-bitmap-scatter');if(scEl)scEl.value=bmSpec.scatter;
-          var opEl=document.getElementById('p-bitmap-opacity');if(opEl)opEl.value=Math.round(bmSpec.opacity*100);
-          var prEl=document.getElementById('p-bitmap-pressure');if(prEl)prEl.checked=!!bmSpec.pressure;
-          if(window.BitmapTipPicker)BitmapTipPicker.paintButton(bmSpec.tip);
-        }
+      state.bitmapBrushOn=!!bmSpec;
+      if(bmSpec){
+        state.bitmapTip=bmSpec.tip;state.bitmapSpacing=bmSpec.spacing;
+        state.bitmapScatter=bmSpec.scatter;state.bitmapOpacity=Math.round(bmSpec.opacity*100);
+        state.bitmapPressure=!!bmSpec.pressure;
       }
     }
   }
@@ -4941,8 +4940,14 @@ document.getElementById('btn-bool-exclude').addEventListener('click',function(){
 document.getElementById('p-erasersize').addEventListener('input',function(){window.SM.setEraserSize(this.value);});
 document.getElementById('p-fillbrushsize').addEventListener('input',function(){window.SM.setFillBrushSize(this.value);});
 document.getElementById('p-brushpreset').addEventListener('change',function(){window.SM.setBrushPreset(this.value);if(window.BrushPresetPicker)window.BrushPresetPicker.paintButton(this.value);});
-document.getElementById('btn-brushpreset-apply').addEventListener('click',function(){
-  var preset=state.brushPreset;
+// Applies a vector brush preset to the current selection — was wired to a
+// dedicated "Apply to selection" button in the Stroke panel; that button
+// (and its Bitmap Brush counterpart) is gone (2026-07 harmonization, moved
+// out to the floating Brush panel), so this is now a plain function the
+// floating panel (brush-menu-bridge.js) calls directly the moment a preset
+// swatch is clicked — same eligibility/strip/apply logic as before, just
+// callable from more than one caller.
+function applyVectorBrushToSelection(preset){
   // `p.strokeColor` used to gate eligibility — excluded every fill-
   // camouflaged anchor (a Bitmap Brush stroke with a fill, or any already-
   // textured anchor with strokeColor nulled by the SAME camouflage
@@ -4965,7 +4970,8 @@ document.getElementById('btn-brushpreset-apply').addEventListener('click',functi
     if(preset&&preset!=='none')applyBrushTexture(p,preset);
   });
   saveActiveLayerFrame();updateUI();showToast('Brush appliqué à la sélection');
-});
+}
+window.SM.applyVectorBrushToSelection=applyVectorBrushToSelection;
 if(window.BrushPresetPicker)window.BrushPresetPicker.paintButton(state.brushPreset);
 document.getElementById('p-drawmode').addEventListener('change',function(){window.SM.setDrawMode(this.value);});
 document.getElementById('p-pmin').addEventListener('input',function(){window.SM.setPressureMin(this.value);});


### PR DESCRIPTION
## Summary
- Removed the Stroke panel's "Apply to selection" buttons (vector + bitmap) and the whole "Bitmap Brush (Draw tool)" checkbox section — pure duplication of the floating Brush panel.
- Picking a preset/tip in the floating panel now auto-applies to the current selection directly (no button needed) — same convention as the Bitmap Brush checkbox's existing toggle-auto-applies behavior.
- Added canvas hover-preview on brush swatches (mirrors the layer blend-mode hover-preview pattern).
- Added `brush-menu` to Select/Subselect tool contexts so the floating panel is reachable with an existing selection, not just while drawing.
- Added an "Import .abr tip…" button to the floating panel's Bitmap tab (the Stroke panel's own button is gone).
- Fixed a pre-existing double-apply/double-undo bug in `brush-preset-picker.js`'s `selectPreset()` found while testing this (it and `SM.setBrushPreset()` both retroactively re-applied to the selection).

## Test plan
- [x] `node --check` on all 6 changed files
- [x] Vector: hover a preset → live preview applies (verified via `p.data.brushTexturePreset`/companion count, not just visually) → mouseleave reverts → click commits with exactly one new undo entry → undo restores the plain shape
- [x] Bitmap: checkbox toggle auto-applies/removes to selection; tip click applies with correct spec
- [x] Floating Brush panel now opens from the Select tool with a selection active
- [x] Stroke panel confirmed to no longer show Brush/Bitmap Brush apply controls; no console errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)