### PR TITLE
Fix tween frames turning into keyframes on scrub + broken default easing

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -146,7 +146,18 @@ var state={
   exportIncludeShadowGuides:false,
   customBrushPresets:{}, // user-saved procedural brush presets, keyed by generated id — see brush-editor.js
   layers:[],activeLayerIdx:0,
-  motionArcs:{},easingCurve:{points:[{x:0,y:0},{x:.42,y:0},{x:.58,y:1},{x:1,y:1}]},
+  // Default tween easing (2026-07 fix, "le moteur tween gère mal des
+  // intervalles"): the old default points {.42,0}/{.58,1} were CSS
+  // cubic-bezier(.42,0,.58,1) CONTROL points pasted in as-is — but
+  // evalPointsCurve (ui.js) treats points as ON-CURVE knots of a
+  // Catmull-Rom-tangent spline, so that default actually meant "y stays 0
+  // until x=.42, cliff to 1 by x=.58, flat after" plus spline under/
+  // overshoot on the outer segments (measured live: eased t of -0.074 and
+  // 1.074, and adjacent inbetweens jumping 0.02 -> 0.98). On any span with
+  // several inbetweens the motion visibly parked, teleported mid-span,
+  // then parked again. These are ui.js's own 'ease-in-out' PRESET knots —
+  // the same curve family, expressed correctly for this evaluator.
+  motionArcs:{},easingCurve:{points:[{x:0,y:0},{x:.3,y:.05},{x:.7,y:.95},{x:1,y:1}]},
   // v16: manual inbetween/tween reassignment — {layer+':'+fA+'-'+fB: [{aId,bId},...]}
   // forces autoMatch (tweens.js generateTweens) to pair a specific stroke
   // (by stable data.strokeId) on keyframe A with a specific stroke on
@@ -1639,6 +1650,22 @@ function _normStrokeForCompare(sd){
   // hasRealStroke consumer (isTexAnchor branch above): derive it from
   // strokeColor when absent, so this isn't seen as a real content change.
   n.hasRealStroke=n.hasRealStroke!==undefined?n.hasRealStroke:!!n.strokeColor;
+  // Keyline fields of a pressure-brush ribbon are DERIVED, not stored
+  // content: desP() calls applyBrushKeyline() on every load, which
+  // recomputes strokeColor/strokeWidth/cap/join from fillColor +
+  // centerSegments (fractional width, e.g. 0.53). A generated tween
+  // frame's stored record meanwhile has whatever its producer left there
+  // (typically nothing -> normalized to 3 above). Comparing a recomputed
+  // cache against a stale stored copy is a guaranteed phantom diff —
+  // confirmed live 2026-07 ("des clés tween qui deviennent vertes... un
+  // bug qui revient sans cesse"): merely scrubbing past a tween frame of
+  // pressure-brush strokes promoted it to a full keyframe every time,
+  // via _maybePromoteInterpolated seeing strokeWidth 3 vs 0.53. Neutralize
+  // exactly the fields applyBrushKeyline owns, under exactly its own
+  // applicability condition (see that function's guard in this file).
+  if(n.isVectorBrush&&!n.isBrushTextureCopy&&!n.isFillShape){
+    n.strokeColor='__keyline__';n.strokeWidth=0;n.strokeCap='round';n.strokeJoin='round';n.hasRealStroke='__keyline__';
+  }
   // isRaster width/height round-trip through Paper.js's Raster.size setter,
   // which snaps to whole pixels internally (a bitmap can't have fractional
   // backing-store dimensions) — and it FLOORS, never rounds: measured live

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -119,13 +119,26 @@
   function cloneCurvePts(pts) { return pts.map(function (p) { var o = { x: p.x, y: p.y }; if (typeof p.tx === 'number') { o.tx = p.tx; o.ty = p.ty || 0; } return o; }); }
   function curveCubicAt(t, a, b, c, d) { var u = 1 - t; return u * u * u * a + 3 * u * u * t * b + 3 * u * t * t * c + t * t * t * d; }
   function curveCubicDerivAt(t, a, b, c, d) { var u = 1 - t; return 3 * u * u * (b - a) + 6 * u * t * (c - b) + 3 * t * t * (d - c); }
-  // Manual tangent override (tx/ty) or derived Catmull-Rom — duplicated
-  // from ui.js's tangentAt (CLAUDE.md §3 pure-math pair, keep in sync).
+  // Manual tangent override (tx/ty) or derived monotone-limited tangent —
+  // duplicated from ui.js's tangentAt (CLAUDE.md §3 pure-math pair, keep
+  // in sync — see that copy's comment for the Fritsch–Carlson rationale).
   function curveTangentAt(pts, i) {
     var p = pts[i];
     if (typeof p.tx === 'number') return { x: p.tx, y: p.ty || 0 };
     var prev = pts[i - 1] || p, next = pts[i + 1] || p;
-    return { x: (next.x - prev.x) / 2, y: (next.y - prev.y) / 2 };
+    var tx = (next.x - prev.x) / 2;
+    var dx0 = p.x - prev.x, dx1 = next.x - p.x;
+    var s0 = dx0 > 1e-9 ? (p.y - prev.y) / dx0 : 0, s1 = dx1 > 1e-9 ? (next.y - p.y) / dx1 : 0;
+    var m;
+    if (prev === p) m = s1;
+    else if (next === p) m = s0;
+    else if (s0 * s1 <= 0) m = 0;
+    else {
+      m = (s0 + s1) / 2;
+      var lim = 3 * Math.min(Math.abs(s0), Math.abs(s1));
+      if (Math.abs(m) > lim) m = (m > 0 ? 1 : -1) * lim;
+    }
+    return { x: tx, y: m * tx };
   }
   function curveSegCtrl(pts, i) {
     var p0 = pts[i], p3 = pts[i + 1];

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1158,7 +1158,21 @@ window.SM={
       state.layers[idx].color=ld.color||nextLayerColor();
       ld.frames.forEach(function(f){if(!f.isInterpolated)f.isInterpolated=false;});while(state.layers[idx].frames.length<state.totalFrames)state.layers[idx].frames.push({strokes:[],isKeyframe:false,isInterpolated:false});});
     state.layerFolders=d.layerFolders||{};state.layerLinkGroups=d.layerLinkGroups||{};
-    state.motionArcs=d.motionArcs||{};state.tweenOverrides=d.tweenOverrides||{};state.tweenEasing=d.tweenEasing||{};if(d.easingCurve){state.easingCurve=d.easingCurve;if(window._curveEditor)window._curveEditor.setState(d.easingCurve);}
+    state.motionArcs=d.motionArcs||{};state.tweenOverrides=d.tweenOverrides||{};state.tweenEasing=d.tweenEasing||{};
+    // Migration (2026-07): the old shipped DEFAULT easing points
+    // ({.42,0}/{.58,1} — CSS control values misread as on-curve knots, a
+    // park/teleport/park cliff, see app.js's easingCurve comment) were
+    // never a deliberate user choice — any project still carrying exactly
+    // that default gets the corrected one. A curve the user actually
+    // edited (any other point set) is left untouched.
+    if(d.easingCurve){
+      var _ec=d.easingCurve,_ep=_ec.points;
+      var _isOldDefault=_ep&&_ep.length===4&&_ep.every(function(p){return typeof p.tx!=='number';})&&
+        Math.abs(_ep[0].x)<1e-6&&Math.abs(_ep[0].y)<1e-6&&Math.abs(_ep[1].x-0.42)<1e-6&&Math.abs(_ep[1].y)<1e-6&&
+        Math.abs(_ep[2].x-0.58)<1e-6&&Math.abs(_ep[2].y-1)<1e-6&&Math.abs(_ep[3].x-1)<1e-6&&Math.abs(_ep[3].y-1)<1e-6;
+      if(_isOldDefault)_ec={points:[{x:0,y:0},{x:.3,y:.05},{x:.7,y:.95},{x:1,y:1}]};
+      state.easingCurve=_ec;if(window._curveEditor)window._curveEditor.setState(_ec);
+    }
     state.comments=d.comments||[];
     if(typeof refreshFbAvatars==='function')refreshFbAvatars(); // avatar stack mirrors state.comments — resync on project import
     state.cameraKeys=d.cameraKeys||[];state.cameraLayerOn=!!d.cameraLayerOn;state.cameraView=false;

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -149,7 +149,31 @@
     var p=pts[i];
     if(typeof p.tx==='number')return{x:p.tx,y:p.ty||0};
     var prev=pts[i-1]||p,next=pts[i+1]||p;
-    return{x:(next.x-prev.x)/2,y:(next.y-prev.y)/2};
+    var tx=(next.x-prev.x)/2;
+    // Monotone-limited derived tangent (Fritsch–Carlson), replacing the
+    // raw Catmull-Rom (next-prev)/2 y-component (2026-07, "le moteur tween
+    // gère mal des intervalles"): raw C-R at a knot whose two secants
+    // disagree in slope over/undershoots the segment — measured live, a
+    // monotone-intent easing curve evaluated to -0.074 (motion running
+    // BACKWARD before starting) and 1.074. F-C's classic recipe: flat
+    // tangent at any local extremum (secant signs differ), else the
+    // average slope clamped to 3x the shallower secant — deliberate
+    // overshoot still works exactly as before, since back/elastic/bounce
+    // presets place their KNOTS outside [0,1] rather than relying on
+    // spline overshoot. Endpoints keep the one-sided secant (identical to
+    // the old formula there, where prev===p or next===p).
+    var dx0=p.x-prev.x,dx1=next.x-p.x;
+    var s0=dx0>1e-9?(p.y-prev.y)/dx0:0,s1=dx1>1e-9?(next.y-p.y)/dx1:0;
+    var m;
+    if(prev===p)m=s1;
+    else if(next===p)m=s0;
+    else if(s0*s1<=0)m=0;
+    else{
+      m=(s0+s1)/2;
+      var lim=3*Math.min(Math.abs(s0),Math.abs(s1));
+      if(Math.abs(m)>lim)m=(m>0?1:-1)*lim;
+    }
+    return{x:tx,y:m*tx};
   }
   // Tangent at each knot (manual override or derived Catmull-Rom),
   // converted to the pair of cubic-Bezier control points for the segment


### PR DESCRIPTION
## Summary
Two root causes behind the recurring "tween keys turn green" report and the "tween engine mishandles intervals" complaint, both reproduced live on the user's real scene:

1. **Scrub promotion (phantom diff)** — a pressure-brush ribbon's keyline fields are *derived* on every load (`applyBrushKeyline`, fractional strokeWidth) but were compared as stored content: `_maybePromoteInterpolated` saw `3` vs `0.53` and promoted the tween frame to a keyframe on every scrub-past (a bare `goToFrame()` was enough). Keyline fields are now neutralized in `_normStrokeForCompare` under exactly `applyBrushKeyline`'s own condition. Real edits still promote (verified).
2. **Default easing was a cliff** — the shipped default points `(.42,0)/(.58,1)` are CSS cubic-bezier *control* values, but the evaluator treats points as *on-curve* knots: measured eased t of **-0.074** (backward motion), a 0.02→0.98 jump between adjacent inbetweens, and 1.074 overshoot. Fixed: sane default knots (the app's own ease-in-out preset), migration for projects still carrying the old default verbatim, and Fritsch–Carlson monotone-limited derived tangents in both `ui.js` and its `motion.js` twin (deliberate overshoot presets unaffected — their knots sit outside [0,1]).

## Test plan
- [x] 5 tween frames survive scrub+save across each (was: promoted to keyframes).
- [x] A real edit on a tween frame still promotes it.
- [x] New default eval: 0/.008/.043/.29/.71/.96/.99/1 — smooth monotone (was -0.046/-0.074/0.017/0.983/1.074/1.046).
- [x] Old broken points through fixed tangents: no more negatives/overshoot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)