### PR TITLE
Add copy/cut/paste for canvas shapes (⌘C/⌘X/⌘V)

### DIFF
--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -1330,14 +1330,30 @@
       state.selectedStrokeIndices = selectedPaths.map(getSI).filter(function (i) { return i >= 0; });
       renderArcs(); updateUI(); window.SMEngineBridge.renderNow();
     }
-    if (!selectedPaths.length) return; // empty canvas — let the native menu show, nothing to act on yet
+    if (!selectedPaths.length) {
+      // Empty canvas: nothing to duplicate/delete, but a right-click here is
+      // still the standard place to offer Paste (2026-07, "vérifie que
+      // copier/couper/coller existe pour tous les éléments") — only shown
+      // when there's actually something in the canvas clipboard, otherwise
+      // fall through to the native menu exactly as before.
+      if (!(_canvasClip && _canvasClip.snaps && _canvasClip.snaps.length)) return;
+      e.preventDefault(); e.stopImmediatePropagation();
+      window.showContextMenu(e.clientX, e.clientY, [
+        { label: 'Coller', shortcut: '⌘V', action: function () { pasteSelection(); } },
+      ]);
+      return;
+    }
     e.preventDefault(); e.stopImmediatePropagation();
     var multi = selectedPaths.length > 1;
     var p0 = selectedPaths[0];
     var isDeleteGhost = !multi && p0.data && p0.data.isRevisionGhost && p0.data.revisionAction === 'delete';
     var isActiveRevision = !multi && p0.data && p0.data.revisionParentId && !p0.data.isRevisionGhost;
     var isGrouped = !multi && p0.data && p0.data.groupId;
+    var hasCanvasClip = !!(_canvasClip && _canvasClip.snaps && _canvasClip.snaps.length);
     var items = [
+      { label: 'Copier', shortcut: '⌘C', action: function () { copySelection(); } },
+      { label: 'Couper', shortcut: '⌘X', action: function () { cutSelection(); } },
+      { label: 'Coller', shortcut: '⌘V', disabled: !hasCanvasClip, action: function () { pasteSelection(); } },
       { label: 'Dupliquer', shortcut: '⌘D', action: function () { duplicateSelection(); } },
       { label: multi ? 'Supprimer la sélection' : 'Supprimer', shortcut: 'Suppr', action: function () { window.SM.deleteSelStrokes(); } },
       { sep: true },

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -781,6 +781,7 @@ window.SM={
       _sel.clipboard.push({rl:s.layer-b.minL,rf:s.frame-b.minF,content:JSON.parse(JSON.stringify(ld.frames[s.frame]))});
     });
     _sel.clipOp='copy';
+    if(typeof window!=='undefined')window._lastClipKind='frames';
     showToast('Copié ('+_sel.frames.length+' frames)');
   },
   cutFrames:function(){
@@ -796,6 +797,7 @@ window.SM={
       ld.frames[s.frame]={strokes:[],isKeyframe:false,isInterpolated:false};
     });
     _sel.clipOp='cut';
+    if(typeof window!=='undefined')window._lastClipKind='frames';
     selClear();loadFrame(state.currentFrame);renderOS();renderArcs();updateUI();
     showToast('Coupé ('+_sel.clipboard.length+' frames)');
   },
