### PR TITLE
Right-click custom WGSL effect row to edit shader

### DIFF
--- a/src/js/effects-panel.js
+++ b/src/js/effects-panel.js
@@ -370,6 +370,15 @@
           if (def && window.openCustomEffectEditor) window.openCustomEffectEditor(def);
         });
         row.appendChild(edit);
+        // Right-click on the row itself opens the same editor (2026-07 —
+        // the pencil icon was the ONLY entry point, easy to miss at that
+        // size) — same code path as the pencil's own click handler above,
+        // not a second way to open something different.
+        row.addEventListener('contextmenu', function (e) {
+          e.preventDefault(); e.stopPropagation();
+          var def = customDefFor(eff.type);
+          if (def && window.openCustomEffectEditor) window.openCustomEffectEditor(def);
+        });
       }
       var del = document.createElement('div'); del.className = 'fx-row-del'; del.textContent = '×'; del.title = window.SM.t('fxDelete');
       del.addEventListener('click', function (e) { e.stopPropagation(); deleteEffect(idx); });


### PR DESCRIPTION
## Summary
- Right-clicking a custom WGSL effect row now opens the shader editor, same as the ✎ pencil icon — reuses `window.openCustomEffectEditor(def)` directly, no duplicated logic.
- Only wired for custom-type effect rows (`isCustomEffect(eff.type)`); built-in effects (blur, glow, etc.) are untouched.

## Test plan
- [x] `node --check src/js/effects-panel.js`
- [x] Added a test custom effect, right-clicked its row → "Custom WGSL Effect" modal opens with correct name/source pre-filled
- [x] Native context menu suppressed (`preventDefault`) only for custom rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)