### PR TITLE
Fix 6 bugs found in post-session audit

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1218,7 +1218,7 @@
          before (updatePlayhead/updateUI, timeline.js), and a 'change'
          listener drives goToFrame(). tl-tf (the total) stays a plain
          <span> — its own value is already editable via #tl-total. -->
-    <div class="ti"><input type="number" class="scrub" id="tl-cf" min="1" value="1" data-step="1" style="width:32px;font-weight:600"> / <span id="tl-tf">24</span></div>
+    <div class="ti"><input type="number" class="scrub" id="tl-cf" min="1" value="1" data-step="1" data-nav-only="1" style="width:32px;font-weight:600"> / <span id="tl-tf">24</span></div>
     <button class="tb" id="btn-ff" data-i18n-title="btnFirstFrameTitle" title="Go to first frame"><span class="material-symbols-rounded">&#xe045;</span></button>
     <button class="tb" id="btn-pf" data-i18n-title="btnPrevFrameTitle" title="Previous frame"><span class="material-symbols-rounded">&#xe5cb;</span></button>
     <button class="tb" id="btn-play" data-i18n-title="btnPlayTitle" title="Play / Stop (Enter)"><span class="material-symbols-rounded">&#xe037;</span></button>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1852,6 +1852,9 @@ function convertLayerToStrokeFillShadowFolder(layerIdx){
 }
 function goToFrame(idx){
   if(idx<0||idx>=state.totalFrames)return;
+  // Already on this frame (e.g. a live-scrub tick that re-dispatched 'change'
+  // without the value actually moving) — avoid a redundant save+reload pass.
+  if(idx===state.currentFrame)return;
   saveAllLayerFrames();state.currentFrame=idx;window._curFrame=idx;
   if(window.SMAudio&&!state.playing)SMAudio.scrubAt(idx); // scrub audio au deplacement du playhead (v19)
   loadFrame(idx);if(!state.playing){renderOS();renderArcs();updateUI();}else{updatePlayhead();}

--- a/src/js/effects-panel.js
+++ b/src/js/effects-panel.js
@@ -353,10 +353,15 @@
       chevron.innerHTML = '<svg viewBox="0 0 24 24" width="10" height="10" fill="none" stroke="currentColor" stroke-width="2.4"><path d="M9 6l6 6-6 6"/></svg>';
       chevron.title = window.SM.t(expandedIdx === idx ? 'fxCollapse' : 'fxExpand');
       chevron.addEventListener('click', function (e) { e.stopPropagation(); expandedIdx = expandedIdx === idx ? -1 : idx; renderEffectsList(); });
+      // Right-click on a child control must not bubble into the row's own
+      // contextmenu listener below (opens the shader editor) — a right-click
+      // on the chevron/eye/delete should do nothing, not surprise-open it.
+      chevron.addEventListener('contextmenu', function (e) { e.stopPropagation(); });
       var eye = document.createElement('div'); eye.className = 'fx-row-eye';
       eye.innerHTML = eff.enabled ? ICON_EYE : ICON_EYE_OFF;
       eye.title = window.SM.t(eff.enabled ? 'fxDisable' : 'fxEnable');
       eye.addEventListener('click', function (e) { e.stopPropagation(); toggleEnabled(idx); });
+      eye.addEventListener('contextmenu', function (e) { e.stopPropagation(); });
       var name = document.createElement('span'); name.className = 'fx-row-name';
       name.textContent = labelFor(eff.type);
       row.appendChild(chevron); row.appendChild(eye); row.appendChild(name);
@@ -369,6 +374,7 @@
           var def = customDefFor(eff.type);
           if (def && window.openCustomEffectEditor) window.openCustomEffectEditor(def);
         });
+        edit.addEventListener('contextmenu', function (e) { e.stopPropagation(); });
         row.appendChild(edit);
         // Right-click on the row itself opens the same editor (2026-07 —
         // the pencil icon was the ONLY entry point, easy to miss at that
@@ -382,6 +388,7 @@
       }
       var del = document.createElement('div'); del.className = 'fx-row-del'; del.textContent = '×'; del.title = window.SM.t('fxDelete');
       del.addEventListener('click', function (e) { e.stopPropagation(); deleteEffect(idx); });
