### PR TITLE
Pair short numeric fields on one row (FPS/Frames + 3 others)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -477,8 +477,10 @@
              needed, reference-bridge.js's existing 'input' listener on
              #p-ref-opacity already reads .value the same way either type
              produces it). -->
-        <div class="pr"><span class="pl" data-i18n="fieldOpacity">Opacity</span><input type="number" class="pi scrub" id="p-ref-opacity" min="5" max="100" value="50" data-step="1"></div>
-        <div class="pr"><span class="pl" data-i18n="fieldOffset">Offset</span><input type="number" class="pi scrub" id="p-ref-offset" value="0" data-step="1" data-i18n-title="refOffsetTitle" title="Frame de la timeline où la référence démarre"></div>
+        <div class="pr dims-row">
+          <span class="pl" data-i18n="fieldOpacity">Opacity</span><input type="number" class="pi scrub" id="p-ref-opacity" min="5" max="100" value="50" data-step="1">
+          <span class="pl" data-i18n="fieldOffset">Offset</span><input type="number" class="pi scrub" id="p-ref-offset" value="0" data-step="1" data-i18n-title="refOffsetTitle" title="Frame de la timeline où la référence démarre">
+        </div>
       </div>
     </div>
     <div class="psec" id="canvas-sec">
@@ -499,8 +501,15 @@
           <span class="pl" style="min-width:14px" data-i18n="fieldH">H</span><input type="number" class="pi scrub" id="p-ch" value="1080" min="1" max="4320" data-step="1">
           <button class="dims-lock-btn" id="btn-dims-lock" type="button" data-i18n-title="dimsLockTitle" title="Lier largeur/hauteur (garder les proportions)"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg></button>
         </div>
