### PR TITLE
Fix guide-editing while drawing, eraser on open fills, Fill Brush smoothing

### DIFF
--- a/src/js/labs/labs-float-panel.js
+++ b/src/js/labs/labs-float-panel.js
@@ -59,16 +59,13 @@
         if (state.symmetryEnabled) {
           if (window.ensureSymmetryAxis) window.ensureSymmetryAxis();
           if (window.ensureSymmetryRadialCenter) window.ensureSymmetryRadialCenter();
-          // Feedback: "on ne peut pas changer l'emplacement des points/
-          // guides" — turning the guide on from HERE used to leave
-          // state.tool at whatever it was (almost always Draw/Fillbrush),
-          // so the axis appeared but nothing you clicked on it did
-          // anything: dragging is gated on state.tool==='symmetry' (see
-          // symmetry-bridge.js's shouldEdit). Jumping into that tool the
-          // instant the guide turns on means the very first thing the user
-          // can do is drag it into place, no separate "now click the tiny
-          // toolbar icon" step required.
-          if (window.SM && window.SM.setTool) window.SM.setTool('symmetry');
+          // No longer force-switches into the 'symmetry' tool (2026-07
+          // feedback: "je perds la sélection de l'outil brush... les
+          // boutons du menu flottant disparaissent") — symmetry-bridge.js's
+          // shouldEdit no longer requires actually BEING in that tool, just
+          // the guide being enabled, so the axis is draggable immediately
+          // from whatever tool (Brush, Fill Brush...) is already active,
+          // and the floating panel (keyed off the CURRENT tool) stays put.
         }
         var cb = document.getElementById('p-sym-on'); if (cb) cb.checked = state.symmetryEnabled;
         if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
@@ -80,8 +77,8 @@
         state.perspectiveEnabled = !state.perspectiveEnabled;
         if (state.perspectiveEnabled) {
           if (window.ensurePerspectiveVPs) window.ensurePerspectiveVPs();
-          // Same reasoning as symmetry's toggle above.
-          if (window.SM && window.SM.setTool) window.SM.setTool('perspective');
+          // No longer force-switches tool — same reasoning as symmetry's
+          // toggle above.
         }
         var cb = document.getElementById('p-persp-on'); if (cb) cb.checked = state.perspectiveEnabled;
         if (window.SMEngineBridge) window.SMEngineBridge.renderNow();

--- a/src/js/perspective-bridge.js
+++ b/src/js/perspective-bridge.js
@@ -287,7 +287,14 @@
   // Locked VPs stay put even during a whole-guide drag.
   var dragging = null; // the VP object currently being dragged, or null
   var draggingWhole = null; // {startX,startY,orig:[{x,y}...]} or null