+      del.addEventListener('contextmenu', function (e) { e.stopPropagation(); });
       row.appendChild(del);
       row.addEventListener('click', function () {
         expandedIdx = expandedIdx === idx ? -1 : idx;

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -392,7 +392,11 @@
       return;
     }
     if (hh && e.ctrlKey && hh.type === 'scale' && (hh.dir === 'nw' || hh.dir === 'ne' || hh.dir === 'sw' || hh.dir === 'se') && distortEligibleCornerAt(pt) === hh.dir) {
-      beginDistort(hh.dir);
+      // If beginDistort() fails (computeHandles() returned null), `mode`
+      // stays null — onUp()'s `if (!mode) return;` would then skip the
+      // resume() at its tail entirely, leaving the engine suspended forever
+      // (suspend() already ran a few lines above, unconditionally).
+      if (!beginDistort(hh.dir)) window.SMEngineBridge.resume();
       return;
     }
     if (hh) {
@@ -1151,6 +1155,16 @@
     } else if (mode === 'xform-distort') {
       selectedPaths.forEach(function (p) { forkIfForeignOwner(p); });
       fillRegenerateLinked(userLayers[state.activeLayerIdx], null);
+      // Same re-bake as the xform-scale/xform-rotate tail above — a corner-pin
+      // distort warps the path's own segments live, but never touched the
+      // bitmap-brush raster companion (not a simple scale/rotate, so onMove
+      // above leaves it untouched during the drag); without this it stays
+      // frozen at its pre-distort shape forever on that stroke.
+      if (window.SMBitmapBrush) {
+        selectedPaths.forEach(function (p) {
+          if (p.data && p.data.bitmapBrushSpec) SMBitmapBrush.regenerate(p, userLayers[state.activeLayerIdx]);
+        });
+      }
       saveActiveLayerFrame();
       renderOS();
       renderArcs(); updateUI();
@@ -1254,7 +1268,10 @@
       if (distortDirAt) {
         e.preventDefault(); e.stopImmediatePropagation();
         window.SMEngineBridge.suspend();
-        beginDistort(distortDirAt);
+        // Same guard as onDown's ctrl+corner branch — resume immediately on
+        // failure instead of relying on an onUp that will never fire (this
+        // is a synthetic-mode contextmenu path, no real onUp gesture follows).
+        if (!beginDistort(distortDirAt)) window.SMEngineBridge.resume();
         return;
       }
     }

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -37,7 +37,14 @@ function advancePlayFrame(cur){
   }
   return next;
 }
