### PR TITLE
Fix eraser deleting whole open-fill shapes; add Fill/Stroke Select mode buttons

### DIFF
--- a/src/js/labs/labs-float-panel.js
+++ b/src/js/labs/labs-float-panel.js
@@ -43,6 +43,14 @@
     // making that whole apply-to-selection path unreachable.
     select: ['brush-menu', 'vector-sculpt', 'canvas-grid'],
     subselect: ['brush-menu', 'vector-sculpt'],
+    // 2026-07 feedback ("impossible de faire de faire des multiselection
+    // avec fill/stroke select + shift... il faudrait afficher les outils de
+    // lasso et rectangle de selection pour cette outil"): the marquee/lasso
+    // drag itself was built (tools.js, Shift+click / Alt-drag) but only as a
+    // hidden modifier-key convention — no VISIBLE way to pick a mode, which
+    // is what was actually asked for. These two entries give it real toggle
+    // buttons, same pattern as everything else in this panel.
+    fsselect: ['fs-select-rect', 'fs-select-lasso'],
     hand: ['canvas-grid'],
   };
   // Real `state.*`-backed features (NOT Labs prototypes — no localStorage
@@ -97,6 +105,19 @@
       isActive: function () { return !!(window.BrushMenu && window.BrushMenu.isOpen()); },
       onClick: function (btn) { if (window.BrushMenu) window.BrushMenu.toggle(btn); },
     },
+    // Fill/Stroke Select's marquee mode picker — mutually exclusive with
+    // 'fs-select-lasso' below (isActive reflects state.fsSelectMode, default
+    // 'rect'). tools.js reads state.fsSelectMode when starting a marquee on
+    // empty-canvas click; Alt still works as a one-off override of whichever
+    // mode is picked here (see the fsselect onMouseDown branch, tools.js).
+    'fs-select-rect': {
+      isActive: function () { return !(window.state && state.fsSelectMode === 'lasso'); },
+      onClick: function () { if (window.state) state.fsSelectMode = 'rect'; renderLabsFloatPanel(); },
+    },
+    'fs-select-lasso': {
+      isActive: function () { return !!(window.state && state.fsSelectMode === 'lasso'); },
+      onClick: function () { if (window.state) state.fsSelectMode = 'lasso'; renderLabsFloatPanel(); },
+    },
   };
   // Tools armed by a held key regardless of the active tool (flip-roll=R,
   // mirror-check=M, lagoon-menu=Q) — always available, shown after a
@@ -118,6 +139,8 @@
     'flip-roll': "Rouleau d'animateur (maintenir R)",
     'mirror-check': 'Miroir de contrôle (maintenir M)',
     'lagoon-menu': "Menu radial d'outils (maintenir Q)",
+    'fs-select-rect': 'Sélection rectangle (Fill/Stroke Select)',
+    'fs-select-lasso': 'Sélection lasso (Fill/Stroke Select) — Alt+glisser inverse temporairement',
   };
 
   // Solid/filled icons (2026-07, "les icônes ne sont pas trop flat design
@@ -152,6 +175,11 @@
     'flip-roll': '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M17 1l4 4-4 4V6.5H8a4.5 4.5 0 00-4.5 4.5H1.5A7 7 0 018.5 4H17V1z"/><path d="M7 23l-4-4 4-4v3.5h9A4.5 4.5 0 0020.5 14H23a7 7 0 01-7 7H7v2z"/></svg>',
     'mirror-check': '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M9 6L3 12L9 18V14H15V18L21 12L15 6V10H9Z"/></svg>',
     'lagoon-menu': '<svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M12 12V3A9 9 0 0119.8 7.5Z"/><path d="M12 12L19.8 7.5A9 9 0 0119.8 16.5Z" opacity=".65"/><path d="M12 12L19.8 16.5A9 9 0 014.2 16.5Z" opacity=".4"/><path d="M12 12L4.2 16.5A9 9 0 0112 3V12Z" opacity=".2"/></svg>',
