### PR TITLE
Fix kinked tangents left behind by degenerate self-loop cleanup

### DIFF
--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -3939,7 +3939,7 @@ function _mergeHoleIntoExterior(extSegs,holeSegs){
 // to within 0.3% (the removed loops really were negligible slivers).
 function _eraseDegenerateSelfLoops(path){
   if(!path||!path.segments)return;
-  var changed=true,guard=0;
+  var changed=true,guard=0,anySpliced=false;
   while(changed&&guard<5000){
     changed=false;guard++;
     var segs=path.segments,n=segs.length,seen={};
@@ -3947,12 +3947,23 @@ function _eraseDegenerateSelfLoops(path){
       var key=Math.round(segs[i].point.x*10)+','+Math.round(segs[i].point.y*10);
       if(seen[key]!==undefined){
         path.removeSegments(seen[key]+1,i+1);
-        changed=true;
+        changed=true;anySpliced=true;
         break;
       }
       seen[key]=i;
     }
   }
+  // The kept "first visit" anchor at each splice keeps ITS OWN original
+  // handleOut — which was aimed at the (now-removed) start of the detour,
+  // not at whatever real neighbor the splice just reconnected it to.
+  // Confirmed live (2026-07, "la vertice extérieur... perdent leur
+  // tangent"): that stale handle survives completely unchanged, producing
+  // a visible kink exactly at every splice point even though the anchor's
+  // POSITION never moved. Re-fitting the whole path once, only if anything
+  // was actually spliced, recomputes every handle from the real (now
+  // clipper-noise-free) neighbor positions — same technique
+  // buildClosedRingOutline's own offset curves already use.
+  if(anySpliced)path.smooth({type:'continuous'});
 }
 // strokeInfo (optional, 2026-07 — "l'eraser supprime le stroke entier"):
 // every branch below used to hardcode strokeColor=null on its island(s),


### PR DESCRIPTION
## Summary
Direct follow-up to the previous PR (strip clipper-noise self-loops). That fix correctly removed the spurious detour points, but left the "kept" anchor at each splice point with its ORIGINAL `handleOut` — still aimed at the removed detour's direction, not its new real neighbor. Same position, wrong tangent — a visible kink at every splice.

`_eraseDegenerateSelfLoops` now re-smooths the path once (`smooth({type:'continuous'})`, only when a splice actually happened) after cleanup.

## Test plan
- [x] Verified live: injected a synthetic detour into a smooth circle, ran the cleanup — the splice anchor's handle now aligns almost perfectly (dot product 0.99) with its real new neighbor direction (was ~0, i.e. unrelated, before this fix).
- [ ] User to confirm on the real reported shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)