### PR TITLE
Fill Brush: auto-merge same-color strokes; fix stale-tag paint-bucket gap

### DIFF
--- a/src/js/draw-bridge.js
+++ b/src/js/draw-bridge.js
@@ -548,8 +548,23 @@
       delete path.data.centerSegments;
       delete path.data.widthProfile;
       // Placement (Above/Below/Merge) — see applyFillBrushPlacement's own
-      // comment; replaces the old unconditional "always at the back".
-      applyFillBrushPlacement(path, userLayers[state.activeLayerIdx]);
+      // comment; replaces the old unconditional "always at the back". The
+      // return value MUST be captured: 'merge' mode, when it finds an
+      // overlapping fill, removes `path` entirely and returns a NEW united
+      // path (insertBooleanResult) — this call site never captured that
+      // before, so tagOwner/SMLabs/SMSymmetry hooks a few lines down were
+      // silently operating on the stale, already-removed original instead
+      // of the real merged result.
+      path = applyFillBrushPlacement(path, userLayers[state.activeLayerIdx]);
+      // 2026-07 feedback ("plusieurs coup de pinceau avec la même couleur
+      // doivent merger automatiquement") — Placement's own 'merge' option
+      // unions with whatever fill it happens to overlap regardless of
+      // color; genuine same-color fusion already exists
+      // (fillMergeSameColor, used by the paint bucket) but was never
+      // called from the Fill Brush's own commit. Wired in here
+      // unconditionally so consecutive same-color strokes merge into one
+      // shape no matter which Placement mode is active.
+      if (path) path = fillMergeSameColor(userLayers[state.activeLayerIdx], path) || path;
     } else if (state.vectorBrush && !state.strokeEnabled) {
       // Stroke eye OFF + Fill ON: the pressure ribbon IS the stroke, so
       // drawing "fill seul" means committing only the region enclosed by

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -1659,6 +1659,28 @@ function fillMergeSameColor(layer,newFill){
         ||(c.interiorPoint&&newFill.contains(c.interiorPoint))
         ||(newFill.interiorPoint&&c.contains(newFill.interiorPoint));
     }catch(e){}
+    // Near-miss tolerance (2026-07, "je remplis la forme [avec le pot de
+    // peinture], il ne l'a remplis pas complétement et n'en fait pas une
+    // seule forme"): fillVectorFind's traced boundary (paint bucket) can
+    // sit a hairline inside an existing shape's true edge — invisible on
+    // screen (graph-tracing flatten/refine tolerance, tools.js's own
+    // fillVectorFind comments) but enough to fail Paper.js's strict
+    // curve-intersection/contains test above, silently leaving two
+    // same-color fills unmerged with a technically-there seam. Falls back
+    // to a real nearest-point distance check before giving up — samples
+    // points along newFill's own curves (cheap, no dense flatten) and
+    // checks how close the OTHER shape's boundary gets to each.
+    if(!touches){
+      try{
+        var TOL=3,curves=newFill.curves;
+        for(var ci=0;ci<curves.length&&!touches;ci++){
+          var sp=curves[ci].getPointAt(0,true);
+          if(!sp)continue;
+          var np=c.getNearestPoint(sp);
+          if(np&&np.getDistance(sp)<TOL)touches=true;
+        }
+      }catch(e){}
+    }
     if(touches)absorbed.push(c);
   });
   if(!absorbed.length)return newFill;
@@ -4492,9 +4514,34 @@ function onMouseUp(event){
       currentPath.data.centerSegments=fbCs;
       currentPath.data.widthProfile=fbCs.widthProfile;
       rebuildVectorBrushOutline(currentPath);
+      // Drop the centerline/width-profile scaffolding once the outline is
+      // built — mirrors draw-bridge.js's own commit (its comment: "once
+      // built, drop the isVectorBrush/centerSegments/widthProfile linkage
+      // entirely"). Missing here (this Paper-Tool fallback path never had
+      // it) left a COMMITTED Fill Brush shape still tagged as if it were a
+      // live centerline+width ribbon — fillWallPath (paint bucket's wall
+      // tracer) treats that tag as "use the CENTERLINE, not the true
+      // outline", so filling next to one of these shapes traced a
+      // boundary offset half a stroke-width INSIDE the real ink edge,
+      // leaving a visible gap and never touching the ring closely enough
+      // for fillMergeSameColor to fuse them into one shape. isFillShape
+      // stays (still needed by pen-bridge.js's close-path/endpoint-snap
+      // exclusion guard).
+      delete currentPath.data.isVectorBrush;
+      delete currentPath.data.centerSegments;
+      delete currentPath.data.widthProfile;
       // Placement (Above/Below/Merge) — see applyFillBrushPlacement's own
       // comment; replaces the old unconditional "always at the back".
       currentPath=applyFillBrushPlacement(currentPath,userLayers[state.activeLayerIdx]);
+      // 2026-07 feedback ("plusieurs coup de pinceau avec la même couleur
+      // doivent merger automatiquement") — Placement's own 'merge' option
+      // unions with whatever fill it happens to overlap regardless of
+      // color (see applyFillBrushPlacement); genuine same-color fusion
+      // already exists (fillMergeSameColor, used by the paint bucket) but
+      // was never called from the Fill Brush's own commit. Wired in here
+      // unconditionally so consecutive same-color strokes merge into one
+      // shape no matter which Placement mode is active.
+      if(currentPath)currentPath=fillMergeSameColor(userLayers[state.activeLayerIdx],currentPath)||currentPath;
       if(currentPath&&state.shadowMode)currentPath.data.channelTag='shadow';
       if(currentPath)tagOwner(currentPath);
     }


### PR DESCRIPTION
## Summary
- Consecutive Fill Brush strokes in the same color now auto-merge into one shape (reuses `fillMergeSameColor`, already used by the paint bucket), regardless of the Placement setting.
- Fixed a real bug: draw-bridge.js's commit never captured `applyFillBrushPlacement`'s return value, so its 'merge' mode's result (a brand new path) was invisible to every hook after it.
- Fixed the root cause of an incomplete paint-bucket fill on Fill-Brush shapes: the legacy commit path never cleared `centerSegments`/`isVectorBrush` tags after building the outline (draw-bridge.js already did), so the paint bucket's wall tracer used the stale CENTERLINE instead of the true outline.
- Added a near-miss tolerance to `fillMergeSameColor`'s touch test for a hairline-close (but not exactly intersecting) fill boundary.

**Known remaining issue** (documented in the commit, not fixed here): a Fill-Brush **ring** shape specifically can still show a larger gap due to a seam in how `buildVariableWidthPath` sweeps a closed centerline (always caps like an open stroke) — deeper, separate fix needed.

## Test plan
- [x] Verified live: two overlapping same-color Fill Brush-style strokes merge into 1 shape.
- [x] Verified `fillWallPath` returns the true outline (not centerline) once tags are cleared.
- [x] Confirmed (but did not fix) the ring-seam issue remains for closed-centerline sweeps specifically.