### PR TITLE
Address today's beta feedback: size lock, alignment, brush preview, distort feedback

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -328,7 +328,12 @@
                edge-to-edge and visually fuse. -->
           <div style="flex:1;min-width:0;display:flex;flex-direction:column;gap:6px">
             <div class="pr"><span class="pl" data-i18n="fieldPosition">Position</span><input type="number" class="pi scrub" id="sp-x" value="0" data-step="1" data-i18n-title="titleDragX" title="X — drag to scrub, click to type"><input type="number" class="pi scrub" id="sp-y" value="0" data-step="1" data-i18n-title="titleDragY" title="Y — drag to scrub, click to type"></div>
-            <div class="pr"><span class="pl" data-i18n="fieldSize">Size</span><input type="number" class="pi scrub" id="sp-w" value="0" min="1" data-step="1" data-i18n-title="fieldWidth" title="Width"><input type="number" class="pi scrub" id="sp-h" value="0" min="1" data-step="1" data-i18n-title="fieldHeight" title="Height"></div>
+            <!-- Proportion lock (2026-07 feedback: "il manque le cadenas sur
+                 le size pour lier les 2") — same dims-lock-btn as the
+                 Document panel's own W/H lock (index.html above), reused
+                 as-is since it's already generic (see btn-sp-size-lock's
+                 wiring in timeline.js). -->
+            <div class="pr dims-row"><span class="pl" data-i18n="fieldSize">Size</span><input type="number" class="pi scrub" id="sp-w" value="0" min="1" data-step="1" data-i18n-title="fieldWidth" title="Width"><input type="number" class="pi scrub" id="sp-h" value="0" min="1" data-step="1" data-i18n-title="fieldHeight" title="Height"><button class="dims-lock-btn" id="btn-sp-size-lock" type="button" data-i18n-title="dimsLockTitle" title="Lier largeur/hauteur (garder les proportions)"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg></button></div>
             <div class="pr"><span class="pl" data-i18n="fieldRotate">Rotate</span><input type="number" class="pi scrub" id="sp-rot" value="0" data-step="1" data-i18n-title="titleRotateSel" title="Rotation relative to selection state (degrees)"><span style="font-size:9px;color:var(--text-dim)">°</span></div>
           </div>
           <!-- Anchor point (pivot) picker — redesign 2026-07-09, AE-style
@@ -510,7 +515,16 @@
           <span class="pl">FPS</span><input type="number" class="pi scrub" id="proj-fps" value="12" min="1" max="60" data-step="1">
           <span class="pl">Frames</span><input type="number" class="pi scrub" id="proj-frames" value="24" min="1" max="999" data-step="1">
         </div>
