### PR TITLE
Add -webkit-user-select:none for text-selection-on-drag (WebKit/Tauri)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -17,7 +17,18 @@
   --tool-size:36px;--fc:30px;
 }
 html,body{width:100%;height:100%;overflow:hidden;background:var(--gutter);color:var(--text);
-  font-family:'Manrope',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;user-select:none;font-size:13px;-webkit-font-smoothing:antialiased;}
+  font-family:'Manrope',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+  /* -webkit-user-select alongside the unprefixed property (2026-07,
+     "avec l'outil de sélection quand on essaye de drag un menu ça
+     sélectionne plein de texte") — Nemo ships as a Tauri app, rendered by
+     WKWebView (WebKit) on macOS; WebKit's drag-selection code path has a
+     long-documented history of needing the vendor-prefixed property even
+     where the unprefixed one already works for click-based selection, so
+     relying on user-select alone left a real gap specifically on that
+     platform (not reproducible in a Chromium-based dev/automation
+     browser, which already honored the unprefixed property everywhere
+     tested). */
+  -webkit-user-select:none;user-select:none;font-size:13px;-webkit-font-smoothing:antialiased;}
 .material-symbols-rounded{font-family:'Material Symbols Rounded';font-weight:normal;font-style:normal;
   font-size:20px;line-height:1;letter-spacing:normal;text-transform:none;display:inline-block;
   white-space:nowrap;word-wrap:normal;direction:ltr;-webkit-font-feature-settings:'liga';


### PR DESCRIPTION
## Summary
- Feedback: dragging over a menu with the Select tool spuriously selects page text.
- `body{user-select:none}` already exists but couldn't reproduce the bug in the Chromium dev browser across 4 different menus tested (panel headers, floating Brush popover, right-click context menu, main app menu) — all correctly blocked selection.
- Added `-webkit-user-select:none` alongside it — Nemo ships as a Tauri app on WKWebView (WebKit), which has a known history of needing the vendor-prefixed property for its drag-selection code path specifically, even when the unprefixed property already covers click-based selection.

## ⚠️ Not independently verified as fixed
This is a best-effort platform-targeted fix based on a well-documented WebKit gotcha, not a reproduced-then-verified bug fix — I could not trigger the actual reported behavior in this dev environment to confirm before/after. Please confirm on the real Tauri build.

## Test plan
- [x] CSS brace-balance sanity check
- [x] No visual regression in dev browser
- [ ] **Needs confirmation on the actual Tauri/WKWebView build** — the bug wasn't reproducible in the Chromium dev browser used here

🤖 Generated with [Claude Code](https://claude.com/claude-code)