### PR TITLE
Gate tween-frame promotion on a real action, not a content diff

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1741,8 +1741,21 @@ function _collectLayerStrokes(li,ld){
 // navigation (goToFrame persists whatever's on screen before switching
 // away); promoting on every run would turn every tween frame into a real
 // keyframe the moment you scrub past it.
+// Structural fix (2026-07, "une keyframe des tween est devenue verte...
+// un bug qui revient sans cesse"): the !strokesEqual comparison alone can
+// never be a safe promotion trigger, because it silently depends on the
+// serP->desP round-trip being byte-idempotent for EVERY stroke type — and
+// every new derived/defaulted field breaks that for one producer or
+// another (keyline widths, raster size floors, hasRealStroke, miterLimit —
+// see _normStrokeForCompare's growing list of patches for exactly this).
+// Promotion now ALSO requires window._tweenFrameDirty — set by
+// pushUndoLayers (tweens.js), the single choke point every real mutating
+// action already goes through, and cleared on every loadFrame — so pure
+// navigation/scrubbing can never promote no matter what phantom diff a
+// future field introduces. The strokesEqual check stays as the second
+// gate so a no-op action (tool click that aborted) doesn't promote either.
 function _maybePromoteInterpolated(f,strokes){
-  if(f.isInterpolated&&!strokesEqual(strokes,f.strokes)){f.isKeyframe=true;f.isInterpolated=false;}
+  if(window._tweenFrameDirty&&f.isInterpolated&&!strokesEqual(strokes,f.strokes)){f.isKeyframe=true;f.isInterpolated=false;}
 }
 function saveActiveLayerFrame(){
   window._sceneVersion++;
@@ -1763,6 +1776,13 @@ function saveAllLayerFrames(){
 }
 function loadFrame(idx){
   window._sceneVersion++;
+  // See _maybePromoteInterpolated's own comment — loadFrame is the one
+  // choke point every frame navigation (scrub, playback, goToFrame) goes
+  // through, same reasoning as the SMReference hook right below. Cleared
+  // here so scrubbing OFF a frame never carries a stale "dirty" flag onto
+  // whatever gets saved on the way out; pushUndoLayers sets it fresh the
+  // moment a real action actually happens.
+  window._tweenFrameDirty=false;
   // Rotoscopy reference follows the playhead (video seek / sequence frame
   // pick) — loadFrame is the one choke point every frame change goes
   // through, scrub and playback alike.

--- a/src/js/tweens.js
+++ b/src/js/tweens.js
@@ -1729,7 +1729,17 @@ function layersSnapshotNow(){return{type:'layers',layers:JSON.parse(JSON.stringi
 // snapshot par tick aurait pollué la pile pour un seul geste. ui.js pousse
 // UN snapshot pré-geste au premier mouvement puis lève ce flag ; ici on
 // no-op tant qu'il est levé (y compris le 'change' final du release).
-function pushUndoLayers(){if(window._scrubLiveActive)return;saveAllLayerFrames();state.undoStack.push(layersSnapshotNow());if(state.undoStack.length>state.maxUndo)state.undoStack.shift();state.redoStack=[];if(window.SMFeedback)SMFeedback.logAction();}
+function pushUndoLayers(){if(window._scrubLiveActive)return;saveAllLayerFrames();state.undoStack.push(layersSnapshotNow());if(state.undoStack.length>state.maxUndo)state.undoStack.shift();state.redoStack=[];if(window.SMFeedback)SMFeedback.logAction();
+  // See _maybePromoteInterpolated's own comment (app.js) — this is the
+  // SAME choke point SMFeedback.logAction() right above already trusts as
+  // "a real content-mutating action happened" (its own doc comment: "only
+  // fires for actual content mutations"), reused here so a scrub-only
+  // save can never promote a tween frame no matter what future field
+  // desP()/serP() disagree on. Cleared by loadFrame the moment ANY frame
+  // finishes being left (this action's own save already ran above, before
+  // this line, so setting it here — for the NEXT save — is correct).
+  window._tweenFrameDirty=true;
+}
 function restoreLayersSnapshot(s){
   while(userLayers.length>0)userLayers.pop().remove();
   state.layers=[];


### PR DESCRIPTION
## Summary
Follow-up to the previous keyline-field fix — that closed one specific phantom-diff source, but the underlying design was fragile: `_maybePromoteInterpolated` promotes on ANY `strokesEqual()` disagreement, which depends on the serP→desP round-trip being byte-idempotent for every stroke type. Every new derived/defaulted field breaks that for one producer or another — a whack-a-mole, not a fix.

Structural fix: promotion now also requires `window._tweenFrameDirty`, set by `pushUndoLayers` (the same choke point the existing action-log already trusts as "a real mutation happened") and cleared by `loadFrame` (the one choke point every navigation goes through). Pure scrubbing can never promote a tween frame now, regardless of what future field disagrees.

## Test plan
- [x] 7-frame tween span (mixed stroke types) survives 5 full back-and-forth scrub passes, zero promotions.
- [x] A real edit still promotes correctly.
- [x] Undo still correctly reverts a promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)