### PR TITLE
Bump version to 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "2D frame-by-frame vector animation with auto inbetweening",
   "scripts": {
     "tauri": "tauri",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Nemo",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "com.strokemotion.app",
   "build": {
     "frontendDist": "../src",

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Nemo v0.6.1</title>
+<title>Nemo v0.6.2</title>
 <script src="paper-full.min.js"></script>
 <!-- Manrope (redesign, 2026-07-09) — matches the CSS var font stack's own
      fallback order, so an offline load (no internet, no Tauri font cache)
@@ -1340,7 +1340,7 @@
 
 <div id="statusbar">
   <span id="statusbar-help" data-i18n-title="statusbarHelpTitle" title="Aide contextuelle — change selon l'outil actif ou l'élément sélectionné"><span class="sc">F5</span><span data-i18n="scFrame">Frame</span> <span class="sc">F6</span><span data-i18n="scKey">Key</span> <span class="sc">F7</span><span data-i18n="scBlank">Blank</span> <span class="sc">T</span><span data-i18n="scTween">Tween</span> <span class="sc">D</span><span data-i18n="scDupli">Dupli</span> <span class="sc">F</span><span data-i18n="scFlip">Flip</span> <span class="sc">X</span><span data-i18n="scMirror">Mirror</span> <span class="sc">Enter</span><span data-i18n="scPlay">Play</span></span>
-  <span id="status-text">Nemo v0.6.1</span>
+  <span id="status-text">Nemo v0.6.2</span>
 </div>
 </div>
 <div id="toast"></div>


### PR DESCRIPTION
Version bump reflecting today's session (eraser fixes, lasso sub-region carving, per-element tween opt-out, tween-reassign badge, WebKit playhead fix, and more).