-        <div class="pr"><span class="pl">BG</span><input type="color" id="p-cbg" value="#ffffff" style="width:28px;height:22px;border:none;cursor:pointer;padding:0;"></div>
+        <!-- dims-row (2026-07 feedback: "aligner les icônes avec bg") — BG's
+             label used the default .pl (min-width:50px), pushing its swatch
+             ~40px further right than every sibling row's value column (W/H,
+             FPS/Frames, all dims-row). The icon row below had no label at
+             all, so it started flush at the row's own left edge instead —
+             neither one lined up with the other. dims-row shrinks BG's
+             label to its natural width; the icon row gets an identical
+             (hidden) "BG" label as a spacer so its buttons start at the
+             EXACT same x as the swatch above, not a guessed margin. -->
+        <div class="pr dims-row"><span class="pl">BG</span><input type="color" id="p-cbg" value="#ffffff" style="width:28px;height:22px;border:none;cursor:pointer;padding:0;"></div>
         <!-- Icon buttons instead of text (feedback 2026-07: "les boutons
              avec un texte est-ce qu'ils peuvent avoir un bouton icon
              plutôt que texte") — tooltip (title) carries the label, same
@@ -524,7 +538,8 @@
              icon-only + tooltip-carries-the-label convention as Fit/Reset
              View just above, .active toggled on click like every other
              toggle button in this app (btn-ghost-all, btn-loop, etc.). -->
-        <div class="pr" style="gap:4px">
+        <div class="pr dims-row" style="gap:4px">
+          <span class="pl" style="visibility:hidden" aria-hidden="true">BG</span>
           <button class="pbtn icon-only-btn" id="btn-fit" data-i18n-title="btnFitTitle" title="Fit — fit the canvas to the viewport"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M21 16v3a2 2 0 0 1-2 2h-3M3 16v3a2 2 0 0 0 2 2h3"/></svg></button>
           <button class="pbtn icon-only-btn" id="btn-resetv" data-i18n-title="btnResetViewTitle" title="Reset View — restore zoom/pan/rotation to default"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 1 3 6.7"/><path d="M3 21v-5h5"/></svg></button>
           <button class="pbtn icon-only-btn" id="btn-clip" data-i18n-title="clipCanvasTitle" title="Clip to canvas — hide artwork outside the canvas bounds (off by default, so you can see and work with content that spills over the edge)"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 2v14a2 2 0 0 0 2 2h14"/><path d="M18 22V8a2 2 0 0 0-2-2H2"/></svg></button>

--- a/src/js/brush-menu-bridge.js
+++ b/src/js/brush-menu-bridge.js
@@ -93,7 +93,13 @@
         seed: Math.floor(Math.random() * 0xffffffff),
       };
       stripAnyBrushTexture(p);
-      applyBitmapBrushTexture(p, spec);
+      // applyBitmapBrushTexture is local to bitmap-brush.js's own IIFE, not
+      // a global like applyBrushTexture (tools.js) — calling it bare here
+      // threw a ReferenceError, silently killing the hover preview for
+      // every bitmap tip (2026-07 feedback: "on ne voit pas les brush en
+      // direct"). window.SMBitmapBrush.applyToPath is that same function,
+      // exposed for exactly this kind of external caller.
+      window.SMBitmapBrush.applyToPath(p, spec);
     });
     if (window.SMEngineBridge) SMEngineBridge.renderNow();
   }
@@ -101,7 +107,7 @@
     if (!_previewSnapshot) return;
     _previewSnapshot.forEach(function (rec) {
       stripAnyBrushTexture(rec.p);
-      if (rec.bitmapSpec) applyBitmapBrushTexture(rec.p, rec.bitmapSpec);
+      if (rec.bitmapSpec) window.SMBitmapBrush.applyToPath(rec.p, rec.bitmapSpec);
       else if (rec.preset) applyBrushTexture(rec.p, rec.preset);
     });
     _previewSnapshot = null;

--- a/src/js/brush-preset-picker.js
+++ b/src/js/brush-preset-picker.js
@@ -18,8 +18,43 @@
   var popover = null, closeHandlers = null;
   var demoPath = null; // built lazily once Paper.js is ready, reused for every preview render
 
