### PR TITLE
Tween reassign badge (green/yellow bounding-box button)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -297,6 +297,14 @@ body.tools-docked-away #tools-panel-resize{display:none;}
 .labs-float-btn:hover{background:rgba(255,255,255,.09);color:var(--text);}
 .labs-float-btn.active{background:var(--accent-dim);color:var(--accent-hover);}
 .labs-float-divider{width:1px;height:18px;background:var(--border2);margin:0 3px;flex:none;}
+/* Tween reassign badge (2026-07) — pill positioned in JS (updateReassignBadge,
+   tweens.js), right at the selection's bounding-box corner. green = has a
+   tween, click to start reassigning; yellow = reassignment pending, click
+   confirms the current selection as the new target. */
+#tween-reassign-badge{position:fixed;z-index:7;padding:2px 7px;border-radius:10px;font:600 10px/1.6 var(--font-mono,monospace);color:#111;cursor:pointer;box-shadow:0 2px 8px rgba(0,0,0,.4);white-space:nowrap;transition:transform .08s;}
+#tween-reassign-badge:hover{transform:scale(1.08);}
+#tween-reassign-badge.green{background:#4ade80;}
+#tween-reassign-badge.yellow{background:#facc15;}
 /* Params row — [-] value [+] steppers, one pill per adjustable param,
    styled after the reference floating panel (dark rounded pill, minus/
    value/plus in one flat strip). */

--- a/src/index.html
+++ b/src/index.html
@@ -295,6 +295,17 @@
            knob, built/shown by labs-float-panel.js only when relevant. -->
       <div id="labs-float-params" style="display:none"></div>
     </div>
+    <!-- Tween reassign badge (2026-07, "un bouton pour réassigné le tween à
+         un autre ID sur la frame suivante"): a small pill sitting next to
+         the selection's bounding box, positioned in JS (updateReassignBadge,
+         tweens.js) via view.projectToView — same sibling-of-#canvas-area +
+         position:fixed convention as #labs-float-panel just above, for the
+         same reason (never enters #canvas-area's subtree, so no per-tool
+         bridge needs to know about it). Green = this selection has a tween
+         to the next keyframe, click it to jump there and start a
+         reassignment; yellow = a reassignment is pending, click confirms
+         the currently-selected element as the new target. -->
+    <div id="tween-reassign-badge" style="display:none"></div>
   </div>
 
   <div id="props-panel-resize" data-i18n-title="dragToResize" title="Glisser pour redimensionner"></div>