-        <div class="pr"><span class="pl">FPS</span><input type="number" class="pi scrub" id="proj-fps" value="12" min="1" max="60" data-step="1"></div>
-        <div class="pr"><span class="pl">Frames</span><input type="number" class="pi scrub" id="proj-frames" value="24" min="1" max="999" data-step="1"></div>
+        <!-- FPS + Frames paired on one row (2026-07, "dans les différents
+             menu du panel droit quand y a la place mettre ce genre de prop
+             sur la même ligne") — same dims-row treatment as W/H just
+             above (gap + non-growing labels), reused as-is since its CSS
+             is generic, not actually dimensions-specific. -->
+        <div class="pr dims-row">
+          <span class="pl">FPS</span><input type="number" class="pi scrub" id="proj-fps" value="12" min="1" max="60" data-step="1">
+          <span class="pl">Frames</span><input type="number" class="pi scrub" id="proj-frames" value="24" min="1" max="999" data-step="1">
+        </div>
         <div class="pr"><span class="pl">BG</span><input type="color" id="p-cbg" value="#ffffff" style="width:28px;height:22px;border:none;cursor:pointer;padding:0;"></div>
         <!-- Icon buttons instead of text (feedback 2026-07: "les boutons
              avec un texte est-ce qu'ils peuvent avoir un bouton icon
@@ -687,8 +696,10 @@
         </div></div>
         <div class="pr" id="p-fillbrushsize-row" style="display:none" data-i18n-title="fillBrushThicknessTitle" title="Fill Brush's own base thickness — independent of Draw's Stroke Width and Pen's line width"><span class="pl" data-i18n="fieldThickness">Thickness</span><input type="number" class="pi scrub" id="p-fillbrushsize" value="40" min="1" max="500" data-step="1"><span style="font-size:9px;color:var(--text-dim)">px</span></div>
         <div class="pr" id="p-vecbrush-row"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer"><input type="checkbox" id="p-vecbrush" style="accent-color:var(--accent)"> <span data-i18n="pressureBrushLabel">Pressure brush (Draw)</span></label></div>
-        <div class="pr"><span class="pl" data-i18n="fieldPMin">P. min</span><input type="number" class="pi scrub" id="p-pmin" value="30" min="0" max="100" data-step="1" data-i18n-title="pMinTitle" title="Width at zero pressure (% of brush size)"><span style="font-size:9px;color:var(--text-dim)">%</span></div>
-        <div class="pr"><span class="pl" data-i18n="fieldPMax">P. max</span><input type="number" class="pi scrub" id="p-pmax" value="170" min="50" max="300" data-step="1" data-i18n-title="pMaxTitle" title="Width at full pressure (% of brush size)"><span style="font-size:9px;color:var(--text-dim)">%</span></div>
+        <div class="pr dims-row">
+          <span class="pl" data-i18n="fieldPMin">P. min</span><input type="number" class="pi scrub" id="p-pmin" value="30" min="0" max="100" data-step="1" data-i18n-title="pMinTitle" title="Width at zero pressure (% of brush size)"><span style="font-size:9px;color:var(--text-dim)">%</span>
+          <span class="pl" data-i18n="fieldPMax">P. max</span><input type="number" class="pi scrub" id="p-pmax" value="170" min="50" max="300" data-step="1" data-i18n-title="pMaxTitle" title="Width at full pressure (% of brush size)"><span style="font-size:9px;color:var(--text-dim)">%</span>
+        </div>
         <div class="pr"><span class="pl" data-i18n="fieldCurve">Curve</span><select class="pi" id="p-pcurve" data-i18n-title="pCurveTitle" title="Pressure response: sqrt/cbrt = a light touch already widens the line (soft felt-tip), pow2/pow3 = you must press hard to thicken it (hard pencil)"><option value="linear" data-i18n="curveLinear">Linear</option><option value="sqrt" data-i18n="curveSoft">Soft (√)</option><option value="cbrt" data-i18n="curveVerySoft">Very Soft (∛)</option><option value="pow2" data-i18n="curveHard">Hard (x²)</option><option value="pow3" data-i18n="curveVeryHard">Very Hard (x³)</option></select></div>
         <div class="pr"><button class="pbtn" id="btn-edit-pcurve" style="flex:1;font-size:10px" data-i18n-title="editPCurveTitle" title="Dessine ta propre courbe de réponse à la pression (remplace le preset ci-dessus tant qu'elle est active)" data-i18n="editCurveBtn">Éditer la courbe…</button></div>
         <div class="pr"><label style="font-size:9px;color:var(--text-dim);display:flex;align-items:center;gap:5px;cursor:pointer" data-i18n-title="invertPressureTitle" title="Hard press = thin line, light touch = thick line"><input type="checkbox" id="p-pinv" style="accent-color:var(--accent)"> <span data-i18n="invertPressureLabel">Invert pressure</span></label></div>
@@ -804,8 +815,10 @@
       <div class="pbdy">
         <div class="pr"><span class="pl" data-i18n="fieldPlayback">Playback</span><select class="psel" id="comp-playmode"><option value="loop" data-i18n="playbackLoop">Loop</option><option value="pingpong" data-i18n="playbackPingPong">Ping-Pong</option><option value="once" data-i18n="playbackOnce">Play Once</option><option value="single" data-i18n="playbackSingle">Single Frame</option></select></div>
         <div class="pr" id="comp-singleframe-row"><span class="pl" data-i18n="fieldFrame">Frame</span><input type="number" class="pi scrub" id="comp-singleframe" value="0" min="0" data-step="1"></div>
-        <div class="pr"><span class="pl" data-i18n="fieldSpeed">Speed</span><input type="number" class="pi scrub" id="comp-speed" value="1" min="0.1" max="8" step="0.1" data-step="0.1"></div>
-        <div class="pr"><span class="pl" data-i18n="fieldOffset">Offset</span><input type="number" class="pi scrub" id="comp-offset" value="0" data-step="1" data-i18n-title="compOffsetTitle" title="Main-timeline frame at which this instance's own timeline starts"></div>
+        <div class="pr dims-row">
+          <span class="pl" data-i18n="fieldSpeed">Speed</span><input type="number" class="pi scrub" id="comp-speed" value="1" min="0.1" max="8" step="0.1" data-step="0.1">
+          <span class="pl" data-i18n="fieldOffset">Offset</span><input type="number" class="pi scrub" id="comp-offset" value="0" data-step="1" data-i18n-title="compOffsetTitle" title="Main-timeline frame at which this instance's own timeline starts">
+        </div>
         <div class="pr" style="flex-direction:column;align-items:stretch;gap:3px">
           <span class="pl" style="font-size:9px" data-i18n="fieldFrames">Frames</span>
           <div id="comp-frame-strip" style="display:flex;gap:2px;overflow-x:auto;padding:2px 0"></div>


### PR DESCRIPTION
## Summary
- Document's FPS/Frames rows (the reported example) now sit on one row, matching the existing W/H row pattern.
- Same treatment applied to 3 other stacked-but-short pairs found in the right panel: Reference layer Opacity/Offset, Draw tool P.min/P.max, Component instance Speed/Offset.
- Reused the existing `dims-row` CSS class (gap + non-growing labels) rather than inventing a new one.

## Test plan
- [x] Verified each of the 4 pairs visually — fits on one row without wrapping/cramping (P.min/P.max keeps its % suffixes and still fits)
- [x] No console errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)