### PR TITLE
Fix lasso live-drag overlay always showing a rectangle

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -845,6 +845,20 @@
   }
   function buildMarqueeItems() {
     if (_marquee.active && _marquee.rect) {
+      // 2026-07 ("le lasso... pendant le drag j'ai le rect de selection box
+      // pas une selection visuelle libre même si après le relâchement j'ai
+      // bien ma forme dessinée de select") — this always drew the
+      // marquee's BOUNDING BOX (.bounds) regardless of its actual shape,
+      // for BOTH select-bridge's own Alt-drag lasso and fsselect's
+      // toggle-driven one (both share this one live-overlay chokepoint) —
+      // never updated when lasso mode was added. The final hit-test
+      // resolution (tools.js/select-bridge.js pointerup) already reads the
+      // real freehand segments correctly; only this live preview collapsed
+      // it to a rectangle. Serialize the actual traced points instead.
+      if (_marquee.lasso && _marquee.rect.segments.length > 1) {
+        var lassoPts = _marquee.rect.segments.map(function (s) { return { point: [s.point.x, s.point.y] }; });
+        return [{ segments: roundSegs(lassoPts), closed: false, fillColor: [74, 158, 255, 20], strokeColor: [74, 158, 255, 230], strokeWidth: 1 / view.zoom }];
+      }
       var b = _marquee.rect.bounds;
       return [boundsRectItem(b.left, b.top, b.right, b.bottom, [74, 158, 255, 20], [74, 158, 255, 230], 1 / view.zoom)];
     }


### PR DESCRIPTION
## Summary
`buildMarqueeItems()` — the chokepoint that serializes the marquee/lasso into the Rust engine's live scene (Paper.js's own canvas is invisible under it) — always drew the marquee's bounding box regardless of shape, never updated when lasso mode was added (affects both select-bridge's Alt-drag lasso and fsselect's new toggle). The final hit-test resolution was already correct; only the live preview was wrong.

## Test plan
- [x] Verified live: a wavy multi-point lasso drag shows the real curve throughout, not a rectangle, and still resolves to the correct sub-region selection on release.