+  // Hover-preview on the CANVAS (2026-07 feedback: "on ne voit pas les
+  // brush en direct... il faut le même [que le menu flottant]") — same
+  // apply-live-on-mouseenter/revert-on-mouseleave pattern as the floating
+  // Brush Menu's own preview (brush-menu-bridge.js), reusing the same
+  // truly-global helpers (stripAnyBrushTexture/applyBrushTexture, both
+  // declared outside any IIFE) rather than a second copy of that logic.
+  var _hoverSnapshot = null;
+  function eligibleHoverPaths() {
+    if (!(window.state && (state.tool === 'select' || state.tool === 'subselect')) || !window.selectedPaths || !selectedPaths.length) return [];
+    return selectedPaths.filter(function (p) { return p instanceof Path && !(p.data && (p.data.isVectorBrush || p.data.isFillShape)); });
+  }
+  function beginHoverPreview() {
+    if (_hoverSnapshot) return;
+    _hoverSnapshot = eligibleHoverPaths().map(function (p) { return { p: p, preset: (p.data && p.data.brushTexturePreset) || null }; });
+  }
+  function hoverPreview(key) {
+    beginHoverPreview();
+    if (!_hoverSnapshot.length) return;
+    _hoverSnapshot.forEach(function (rec) {
+      stripAnyBrushTexture(rec.p);
+      if (key && key !== 'none') applyBrushTexture(rec.p, key);
+    });
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+  }
+  function revertHoverPreview() {
+    if (!_hoverSnapshot) return;
+    _hoverSnapshot.forEach(function (rec) {
+      stripAnyBrushTexture(rec.p);
+      if (rec.preset) applyBrushTexture(rec.p, rec.preset);
+    });
+    _hoverSnapshot = null;
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+  }
+
   function closePopover() {
     if (!popover) return;
+    revertHoverPreview();
     popover.remove();
     popover = null;
     if (closeHandlers) { closeHandlers(); closeHandlers = null; }
@@ -160,10 +195,22 @@
 
     el.querySelectorAll('.bp-item').forEach(function (btn) {
       drawPreview(btn.querySelector('canvas'), btn.dataset.key);
+      btn.addEventListener('mouseenter', function () { hoverPreview(btn.dataset.key); });
+      btn.addEventListener('mouseleave', function () { revertHoverPreview(); });
       btn.addEventListener('click', function (e) {
         if (e.target.classList.contains('bp-item-del')) return;
+        // Revert the hover preview BEFORE the real commit — onSelect's own
+        // pushUndo (via setBrushPreset) must snapshot the true pre-hover
+        // state, not the already-mutated preview, or Ctrl+Z would restore
+        // to the hovered-but-not-picked brush instead of the original.
+        revertHoverPreview();
         onSelect(btn.dataset.key);
-        closePopover();
+        // Stay open (2026-07 feedback: "il faut le même [que le menu
+        // flottant]... celui-ci disparait une fois que l'on a select une
+        // brush") — same convention as the floating Brush Menu's own grid,
+        // which only re-highlights the active item instead of closing, so
+        // several presets can be tried/compared in one popover visit.
+        el.querySelectorAll('.bp-item').forEach(function (b) { b.classList.toggle('active', b.dataset.key === btn.dataset.key); });
       });
     });
     el.querySelectorAll('.bp-item-del').forEach(function (delBtn) {

--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -752,6 +752,32 @@
     // through the same map.
     var nvMap = (window.SMMotion && SMMotion.layerMotionPointMap) ? SMMotion.layerMotionPointMap(state.activeLayerIdx) : null;
     function W(x, y) { var p = selBoxPt(x, y, box); if (nvMap) { var w = nvMap.fwd(p.x, p.y); return w; } return [p.x, p.y]; }
+    // Live corner-pin distort (2026-07 feedback: "la bounding box ne
+    // reflete pas cette transformation") — select-bridge.js's distortSrcQuad/
+    // distortDstQuad are already past selBoxPt (geometry space, same as the
+    // dragged segments themselves), so only the Motion map (not selBoxPt
+    // again) still needs applying. Draws the ACTUAL warped quad + only its
+    // 4 corners (no edge-midpoints/anchor/rotate-ring — none are meaningful
+    // mid-perspective-warp) instead of the static pre-distort rectangle,
+    // and highlights the corner actually being dragged.
+    var liveDistort = window.SMSelectBridge && SMSelectBridge.getDistortState();
+    if (liveDistort && liveDistort.quad) {
+      function WG(pt) { return nvMap ? nvMap.fwd(pt.x, pt.y) : [pt.x, pt.y]; }
+      var dq = liveDistort.quad;
+      var dc = { nw: WG(dq.nw), ne: WG(dq.ne), se: WG(dq.se), sw: WG(dq.sw) };
+      var dItems = [
+        lineItem(dc.nw, dc.ne, [74, 158, 255, 204], 1 * zs),
+        lineItem(dc.ne, dc.se, [74, 158, 255, 204], 1 * zs),
+        lineItem(dc.se, dc.sw, [74, 158, 255, 204], 1 * zs),
+        lineItem(dc.sw, dc.nw, [74, 158, 255, 204], 1 * zs),
+      ];
+      Object.keys(dc).forEach(function (k) {
+        var isActive = k === liveDistort.dir;
+        var p = dc[k];
+        dItems.push(rectItem(p[0], p[1], (isActive ? 4.5 : 3.5) * zs, [255, 255, 255, 255], isActive ? [255, 159, 10, 255] : [74, 158, 255, 255], 1.2 * zs));
+      });
+      return dItems;
+    }
     if (!box.angle && !(nvMap && nvMap.mat.rot)) {
       // no rotation anywhere — but position/scale from Motion still apply
       var tl = W(b.left, b.top), br = W(b.right, b.bottom);
@@ -772,7 +798,12 @@
     };
     Object.keys(corners).forEach(function (k) {
       var p = corners[k];
-      items.push(rectItem(p[0], p[1], 3.5 * zs, [255, 255, 255, 255], [74, 158, 255, 255], 1.2 * zs));
+      // Ctrl-hover corner-pin affordance (2026-07 feedback: "qd ctrl est
+      // appuyé voir une différence visuelle sur les corner") — same accent
+      // color as the active-drag highlight above, shown BEFORE any drag
+      // starts so the user knows which corner Ctrl+drag would distort.
+      var isDistortHover = state.xformDistortHoverDir === k;
+      items.push(rectItem(p[0], p[1], (isDistortHover ? 4.5 : 3.5) * zs, [255, 255, 255, 255], isDistortHover ? [255, 159, 10, 255] : [74, 158, 255, 255], 1.2 * zs));
     });
     // Anchor/pivot marker (redesign 2026-07-09, AE-style anchor point) — a
     // small ringed crosshair AT the point rotation actually pivots around

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -51,6 +51,12 @@
   // handleIn/handleOut once at gesture start and every subsequent tick
   // re-derives the full transform from that same fixed snapshot.
   var distortDir = null, distortSrcQuad = null, distortSegs = null;
+  // Live quad during an active drag (2026-07 feedback: "la bounding box ne
+  // reflete pas cette transformation") — engine-bridge.js's
+  // buildTransformBoxItems reads this via SMSelectBridge.getDistortState()
+  // to draw the ACTUAL warped quad instead of the static pre-distort
+  // rectangle while dragging.
+  var distortDstQuad = null;
   var rotCenter = null, rotStartAngle = 0, rotLastAngle = 0;
   var marqueeStart = null;
   var moveStarted = false;
@@ -308,6 +314,7 @@
     if (!h) return false;
     distortDir = dir;
     distortSrcQuad = { nw: h.gCorners.nw.clone(), ne: h.gCorners.ne.clone(), se: h.gCorners.se.clone(), sw: h.gCorners.sw.clone() };
+    distortDstQuad = distortSrcQuad; // no drag yet — starts equal to the source quad
     xformMap = h.map;
     distortSegs = [];
     selectedPaths.forEach(function (p) { collectDistortSegs(p, distortSegs); });
@@ -766,9 +773,23 @@
           state.xformRingHovered = isRingHover;
           window.SMEngineBridge.renderNow();
         }
-      } else if (canvasEl.dataset.xformCursor) {
-        canvasEl.style.cursor = 'default';
-        delete canvasEl.dataset.xformCursor;
+        // Ctrl-hover corner-pin affordance (2026-07 feedback: "qd ctrl est
+        // appuyé voir une différence visuelle sur les corner") — passive,
+        // same pattern as xformAnchorHovered/xformRingHovered above: lets
+        // engine-bridge.js's buildTransformBoxItems recolor the ONE corner
+        // that a Ctrl+drag from here would actually distort, before any
+        // drag starts.
+        var distortHoverDir = e.ctrlKey ? distortEligibleCornerAt(hpt) : null;
+        if (distortHoverDir !== (state.xformDistortHoverDir || null)) {
+          state.xformDistortHoverDir = distortHoverDir;
+          window.SMEngineBridge.renderNow();
+        }
+      } else {
+        if (canvasEl.dataset.xformCursor) {
+          canvasEl.style.cursor = 'default';
+          delete canvasEl.dataset.xformCursor;
+        }
+        if (state.xformDistortHoverDir) { state.xformDistortHoverDir = null; window.SMEngineBridge.renderNow(); }
       }
       return;
     }
