### PR TITLE
Convert Clip to canvas/Safety zones to icon toggle buttons

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -403,6 +403,11 @@ input[type="checkbox"]:disabled{opacity:.4;cursor:not-allowed;}
    in the left toolbar. */
 .icon-only-btn{width:30px;height:30px;padding:0;display:flex;align-items:center;justify-content:center;flex:none;}
 .icon-only-btn svg{display:block;}
+/* Toggle state for icon-only buttons used as on/off switches (2026-07 —
+   Clip to canvas/Safety zones converted from checkboxes) — same "tint the
+   icon, don't fully invert" convention as .tb.active elsewhere, so a
+   toggled icon button reads as "on" without looking like an accent CTA. */
+.icon-only-btn.active{color:var(--accent-hover);background:var(--accent-dim);}
 .pbtn:hover{background:#2c2a31;color:var(--text);}
 .pbtn.ac{background:var(--accent);border-color:var(--accent);color:#fff;}
 .pbtn.ac:hover{background:#5254d9;}

--- a/src/index.html
+++ b/src/index.html
@@ -508,12 +508,19 @@
              convention as every .tool-btn in the left toolbar (icon-only,
              no visible text, ui.js's shared instant-tooltip system covers
              discoverability). -->
+        <!-- Clip to canvas / Safety zones converted from checkboxes to icon
+             toggle buttons, joining Fit/Reset View in one horizontal row
+             (2026-07: "possible d'avoir plutôt des bouton icon pour les 2
+             checkbox et d'aligner tout les icon à l'horizontal") — same
+             icon-only + tooltip-carries-the-label convention as Fit/Reset
+             View just above, .active toggled on click like every other
+             toggle button in this app (btn-ghost-all, btn-loop, etc.). -->
         <div class="pr" style="gap:4px">
           <button class="pbtn icon-only-btn" id="btn-fit" data-i18n-title="btnFitTitle" title="Fit — fit the canvas to the viewport"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M21 16v3a2 2 0 0 1-2 2h-3M3 16v3a2 2 0 0 0 2 2h3"/></svg></button>
           <button class="pbtn icon-only-btn" id="btn-resetv" data-i18n-title="btnResetViewTitle" title="Reset View — restore zoom/pan/rotation to default"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 1 3 6.7"/><path d="M3 21v-5h5"/></svg></button>
+          <button class="pbtn icon-only-btn" id="btn-clip" data-i18n-title="clipCanvasTitle" title="Clip to canvas — hide artwork outside the canvas bounds (off by default, so you can see and work with content that spills over the edge)"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 2v14a2 2 0 0 0 2 2h14"/><path d="M18 22V8a2 2 0 0 0-2-2H2"/></svg></button>
+          <button class="pbtn icon-only-btn" id="btn-safety" data-i18n-title="safetyZonesTitle" title="Safety zones — broadcast-safe overlay guides (90% action-safe / 80% title-safe margins, standard TV/film safe areas)"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="18" height="14" rx="1"/><rect x="7" y="8" width="10" height="8" rx="1"/></svg></button>
         </div>
-        <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer" data-i18n-title="clipCanvasTitle" title="Hide artwork outside the canvas bounds — off by default, so you can see and work with content that spills over the edge"><input type="checkbox" id="p-clip" style="accent-color:var(--accent)"> <span data-i18n="clipCanvasLabel">Clip to canvas</span></label></div>
-        <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer" data-i18n-title="safetyZonesTitle" title="Broadcast-safe overlay guides: 90% action-safe / 80% title-safe margins, standard TV/film safe areas"><input type="checkbox" id="p-safety" style="accent-color:var(--accent)"> <span data-i18n="safetyZonesLabel">Safety zones</span></label></div>
       </div>
     </div>
     <div class="psec" id="fill-sec">

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1179,6 +1179,12 @@ function syncDocFields(){
   var els={'p-cw':state.canvasW,'p-ch':state.canvasH,'p-cbg':state.canvasBg,'tl-fps':state.fps,'tl-total':state.totalFrames,
     'proj-fps':state.fps,'proj-frames':state.totalFrames};
   Object.keys(els).forEach(function(id){var el=document.getElementById(id);if(el&&document.activeElement!==el)el.value=els[id];});
+  // Clip to canvas / Safety zones icon-toggle buttons (2026-07, replaced
+  // checkboxes — see index.html's own comment) — synced here alongside
+  // every other Document field so a project load/undo restores their
+  // visible state too, not just the click handler's own toggle.
+  var clipBtn=document.getElementById('btn-clip');if(clipBtn)clipBtn.classList.toggle('active',!!state.canvasClip);
+  var safetyBtn=document.getElementById('btn-safety');if(safetyBtn)safetyBtn.classList.toggle('active',!!state.safetyZones);
 }
 function updateUI(){
   syncDocFields();
@@ -5021,8 +5027,8 @@ document.getElementById('p-shadowmode').addEventListener('change',function(){win
 document.getElementById('p-cw').addEventListener('change',function(){window.SM.setCanvasSize(parseInt(this.value),state.canvasH);});
 document.getElementById('p-ch').addEventListener('change',function(){window.SM.setCanvasSize(state.canvasW,parseInt(this.value));});
 document.getElementById('p-cbg').addEventListener('input',function(){window.SM.setCanvasBg(this.value);});
-document.getElementById('p-clip').addEventListener('change',function(){window.SM.setCanvasClip(this.checked);});
-document.getElementById('p-safety').addEventListener('change',function(){window.SM.setSafetyZones(this.checked);});
+document.getElementById('btn-clip').addEventListener('click',function(){window.SM.setCanvasClip(!state.canvasClip);this.classList.toggle('active',state.canvasClip);});
+document.getElementById('btn-safety').addEventListener('click',function(){window.SM.setSafetyZones(!state.safetyZones);this.classList.toggle('active',state.safetyZones);});
 // Flou/Ombre au sol/effect-layer type/param wiring all moved into
 // effects-panel.js's unified Effects stack (2026-07 rewrite).
 // Perspective/Symmetry Guide (feedback 2026-07: "les onglet guide symétrie


### PR DESCRIPTION
## Summary
- `#p-clip`/`#p-safety` checkboxes replaced with icon-only toggle buttons, joining Fit/Reset View in one horizontal row instead of an icon row + two stacked checkbox rows.
- Added `.icon-only-btn.active` CSS (tints the icon, same convention as `.tb.active`) — didn't exist before.
- `syncDocFields()` now syncs both buttons' active state from `state.canvasClip`/`safetyZones`.

## Test plan
- [x] `node --check src/js/timeline.js`, CSS brace-balance check
- [x] Both buttons toggle correctly (verified `state.canvasClip`/`safetyZones` + `.active` class via JS)
- [x] Visual effect confirmed: Clip to canvas dims out-of-bounds area, Safety zones draws the guide overlay
- [x] Fresh project console check — no new errors (the wgpu shader errors present are stale/pre-existing per this session's established pattern, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)