@@ -4512,9 +4514,24 @@ function onKeyDown(event){
   if(event.key==='Enter'&&event.target.tagName==='INPUT'){event.target.blur();return;}
   if((event.metaKey||event.ctrlKey)&&event.key==='z'){if(inField)return;event.preventDefault();if(event.shiftKey)redo();else undo();return;}
   if((event.metaKey||event.ctrlKey)&&event.key==='s'){event.preventDefault();if(event.shiftKey)window.SMProject.saveAs();else window.SMProject.save();return;}
-  if((event.metaKey||event.ctrlKey)&&event.key==='c'){if(inField)return;event.preventDefault();window.SM.copyFrames();return;}
-  if((event.metaKey||event.ctrlKey)&&event.key==='x'){if(inField)return;event.preventDefault();window.SM.cutFrames();return;}
-  if((event.metaKey||event.ctrlKey)&&event.key==='v'){if(inField)return;event.preventDefault();window.SM.pasteFrames();return;}
+  // ⌘C/⌘X/⌘V routes to whichever clipboard is relevant: a live canvas shape
+  // selection (selectedPaths, Select/Subselect tool) takes priority over a
+  // timeline keyframe-cell selection (_sel.frames) when BOTH happen to be
+  // non-empty — matches how ⌘D (duplicate, below) and Delete already treat
+  // a canvas selection as the more specific/intentional one. Paste has no
+  // "current selection" to disambiguate from, so it follows whichever
+  // clipboard was filled most recently (2026-07, "vérifie que copier/
+  // couper/coller existe pour tous les éléments... les keyframes" — canvas
+  // shapes had NO copy/cut/paste at all before this, only keyframes did).
+  if((event.metaKey||event.ctrlKey)&&event.key==='c'){if(inField)return;event.preventDefault();if(selectedPaths.length)copySelection();else window.SM.copyFrames();return;}
+  if((event.metaKey||event.ctrlKey)&&event.key==='x'){if(inField)return;event.preventDefault();if(selectedPaths.length)cutSelection();else window.SM.cutFrames();return;}
+  if((event.metaKey||event.ctrlKey)&&event.key==='v'){if(inField)return;event.preventDefault();
+    if(window._lastClipKind==='canvas'&&_canvasClip&&_canvasClip.snaps.length)pasteSelection();
+    else if(window._lastClipKind==='frames'&&_sel.clipboard&&_sel.clipboard.length)window.SM.pasteFrames();
+    else if(_canvasClip&&_canvasClip.snaps.length)pasteSelection();
+    else window.SM.pasteFrames();
+    return;
+  }
   // UI/UX audit (2026-07): Ctrl/Cmd+A "select all" existed nowhere in the
   // app — a near-universal convention in every creative tool. Selects
   // every path/raster on the ACTIVE layer at the current frame, mirroring

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -1005,15 +1005,37 @@ function getSI(path){var ch=userLayers[state.activeLayerIdx].children;for(var i=
 // by hand — it's the one code path already proven to correctly carry
 // every field (fill, vector-brush centerline, brush-texture flags...)
 // through a rebuild, so this doesn't need to re-solve that.
-function duplicateSelection(){
-  if(!selectedPaths.length)return;
-  pushUndo();
-  var layer=userLayers[state.activeLayerIdx];
-  var OFFSET=12; // px — small, deliberate nudge so the copy doesn't sit invisibly on top of the source
+// Snapshot a LIVE path into plain data a clone can be rebuilt from later —
+// possibly much later, on a different frame/layer than the source ever
+// existed on (copySelection/pasteSelection below). Captures the two things
+// serP() alone can't round-trip because they're live object references
+// (data.linkedFill, data.brushCompanions), same reasoning as app.js's own
+// linkedFillId/brushGroupId comments. Returns null for a dab (isBrushTextureCopy)
+// — it rides along with its anchor via the anchor's own snapshot, never a
+// primary target itself.
+function _snapshotForClone(p){
+  if(p.data&&p.data.isBrushTextureCopy)return null;
+  var snap={d:serP(p)};
+  if(p.data&&p.data.isVectorBrush&&p.data.linkedFill&&!p.data.linkedFill.removed){
+    snap.vbLinkedFill={fillColor:p.data.linkedFill.fillColor,opacity:p.data.linkedFill.opacity};
+  }
+  if(p.data&&p.data.brushGroupId){
+    snap.dabs=(p.data.brushCompanions||[]).filter(function(dab){return dab&&!dab.removed;}).map(serP);
+  }
+  return snap;
+}
+// Rebuild live Path clones from _snapshotForClone() output into `layer`,
+// offset by `offset` px on both axes (0 = paste exactly in place). Shared by
+// duplicateSelection (snapshots taken and materialized in the same call) and
+// copySelection/pasteSelection (snapshots persisted in between, possibly
+// across a frame/layer change) — a single code path so brush-texture dabs
+// and vector-brush fill backdrops can't drift out of sync between the two
+// features (see CLAUDE.md §1's "family of bug #1").
+function _materializeClones(snaps,layer,offset){
   var clones=[];
   // Brush-texture anchors share a brushGroupId with their dab companions
   // (tools.js applyBrushTexture / app.js relinkBrushCompanions) — every
-  // duplicated member of a group must land on the SAME fresh id, or
+  // cloned member of a group must land on the SAME fresh id, or
   // relinkBrushCompanions can't tell the new anchor and its new dabs
   // apart from the originals.
   var groupIdMap={};
@@ -1021,27 +1043,26 @@ function duplicateSelection(){
     if(!groupIdMap[oldGid])groupIdMap[oldGid]='bg_'+Date.now()+'_'+Math.floor(Math.random()*1e6)+'_'+Object.keys(groupIdMap).length;
     return groupIdMap[oldGid];
   }
-  selectedPaths.forEach(function(p){
-    if(p.data&&p.data.isBrushTextureCopy)return; // dabs ride along with their anchor below, never duplicated as a primary target themselves
-    var d=serP(p);
+  snaps.forEach(function(snap){
+    var d=JSON.parse(JSON.stringify(snap.d));
     d.strokeId=undefined; // fresh identity below — must NOT alias the source's
     if(d.brushGroupId)d.brushGroupId=freshGroupId(d.brushGroupId);
     var clone=desP(d,layer,d.opacity);
-    clone.translate(new Point(OFFSET,OFFSET));
+    if(offset)clone.translate(new Point(offset,offset));
     ensureStrokeId(clone);
-    if(p.data&&p.data.isVectorBrush&&p.data.centerSegments){
-      clone.data.centerSegments=JSON.parse(JSON.stringify(p.data.centerSegments)).map(function(s){s.point[0]+=OFFSET;s.point[1]+=OFFSET;return s;});
+    if(d.isVectorBrush&&d.centerSegments){
+      clone.data.centerSegments=JSON.parse(JSON.stringify(d.centerSegments)).map(function(s){if(offset){s.point[0]+=offset;s.point[1]+=offset;}return s;});
       // Vector-brush fill backdrop (draw-bridge.js) — regenerated from the
       // (now-offset) centerline via the same rebuild every other edit to
       // this stroke type already goes through, rather than hand-cloning
       // its geometry.
-      if(p.data.linkedFill&&!p.data.linkedFill.removed){
-        var fillClone=new Path();fillClone.fillColor=p.data.linkedFill.fillColor;fillClone.strokeColor=null;fillClone.opacity=p.data.linkedFill.opacity;
+      if(snap.vbLinkedFill){
+        var fillClone=new Path();fillClone.fillColor=snap.vbLinkedFill.fillColor;fillClone.strokeColor=null;fillClone.opacity=snap.vbLinkedFill.opacity;
         fillClone.insertBelow(clone);
         clone.data.linkedFill=fillClone;
         // Fresh stable id pair (see draw-bridge.js's own comment) — must NOT
         // reuse the source's linkedFillId, same reasoning as strokeId a few
-        // lines up (freshly-duplicated content is a distinct stroke).
+        // lines up (freshly-cloned content is a distinct stroke).
         clone.data.linkedFillId=ensureStrokeId({data:{}});
         fillClone.data.isLinkedFillCompanion=true;
         fillClone.data.linkedFillId=clone.data.linkedFillId;
@@ -1050,28 +1071,75 @@ function duplicateSelection(){
     }
     clones.push(clone);
   });
-  // Dabs of any duplicated brush-texture anchor — cloned the same way,
-  // tagged with the anchor's fresh group id, so relinkBrushCompanions can
-  // regroup them below exactly like it does after a normal frame load.
-  selectedPaths.forEach(function(p){
-    if(!p.data||!p.data.brushGroupId||p.data.isBrushTextureCopy)return;
-    var newGid=groupIdMap[p.data.brushGroupId];if(!newGid)return;
-    (p.data.brushCompanions||[]).forEach(function(dab){
-      if(!dab||dab.removed)return;
-      var dd=serP(dab);
+  // Dabs of any cloned brush-texture anchor — cloned the same way, tagged
+  // with the anchor's fresh group id, so relinkBrushCompanions can regroup
+  // them below exactly like it does after a normal frame load.
+  snaps.forEach(function(snap){
+    if(!snap.dabs||!snap.dabs.length)return;
+    var newGid=groupIdMap[snap.d.brushGroupId];if(!newGid)return;
+    snap.dabs.forEach(function(dabD){
+      var dd=JSON.parse(JSON.stringify(dabD));
       dd.brushGroupId=newGid;
       var dabClone=desP(dd,layer,dd.opacity);
-      dabClone.translate(new Point(OFFSET,OFFSET));
+      if(offset)dabClone.translate(new Point(offset,offset));
       clones.push(dabClone);
     });
   });
   if(typeof relinkBrushCompanions==='function')relinkBrushCompanions(layer);
   if(typeof fillRegenerateLinked==='function')fillRegenerateLinked(layer,null);
+  return clones;
+}
+function duplicateSelection(){
+  if(!selectedPaths.length)return;
+  pushUndo();
+  var layer=userLayers[state.activeLayerIdx];
+  var snaps=selectedPaths.map(_snapshotForClone).filter(Boolean);
+  var clones=_materializeClones(snaps,layer,12); // px — small, deliberate nudge so the copy doesn't sit invisibly on top of the source
   clearSel();
   selectedPaths=clones.filter(function(c){return!(c.data&&c.data.isBrushTextureCopy);});
   state.selectedStrokeIndices=selectedPaths.map(getSI).filter(function(i2){return i2>=0;});
   saveActiveLayerFrame();renderArcs();updateUI();
   if(window.SMEngineBridge)SMEngineBridge.renderNow();
+}
+// ---- CANVAS ELEMENT COPY / CUT / PASTE (2026-07) ----
+// UI/UX audit: ⌘C/⌘X/⌘V existed ONLY for timeline keyframes (copyFrames/
+// cutFrames/pasteFrames, timeline.js) — there was no way to copy a shape
+// selection at all, only duplicateSelection's immediate in-place clone
+// (⌘D). Built on the same _snapshotForClone/_materializeClones pair so a
+// brush-textured or linked-fill stroke behaves identically whether it's
+// duplicated, copied, or cut — one clone path, not two that can drift
+// apart (see CLAUDE.md §1). The clipboard remembers WHERE it was copied
+// from so pasteSelection can tell "same frame" (offset, so the paste is
+// visibly distinct from the source, matching duplicateSelection) from
+// "different frame/layer" (paste exactly in place — there's no source
+// directly underneath to be confused with).
+var _canvasClip=null; // {snaps, layerIdx, frameIdx}
+function copySelection(){
+  if(!selectedPaths.length)return;
+  var snaps=selectedPaths.map(_snapshotForClone).filter(Boolean);
+  if(!snaps.length)return;
+  _canvasClip={snaps:snaps,layerIdx:state.activeLayerIdx,frameIdx:state.currentFrame};
+  if(typeof window!=='undefined')window._lastClipKind='canvas';
+  showToast('Copié ('+snaps.length+')');
+}
+function cutSelection(){
+  if(!selectedPaths.length)return;
+  copySelection();
+  window.SM.deleteSelStrokes(); // pushes its own undo entry
+  showToast('Coupé ('+_canvasClip.snaps.length+')');
+}
+function pasteSelection(){
+  if(!_canvasClip||!_canvasClip.snaps.length){showToast('Rien à coller');return;}
+  pushUndo();
+  var layer=userLayers[state.activeLayerIdx];
+  var samePlace=(_canvasClip.layerIdx===state.activeLayerIdx&&_canvasClip.frameIdx===state.currentFrame);
+  var clones=_materializeClones(_canvasClip.snaps,layer,samePlace?12:0);
+  clearSel();
+  selectedPaths=clones.filter(function(c){return!(c.data&&c.data.isBrushTextureCopy);});
+  state.selectedStrokeIndices=selectedPaths.map(getSI).filter(function(i2){return i2>=0;});
+  saveActiveLayerFrame();renderArcs();updateUI();
+  if(window.SMEngineBridge)SMEngineBridge.renderNow();
+  showToast('Collé ('+clones.filter(function(c){return!(c.data&&c.data.isBrushTextureCopy);}).length+')');
 }
 var canvasEl=document.getElementById('drawing-canvas');
 


### PR DESCRIPTION
## Summary
- Canvas shape selections had no copy/cut/paste — only keyframes did (timeline.js). ⌘D (duplicate) existed but can't carry a shape to a different frame/layer.
- Refactors duplicateSelection's clone logic into shared `_snapshotForClone`/`_materializeClones` helpers, reused by the new `copySelection`/`cutSelection`/`pasteSelection` — one clone path for brush-texture dabs and vector-brush linked fills instead of two that could drift apart.
- ⌘C/⌘X prefer the canvas clipboard when a shape selection is active, else fall back to the existing frame clipboard; ⌘V pastes from whichever was filled most recently.
- Right-click menu: Copier/Couper/Coller added alongside Dupliquer/Supprimer, plus a Coller-only menu on empty-canvas right-click.

## Test plan
- [x] Cross-frame paste lands at the exact source position (no unwanted offset)
- [x] Same-frame paste offsets +12/+12 (matches duplicate's nudge)
- [x] Cut removes the stroke; undo restores it; clipboard still has the cut content after undo
- [x] Keyboard routing: ⌘C/⌘X/⌘V dispatch to canvas clipboard with a shape selection, frame clipboard otherwise
- [x] Fresh strokeId/brushGroupId/linkedFillId on every paste (no aliasing with the source)
- [x] Right-click context menu renders Copier/Couper/Coller correctly