### PR TITLE
Merge paint-bucket fill into the Fill Brush shape it's patching

### DIFF
--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -1757,7 +1757,20 @@ function fillMergeSameColor(layer,newFill,allowFillShapeAbsorb){
   layer.children.forEach(function(c){
     if(c===newFill||!(c instanceof Path)||!c.closed||!c.fillColor||c.strokeColor)return;
     if(c.data&&(c.data.isVectorBrush||c.data.isLinkedFillCompanion||c.data.isBrushTextureCopy||c.data.isRevisionGhost||c.data.ghostFrame!==undefined))return;
-    if(!allowFillShapeAbsorb&&c.data&&c.data.isFillShape)return;
+    if(c.data&&c.data.isFillShape){
+      // Still excluded by default (preserveFillShapes, above) — UNLESS this
+      // exact Fill Brush shape's own boundary was one of the walls the
+      // paint bucket traced against to build newFill (data.fillWalls,
+      // stamped on newFill just before this call). That's the "patching a
+      // gap in THIS shape's own unclosed loop" case (2026-07 feedback:
+      // "le fill ne se merge pas complet avec le fill brush" — a Fill
+      // Brush ring gesture that didn't quite close, painted-bucket-filled
+      // via Alt+drag) — genuinely the same intended shape, not just an
+      // adjacent neighbor it happens to border, so absorbing it here is
+      // completing the shape rather than reshaping an unrelated one.
+      var tracedAgainstThis=newFill.data&&newFill.data.fillWalls&&c.data.strokeId&&newFill.data.fillWalls.indexOf(c.data.strokeId)>=0;
+      if(!allowFillShapeAbsorb&&!tracedAgainstThis)return;
+    }
     if(colorHex8(c.fillColor)!==col)return;
     if(!c.bounds.intersects(newFill.bounds))return;
     if(_strokeBetween(layer,newFill.interiorPoint,c.interiorPoint))return;


### PR DESCRIPTION
## Summary
`fillMergeSameColor`'s `preserveFillShapes` guard (earlier this session) blanket-excluded any Fill Brush shape from absorption unless `allowFillShapeAbsorb` was passed — correct for stopping the paint bucket reshaping an unrelated neighbor it merely borders, but it also blocked the legitimate case: patching a gap in a Fill Brush ring gesture that didn't fully close (via the Alt+drag closing-line + paint bucket workflow). The new fill's own `data.fillWalls` already records that exact shape's `strokeId` when it was traced against it — now the merge is allowed specifically in that case.

## Test plan
- [x] Verified live: a fill traced against a Fill Brush shape's own strokeId now merges into one shape (2 children → 1).
- [x] Regression: an adjacent fill that merely touches a *different* Fill Brush shape (not traced against it) stays separate, same as before.
- [ ] User to confirm on the real reported shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)