### PR TITLE
Replace fixed-alpha pressure smoothing with a One Euro Filter

### DIFF
--- a/src/js/draw-bridge.js
+++ b/src/js/draw-bridge.js
@@ -82,19 +82,55 @@
   }
   // Raw per-sample pressure (especially the speed-fallback formula, and
   // some stylus hardware) is noisy enough to visibly bump the variable-
-  // width outline's edge — a one-pole low-pass filter (exponential moving
-  // average) smooths that out while still tracking a deliberate press/
-  // release fast enough to feel responsive, not laggy. Reset to null every
-  // stroke so it snaps straight to the first real reading instead of
-  // ramping up from 0 (a real pressed-down pen should register full weight
-  // immediately, not fade in).
-  var smoothedPressure = null;
-  var PRESSURE_SMOOTH_ALPHA = 0.45;
-  function smoothPressure(p) {
-    if (smoothedPressure == null) { smoothedPressure = p; return p; }
-    smoothedPressure += (p - smoothedPressure) * PRESSURE_SMOOTH_ALPHA;
-    return smoothedPressure;
+  // width outline's edge — needs smoothing, but a single FIXED-factor
+  // exponential moving average (the previous 0.45-alpha version) forces
+  // one compromise value for every drawing speed: tuned to kill jitter
+  // during a slow, careful line, it visibly LAGS behind a fast, deliberate
+  // press/release (exactly the "moins naturel qu'un vrai logiciel pro
+  // comme Moho" feedback — a real pen's weight should register close to
+  // instantly, not smear across several samples). 2026-07: replaced with a
+  // One Euro Filter (Casiez/Roussel/Vogel, https://gery.casiez.net/1euro/
+  // — the industry-standard answer to exactly this "filter now, tau
+  // later" tradeoff, used across stylus/motion-tracking software): cutoff
+  // frequency adapts to how FAST pressure is currently changing, so a slow
+  // stroke gets heavy smoothing (kills jitter) while a fast press/release
+  // gets a high cutoff (near-zero lag). mincutoff/beta below are a
+  // reasonable starting point for a 0..1 pressure signal (as opposed to
+  // pixel-position tuning, where beta is usually two orders of magnitude
+  // smaller) — real tuning needs a physical stylus to feel right, adjust
+  // here if it still reads too smoothed/too jittery.
+  function makeOneEuroFilter(mincutoff, beta, dcutoff) {
+    var xPrev = null, dxPrev = 0, tPrev = null;
+    function alpha(cutoff, dt) { var tau = 1 / (2 * Math.PI * cutoff); return 1 / (1 + tau / dt); }
+    return function (x, tMs) {
+      if (xPrev == null) { xPrev = x; tPrev = tMs; dxPrev = 0; return x; }
+      var dt = Math.max(0.001, (tMs - tPrev) / 1000); // seconds; floored so a duplicate-timestamp sample can't divide by zero
+      tPrev = tMs;
+      var dx = (x - xPrev) / dt;
+      dxPrev = dxPrev + alpha(dcutoff, dt) * (dx - dxPrev);
+      var cutoff = mincutoff + beta * Math.abs(dxPrev);
+      var result = xPrev + alpha(cutoff, dt) * (x - xPrev);
+      xPrev = result;
+      return result;
+    };
   }
+  // Tuned empirically (no physical stylus available in this environment —
+  // simulated jitter [0.18-0.25] + press-to-0.9 sample sequences at
+  // realistic ~10-16ms event spacing): beta needs to be ~30x larger than
+  // typical 2D-position One Euro presets, since a 0..1 pressure signal's
+  // derivative is numerically tiny compared to pixel-position deltas.
+  // Result: reaches target within 2 samples on a real press (was 6+ samples
+  // with the old fixed-0.45 filter) while holding a TIGHTER jitter band
+  // than that old filter too — verify/retune live with a real tablet if it
+  // ever reads too twitchy or too smoothed.
+  var PRESSURE_MINCUTOFF = 1.0, PRESSURE_BETA = 20, PRESSURE_DCUTOFF = 1.0;
+  var pressureFilter = makeOneEuroFilter(PRESSURE_MINCUTOFF, PRESSURE_BETA, PRESSURE_DCUTOFF);
+  // Reset every stroke (new filter instance) so it snaps straight to the
+  // first real reading instead of ramping up from a previous stroke's
+  // state — a real pressed-down pen should register full weight
+  // immediately, not fade in.
+  function resetPressureFilter() { pressureFilter = makeOneEuroFilter(PRESSURE_MINCUTOFF, PRESSURE_BETA, PRESSURE_DCUTOFF); }
+  function smoothPressure(p) { return pressureFilter(p, Date.now()); }
 
   function shouldIntercept() {
     return (
@@ -344,7 +380,7 @@
     dragging = true;
     samples = [];
     lastMoveT = 0; lastWorldPt = null; lastPenPressure = null;
-    stabQueue = []; smoothedPressure = null;
+    stabQueue = []; resetPressureFilter();
     var w0 = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
     w0 = guideConstrain(w0, true);
     // engine-bridge.js's own tick() loop keeps running unconditionally in

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -3740,12 +3740,31 @@ var _vb={pts:[],widths:[],lastT:0,lastPt:null};
 // native path is only a fallback (the engine is on by default), but the two
 // must stay in phase per this file's own duplication-hazard convention, or
 // falling back here mid-session would visibly change how a stroke feels.
-var _vbSmoothedPressure=null;
-function vbSmoothPressure(p){
-  if(_vbSmoothedPressure==null){_vbSmoothedPressure=p;return p;}
-  _vbSmoothedPressure+=(p-_vbSmoothedPressure)*0.45;
-  return _vbSmoothedPressure;
+// One Euro Filter (2026-07, replaces a fixed 0.45-alpha exponential moving
+// average — see draw-bridge.js's own copy of this exact comment for the
+// full "moins naturel qu'un logiciel pro" rationale and tuning caveat).
+function _vbMakeOneEuroFilter(mincutoff,beta,dcutoff){
+  var xPrev=null,dxPrev=0,tPrev=null;
+  function alpha(cutoff,dt){var tau=1/(2*Math.PI*cutoff);return 1/(1+tau/dt);}
+  return function(x,tMs){
+    if(xPrev==null){xPrev=x;tPrev=tMs;dxPrev=0;return x;}
+    var dt=Math.max(0.001,(tMs-tPrev)/1000);
+    tPrev=tMs;
+    var dx=(x-xPrev)/dt;
+    dxPrev=dxPrev+alpha(dcutoff,dt)*(dx-dxPrev);
+    var cutoff=mincutoff+beta*Math.abs(dxPrev);
+    var result=xPrev+alpha(cutoff,dt)*(x-xPrev);
+    xPrev=result;
+    return result;
+  };
 }
+// Tuned constants MUST match draw-bridge.js's own copy exactly (see that
+// file's comment for the empirical tuning rationale) — this is the
+// engine-off fallback, per this file's own duplication-hazard convention.
+var _VB_PRESSURE_MINCUTOFF=1.0,_VB_PRESSURE_BETA=20,_VB_PRESSURE_DCUTOFF=1.0;
+var _vbPressureFilter=_vbMakeOneEuroFilter(_VB_PRESSURE_MINCUTOFF,_VB_PRESSURE_BETA,_VB_PRESSURE_DCUTOFF);
+function _vbResetPressureFilter(){_vbPressureFilter=_vbMakeOneEuroFilter(_VB_PRESSURE_MINCUTOFF,_VB_PRESSURE_BETA,_VB_PRESSURE_DCUTOFF);}
+function vbSmoothPressure(p){return _vbPressureFilter(p,Date.now());}
 function vbStabilizePoint(pt){
   var stab=state.stabilizer;
   if(!stab){stabQueue.length=0;return pt;}
@@ -3878,7 +3897,7 @@ function onMouseDown(event){
     if(!state.strokeEnabled&&!state.fillEnabled){showToast('Stroke et Fill désactivés — rien à dessiner');return;}
     pushUndo();ensureKeyframe();layer.activate();
     if(state.vectorBrush){
-      _vbLastPenPressure=null;_vbSmoothedPressure=null;stabQueue=[event.point.clone()];_vb.pts=[event.point.clone()];_vb.widths=[vbPressureOf(event)];_vb.lastT=Date.now();_vb.lastPt=event.point.clone();
+      _vbLastPenPressure=null;_vbResetPressureFilter();stabQueue=[event.point.clone()];_vb.pts=[event.point.clone()];_vb.widths=[vbPressureOf(event)];_vb.lastT=Date.now();_vb.lastPt=event.point.clone();
       currentPath=new Path();currentPath.fillColor=state.strokeEnabled?state.strokeColor:state.fillColor;currentPath.strokeColor=null;currentPath.opacity=state.opacity/100;
       currentPath.data.isVectorBrush=true;
       applyBrushKeyline(currentPath); // visual separation from any nearby stroke — see app.js


### PR DESCRIPTION
## Summary
Researched how pro tablet apps (Procreate's pressure-driven taper, MyPaint/Krita's dynamics mapping, the industry-standard One Euro Filter used across stylus/motion-tracking software) get a more natural pressure feel, and applied the most directly actionable finding: replaced the fixed 0.45-alpha exponential moving average (one compromise smoothing strength for every drawing speed) with a proper One Euro Filter, whose cutoff adapts to how fast pressure is currently changing — heavy smoothing during a slow/jittery touch, near-instant response during a real press.

Mirrored in both draw-bridge.js (engine-on) and tools.js (Paper-Tool fallback) per this codebase's own duplication convention.

## Test plan
- [x] Verified numerically (simulated jitter + press sequences): reaches a hard press's target within 2 samples (was 6+), while holding a *tighter* jitter band than the old filter.
- [x] Verified live: drawing still works with no console errors.
- Constants were tuned without a physical stylus — flagged in the commit for live re-tuning if it ever feels too twitchy or too smoothed on a real tablet.