### PR TITLE
Picking a bitmap tip from the floating Brush Menu now actually applies to new strokes

### DIFF
--- a/src/js/brush-menu-bridge.js
+++ b/src/js/brush-menu-bridge.js
@@ -313,6 +313,18 @@
       g.keys.forEach(function (k) { grid.appendChild(makeTipItem(k, k === current, function (key) {
         commitBrushPreview();
         window.BitmapTipPicker.selectTip(key);
+        // 2026-07 feedback: "si je select une brush bitmap celle-ci n'est
+        // pas appliqué après quand je dessine" — selectTip only records
+        // WHICH tip a future bitmap stroke would use; it never turned
+        // bitmap-brush mode itself on (nor vector-brush off, which draw-
+        // bridge.js requires be off for bitmap texture to apply at all —
+        // see its own `!state.vectorBrush` gate). Picking a tip from this
+        // gallery is the user's clear signal they want to draw with IT
+        // next, not just retexture whatever's currently selected.
+        if (window.SM) {
+          if (window.SM.setBitmapBrushOn) window.SM.setBitmapBrushOn(true);
+          if (window.SM.setVectorBrush) window.SM.setVectorBrush(false);
+        }
         if (window.SM && window.SM.applyBitmapBrushToSelection) window.SM.applyBitmapBrushToSelection();
         buildBitmapGrid(container);
       })); });
@@ -326,6 +338,18 @@
       custom.forEach(function (k) { cgrid.appendChild(makeTipItem(k, k === current, function (key) {
         commitBrushPreview();
         window.BitmapTipPicker.selectTip(key);
+        // 2026-07 feedback: "si je select une brush bitmap celle-ci n'est
+        // pas appliqué après quand je dessine" — selectTip only records
+        // WHICH tip a future bitmap stroke would use; it never turned
+        // bitmap-brush mode itself on (nor vector-brush off, which draw-
+        // bridge.js requires be off for bitmap texture to apply at all —
+        // see its own `!state.vectorBrush` gate). Picking a tip from this
+        // gallery is the user's clear signal they want to draw with IT
+        // next, not just retexture whatever's currently selected.
+        if (window.SM) {
+          if (window.SM.setBitmapBrushOn) window.SM.setBitmapBrushOn(true);
+          if (window.SM.setVectorBrush) window.SM.setVectorBrush(false);
+        }
         if (window.SM && window.SM.applyBitmapBrushToSelection) window.SM.applyBitmapBrushToSelection();
         buildBitmapGrid(container);
       })); });


### PR DESCRIPTION
## Summary
- The floating Brush Menu's Bitmap tab let you pick a tip and retroactively re-texture the current selection, but never turned bitmap-brush mode itself on — so the next brand-new stroke you drew ignored the pick entirely (still using whatever mode — plain/vector — was active before). Picking a tip now also flips `bitmapBrushOn` on and `vectorBrush` off (mirroring the existing "Bitmap Brush actif" checkbox in the same menu, plus draw-bridge.js's own `!vectorBrush` requirement for bitmap texture to apply).

## Test plan
- [x] `node --check`
- [x] Verified live: with `vectorBrush` pre-set true and `bitmapBrushOn` false, simulating the picker's onSelect sequence flips both correctly, and drawing a fresh stroke afterward produces real bitmap-brush data (companion Raster + `bitmapBrushSpec`-tagged path) instead of a plain stroke

🤖 Generated with [Claude Code](https://claude.com/claude-code)