### PR TITLE
Fill/Stroke Select: multi-selection, rectangle marquee, and lasso

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -959,26 +959,32 @@
     return out;
   }
   function buildFSSelectionItems() {
-    if (state.tool !== 'fsselect' || !_fsSel || typeof fsHighlightPath !== 'function') return [];
-    var hl = fsHighlightPath(_fsSel);
-    if (!hl || !hl.segments || !hl.segments.length) { if (hl) hl.remove(); return []; }
-    var segs = hl.segments.map(function (s) { return { point: [s.point.x, s.point.y], handleIn: [s.handleIn.x, s.handleIn.y], handleOut: [s.handleOut.x, s.handleOut.y] }; });
-    var closed = !!hl.closed;
-    var zs = 1 / view.zoom;
-    if (_fsSel.kind === 'fill' || _fsSel.kind === 'fillregion') {
-      var hatchLines = closed ? fsHatchClipLines(hl, 9 * zs, 45) : [];
-      hl.remove();
-      var items = [{ segments: roundSegs(segs), closed: closed, fillColor: [255, 152, 0, 45], strokeColor: [255, 152, 0, 230], strokeWidth: 2 * zs, dashPattern: [4 * zs, 3 * zs] }];
-      hatchLines.forEach(function (ln) {
-        items.push({
-          segments: [{ point: [ln[0], ln[1]], handleIn: [0, 0], handleOut: [0, 0] }, { point: [ln[2], ln[3]], handleIn: [0, 0], handleOut: [0, 0] }],
-          closed: false, fillColor: null, strokeColor: [255, 152, 0, 150], strokeWidth: 1 * zs,
+    if (state.tool !== 'fsselect' || !_fsSel || !_fsSel.length || typeof fsHighlightPath !== 'function') return [];
+    // Multi-select (2026-07) — draw every selected entry's own highlight,
+    // not just one.
+    var out = [];
+    _fsSel.forEach(function (sel) {
+      var hl = fsHighlightPath(sel);
+      if (!hl || !hl.segments || !hl.segments.length) { if (hl) hl.remove(); return; }
+      var segs = hl.segments.map(function (s) { return { point: [s.point.x, s.point.y], handleIn: [s.handleIn.x, s.handleIn.y], handleOut: [s.handleOut.x, s.handleOut.y] }; });
+      var closed = !!hl.closed;
+      var zs = 1 / view.zoom;
+      if (sel.kind === 'fill' || sel.kind === 'fillregion') {
+        var hatchLines = closed ? fsHatchClipLines(hl, 9 * zs, 45) : [];
+        hl.remove();
+        out.push({ segments: roundSegs(segs), closed: closed, fillColor: [255, 152, 0, 45], strokeColor: [255, 152, 0, 230], strokeWidth: 2 * zs, dashPattern: [4 * zs, 3 * zs] });
+        hatchLines.forEach(function (ln) {
+          out.push({
+            segments: [{ point: [ln[0], ln[1]], handleIn: [0, 0], handleOut: [0, 0] }, { point: [ln[2], ln[3]], handleIn: [0, 0], handleOut: [0, 0] }],
+            closed: false, fillColor: null, strokeColor: [255, 152, 0, 150], strokeWidth: 1 * zs,
+          });
         });
-      });
-      return items;
-    }
-    hl.remove();
-    return [{ segments: roundSegs(segs), closed: closed, fillColor: null, strokeColor: [255, 152, 0, 230], strokeWidth: (( _fsSel.path.strokeWidth || 2) + 4) * zs, dashPattern: [5 * zs, 4 * zs] }];
+      } else {
+        hl.remove();
+        out.push({ segments: roundSegs(segs), closed: closed, fillColor: null, strokeColor: [255, 152, 0, 230], strokeWidth: ((sel.path.strokeWidth || 2) + 4) * zs, dashPattern: [5 * zs, 4 * zs] });
+      }
+    });
+    return out;
   }
 
   // Set by eraser-bridge.js on every pointermove while the Eraser tool is

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -378,7 +378,7 @@ window.SM={
     // Fill/Stroke Select tool: recolor ONLY the clicked aspect — a 'stroke'
     // selection here means strokeColor, never touches fillColor even on a
     // combined shape (that's the whole point of this tool vs plain Select).
-    else if(state.tool==='fsselect'&&_fsSel&&_fsSel.kind==='stroke'){pushUndo();var arc=fsRealizeStrokeSegment(_fsSel,userLayers[state.activeLayerIdx]);_fsSel={path:arc,kind:'stroke',segStart:0,segEnd:arc.length,closed:arc.closed};arc.strokeColor=v;saveActiveLayerFrame();updateUI();}},
+    else if(state.tool==='fsselect'&&_fsSel.some(function(s){return s.kind==='stroke';})){pushUndo();_fsSel=_fsSel.map(function(sel){if(sel.kind!=='stroke')return sel;var arc=fsRealizeStrokeSegment(sel,userLayers[state.activeLayerIdx]);arc.strokeColor=v;return{path:arc,kind:'stroke',segStart:0,segEnd:arc.length,closed:arc.closed};});saveActiveLayerFrame();updateUI();}},
   setFillColor:function(v){state.fillColor=v;
     // Background is written unconditionally (even while fill is disabled) so
     // the swatch shows the last-picked color as soon as fill is re-enabled —
@@ -390,12 +390,12 @@ window.SM={
     // not just this function's own callers.
     var fhex=document.getElementById('p-fill-hex');if(fhex&&document.activeElement!==fhex)fhex.value=hexDisplayValue(v);
     if((state.tool==='select'||state.tool==='subselect')&&selectedPaths.length){pushUndo();selectedPaths.forEach(function(p){if(p.fillColor)p.fillColor=v;});saveActiveLayerFrame();updateUI();}
-    else if(state.tool==='fsselect'&&_fsSel&&(_fsSel.kind==='fill'||_fsSel.kind==='fillregion')){pushUndo();if(_fsSel.kind==='fillregion')_fsSel=fsRealizeFillRegion(_fsSel,userLayers[state.activeLayerIdx]);_fsSel.path.fillColor=v;saveActiveLayerFrame();updateUI();}},
+    else if(state.tool==='fsselect'&&_fsSel.some(function(s){return s.kind==='fill'||s.kind==='fillregion';})){pushUndo();_fsSel=_fsSel.map(function(sel){if(sel.kind!=='fill'&&sel.kind!=='fillregion')return sel;if(sel.kind==='fillregion')sel=fsRealizeFillRegion(sel,userLayers[state.activeLayerIdx]);sel.path.fillColor=v;return sel;});saveActiveLayerFrame();updateUI();}},
   setFillEnabled:function(v){state.fillEnabled=v;var fw=document.getElementById('fill-well'),pf=document.getElementById('pm-fill');fw.classList.toggle('none',!v);pf.classList.toggle('none',!v);document.getElementById('p-fill-on').checked=v;
     var ft=document.getElementById('fill-enable-toggle');if(ft){ft.classList.toggle('off',!v);ft.innerHTML=v?ICO_EYE:ICO_EYE_CLOSED;}
     var ftlp=document.getElementById('fill-enable-toggle-lp');if(ftlp){ftlp.classList.toggle('off',!v);ftlp.innerHTML=v?ICO_EYE:ICO_EYE_CLOSED;}
     if((state.tool==='select'||state.tool==='subselect')&&selectedPaths.length){pushUndo();selectedPaths.forEach(function(p){if(p.data&&p.data.isVectorBrush)return;p.fillColor=v?state.fillColor:null;});saveActiveLayerFrame();updateUI();}
-    else if(state.tool==='fsselect'&&_fsSel&&(_fsSel.kind==='fill'||_fsSel.kind==='fillregion')){pushUndo();if(_fsSel.kind==='fillregion')_fsSel=fsRealizeFillRegion(_fsSel,userLayers[state.activeLayerIdx]);_fsSel.path.fillColor=v?state.fillColor:null;if(!v){fsUnlinkFillRegen(_fsSel.path);if(!_fsSel.path.strokeColor){_fsSel.path.remove();fsClearSel();}}saveActiveLayerFrame();updateUI();}},
+    else if(state.tool==='fsselect'&&_fsSel.some(function(s){return s.kind==='fill'||s.kind==='fillregion';})){pushUndo();_fsSel=_fsSel.map(function(sel){if(sel.kind!=='fill'&&sel.kind!=='fillregion')return sel;if(sel.kind==='fillregion')sel=fsRealizeFillRegion(sel,userLayers[state.activeLayerIdx]);sel.path.fillColor=v?state.fillColor:null;if(!v){fsUnlinkFillRegen(sel.path);if(!sel.path.strokeColor){sel.path.remove();return null;}}return sel;}).filter(Boolean);saveActiveLayerFrame();updateUI();}},
   // Mirrors setFillEnabled exactly, for the Stroke side — didn't exist
   // before (Stroke had no on/off concept, only a color), added alongside
   // the quick phdr toggle button since disabling stroke without it required