--- a/src/js/tweens.js
+++ b/src/js/tweens.js
@@ -1528,6 +1528,7 @@ function computeArcMatchState(){
   return {fA:fA,fB:fB,sA:sA,sB:sB,matches:matches,fm:fm};
 }
 function renderArcs(cached){
+  updateReassignBadge();
   arcLayer.removeChildren();arcHandles=[];
   renderNodeHandles();
   renderTransformHandles();
@@ -1756,6 +1757,7 @@ function cancelReassign(silent){
   if(!_reassign.active)return;
   _reassign.active=false;_reassign.step=0;_reassign.aIds=[];
   reassignSetStatus(null);
+  hideReassignBadge();
   if(!silent)showToast('Réattribution annulée');
 }
 function startReassign(){
@@ -1846,6 +1848,89 @@ document.addEventListener('keydown',function(e){
 function initReassignUI(){
   var btn=document.getElementById('btn-tw-reassign');
   if(btn)btn.addEventListener('click',startReassign);
+  var badge=document.getElementById('tween-reassign-badge');
+  if(badge)badge.addEventListener('click',function(e){e.stopPropagation();e.preventDefault();if(_reassignBadgeAction)_reassignBadgeAction();});
 }
 if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',initReassignUI);else initReassignUI();
+
+// ---- Reassign badge (2026-07, "un bouton pour réassigné le tween à un
+// autre ID sur la frame suivante") — a discoverable, bounding-box-anchored
+// alternative to the #btn-tw-reassign + raw-canvas-click flow above (which
+// still works unchanged; this is just a second entry point onto the SAME
+// _reassign state machine/state.tweenOverrides data). Green: the current
+// single selection has an active tween pair to the next keyframe — click
+// jumps there and arms step 2. Yellow: step 2 is pending — click confirms
+// whatever's currently selected as the new target, same effect as clicking
+// the shape directly (reassignHandleClick's step-2 branch), just a more
+// discoverable explicit action instead of an invisible click-anywhere.
+var _reassignBadgeAction=null;
+function reassignBadgeEl(){return document.getElementById('tween-reassign-badge');}
+function hideReassignBadge(){var el=reassignBadgeEl();if(el)el.style.display='none';_reassignBadgeAction=null;}
+// Purely cosmetic: strokeId is a long opaque string, not meaningful shown
+// verbatim on a small pill — hashed down to a short 3-digit label so the
+// SAME element keeps the SAME label across renders/frames.
+function shortIdLabel(strokeId){
+  var h=0;for(var i=0;i<strokeId.length;i++){h=((h<<5)-h+strokeId.charCodeAt(i))|0;}
+  return String(Math.abs(h)%900+100);
+}
+function positionReassignBadge(worldBounds,label,color){
+  var el=reassignBadgeEl();if(!el)return;
+  var canvas=document.getElementById('drawing-canvas');if(!canvas)return;
+  var rect=canvas.getBoundingClientRect();
+  var tr=view.projectToView(new Point(worldBounds.right,worldBounds.top));
+  el.textContent='Id:'+label;
+  el.className=color;
+  el.style.display='block';
+  el.style.left=(rect.left+tr.x+8)+'px';
+  el.style.top=(rect.top+tr.y-10)+'px';
+}
+function updateReassignBadge(){
+  var el=reassignBadgeEl();if(!el)return;
+  if(_reassign.active&&_reassign.step===2){
+    // Guards against a STALE selectedPaths[0] left over from before the
+    // jump to frameB — loadFrame(fB) rebuilds the layer's children from
+    // scratch, so the old (pre-jump) Path is still `instanceof Path` but no
+    // longer actually IN the layer; without this check the badge could
+    // render using a detached object's frozen bounds instead of staying
+    // hidden until the artist picks a real target on the new frame.
+    var liveLayer=userLayers[state.activeLayerIdx];
+    if(state.activeLayerIdx!==_reassign.layer||state.currentFrame!==_reassign.frameB||selectedPaths.length!==1||!(selectedPaths[0]instanceof Path)||liveLayer.children.indexOf(selectedPaths[0])<0){hideReassignBadge();return;}
+    var p=selectedPaths[0];
+    positionReassignBadge(p.bounds,shortIdLabel(_reassign.aIds[0]||''),'yellow');
+    _reassignBadgeAction=function(){
+      var target=selectedPaths[0];if(!target)return;
+      var sid=ensureStrokeId(target);
+      saveActiveLayerFrame();
+      var li=_reassign.layer;
+      var key=li+':'+_reassign.frameA+'-'+_reassign.frameB;
+      var list=state.tweenOverrides[key]=state.tweenOverrides[key]||[];
+      state.tweenOverrides[key]=list.filter(function(ov){
+        var ovA=ov.aIds||[ov.aId];
+        return _reassign.aIds.every(function(id){return ovA.indexOf(id)<0;})&&ov.bId!==sid;
+      });
+      state.tweenOverrides[key].push(_reassign.aIds.length===1?{aId:_reassign.aIds[0],bId:sid}:{aIds:_reassign.aIds.slice(),bId:sid});
+      var doneA=_reassign.frameA;
+      cancelReassign(true);
+      selClear();selAdd(li,doneA);
+      generateTweens();
+      selClear();
+      showToast('Inbetween réattribué');
+    };
+    return;
+  }
+  if(_reassign.active){hideReassignBadge();return;} // mid legacy step-1 multi-click flow -- avoid a stale green badge underneath
+  var st=computeArcMatchState();
+  if(!st||st.fm.length!==1||selectedPaths.length!==1||!(selectedPaths[0]instanceof Path)||userLayers[state.activeLayerIdx].children.indexOf(selectedPaths[0])<0){hideReassignBadge();return;}
+  var m=st.fm[0],sd=st.sA[m.a],p2=selectedPaths[0];
+  var aStrokeId=sd.strokeId||ensureStrokeId(p2);
+  var fA=st.fA,fB=st.fB;
+  positionReassignBadge(p2.bounds,shortIdLabel(aStrokeId),'green');
+  _reassignBadgeAction=function(){
+    saveAllLayerFrames();
+    _reassign.active=true;_reassign.step=2;_reassign.layer=state.activeLayerIdx;_reassign.frameA=fA;_reassign.frameB=fB;_reassign.aIds=[aStrokeId];
+    goToFrame(fB);
+    reassignSetStatus('2/2 — Cliquez l\'élément correspondant sur la keyframe '+(fB+1)+' (ou sélectionnez-le puis cliquez le bouton jaune)');
+    showToast('Sélectionnez l\'élément correspondant, puis cliquez le bouton jaune');
+  };
+}
 


### PR DESCRIPTION
## Summary
Front-end for the existing (v16) manual tween-reassignment engine, per the requested screenshot mockup — a green/yellow badge at the selection's bounding-box corner instead of only a Réglages panel button + invisible click-anywhere flow (both of which still work unchanged).

- Green "Id:N" badge on a single selection with an active tween → click jumps to the next keyframe and arms reassignment.
- Yellow badge on the newly-selected target at that keyframe → click confirms, writes the override, regenerates that span's tween.

## Test plan
- [x] Verified live: reassigned a shape's tween away from its auto-matched partner to a new unrelated shape; the generated inbetween frame correctly morphs toward the reassigned target.
- [x] Verified the yellow badge stays hidden until a genuinely new (live, in-layer) selection is made on the target keyframe — guards against showing a stale badge using a detached pre-jump selection.