-function startPlay(){if(state.playing)return;state.playing=true;state.playDir=1;
+function startPlay(){if(state.playing)return;
+  // A brush-menu hover-preview mutates live paths with no pushUndo/save (see
+  // brush-menu-bridge.js) — if playback starts while one is active, the next
+  // frame change's saveAllLayerFrames() would bake the uncommitted preview
+  // into persisted frame data. Close the popover (its close() already
+  // reverts any live preview) before playback can advance a frame.
+  if(window.BrushMenu&&window.BrushMenu.isOpen())window.BrushMenu.close();
+  state.playing=true;state.playDir=1;
   document.getElementById('btn-play').innerHTML='<span class="material-symbols-rounded">\u{e034}</span>';
   document.getElementById('btn-play').classList.add('playing');
   if(window.SMAudio)SMAudio.onPlayStart(state.currentFrame);
@@ -1705,14 +1712,14 @@ function selectGhostAll(){
   // own) that read as "le bouton n'a pas l'air de marcher" (2026-07). Now
   // self-enables Ghost All instead of requiring that separate step —
   // same side effects toggleGhostAll's own "turning on" branch has.
+  var li=state.activeLayerIdx,cf=state.currentFrame;
+  var ld=state.layers[li];if(!ld||ld.symbolId){showToast('Ghost All ne fonctionne pas sur un composant');return;}
   if(!state.ghostAllFrames){
     state.ghostAllFrames=true;
     renderOS();
     var gb=document.getElementById('btn-ghost-all');if(gb)gb.classList.add('active');
   }
   window.SM.setTool('select');
-  var li=state.activeLayerIdx,cf=state.currentFrame;
-  var ld=state.layers[li];if(!ld||ld.symbolId){showToast('Ghost All ne fonctionne pas sur un composant');return;}
   var layer=userLayers[li];
   pushUndo();
   var count=0,frameCount=0;

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -535,9 +535,16 @@ function nodeSelBounds(){
   return new Rectangle(minX,minY,maxX-minX,maxY-minY);
 }
 function nodeSelCommitTail(path){
+  // Same commit sequence as subselect-bridge.js's own node-edit tail (the
+  // sibling gesture for the same kind of vertex edit) — forking/texture
+  // regen/onion-refresh were missing here, so a vertex drag through THIS
+  // path silently skipped all three while the other path handled them.
+  forkIfForeignOwner(path);
   fillRegenerateLinked(userLayers[state.activeLayerIdx],path);
+  if(window.regenerateBrushTexture)regenerateBrushTexture(path,userLayers[state.activeLayerIdx]);
   if(path.data&&path.data.bitmapBrushSpec&&window.SMBitmapBrush)SMBitmapBrush.regenerate(path,userLayers[state.activeLayerIdx]);
   saveActiveLayerFrame();
+  renderOS();
   if(window.renderNodeHandles)renderNodeHandles();
   renderArcs();updateUI();
   if(window.SMEngineBridge)SMEngineBridge.renderNow();

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -1018,7 +1018,10 @@
     if(!scrubState.moved){
       if(Math.abs(dx)<3)return;
       scrubState.moved=true;scrubState.el.classList.add('scrubbing');
-      if(window.pushUndo)window.pushUndo(); // snapshot pré-geste, AVANT de lever le flag
+      // data-nav-only (tl-cf) : le champ ne fait QUE naviguer (goToFrame),
+      // aucune édition de document — un pushUndo ici ne ferait que polluer
+      // la pile d'un snapshot identique et vider le redo pour rien.
+      if(window.pushUndo&&!scrubState.el.dataset.navOnly)window.pushUndo(); // snapshot pré-geste, AVANT de lever le flag
       window._scrubLiveActive=true;
     }
     var step=parseFloat(scrubState.el.dataset.step)||1;


### PR DESCRIPTION
## Summary
Fixes for bugs surfaced by an audit of the previous session's ~16 merged PRs (research agents + partial adversarial verification), plus two more found while re-verifying manually:

- **Brush hover-preview permanence**: a brush-menu popover's hover preview mutates live paths with no undo/save; if playback started while hovering, the next frame change's `saveAllLayerFrames()` would bake the uncommitted preview into persisted data. Now the popover (and its preview) closes whenever playback starts.
- **Ghost All self-enable ordering**: `selectGhostAll()` turned the button "on" and rendered before checking whether the active layer is a component (which refuses the operation) — left the UI showing enabled state on a no-op.
- **Frame-counter scrub undo pollution**: the generic scrub-drag mechanism unconditionally pushes an undo snapshot at drag-start; the frame counter (`tl-cf`) is pure navigation, not an edit, so scrubbing it wiped the redo stack for nothing. Opts out via a new `data-nav-only` marker.
- **Redundant save/reload thrash**: `goToFrame()` ran a full save+reload even when the target frame was already current (happens on live-scrub ticks that re-dispatch `change` without the value moving).
- **Effect row context-menu bubbling**: right-clicking a custom effect's chevron/eye/delete controls bubbled into the row's own `contextmenu` handler, unexpectedly opening the shader editor.
- **Distort leaves engine suspended**: a failed corner-pin distort (drag or ctrl+right-click entry point) never sets `mode`, so `onUp()`'s early return skips `resume()` — the render engine stayed suspended until an unrelated gesture happened to fix it.
- **Distort skips brush re-bake**: unlike the sibling xform-scale/rotate commit path, a corner-pin distort never re-baked the bitmap-brush raster companion at gesture end.
- **Node-edit commit tail inconsistency**: `tools.js`'s `nodeSelCommitTail` skipped `forkIfForeignOwner`/`regenerateBrushTexture`/`renderOS`, unlike `subselect-bridge.js`'s equivalent tail for the same kind of vertex edit.

## Test plan
- [x] `node --check` on all edited JS files
- [x] Dev app (`npm run dev`) loads cleanly, zero console errors
- [x] Created a project, confirmed a frame-counter scrub drag leaves `undoStack`/`redoStack` at 0 (no pollution)
- [ ] Manual pass on distort/brush-preview paths in a real drawing session (not exercised live — no test asset with a bitmap-brushed stroke was set up this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)