### PR TITLE
Trust real pressure from pointerType:'mouse' devices

### DIFF
--- a/src/js/draw-bridge.js
+++ b/src/js/draw-bridge.js
@@ -195,6 +195,28 @@
       lastPenPressure = _stylus.force;
       return _stylus.force;
     }
+    // Some tablet drivers emulate a "pressure-sensitive mouse" instead of a
+    // proper HID pen device: confirmed live (2026-07, feedback "je perds la
+    // pression") — a real stylus whose EVERY pointerdown/move reported
+    // pointerType:'mouse', never 'pen', while e.pressure still carried
+    // genuine fine-grained analog values (0.007, 0.35, 0.6…), captured via
+    // a raw-event logger in the browser preview. The pointerType==='pen'
+    // gate above rejected all of it, silently degrading every stroke to
+    // the speed heuristic below. tools.js's own vbPressureOf (legacy
+    // Paper.js fallback) already guards this exact case correctly — a
+    // genuine plain mouse (no pressure hardware) is spec-mandated to
+    // report EXACTLY 0.5 while pressed, never anything else, so excluding
+    // just that one constant is enough to keep trusting a real mouse's
+    // absence of pressure without also rejecting a mislabeled real device.
+    // This bridge (the primary path whenever the Rust engine is on, i.e.
+    // almost always) never had this fallback — dropped during the C7
+    // cutover port from tools.js, the exact "duplicated pipeline drifted
+    // out of sync" failure this file's own header comment warns about.
+    if (typeof e.pressure === 'number' && e.pressure > 0 && e.pressure !== 0.5) {
+      lastPenPressure = Math.min(1, e.pressure);
+      return lastPenPressure;
+    }
+    if (lastPenPressure != null) return lastPenPressure;
     var now = Date.now();
     var dt = Math.max(8, now - (lastMoveT || now));
     lastMoveT = now;


### PR DESCRIPTION
## Summary
- Root cause of "je perds la pression" (browser preview): the user's tablet driver reports `pointerType:'mouse'` on every touch, never `'pen'`, but still carries genuine analog pressure in `e.pressure`. `draw-bridge.js`'s `pressureOf()` only trusted real pressure when `pointerType==='pen'`, so every stroke silently fell back to the speed heuristic (fake, non-pressure-driven width).
- `tools.js`'s legacy `vbPressureOf` already handles this correctly (`raw!==0.5`, no pointerType gate — a genuine plain mouse is spec-mandated to report exactly 0.5 while pressed). Mirrors that same fallback into `draw-bridge.js`, the primary path whenever the Rust engine is on (default).
- Ruled out Stabilizer as a cause first (code read + live A/B testing, Medium vs Off, both clean and jittery-hand simulated strokes) before finding the real culprit via a live raw pointer-event logger in the Browser pane.

## Test plan
- [x] Live-tested with the reporter's real tablet in the shared Browser pane: before the fix, `pointerdown` showed `pointerType:'mouse'` with real varying `pressure` (0.007–0.6) being ignored; after the fix + reload, the committed stroke's width profile tracks that same real pressure end to end (0.27 → 17 → 4.66)
- [x] Confirmed no regression for genuine plain mice (still only ever hit the speed fallback, since they never report a non-0.5 pressure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)