+    // Dashed rectangle = the marquee shape itself, same visual language as
+    // the app's own marquee overlay (dashed stroke, translucent fill).
+    'fs-select-rect': '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="4" y="5" width="16" height="14" rx="1" stroke-dasharray="3.2 2.4"/></svg>',
+    // Freehand wavy loop = lasso, distinct silhouette from the rectangle.
+    'fs-select-lasso': '<svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M12 3c-4.5 0-8 2.7-8 6.5 0 3 2.3 5.3 5.6 6.1L8 20l2.2-1.1c.6.1 1.2.1 1.8.1 4.5 0 8-2.7 8-6.5S16.5 3 12 3z" stroke-dasharray="2.6 2.2"/></svg>',
   };
 
   // Adjustable-parameter tools get a second row below the icon strip

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -3422,14 +3422,6 @@ function eraseAtPoint(path,worldPt,radius,fromPt){
   var idx=layer.children.indexOf(path);
   var target=path;
   var isVB=!!(path.data&&path.data.isVectorBrush);
-  // An OPEN path has zero real fill area no matter what fillColor says —
-  // since Draw-tool strokes now get a fillColor by default (fillEnabled
-  // defaults true), an open hand-drawn line can reach here with
-  // path.fillColor set but path.closed===false. Subtracting directly
-  // against that degenerate zero-area "fill" always empties out, which
-  // deleted the ENTIRE stroke on any erase touch instead of notching it.
-  // Still expand to a proper capsule/ribbon whenever the path isn't closed.
-  //
   // A CLOSED path with BOTH a fill AND a visible stroke (the default for
   // almost anything drawn — fillEnabled defaults true) used to skip this
   // whole branch and erase only the interior fill polygon, then unconditionally
@@ -3440,36 +3432,47 @@ function eraseAtPoint(path,worldPt,radius,fromPt){
   // whenever there IS a strokeColor, always expand it into real ink geometry
   // and UNION it with the existing fill first, so the border becomes part of
   // the erasable area instead of being discarded outright.
-  // 2026-07 feedback: "sur une forme non fermé et dessiné avec brush, si
-  // j'utilise la gomme sur fill celui-ci est supprimé totalement au lieu
-  // d'avoir la brush qui mange la forme" — the guard above only expanded an
-  // open path into real ink geometry when it ALSO had a strokeColor; a
-  // strokeless open fill (Draw tool with Stroke off) skipped it entirely and
-  // fell straight to the degenerate-zero-area subtract this whole comment
-  // block already describes, deleting the entire shape on first touch.
-  if(!isVB&&(path.strokeColor||(!path.closed&&path.fillColor))){
-    var expanded=eraseExpandStrokeToFill(path);
-    if(expanded){
-      // eraseExpandStrokeToFill always paints the expansion from
-      // path.strokeColor (the normal case); a strokeless open fill has none,
-      // so borrow path.fillColor instead — same visible color the erased
-      // result should end up filled with either way.
-      if(!path.strokeColor)expanded.fillColor=path.fillColor;
-      if(path.fillColor&&path.closed){
-        var fillCopy=path.clone({insert:false});
-        fillCopy.strokeColor=null;
-        var merged=fillCopy.unite(expanded,{insert:false});
-        fillCopy.remove();expanded.remove();
-        merged.fillColor=path.fillColor;merged.opacity=path.opacity;
-        layer.insertChild(idx,merged);
-        path.remove();
-        target=merged;
-      }else{
-        layer.insertChild(idx,expanded);
-        path.remove();
-        target=expanded;
-      }
-    }else if(!path.fillColor||!path.closed){
+  //
+  // An OPEN path needs the SAME treatment for its stroke ink (a bare open
+  // contour has zero fill area of its own by Paper.js's own boolean-op
+  // rules), but NOT for its fill: Paper.js implicitly closes an open path
+  // to render its fillColor (that's the only reason "Draw tool, Stroke
+  // off, unclosed shape" shows any visible fill at all) — 2026-07 bug,
+  // found live: the first fix here ("sur une forme non fermé et dessiné
+  // avec brush, si j'utilise la gomme sur fill celui-ci est supprimé
+  // totalement") treated that implicit-close fill as "degenerate zero
+  // area" and rerouted it through eraseExpandStrokeToFill(), which rebuilds
+  // a synthetic ribbon only `strokeWidth`/`brushSize` wide along the
+  // CENTERLINE — nowhere near the real filled interior of a wide freehand
+  // blob, so the very first erase sample replaced the whole visible shape
+  // with that near-invisible sliver. Fixed properly below: a strokeless
+  // open fill uses a closed=true CLONE of its own boundary (the real
+  // implicit-close polygon Paper.js already renders) instead of a
+  // synthetic ribbon; the stroke ribbon (when there IS a strokeColor) and
+  // this fill polygon are computed independently, then unioned if both
+  // exist — same fillColor||strokeColor color-precedence for the result.
+  if(!isVB&&(path.strokeColor||!path.closed)){
+    var strokeGeom=path.strokeColor?eraseExpandStrokeToFill(path):null;
+    var fillGeom=null;
+    if(path.fillColor){
+      fillGeom=path.clone({insert:false});
+      fillGeom.closed=true;
+      fillGeom.strokeColor=null;
+    }
+    var combined=null;
+    if(strokeGeom&&fillGeom){
+      combined=fillGeom.unite(strokeGeom,{insert:false});
+      fillGeom.remove();strokeGeom.remove();
+    }else{
+      combined=strokeGeom||fillGeom;
+    }
+    if(combined){
+      combined.fillColor=path.fillColor||path.strokeColor;
+      combined.opacity=path.opacity;
+      layer.insertChild(idx,combined);
+      path.remove();
+      target=combined;
+    }else{
       return;
     }
   }
@@ -3914,13 +3917,19 @@ function onMouseDown(event){
       }
     }else{
       if(!event.event.shiftKey)fsClearSel();
-      // Clicked empty canvas: start a rubber-band marquee (Alt held = a
-      // freehand lasso instead) — same feedback, "il faudrait les outils
-      // de lasso et rectangle de selection pour cet outil". Reuses the
-      // Select tool's own _marquee state/rendering below (tagged with
-      // .mode so onMouseUp knows to resolve it into _fsSel instead of
-      // selectedPaths), rather than a second marquee implementation.
-      _marquee.active=true;_marquee.start=event.point.clone();_marquee.rect=null;_marquee.lasso=!!event.event.altKey;_marquee.mode='fsselect';
+      // Clicked empty canvas: start a rubber-band marquee (Alt held =
+      // temporarily flips to/from lasso) — same feedback, "il faudrait les
+      // outils de lasso et rectangle de selection pour cet outil". The
+      // default mode (rect vs lasso) is set via the two dedicated buttons
+      // in the Labs floating panel (labs-float-panel.js, state.fsSelectMode,
+      // 2026-07: original ask was for VISIBLE buttons, not just a hidden
+      // Alt-modifier convention) — Alt still works as a one-off override of
+      // whichever mode is currently selected. Reuses the Select tool's own
+      // _marquee state/rendering below (tagged with .mode so onMouseUp
+      // knows to resolve it into _fsSel instead of selectedPaths), rather
+      // than a second marquee implementation.
+      var fsWantLasso=state.fsSelectMode==='lasso';
+      _marquee.active=true;_marquee.start=event.point.clone();_marquee.rect=null;_marquee.lasso=event.event.altKey?!fsWantLasso:fsWantLasso;_marquee.mode='fsselect';
     }
     updateUI();
     // A plain click-to-select mutates no layer content, so it never bumps


### PR DESCRIPTION
## Summary
- Eraser: a strokeless open-fill brush shape (Draw tool, Stroke off, unclosed) was replaced entirely by a synthetic centerline ribbon on first erase touch instead of being partially eaten into. Root cause: `eraseExpandStrokeToFill()` (designed for real strokes) was being applied to fill-only geometry it was never meant for. Fixed by using the path's own implicit-closed boundary (matches how Paper.js/vello actually render it) for the fill polygon.
- Fill/Stroke Select: the marquee/lasso mechanic existed but only via a hidden Alt-drag convention. Added visible toggle buttons (rectangle/lasso) to the Labs floating panel, per the original feedback ask.

## Test plan
- [x] Verified live in browser preview: drew a curvy open fill-only shape (~62800 area units), eraser now erodes it gradually across repeated samples instead of deleting it on first touch.
- [x] Verified the new fs-select-rect/fs-select-lasso buttons render, toggle `state.fsSelectMode`, and correctly drive the marquee's lasso/rect mode without needing Alt held.