@@ -409,7 +409,7 @@ window.SM={
     // means the same real split-and-remove fsApplyDelete's Delete key does.
     // No re-enable path: once a segment is split out there's nothing left
     // to flip back on, and the stroke-sec panel disappears with _fsSel.
-    else if(state.tool==='fsselect'&&_fsSel&&_fsSel.kind==='stroke'&&!v){pushUndo();fsDeleteSegment(_fsSel,userLayers[state.activeLayerIdx]);fsClearSel();renderArcs();updateUI();}},
+    else if(state.tool==='fsselect'&&_fsSel.some(function(s){return s.kind==='stroke';})&&!v){pushUndo();_fsSel=_fsSel.filter(function(sel){if(sel.kind!=='stroke')return true;fsDeleteSegment(sel,userLayers[state.activeLayerIdx]);return false;});renderArcs();updateUI();}},
   // Illustrator's "X" swap — exchanges the stroke and fill colors (tool
   // defaults, and the current selection's actual colors if select/subselect
   // is active, since setStrokeColor/setFillColor already apply to
@@ -1056,10 +1056,11 @@ window.SM={
   // la sequence en un clic, facon CTG TVPaint).
   propagateColorAllFrames:function(){
     var sid=null,fillHex=null,strokeHex=null;
-    if(state.tool==='fsselect'&&_fsSel&&_fsSel.path&&_fsSel.path.data){
-      sid=_fsSel.path.data.strokeId;
-      if(_fsSel.kind==='stroke'&&_fsSel.path.strokeColor)strokeHex=colorHex8(_fsSel.path.strokeColor);
-      else if(_fsSel.path.fillColor)fillHex=colorHex8(_fsSel.path.fillColor);
+    var fsPrimPCA=fsPrimarySel();
+    if(state.tool==='fsselect'&&fsPrimPCA&&fsPrimPCA.path&&fsPrimPCA.path.data){
+      sid=fsPrimPCA.path.data.strokeId;
+      if(fsPrimPCA.kind==='stroke'&&fsPrimPCA.path.strokeColor)strokeHex=colorHex8(fsPrimPCA.path.strokeColor);
+      else if(fsPrimPCA.path.fillColor)fillHex=colorHex8(fsPrimPCA.path.fillColor);
     }else if(selectedPaths.length===1&&selectedPaths[0].data){
       var p0=selectedPaths[0];sid=p0.data.strokeId;
       if(p0.fillColor)fillHex=colorHex8(p0.fillColor);
@@ -1327,8 +1328,10 @@ function updateStatusBarHelp(){
     return;
   }
   // 2. fsselect has an active fill/stroke pick.
-  if(state.tool==='fsselect'&&typeof _fsSel!=='undefined'&&_fsSel){
-    statusbarHelpRender(tt(_fsSel.kind==='stroke'?'hdrStroke':'hdrFill')+' '+tt('thSelected')+' —',[['Suppr',tt('thErase')],['Échap',tt('thDeselect')]]);
+  if(state.tool==='fsselect'&&typeof _fsSel!=='undefined'&&_fsSel.length){
+    var fsPrimSB=fsPrimarySel();
+    var fsCountSB=_fsSel.length>1?' ('+_fsSel.length+')':'';
+    statusbarHelpRender(tt(fsPrimSB.kind==='stroke'?'hdrStroke':'hdrFill')+fsCountSB+' '+tt('thSelected')+' —',[['Suppr',tt('thErase')],['Échap',tt('thDeselect')]]);
     return;
   }
   // 3. A timeline keyframe cell (or span) is selected.
@@ -1385,16 +1388,19 @@ function updatePropsContext(){
   var hasSel=(state.tool==='select'||state.tool==='subselect')&&selectedPaths.length>0;
   var ctx,hdrText;
   var show={'sel-props-sec':false,'fill-sec':false,'stroke-sec':false,'tool-opts-sec':false,'effects-sec':false,'canvas-sec':false,'layer-sec':false};
-  if(state.tool==='fsselect'&&_fsSel){
-    // Only the ONE clicked aspect's panel shows — no Position/Size (this
-    // tool doesn't offer transform, Select already owns that) and no
-    // Effects (blend mode lives on the layer, not a fill/stroke aspect).
+  if(state.tool==='fsselect'&&_fsSel.length){
+    // Multi-select (2026-07): show BOTH sections if the selection mixes
+    // fill and stroke picks — no Position/Size (this tool doesn't offer
+    // transform, Select already owns that) and no Effects (blend mode
+    // lives on the layer, not a fill/stroke aspect).
     ctx='fsselect';
-    show['fill-sec']=_fsSel.kind==='fill'||_fsSel.kind==='fillregion';
-    show['stroke-sec']=_fsSel.kind==='stroke';
-    var fsSegLabel=_fsSel.kind==='stroke'&&!(_fsSel.segStart===0&&_fsSel.segEnd===_fsSel.path.length)?' (segment)':'';
-    var fsFillLabel=_fsSel.kind==='fillregion'?' (région)':'';
-    hdrText=(_fsSel.kind==='stroke'?'Stroke'+fsSegLabel:'Fill'+fsFillLabel)+' sélectionné(e)';
+    show['fill-sec']=_fsSel.some(function(s){return s.kind==='fill'||s.kind==='fillregion';});
+    show['stroke-sec']=_fsSel.some(function(s){return s.kind==='stroke';});
+    var fsPrimPC=fsPrimarySel();
+    var fsSegLabel=fsPrimPC.kind==='stroke'&&!(fsPrimPC.segStart===0&&fsPrimPC.segEnd===fsPrimPC.path.length)?' (segment)':'';
+    var fsFillLabel=fsPrimPC.kind==='fillregion'?' (région)':'';
+    var fsCountPC=_fsSel.length>1?' ('+_fsSel.length+')':'';
+    hdrText=(fsPrimPC.kind==='stroke'?'Stroke'+fsSegLabel:'Fill'+fsFillLabel)+fsCountPC+' sélectionné(e)';
   }else if(hasSel){
     ctx='selection';
     show['sel-props-sec']=show['fill-sec']=show['stroke-sec']=show['effects-sec']=true;
@@ -1672,8 +1678,9 @@ function updateSelPropsPanel(){
 // NOT go through setFillColor/setStrokeColor, which would re-apply back
 // onto the selection and turn a read into a write).
 function updateFsSelPanel(){
-  if(state.tool!=='fsselect'||!_fsSel)return;
-  var p=_fsSel.path;
+  if(state.tool!=='fsselect'||!_fsSel.length)return;
+  var _fsSel0=fsPrimarySel();
+  var p=_fsSel0.path;
   var ftog=document.getElementById('fill-enable-toggle'),stog=document.getElementById('stroke-enable-toggle');
   // Pressure-brush ribbons and fill-brush shapes are ALWAYS fillColor:<ink>/
   // strokeColor:null by construction (draw-bridge.js commitStroke) — same
@@ -1681,7 +1688,7 @@ function updateFsSelPanel(){
   // reason: their fillColor being set is NOT a signal that the Fill/Stroke
   // eyes were actually on at draw time.
   var isBrushShape=p.data&&(p.data.isVectorBrush||p.data.isFillShape);
-  if((_fsSel.kind==='fill'||_fsSel.kind==='fillregion')&&p.fillColor&&!isBrushShape){
+  if((_fsSel0.kind==='fill'||_fsSel0.kind==='fillregion')&&p.fillColor&&!isBrushShape){
     var fc=colorHex8(p.fillColor);
     document.getElementById('fill-well').style.background=fc;document.getElementById('pm-fill').style.background=fc;
     ['color-fill','pm-fill-c'].forEach(function(id){var el=document.getElementById(id);if(el){el.value=fc;el.dataset.hex8=fc;}});
@@ -1693,7 +1700,7 @@ function updateFsSelPanel(){
     // conflits" on Fill/Stroke enabled state). Now both move together.
     state.fillEnabled=true;
     if(ftog)ftog.classList.remove('off');
-  }else if(_fsSel.kind==='stroke'&&p.strokeColor){
+  }else if(_fsSel0.kind==='stroke'&&p.strokeColor){
     var sc=colorHex8(p.strokeColor);
     document.getElementById('stroke-well').style.background=sc;document.getElementById('pm-stroke').style.background=sc;
     ['color-stroke','pm-stroke-c'].forEach(function(id){var el=document.getElementById(id);if(el){el.value=sc;el.dataset.hex8=sc;}});
@@ -4707,7 +4714,7 @@ function onKeyDown(event){
       saveActiveLayerFrame();updateUI();
     }
     else if(_sel.frames.length>0){event.preventDefault();window.SM.deleteSelectedFrames();}
-    else if(state.tool==='fsselect'&&_fsSel){event.preventDefault();fsApplyDelete();}
+    else if(state.tool==='fsselect'&&_fsSel.length){event.preventDefault();fsApplyDelete();}
     // Subselect: Delete removes just the selected anchor(s) from the path
     // and lets the curve reflow through the remaining points (Illustrator/
     // Figma convention) — previously had NO handler at all here, so Delete

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -50,8 +50,68 @@ function hitTestComponentLayers(point){
 // computes those crossing points live (Paper's getIntersections) and
 // scopes the selection (and, on Delete, an ACTUAL path split) to just that
 // bounded arc — the rest of the stroke and any fill are left untouched.
-var _fsSel=null; // {path, kind:'fill'|'stroke', segStart, segEnd, closed} | null
-function fsClearSel(){_fsSel=null;}
+// Multi-select array (2026-07, "impossible de faire de la multiselection
+// avec fill/stroke select + shift... lasso et rectangle") — each entry is
+// {path, kind:'fill'|'stroke'|'fillregion', segStart, segEnd, closed}, same
+// shape fsHitTest always returned; single-select is just the length-1 case.
+var _fsSel=[];
+function fsClearSel(){_fsSel=[];}
+// Last-touched entry — every place that used to read _fsSel.kind/.path
+// directly for a SINGLE-value display (panel color swatch, header text)
+// keeps doing that against this one, while actions (recolor/delete/opacity)
+// loop over the whole _fsSel array.
+function fsPrimarySel(){return _fsSel.length?_fsSel[_fsSel.length-1]:null;}
+// Raw pointermove/pointerup listeners for the fsselect marquee/lasso
+// (2026-07) — NOT Paper.js Tool's own onMouseDrag/onMouseUp (the branches
+// below still handle those, for when the Rust engine is off and Paper's
+// own Tool event loop runs normally). Confirmed live: with the engine on
+// (the default), Paper's Tool onMouseDrag/onMouseUp never fire at all for
+// a real drag gesture on this tool (view.autoUpdate=false likely stops
+// Paper's own queued-event dispatch loop) — onMouseDown still fires fine
+// (that's what starts the marquee/lasso below), but nothing ever grew or
+// resolved it, so a drag-select silently did nothing. select-bridge.js's
+// OWN marquee for the Select tool sidesteps this entirely by never
+// depending on Paper's Tool system in the first place (raw DOM listeners
+// throughout) — mirrored here rather than fighting Paper's dead event
+// loop. Harmless alongside the Paper-Tool branches below when the engine
+// IS off: whichever resolves first clears _marquee.active, making the
+// other a no-op.
+document.addEventListener('pointermove',function(e){
+  if(!(_marquee.active&&_marquee.mode==='fsselect')||!window.SMEngineBridge)return;
+  var w=window.SMEngineBridge.screenToWorld(e.clientX,e.clientY);
+  var pt=new Point(w[0],w[1]);
+  var prevA=project.activeLayer;marqueeLayer.activate();
+  if(_marquee.lasso){
+    if(!_marquee.rect)_marquee.rect=new Path({segments:[_marquee.start],closed:false,strokeColor:'rgba(74,158,255,.9)',strokeWidth:1/view.zoom,dashArray:[4/view.zoom,3/view.zoom],fillColor:new Color(0.29,0.62,1,0.08),insert:true});
+    _marquee.rect.add(pt);
+  }else{
+    var mx1=Math.min(_marquee.start.x,pt.x),my1=Math.min(_marquee.start.y,pt.y);
+    var mx2=Math.max(_marquee.start.x,pt.x),my2=Math.max(_marquee.start.y,pt.y);
+    if(_marquee.rect)_marquee.rect.remove();
+    _marquee.rect=new Path.Rectangle({from:new Point(mx1,my1),to:new Point(mx2,my2),strokeColor:'rgba(74,158,255,.9)',strokeWidth:1/view.zoom,dashArray:[4/view.zoom,3/view.zoom],fillColor:new Color(0.29,0.62,1,0.08),insert:true});
+  }
+  prevA.activate();
+  if(window.SMEngineBridge.renderNow)window.SMEngineBridge.renderNow();
+},{capture:true});
+document.addEventListener('pointerup',function(e){
+  if(!(_marquee.active&&_marquee.mode==='fsselect'))return;
+  if(_marquee.rect){
+    var mbf=_marquee.rect.bounds;
+    var lassoF=null;
+    if(_marquee.lasso&&_marquee.rect.segments.length>2){_marquee.rect.closePath();lassoF=_marquee.rect;}
+    var layerF=userLayers[state.activeLayerIdx];
+    layerF.children.forEach(function(c){
+      if(!(c instanceof Path)||c.segments.length===0||!(c.strokeColor||c.fillColor))return;
+      if(!mbf.intersects(c.bounds))return;
+      if(lassoF&&!(lassoF.contains(c.position)||lassoF.intersects(c)))return;
+      if(_fsSel.some(function(s){return s.path===c;}))return; // already selected — Shift+lasso over the same shape twice shouldn't duplicate it
+      _fsSel.push(c.fillColor?{path:c,kind:'fill'}:{path:c,kind:'stroke',segStart:0,segEnd:c.length,closed:c.closed});
+    });
+    _marquee.rect.remove();_marquee.rect=null;_marquee.mode=null;
+  }
+  _marquee.active=false;renderArcs();updateUI();
+  if(window.SMEngineBridge&&window.SMEngineBridge.renderNow)window.SMEngineBridge.renderNow();
+},{capture:true});
 // Every OTHER path in the same layer, plus this path's own self-crossings
 // — each contributes its crossing points as offsets (0..path.length)
 // along `path`'s own parametrization.
@@ -429,21 +489,23 @@ function fsUnlinkFillRegen(p){
   delete p.data.fillSeed;delete p.data.fillWalls;delete p.data.fillGapPx;
 }
 function fsApplyDelete(){
-  if(!_fsSel)return;
+  if(!_fsSel.length)return;
   pushUndo();
   var layer=userLayers[state.activeLayerIdx];
-  if(_fsSel.kind==='fillregion')_fsSel=fsRealizeFillRegion(_fsSel,layer);
-  if(_fsSel.kind==='fill'){
-    var p=_fsSel.path;
-    fsUnlinkFillRegen(p);
-    if(!markDeleteAsRevision(p)){ // foreign-owned fill: ghosted in place, keep its color so the ghost still reads correctly
-      p.fillColor=null;
-      if(!p.strokeColor)p.remove();
+  _fsSel.slice().forEach(function(sel){
+    if(sel.kind==='fillregion')sel=fsRealizeFillRegion(sel,layer);
+    if(sel.kind==='fill'){
+      var p=sel.path;
+      fsUnlinkFillRegen(p);
+      if(!markDeleteAsRevision(p)){ // foreign-owned fill: ghosted in place, keep its color so the ghost still reads correctly
+        p.fillColor=null;
+        if(!p.strokeColor)p.remove();
+      }
+      saveActiveLayerFrame();
+    }else{
+      fsDeleteSegment(sel,layer);
     }
-    saveActiveLayerFrame();
-  }else{
-    fsDeleteSegment(_fsSel,layer);
-  }
+  });
   fsClearSel();
   renderArcs();updateUI();
 }
@@ -3833,7 +3895,33 @@ function onMouseDown(event){
     // finalized in onMouseUp once the drag distance is known.
     _textDragStart=event.point.clone();
   }else if(state.tool==='fsselect'){
-    _fsSel=fsHitTest(event.point,layer);
+    var fsHit=fsHitTest(event.point,layer);
+    // event.event.shiftKey/altKey (native event), not event.modifiers.shift/alt
+    // (Paper.js's own tracking) -- same proven-reliable pattern the Pen tool
+    // and Zoom tool already use in this exact file: this app's own global
+    // keydown handlers intercept the key before Paper's internal listener
+    // ever sees it, so event.modifiers silently never reads true here.
+    if(fsHit){
+      // Shift toggles this hit in/out of the multi-selection (2026-07,
+      // "impossible de faire de la multiselection avec fill/stroke select
+      // + shift") — a plain click still replaces the whole selection with
+      // just this one hit, same as before.
+      if(event.event.shiftKey){
+        var fsExistIdx=_fsSel.findIndex(function(s){return s.path===fsHit.path&&s.kind===fsHit.kind;});
+        if(fsExistIdx>=0)_fsSel.splice(fsExistIdx,1);else _fsSel.push(fsHit);
+      }else{
+        _fsSel=[fsHit];
+      }
+    }else{
+      if(!event.event.shiftKey)fsClearSel();
+      // Clicked empty canvas: start a rubber-band marquee (Alt held = a
+      // freehand lasso instead) — same feedback, "il faudrait les outils
+      // de lasso et rectangle de selection pour cet outil". Reuses the
+      // Select tool's own _marquee state/rendering below (tagged with
+      // .mode so onMouseUp knows to resolve it into _fsSel instead of
+      // selectedPaths), rather than a second marquee implementation.
+      _marquee.active=true;_marquee.start=event.point.clone();_marquee.rect=null;_marquee.lasso=!!event.event.altKey;_marquee.mode='fsselect';
+    }
     updateUI();
     // A plain click-to-select mutates no layer content, so it never bumps
     // window._sceneVersion (saveActiveLayerFrame/loadFrame's job) — without
@@ -4201,11 +4289,18 @@ function onMouseDrag(event){
       }
       renderTransformHandles();
     }else if(_marquee.active){
-      var mx1=Math.min(_marquee.start.x,event.point.x),my1=Math.min(_marquee.start.y,event.point.y);
-      var mx2=Math.max(_marquee.start.x,event.point.x),my2=Math.max(_marquee.start.y,event.point.y);
-      if(_marquee.rect)_marquee.rect.remove();
       var prevA=project.activeLayer;marqueeLayer.activate();
-      _marquee.rect=new Path.Rectangle({from:new Point(mx1,my1),to:new Point(mx2,my2),strokeColor:'rgba(74,158,255,.9)',strokeWidth:1/view.zoom,dashArray:[4/view.zoom,3/view.zoom],fillColor:new Color(0.29,0.62,1,0.08),insert:true});
+      if(_marquee.lasso){
+        // Freehand lasso (Alt-held drag) — grows an open Path point-by-point,
+        // same convention select-bridge.js's own lasso already uses.
+        if(!_marquee.rect)_marquee.rect=new Path({segments:[_marquee.start],closed:false,strokeColor:'rgba(74,158,255,.9)',strokeWidth:1/view.zoom,dashArray:[4/view.zoom,3/view.zoom],fillColor:new Color(0.29,0.62,1,0.08),insert:true});
+        _marquee.rect.add(event.point);
+      }else{
+        var mx1=Math.min(_marquee.start.x,event.point.x),my1=Math.min(_marquee.start.y,event.point.y);
+        var mx2=Math.max(_marquee.start.x,event.point.x),my2=Math.max(_marquee.start.y,event.point.y);
+        if(_marquee.rect)_marquee.rect.remove();
+        _marquee.rect=new Path.Rectangle({from:new Point(mx1,my1),to:new Point(mx2,my2),strokeColor:'rgba(74,158,255,.9)',strokeWidth:1/view.zoom,dashArray:[4/view.zoom,3/view.zoom],fillColor:new Color(0.29,0.62,1,0.08),insert:true});
+      }
       prevA.activate();
     }else if(draggingArc){setArcHandle(draggingArc.fA,draggingArc.fB,draggingArc.matchIdx,draggingArc.which,draggingArc.ptA,draggingArc.ptB,event.point.x,event.point.y);renderArcs(arcDragCache);}
     else if(selectedPaths.length>0){
@@ -4380,6 +4475,24 @@ function onMouseUp(event){
         saveActiveLayerFrame();
       }
       renderTransformHandles();renderNodeHandles();updateUI();
+    }
+    else if(_marquee.active&&_marquee.mode==='fsselect'){
+      if(_marquee.rect){
+        var mbf=_marquee.rect.bounds;
+        var lassoF=null;
+        if(_marquee.lasso&&_marquee.rect.segments.length>2){_marquee.rect.closePath();lassoF=_marquee.rect;}
+        var layerF=userLayers[state.activeLayerIdx];
+        layerF.children.forEach(function(c){
+          if(!(c instanceof Path)||c.segments.length===0||!(c.strokeColor||c.fillColor))return;
+          if(!mbf.intersects(c.bounds))return;
+          if(lassoF&&!(lassoF.contains(c.position)||lassoF.intersects(c)))return;
+          if(_fsSel.some(function(s){return s.path===c;}))return; // already selected — Shift+lasso over the same shape twice shouldn't duplicate it
+          _fsSel.push(c.fillColor?{path:c,kind:'fill'}:{path:c,kind:'stroke',segStart:0,segEnd:c.length,closed:c.closed});
+        });
+        _marquee.rect.remove();_marquee.rect=null;_marquee.mode=null;
+      }
+      _marquee.active=false;renderArcs();updateUI();
+      if(window.SMEngineBridge&&window.SMEngineBridge.renderNow)window.SMEngineBridge.renderNow();
     }
     else if(_marquee.active){
       if(_marquee.rect){

--- a/src/js/tutorial.js
+++ b/src/js/tutorial.js
@@ -1229,12 +1229,13 @@
         stateIncreaseStep({ target: '#drawing-canvas', title: 'Dessine un rectangle', body: 'Clique-glisse pour tracer un rectangle — il a déjà un fond ET un trait par défaut.', hint: 'En attente de ta forme…', measure: measureStrokeCount }),
         { type: 'click', target: '.tool-btn[data-tool="fsselect"]', title: 'Choisis Fill/Stroke Select', body: 'Clique sur l\'outil Fill/Stroke Select dans la barre de gauche (raccourci M).' },
         // Un clic fsselect ne mute RIEN dans le calque (tools.js) — juste
-        // une variable globale `_fsSel` ({path, kind:'fill'|'stroke'}).
-        // measureLayerFingerprint ne bougerait jamais ; _fsSel est le seul
-        // signal réel qu'une sélection indépendante a eu lieu.
+        // une variable globale `_fsSel` (tableau multi-select depuis 2026-07,
+        // chaque entrée {path, kind:'fill'|'stroke'}). measureLayerFingerprint
+        // ne bougerait jamais ; _fsSel est le seul signal réel qu'une
+        // sélection indépendante a eu lieu.
         stateChangedStep({
           target: '#drawing-canvas', title: 'Clique sur le fond du rectangle', body: 'Clique à l\'intérieur du rectangle pour sélectionner juste son fond (pas le contour).',
-          hint: 'En attente de ton clic…', measure: function (win) { return win._fsSel ? win._fsSel.kind : null; }
+          hint: 'En attente de ton clic…', measure: function (win) { return (win._fsSel && win._fsSel.length) ? win._fsSel[win._fsSel.length - 1].kind : null; }
         }),
         { type: 'info', title: 'Bien joué !', body: 'Maj+clic sur le contour sélectionne le trait au lieu du fond. Une fois sélectionné, change sa couleur via les carrés Fond/Trait habituels — seule cette partie change.' }
       ]


### PR DESCRIPTION
## Summary
- \`_fsSel\` is now a multi-select array instead of a single object (feedback: "impossible de faire de la multiselection avec fill/stroke select + shift... il faudrait les outils de lasso et rectangle"). Shift+click toggles a hit in/out; a plain click still replaces the selection.
- Clicking empty canvas starts a rectangle marquee; holding Alt starts a freehand lasso instead — same convention as the Select tool's own marquee.
- Every consumer (recolor, opacity toggle, delete, panel color swatch, header text, propagate-color source) updated to work across the whole selection, realizing each entry's own fillregion/stroke-segment split independently. Single-value displays read the last-touched entry via a new \`fsPrimarySel()\` helper.

## Two bugs caught and fixed while building this
- \`event.modifiers.shift/alt\` (Paper.js's own key tracking) silently never read true for this tool — a known issue already worked around elsewhere in this file (Pen tool, Zoom tool: this app's own global keydown handlers intercept the key before Paper's internal listener sees it) but not yet applied to this new code. Switched to \`event.event.shiftKey/altKey\`, confirmed reliable via a live Shift+click test.
- Paper.js's own Tool \`onMouseDrag\`/\`onMouseUp\` never fire at all for a real drag gesture on this tool once the Rust engine is on (only \`onMouseDown\` fires). Confirmed by comparing against the Select tool's own marquee, which already avoids this by using raw DOM listeners instead of Paper's Tool system. Rebuilt the marquee/lasso tracking as raw \`pointermove\`/\`pointerup\` listeners, kept alongside (not replacing) the existing Paper-Tool code path, which still covers the engine-off fallback.

## Test plan
- [x] \`node --check\` on all 4 edited files
- [x] Dev app loads with zero console errors
- [x] Live: Shift+click adds a second shape to the selection (didn't work before the \`event.event.shiftKey\` fix — confirmed both the before-fix failure and the after-fix success)
- [x] Live: recoloring a 2-item selection recolors both, leaves a third untouched shape alone
- [x] Live: rectangle marquee drag selects both enclosed shapes
- [x] Live: multi-item Delete removes all selected shapes and clears the selection
- [x] Direct logic test: lasso containment correctly isolates only the enclosed shape, not a nearby one outside the lasso path (couldn't drive a real Alt+drag through this automation harness, so verified the resolve logic directly instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)