### PR TITLE
Subselect tool: vertex transform panel, hide Document, fix invisible marquee

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -813,9 +813,26 @@
     return items;
   }
   function buildMarqueeItems() {
-    if (!_marquee.active || !_marquee.rect) return [];
-    var b = _marquee.rect.bounds;
-    return [boundsRectItem(b.left, b.top, b.right, b.bottom, [74, 158, 255, 20], [74, 158, 255, 230], 1 / view.zoom)];
+    if (_marquee.active && _marquee.rect) {
+      var b = _marquee.rect.bounds;
+      return [boundsRectItem(b.left, b.top, b.right, b.bottom, [74, 158, 255, 20], [74, 158, 255, 230], 1 / view.zoom)];
+    }
+    // Subselect tool's own node-marquee (_nmq, subselect-bridge.js/tools.js)
+    // was never drawn when the Rust engine is on (the default) — its rect IS
+    // built in Paper.js (marqueeLayer) and the underlying vertex-selection
+    // math works fine either way, but nothing here ever read _nmq to put it
+    // in the rendered scene, so the drag box itself was completely invisible
+    // on screen (found live, "le rec de sélection avec l'outil subselect
+    // n'est pas présent" — reproduced by dispatching a real pointer drag and
+    // confirming _nodeSel populated correctly with zero visual feedback).
+    // Orange (matching _nmq.rect's own Paper-native styling, 'rgba(255,184,
+    // 108,...)') rather than the Select tool's blue, so the two marquees
+    // stay visually distinct.
+    if (_nmq.active && _nmq.rect) {
+      var nb = _nmq.rect.bounds;
+      return [boundsRectItem(nb.left, nb.top, nb.right, nb.bottom, [255, 184, 108, 20], [255, 184, 108, 230], 1 / view.zoom)];
+    }
+    return [];
   }
   // Fill/Stroke Select tool (v18, tools.js _fsSel) — a fill selection gets
   // a filled orange highlight tracing the SAME geometry (Animate's dotted-

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1381,7 +1381,12 @@ function updatePropsContext(){
     // Mockup 2026-07-17 (réordonnancement du panel) : Layer (Blend) et
     // Document restent visibles pendant une sélection, juste sous le bloc
     // transform — avant, sélectionner un trait les faisait disparaître.
-    show['canvas-sec']=true;
+    // EXCEPT the Subselect tool (2026-07, "avec subselection le panneau
+    // document n'a pas besoin d'être ouvert") — editing individual vertices
+    // has no use for canvas W/H/FPS/BG, and the panel real estate is more
+    // useful given over to the Position/Size/Rotation-of-selected-vertices
+    // fields (updateSelPropsPanel) that section sits right above.
+    show['canvas-sec']=state.tool!=='subselect';
     show['layer-sec']=!!(state.layers[state.activeLayerIdx]);
     hdrText=selectedPaths.length+(selectedPaths.length>1?' éléments sélectionnés':' élément sélectionné');
   }else if(FILL_STROKE_TOOLS.indexOf(state.tool)>=0){
@@ -1506,7 +1511,11 @@ function updatePropsContext(){
 // updatePropsContext(), called separately.
 function updateSelPropsPanel(){
   if((state.tool!=='select'&&state.tool!=='subselect')||!selectedPaths.length){_selPropsSig='';return;}
-  var b=xformSelBounds();if(!b)return;
+  // Subselect + vertices picked: show/drive THEIR bounds, not the whole
+  // path's (activeXformBounds/Vertex mode, wired further down alongside
+  // wireLiveXformField) — 2026-07, "la position du panneau doivent driver
+  // les vertices".
+  var b=activeXformBounds();if(!b)return;
   // Align toolbar only makes sense with 2+ objects (nothing to align a
   // single selection AGAINST) — toggled every call, not gated behind the
   // signature-change check below, since it only depends on count.
@@ -4893,11 +4902,22 @@ function wireLiveXformField(id,apply){
   el.addEventListener('input',function(){apply(this,started);started=true;});
   el.addEventListener('change',function(){started=false;});
 }
-wireLiveXformField('sp-x',function(el,started){var b=xformSelBounds();if(!b)return;selPropsApplyMove((parseFloat(el.value)||0)-b.x,0,started);});
-wireLiveXformField('sp-y',function(el,started){var b=xformSelBounds();if(!b)return;selPropsApplyMove(0,(parseFloat(el.value)||0)-b.y,started);});
-wireLiveXformField('sp-w',function(el,started){var b=xformSelBounds();if(!b||b.width<0.01)return;var nv=Math.max(0.01,parseFloat(el.value)||b.width);selPropsApplyScale(nv/b.width,1,b.topLeft,started);});
-wireLiveXformField('sp-h',function(el,started){var b=xformSelBounds();if(!b||b.height<0.01)return;var nv=Math.max(0.01,parseFloat(el.value)||b.height);selPropsApplyScale(1,nv/b.height,b.topLeft,started);});
-wireLiveXformField('sp-rot',function(el,started){var b=xformSelBounds();if(!b)return;var nv=parseFloat(el.value)||0;var delta=nv-(state.selRotAccum||0);state.selRotAccum=nv;selPropsApplyRotate(delta,xformAnchorPoint(b),started);});
+// Subselect tool + at least one vertex picked (_nodeSel) drives THOSE
+// vertices' bounds/move/scale/rotate instead of the whole path's — 2026-07,
+// "la position du panneau doivent driver les vertices... pareil pour size
+// ... et rotation aussi". Falls back to the existing whole-selection
+// behavior for every other case (Select tool, or Subselect with nothing
+// vertex-picked yet — same as before this change).
+function activeXformVertexMode(){return state.tool==='subselect'&&_nodeSel.length>0;}
+function activeXformBounds(){return activeXformVertexMode()?nodeSelBounds():xformSelBounds();}
+function activeXformApplyMove(dx,dy,skipUndo){if(activeXformVertexMode())nodeSelApplyMove(dx,dy,skipUndo);else selPropsApplyMove(dx,dy,skipUndo);}
+function activeXformApplyScale(sx,sy,anchor,skipUndo){if(activeXformVertexMode())nodeSelApplyScale(sx,sy,anchor,skipUndo);else selPropsApplyScale(sx,sy,anchor,skipUndo);}
+function activeXformApplyRotate(deltaDeg,center,skipUndo){if(activeXformVertexMode())nodeSelApplyRotate(deltaDeg,center,skipUndo);else selPropsApplyRotate(deltaDeg,center,skipUndo);}
+wireLiveXformField('sp-x',function(el,started){var b=activeXformBounds();if(!b)return;activeXformApplyMove((parseFloat(el.value)||0)-b.x,0,started);});
+wireLiveXformField('sp-y',function(el,started){var b=activeXformBounds();if(!b)return;activeXformApplyMove(0,(parseFloat(el.value)||0)-b.y,started);});
+wireLiveXformField('sp-w',function(el,started){var b=activeXformBounds();if(!b||b.width<0.01)return;var nv=Math.max(0.01,parseFloat(el.value)||b.width);activeXformApplyScale(nv/b.width,1,b.topLeft,started);});
+wireLiveXformField('sp-h',function(el,started){var b=activeXformBounds();if(!b||b.height<0.01)return;var nv=Math.max(0.01,parseFloat(el.value)||b.height);activeXformApplyScale(1,nv/b.height,b.topLeft,started);});
+wireLiveXformField('sp-rot',function(el,started){var b=activeXformBounds();if(!b)return;var nv=parseFloat(el.value)||0;var delta=nv-(state.selRotAccum||0);state.selRotAccum=nv;activeXformApplyRotate(delta,xformAnchorPoint(b),started);});
 // Anchor-point (pivot) picker — see tools.js xformAnchorPoint's own comment.
 // Clicking a dot just changes WHICH point future rotations pivot around
 // (state.xformAnchorKey); it doesn't move anything on its own, so no

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -508,6 +508,99 @@ function nodeEditSegmentsData(path){
   if(path.data&&path.data.isVectorBrush&&path.data.centerSegments)return path.data.centerSegments;
   return path.segments.map(function(s){return{point:[s.point.x,s.point.y],handleIn:[s.handleIn.x,s.handleIn.y],handleOut:[s.handleOut.x,s.handleOut.y]};});
 }
+// ---- Subselect Position/Size/Rotation panel (2026-07, "la position du
+// panneau doivent driver les vertices... pareil pour size... et rotation
+// aussi") — the right panel's transform fields always read/wrote the
+// WHOLE selected path's bounds (xformSelBounds/selPropsApplyMove/Scale/
+// Rotate below), even under the Subselect tool with individual vertices
+// picked out of _nodeSel. These are the vertex-scoped equivalents,
+// dispatched to from timeline.js's wireLiveXformField wrappers whenever
+// state.tool==='subselect'&&_nodeSel.length — same real Rectangle return
+// shape as xformSelBounds() (so xformAnchorPoint/.topLeft etc. all still
+// work unchanged) and the same commit tail (saveActiveLayerFrame/
+// renderNodeHandles/renderArcs/updateUI) subselect-bridge.js's own drag
+// handlers already use at gesture end.
+function nodeSelBounds(){
+  var path=nodeEditTargetPath();
+  if(!path||!_nodeSel.length)return null;
+  var segs=nodeEditSegmentsData(path);
+  var minX=Infinity,minY=Infinity,maxX=-Infinity,maxY=-Infinity;
+  _nodeSel.forEach(function(i){
+    var s=segs[i];if(!s)return;
+    var x=s.point[0],y=s.point[1];
+    if(x<minX)minX=x;if(x>maxX)maxX=x;
+    if(y<minY)minY=y;if(y>maxY)maxY=y;
+  });
+  if(minX===Infinity)return null;
+  return new Rectangle(minX,minY,maxX-minX,maxY-minY);
+}
+function nodeSelCommitTail(path){
+  fillRegenerateLinked(userLayers[state.activeLayerIdx],path);
+  if(path.data&&path.data.bitmapBrushSpec&&window.SMBitmapBrush)SMBitmapBrush.regenerate(path,userLayers[state.activeLayerIdx]);
+  saveActiveLayerFrame();
+  if(window.renderNodeHandles)renderNodeHandles();
+  renderArcs();updateUI();
+  if(window.SMEngineBridge)SMEngineBridge.renderNow();
+}
+function nodeSelApplyMove(dx,dy,skipUndo){
+  var path=nodeEditTargetPath();
+  if((!dx&&!dy)||!path||!_nodeSel.length)return;
+  if(!skipUndo)pushUndo();
+  if(path.data&&path.data.isVectorBrush&&path.data.centerSegments){
+    _nodeSel.forEach(function(i){var cs=path.data.centerSegments[i];if(cs)cs.point=[cs.point[0]+dx,cs.point[1]+dy];});
+    rebuildVectorBrushOutline(path);
+  }else{
+    _nodeSel.forEach(function(i){var sg=path.segments[i];if(sg)sg.point=sg.point.add(new Point(dx,dy));});
+  }
+  nodeSelCommitTail(path);
+}
+function nodeSelApplyScale(sx,sy,anchor,skipUndo){
+  var path=nodeEditTargetPath();
+  if((sx===1&&sy===1)||!path||!_nodeSel.length)return;
+  if(!skipUndo)pushUndo();
+  if(path.data&&path.data.isVectorBrush&&path.data.centerSegments){
+    _nodeSel.forEach(function(i){
+      var cs=path.data.centerSegments[i];if(!cs)return;
+      cs.point=[anchor.x+(cs.point[0]-anchor.x)*sx,anchor.y+(cs.point[1]-anchor.y)*sy];
+    });
+    rebuildVectorBrushOutline(path);
+  }else{
+    _nodeSel.forEach(function(i){
+      var sg=path.segments[i];if(!sg)return;
+      var p=sg.point;
+      sg.point=new Point(anchor.x+(p.x-anchor.x)*sx,anchor.y+(p.y-anchor.y)*sy);
+      // Handles are RELATIVE offset vectors (Paper.js convention) — a
+      // non-uniform scale scales each axis of the vector directly, no
+      // anchor math needed since they're already relative to the point.
+      if(sg.handleIn)sg.handleIn=new Point(sg.handleIn.x*sx,sg.handleIn.y*sy);
+      if(sg.handleOut)sg.handleOut=new Point(sg.handleOut.x*sx,sg.handleOut.y*sy);
+    });
+  }
+  nodeSelCommitTail(path);
+}
+function nodeSelApplyRotate(deltaDeg,center,skipUndo){
+  var path=nodeEditTargetPath();
+  if(!deltaDeg||!path||!_nodeSel.length)return;
+  if(!skipUndo)pushUndo();
+  var rad=deltaDeg*Math.PI/180,cos=Math.cos(rad),sin=Math.sin(rad);
+  function rotPt(x,y){var dx=x-center.x,dy=y-center.y;return[center.x+dx*cos-dy*sin,center.y+dx*sin+dy*cos];}
+  function rotVec(x,y){return[x*cos-y*sin,x*sin+y*cos];}
+  if(path.data&&path.data.isVectorBrush&&path.data.centerSegments){
+    _nodeSel.forEach(function(i){var cs=path.data.centerSegments[i];if(cs)cs.point=rotPt(cs.point[0],cs.point[1]);});
+    rebuildVectorBrushOutline(path);
+  }else{
+    _nodeSel.forEach(function(i){
+      var sg=path.segments[i];if(!sg)return;
+      var np=rotPt(sg.point.x,sg.point.y);
+      sg.point=new Point(np[0],np[1]);
+      // Handles are relative vectors too — rotate the vector itself, no
+      // center needed (same reasoning as the scale branch above).
+      if(sg.handleIn){var nh=rotVec(sg.handleIn.x,sg.handleIn.y);sg.handleIn=new Point(nh[0],nh[1]);}
+      if(sg.handleOut){var nh2=rotVec(sg.handleOut.x,sg.handleOut.y);sg.handleOut=new Point(nh2[0],nh2[1]);}
+    });
+  }
+  nodeSelCommitTail(path);
+}
 function renderNodeHandles(){
   nodeLayer.removeChildren();nodeHandles=[];
   var path=nodeEditTargetPath();if(!path)return;


### PR DESCRIPTION
## Summary
- Position/Size/Rotation panel drives selected vertices (`_nodeSel`) under Subselect, not the whole path — falls back to whole-selection behavior when no vertices are picked.
- Document section no longer shows while Subselect is active.
- Fixed the Subselect tool's marquee-drag being invisible whenever the Rust engine is on (default) — the selection math worked, but `buildMarqueeItems()` never read `_nmq` (only the Select tool's own `_marquee`), so the drag box never reached the rendered scene.

## Test plan
- [x] `node --check` on all 3 changed files
- [x] Marquee-drag 2 vertices → panel shows Position/Size of just those 2 (verified Size height = 0 for two same-Y vertices, not the whole path)
- [x] Editing the panel's X field moves only the selected vertices — verified via segment coordinates, shape became a real parallelogram
- [x] Document section confirmed hidden with Subselect active + path selected
- [x] Undo correctly restores original vertex positions
- [x] Regular right-click / Select tool marquee unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)