### PR TITLE
Make timeline current-frame field draggable (scrub)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1191,7 +1191,14 @@
          spacer. -->
     <div id="symbol-tabs"><div class="sym-tab act" data-sym="" data-i18n="sceneTab">Scene</div></div>
     <div style="flex:1"></div>
-    <div class="ti"><b id="tl-cf">1</b> / <span id="tl-tf">24</span></div>
+    <!-- tl-cf: draggable current-frame field (2026-07, "rendre la frame
+         1/120 draggable") — a real scrub input like tl-fps/tl-total below,
+         not a plain <b>; its value/max are kept in sync with
+         state.currentFrame/totalFrames wherever they were textContent-set
+         before (updatePlayhead/updateUI, timeline.js), and a 'change'
+         listener drives goToFrame(). tl-tf (the total) stays a plain
+         <span> — its own value is already editable via #tl-total. -->
+    <div class="ti"><input type="number" class="scrub" id="tl-cf" min="1" value="1" data-step="1" style="width:32px;font-weight:600"> / <span id="tl-tf">24</span></div>
     <button class="tb" id="btn-ff" data-i18n-title="btnFirstFrameTitle" title="Go to first frame"><span class="material-symbols-rounded">&#xe045;</span></button>
     <button class="tb" id="btn-pf" data-i18n-title="btnPrevFrameTitle" title="Previous frame"><span class="material-symbols-rounded">&#xe5cb;</span></button>
     <button class="tb" id="btn-play" data-i18n-title="btnPlayTitle" title="Play / Stop (Enter)"><span class="material-symbols-rounded">&#xe037;</span></button>

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -91,7 +91,8 @@ function togglePlay(){if(state.playing)stopPlay();else startPlay();}
 
 function updatePlayhead(){
   if(window.SMCamera){SMCamera.applyCameraView();if(window.updateCameraPanel)updateCameraPanel();}
-  document.getElementById('tl-cf').textContent=state.currentFrame+1;
+  var tlCfEl0=document.getElementById('tl-cf');
+  if(document.activeElement!==tlCfEl0)tlCfEl0.value=state.currentFrame+1;
   document.getElementById('info-frame').textContent=state.currentFrame+1;
   document.getElementById('playhead').style.left=(state.currentFrame*FC)+'px';
   document.getElementById('playhead-flag').textContent=state.currentFrame+1;
@@ -1184,7 +1185,9 @@ function updateUI(){
   var strokes=getEffectiveStrokes(state.activeLayerIdx,state.currentFrame);
   document.getElementById('info-frame').textContent=state.currentFrame+1;
   document.getElementById('info-strokes').textContent=(window.SM&&SM.t?SM.t(strokes.length===1?'strokeCountOne':'strokeCountOther'):(strokes.length+' trait'+(strokes.length!==1?'s':''))).replace('{n}',strokes.length);
-  document.getElementById('tl-cf').textContent=state.currentFrame+1;
+  var tlCfEl=document.getElementById('tl-cf');
+  if(document.activeElement!==tlCfEl)tlCfEl.value=state.currentFrame+1;
+  tlCfEl.max=state.totalFrames;
   document.getElementById('tl-tf').textContent=state.totalFrames;
   var f=state.layers[state.activeLayerIdx].frames[state.currentFrame];
   var badge=document.getElementById('info-badge');
@@ -5290,6 +5293,17 @@ document.getElementById('btn-nf').addEventListener('click',function(){if(state.p
 document.getElementById('btn-lf').addEventListener('click',function(){if(state.playing)stopPlay();goToFrame(state.waOut);});
 document.getElementById('tl-fps').addEventListener('change',function(){window.SM.setFps(parseInt(this.value));});
 document.getElementById('tl-total').addEventListener('change',function(){window.SM.setTotalFrames(parseInt(this.value));});
+// tl-cf drag/type-to-scrub through frames (2026-07, "rendre la frame 1/120
+// draggable") — goToFrame() itself no-ops silently on an out-of-range
+// index (app.js) rather than clamping, so clamp here first or a
+// drag-past-the-end would leave the input showing a stale/invalid number
+// nothing ever applied.
+document.getElementById('tl-cf').addEventListener('change',function(){
+  var v=Math.max(1,Math.min(state.totalFrames,parseInt(this.value)||1));
+  this.value=v;
+  if(state.playing)stopPlay();
+  goToFrame(v-1);
+});
 document.getElementById('btn-al').addEventListener('click',function(){window.SM.addLayer();});
 document.getElementById('btn-dl').addEventListener('click',function(){window.SM.deleteLayer();});
 document.getElementById('btn-dupl').addEventListener('click',function(){window.SM.duplicateLayer();});


### PR DESCRIPTION
## Summary
- `#tl-cf` (current-frame display, "1 / 120") was a plain `<b>`, not an input — converted to a real `<input type="number" class="scrub">` matching its `tl-fps`/`tl-total` neighbors.
- Dragging it now scrubs through frames via `goToFrame()`, clamped to `[1, totalFrames]`.
- Checked the "align right of tabs" half of the same feedback against the live app: `#tl-toolbar` already does this correctly (2026-07-09 redesign) — no change needed there.

## Test plan
- [x] `node --check src/js/timeline.js`
- [x] Drag the field → playhead scrubs, canvas frame counter and timeline stay in sync (verified `state.currentFrame`/`.value` match)
- [x] Dragging/setting past the end clamps to `totalFrames` instead of silently no-op'ing
- [x] No console errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)