-  function shouldEdit() { return engineOn() && state.tool === 'perspective'; }
+  // Broadened 2026-07 — same reasoning as symmetry-bridge.js's own
+  // shouldEdit (feedback: "garder l'outil brush sélectionné et pouvoir
+  // modifier les guides dans le canvas quand même"): dragging a VP/horizon
+  // handle no longer requires switching into the dedicated 'perspective'
+  // tool, just the guide being enabled — safe since onDown only claims an
+  // explicit hit-test hit and this file loads before every drawing-tool
+  // bridge.
+  function shouldEdit() { return engineOn() && (state.tool === 'perspective' || state.perspectiveEnabled); }
   function hitVP(worldPt) {
     var vps = ensurePerspectiveVPs();
     var tol = 12 / view.zoom;
@@ -312,12 +319,18 @@
   }
   function onDown(e) {
     if (!shouldEdit()) return;
-    e.stopImmediatePropagation(); e.preventDefault();
+    // Only claim the event on an ACTUAL hit — same fix as
+    // symmetry-bridge.js's own onDown (see its comment): calling
+    // stopImmediatePropagation/preventDefault unconditionally here was safe
+    // while shouldEdit() required actually being in the dedicated
+    // 'perspective' tool, but broke ordinary drawing entirely once
+    // shouldEdit() could also be true during Draw/Fill Brush.
     var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
     var wp = new Point(w[0], w[1]);
     dragging = hitVP(wp);
-    if (dragging) { window.SMEngineBridge.suspend(); return; }
+    if (dragging) { e.stopImmediatePropagation(); e.preventDefault(); window.SMEngineBridge.suspend(); return; }
     if (hitHorizon(wp)) {
+      e.stopImmediatePropagation(); e.preventDefault();
       draggingWhole = { startX: wp.x, startY: wp.y, orig: ensurePerspectiveVPs().map(function (v) { return { x: v.x, y: v.y }; }) };
       window.SMEngineBridge.suspend();
     }

--- a/src/js/symmetry-bridge.js
+++ b/src/js/symmetry-bridge.js
@@ -289,7 +289,19 @@
   var draggingEndpoint = null; // 'p1' | 'p2' | null
   var draggingWhole = null; // {startX,startY,orig:{x1,y1,x2,y2}} | null
   var draggingCenter = false;
-  function shouldEdit() { return engineOn() && state.tool === 'symmetry'; }
+  // Broadened 2026-07 (feedback: "quand j'utilise brush et clic sur les
+  // boutons de guides je perds la sélection de l'outil brush... il faudrait
+  // garder l'outil brush sélectionné et pouvoir modifier les guides dans le
+  // canvas quand même") — dragging the axis/endpoints/center no longer
+  // requires actually switching into the dedicated 'symmetry' tool, just
+  // the guide being enabled. Safe regardless of which tool is active: this
+  // file's onDown/onMove/onUp only ever act on an explicit hit-test hit
+  // (hitEndpoint/hitAxisLine/hitCenter) and fall through untouched on a
+  // miss, and load BEFORE every drawing-tool bridge (draw-bridge.js,
+  // pen-bridge.js, shape-bridge.js — see index.html's script order), so a
+  // real hit is always claimed here first, before that tool's own onDown
+  // ever sees the event.
+  function shouldEdit() { return engineOn() && (state.tool === 'symmetry' || state.symmetryEnabled); }
   function hitEndpoint(worldPt, axis) {
     var tol = 12 / view.zoom;
     if (Math.hypot(axis.x1 - worldPt.x, axis.y1 - worldPt.y) < tol) return 'p1';
@@ -310,20 +322,31 @@
   }
   function onDown(e) {
     if (!shouldEdit()) return;
-    e.stopImmediatePropagation(); e.preventDefault();
+    // stopImmediatePropagation/preventDefault only on an ACTUAL hit, not on
+    // every shouldEdit()-true pointerdown — 2026-07 regression found while
+    // verifying the broadened shouldEdit() above (see its own comment):
+    // this used to fire unconditionally right here, which was harmless
+    // when shouldEdit() required actually BEING in the dedicated 'symmetry'
+    // tool (nothing else needed the event then anyway), but now that
+    // shouldEdit() can be true while Draw/Fill Brush is active, doing this
+    // before the hit-test swallowed EVERY click on the canvas the instant
+    // the guide was enabled — not just clicks on the guide itself — which
+    // silently broke ordinary drawing. Confirmed live: drawing off-axis
+    // committed 0 strokes with the guide on vs 1 with it off, same drag.
     var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
     var wp = new Point(w[0], w[1]);
     if (state.symmetryMode === 'radial') {
       var c = ensureSymmetryRadialCenter();
-      if (hitCenter(wp, c)) { draggingCenter = true; window.SMEngineBridge.suspend(); }
+      if (hitCenter(wp, c)) { e.stopImmediatePropagation(); e.preventDefault(); draggingCenter = true; window.SMEngineBridge.suspend(); }
       return;
     }
     var axis = ensureSymmetryAxis();
     if (state.symmetryMode === 'free') {
       var hit = hitEndpoint(wp, axis);
-      if (hit) { draggingEndpoint = hit; window.SMEngineBridge.suspend(); return; }
+      if (hit) { e.stopImmediatePropagation(); e.preventDefault(); draggingEndpoint = hit; window.SMEngineBridge.suspend(); return; }
     }
     if (hitAxisLine(wp, axis)) {
+      e.stopImmediatePropagation(); e.preventDefault();
       draggingWhole = { startX: wp.x, startY: wp.y, orig: { x1: axis.x1, y1: axis.y1, x2: axis.x2, y2: axis.y2 } };
       window.SMEngineBridge.suspend();
     }

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -3073,7 +3073,15 @@ function rebuildVectorBrushOutline(path){
     // every edit. Only fill-brush shapes get this extra simplify pass,
     // right here in the single choke point every edit (scale/rotate/node-
     // drag) already funnels through, so it stays smooth after edits too.
-    if(path.data&&path.data.isFillShape)path.simplify(2.5);
+    // simplifyIfNeeded (not a bare path.simplify(2.5)) — 2026-07 feedback:
+    // "quand je mets stabilizer à 0 et smooth à 0, j'ai l'impression qu'il y
+    // a encore une passe de smooth". This hardcoded 2.5 tolerance ran
+    // UNCONDITIONALLY regardless of state.smoothing, so a Fill Brush shape
+    // always got re-fit even with Smooth explicitly set to 0 — same
+    // Paper.js `t||2.5` footgun simplifyIfNeeded's own comment already
+    // documents (passing 0 silently falls back to the default tolerance,
+    // so the guard has to skip the call entirely, not pass 0 through).
+    if(path.data&&path.data.isFillShape)simplifyIfNeeded(path,state.smoothing);
   }
 }
 
@@ -3305,9 +3313,21 @@ function eraseAtPoint(path,worldPt,radius,fromPt){
   // whenever there IS a strokeColor, always expand it into real ink geometry
   // and UNION it with the existing fill first, so the border becomes part of
   // the erasable area instead of being discarded outright.
-  if(!isVB&&path.strokeColor){
+  // 2026-07 feedback: "sur une forme non fermé et dessiné avec brush, si
+  // j'utilise la gomme sur fill celui-ci est supprimé totalement au lieu
+  // d'avoir la brush qui mange la forme" — the guard above only expanded an
+  // open path into real ink geometry when it ALSO had a strokeColor; a
+  // strokeless open fill (Draw tool with Stroke off) skipped it entirely and
+  // fell straight to the degenerate-zero-area subtract this whole comment
+  // block already describes, deleting the entire shape on first touch.
+  if(!isVB&&(path.strokeColor||(!path.closed&&path.fillColor))){
     var expanded=eraseExpandStrokeToFill(path);
     if(expanded){
+      // eraseExpandStrokeToFill always paints the expansion from
+      // path.strokeColor (the normal case); a strokeless open fill has none,
+      // so borrow path.fillColor instead — same visible color the erased
+      // result should end up filled with either way.
+      if(!path.strokeColor)expanded.fillColor=path.fillColor;
       if(path.fillColor&&path.closed){
         var fillCopy=path.clone({insert:false});
         fillCopy.strokeColor=null;


### PR DESCRIPTION
## Summary
Three more fixes from today's beta feedback:

- **Guides forced a tool switch** (11:55 feedback): clicking the symmetry/perspective guide toggle in the floating menu jumped into the dedicated 'symmetry'/'perspective' tool, losing the Brush tool selection and hiding the floating panel (which is keyed off the current tool). Broadened both bridges' `shouldEdit()` so dragging the guide only requires it being *enabled*, not being in that specific tool, and removed the forced `setTool()` call. **Caught a real regression from this same change during verification**: both bridges called `stopImmediatePropagation`/`preventDefault` unconditionally as soon as `shouldEdit()` passed — safe before (nothing else needed the event in the dedicated tool), but with the broadened condition this swallowed *every* click on the canvas while a guide was on, not just clicks on the guide itself, silently breaking ordinary drawing. Fixed by moving both calls to only fire on an actual hit.
- **Eraser deletes whole open fill** (11:48 feedback): an open (unclosed) brush-fill shape got deleted entirely on the first eraser touch instead of being notched, because the existing open-path→ribbon expansion only triggered when the shape also had a stroke color. Broadened it to cover strokeless open fills too.
- **Fill Brush ignores Smooth=0** (12:08 feedback): a hardcoded `path.simplify(2.5)` ran unconditionally on every Fill Brush commit/edit, regardless of the Smooth slider. Switched to the existing `simplifyIfNeeded` helper (already a no-op at 0) using the actual user setting.

Two other feedback items from today were investigated but not fixed here:
- "Stroke+Fill draws nothing" — a dedicated research pass through the full commit/serialize/render path found every code site handling this combination correctly; couldn't reproduce statically. Left open, needs live reproduction.
- "Tween only selected elements" — a legitimate feature request the reporter themselves flagged as "changes a lot of things" (per-element tween opt-in vs. today's per-keyframe model). Out of scope for a bug-fix pass, needs its own design discussion.

## Test plan
- [x] `node --check` on all edited files
- [x] Verified live in the dev app (real clicks, not synthetic events) on a cache-busted port:
  - Ctrl-independent: dragging the symmetry axis moves it while the tool stays "draw" and the floating panel stays visible
  - Drawing off-axis with the guide enabled still commits a stroke (mirrored copy included) — confirms the regression caught mid-fix is resolved
- [ ] Eraser-on-open-fill and Fill Brush smoothing fixes verified by code reading only, not exercised live this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)