@@ -982,6 +1003,7 @@
       if (xformMap) { var ptgD = xformMap.inv(pt.x, pt.y); ptD = new Point(ptgD[0], ptgD[1]); }
       var dstQuad = { nw: distortSrcQuad.nw, ne: distortSrcQuad.ne, se: distortSrcQuad.se, sw: distortSrcQuad.sw };
       dstQuad[distortDir] = ptD;
+      distortDstQuad = dstQuad;
       var srcUV = rectUVSolver(distortSrcQuad.nw, distortSrcQuad.ne, distortSrcQuad.sw);
       var dstFwd = unitSquareToQuad(dstQuad.nw, dstQuad.ne, dstQuad.se, dstQuad.sw);
       distortSegs.forEach(function (rec) {
@@ -1168,7 +1190,7 @@
       saveActiveLayerFrame();
       renderOS();
       renderArcs(); updateUI();
-      distortDir = null; distortSrcQuad = null; distortSegs = null;
+      distortDir = null; distortSrcQuad = null; distortSegs = null; distortDstQuad = null;
     } else if (mode === 'marquee') {
       if (_marquee.rect) {
         var mb = _marquee.rect.bounds;
@@ -1381,6 +1403,16 @@
     }
     window.showContextMenu(e.clientX, e.clientY, items);
   }
+
+  // Read-only peek for engine-bridge.js's buildTransformBoxItems (2026-07
+  // feedback: "la bounding box ne reflete pas cette transformation") — lets
+  // the gizmo draw the ACTUAL live-distorted quad instead of the static
+  // pre-distort rectangle while a corner-pin drag is in progress.
+  window.SMSelectBridge = {
+    getDistortState: function () {
+      return mode === 'xform-distort' ? { dir: distortDir, quad: distortDstQuad } : null;
+    },
+  };
 
   function init() {
     var target = document.getElementById('canvas-area') || document.getElementById('drawing-canvas');

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -4945,8 +4945,39 @@ function activeXformApplyScale(sx,sy,anchor,skipUndo){if(activeXformVertexMode()
 function activeXformApplyRotate(deltaDeg,center,skipUndo){if(activeXformVertexMode())nodeSelApplyRotate(deltaDeg,center,skipUndo);else selPropsApplyRotate(deltaDeg,center,skipUndo);}
 wireLiveXformField('sp-x',function(el,started){var b=activeXformBounds();if(!b)return;activeXformApplyMove((parseFloat(el.value)||0)-b.x,0,started);});
 wireLiveXformField('sp-y',function(el,started){var b=activeXformBounds();if(!b)return;activeXformApplyMove(0,(parseFloat(el.value)||0)-b.y,started);});
-wireLiveXformField('sp-w',function(el,started){var b=activeXformBounds();if(!b||b.width<0.01)return;var nv=Math.max(0.01,parseFloat(el.value)||b.width);activeXformApplyScale(nv/b.width,1,b.topLeft,started);});
-wireLiveXformField('sp-h',function(el,started){var b=activeXformBounds();if(!b||b.height<0.01)return;var nv=Math.max(0.01,parseFloat(el.value)||b.height);activeXformApplyScale(1,nv/b.height,b.topLeft,started);});
+// Proportion lock (2026-07, "il manque le cadenas sur le size pour lier
+// les 2") — same on/off toggle convention as btn-dims-lock (Document
+// panel's W/H), but applies the SAME scale factor to both axes in one
+// activeXformApplyScale call (a true uniform transform) rather than
+// deriving one field from a remembered ratio like the canvas-size lock
+// does — simpler here since both fields already read live bounds.
+var _spSizeLockOn=false;
+document.getElementById('btn-sp-size-lock').addEventListener('click',function(){
+  _spSizeLockOn=!this.classList.contains('on');
+  this.classList.toggle('on',_spSizeLockOn);
+});
+wireLiveXformField('sp-w',function(el,started){
+  var b=activeXformBounds();if(!b||b.width<0.01)return;
+  var nv=Math.max(0.01,parseFloat(el.value)||b.width);
+  var sx=nv/b.width;
+  if(_spSizeLockOn&&b.height>=0.01){
+    document.getElementById('sp-h').value=Math.round(b.height*sx);
+    activeXformApplyScale(sx,sx,b.topLeft,started);
+  }else{
+    activeXformApplyScale(sx,1,b.topLeft,started);
+  }
+});
+wireLiveXformField('sp-h',function(el,started){
+  var b=activeXformBounds();if(!b||b.height<0.01)return;
+  var nv=Math.max(0.01,parseFloat(el.value)||b.height);
+  var sy=nv/b.height;
+  if(_spSizeLockOn&&b.width>=0.01){
+    document.getElementById('sp-w').value=Math.round(b.width*sy);
+    activeXformApplyScale(sy,sy,b.topLeft,started);
+  }else{
+    activeXformApplyScale(1,sy,b.topLeft,started);
+  }
+});
 wireLiveXformField('sp-rot',function(el,started){var b=activeXformBounds();if(!b)return;var nv=parseFloat(el.value)||0;var delta=nv-(state.selRotAccum||0);state.selRotAccum=nv;activeXformApplyRotate(delta,xformAnchorPoint(b),started);});
 // Anchor-point (pivot) picker — see tools.js xformAnchorPoint's own comment.
 // Clicking a dot just changes WHICH point future rotations pivot around

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -761,12 +761,31 @@ function renderTransformHandles(){
   var box=orientedSelBox();if(!box)return;
   var b=box.b;
   xformLayer.activate();var zs=1/view.zoom;
+  // Live corner-pin distort (2026-07 feedback: "la bounding box ne reflete
+  // pas cette transformation") — same live-quad treatment as
+  // engine-bridge.js's buildTransformBoxItems, mirrored here for the
+  // Paper-native fallback path (see that function's own parity comment).
+  var liveDistort=window.SMSelectBridge&&SMSelectBridge.getDistortState();
+  if(liveDistort&&liveDistort.quad){
+    var dq=liveDistort.quad;
+    var dPath=new Path({segments:[dq.nw,dq.ne,dq.se,dq.sw],closed:true,strokeColor:'rgba(74,158,255,.8)',strokeWidth:1*zs,dashArray:[4*zs,3*zs],insert:true});
+    ['nw','ne','se','sw'].forEach(function(k){
+      var pos=dq[k],isActive=k===liveDistort.dir;
+      new Path.Rectangle({center:pos,size:[(isActive?9:7)*zs,(isActive?9:7)*zs],fillColor:'#ffffff',strokeColor:isActive?'#ff9f0a':'#4a9eff',strokeWidth:1.2*zs,insert:true});
+      xformHandles.push({type:'scale',dir:k,pos:pos});
+    });
+    return;
+  }
   var boxRect=new Path.Rectangle({rectangle:b,strokeColor:'rgba(74,158,255,.8)',strokeWidth:1*zs,dashArray:[4*zs,3*zs],insert:true});
   if(box.angle)boxRect.rotate(box.angle,box.pivot);
   var corners={nw:selBoxPt(b.left,b.top,box),ne:selBoxPt(b.right,b.top,box),sw:selBoxPt(b.left,b.bottom,box),se:selBoxPt(b.right,b.bottom,box),n:selBoxPt(b.center.x,b.top,box),s:selBoxPt(b.center.x,b.bottom,box),e:selBoxPt(b.right,b.center.y,box),w:selBoxPt(b.left,b.center.y,box)};
   Object.keys(corners).forEach(function(k){
     var pos=corners[k];
-    new Path.Rectangle({center:pos,size:[7*zs,7*zs],fillColor:'#ffffff',strokeColor:'#4a9eff',strokeWidth:1.2*zs,insert:true});
+    // Ctrl-hover corner-pin affordance — same accent as the active-drag
+    // highlight above, shown before any drag starts (see select-bridge.js's
+    // onMove hover pass for state.xformDistortHoverDir).
+    var isDistortHover=state.xformDistortHoverDir===k;
+    new Path.Rectangle({center:pos,size:[(isDistortHover?9:7)*zs,(isDistortHover?9:7)*zs],fillColor:'#ffffff',strokeColor:isDistortHover?'#ff9f0a':'#4a9eff',strokeWidth:1.2*zs,insert:true});
     xformHandles.push({type:'scale',dir:k,pos:pos});
   });
   // Rotate RING (2026-07, replaces the old tiny offset stem+dot handle —


### PR DESCRIPTION
## Summary
Fixes for the 4 non-resolved feedback items submitted today (2026-07-20), all confirmed as real bugs by reading the actual code paths involved:

- **Sub-selection Size lock** (11:35): added a width/height proportion-lock button to the Position/Size/Rotate panel's Size row, matching the Document panel's existing W/H lock — applies a true uniform scale to both axes at once.
- **BG/icon-row alignment** (11:34): the Document panel's BG swatch and the Fit/Reset View/Clip/Safety icon row below it used inconsistent label widths, so they didn't line up. Now share the same left edge (verified: both start at x≈518-519).
- **Brush hover-preview** (11:37): the floating Brush Menu's bitmap-tip hover-preview called `applyBitmapBrushTexture` as a bare global, but it's local to `bitmap-brush.js`'s own scope — every hover threw a silent `ReferenceError`, killing the live preview. Fixed to use the exposed `window.SMBitmapBrush.applyToPath`. Also brought the smaller Stroke-panel brush popover up to parity with the floating menu: live hover-preview on canvas, and it no longer auto-closes after picking a preset (so several can be tried in one visit).
- **Distort visual feedback** (11:45): a corner-pin distort (Ctrl+drag a scale handle) warped the actual path live but the bounding-box gizmo stayed at its static pre-distort rectangle for the whole drag. The gizmo now draws the real warped quad, and highlights the corner being dragged (or hovered while Ctrl is held, before any drag starts) in orange. Fixed in both the Rust-engine renderer (`engine-bridge.js`) and the Paper.js fallback renderer (`tools.js`), which are meant to stay in visual parity per this repo's own conventions.

The anchor-point feedback from earlier today (11:32) was investigated separately and closed as a false positive (stale 0.5.0 install, not a code bug) — not part of this PR.

## Test plan
- [x] `node --check` on all edited JS files
- [x] Dev app loads with zero console errors
- [x] Size lock: scrubbing width with lock on drives height by the same factor (535→1070 drove 377→755)
- [x] BG/icon alignment: verified via `getBoundingClientRect()` (BG swatch left=519, icon row left=518)
- [x] Distort: dispatched synthetic Ctrl+drag pointer events — confirmed `xformDistortHoverDir` sets on Ctrl-hover, and the live quad (`SMSelectBridge.getDistortState()`) correctly reflects the dragged corner moving while the other 3 stay fixed, clearing on release
- [ ] Brush hover-preview fix verified by code-reading only (the ReferenceError root cause is unambiguous) — not exercised live with an actual bitmap-brushed stroke this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)