### PR TITLE
motion: fix the default ease, add the AE keyboard layer

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -112,7 +112,200 @@
   // widget/model the Tween feature already has, just scoped per motion
   // segment instead of one curve applying everywhere. See CLAUDE.md §3 on
   // why this stays a small separate copy rather than a shared import. ----
-  var DEFAULT_CURVE = [{ x: 0, y: 0 }, { x: 0.42, y: 0 }, { x: 0.58, y: 1 }, { x: 1, y: 1 }];
+  // Every motion keyframe's default ease. These are ON-CURVE WAYPOINTS (the
+  // model this file and ui.js share — see MOTION_DEFAULT_CURVE's comment
+  // there), NOT bezier control handles.
+  //
+  // That distinction was the bug (2026-07-25). The old value was
+  // [{0,0},{.42,0},{.58,1},{1,1}] — the four numbers of CSS
+  // `cubic-bezier(.42,0,.58,1)`, i.e. `ease-in-out`, where .42/.58 are
+  // CONTROL HANDLES the curve merely leans toward. Fed to evalCurvePoints as
+  // waypoints, they became points the curve is forced THROUGH: pinned to 0
+  // until 42% of the segment and to 1 from 58% on. Measured on two position
+  // keys 12 frames apart, x going 40 -> 120:
+  //
+  //   legacy       40 40 40 40 40 40 80 120 120 120 120 120 120
+  //   linear       40 47 53 60 67 73 80  87  93 100 107 113 120
+  //   this curve   40 43 47 52 61 70 80  90  99 108 113 117 120
+  //
+  // Every default keyframe pair in Motion held still, snapped across in two
+  // frames, and held still again — a step, not an ease.
+  //
+  // Same intent as before (a gentle ease-in-out), expressed correctly for
+  // this model: these are the samples of smoothstep 3t^2-2t^3 at quarter
+  // points, so the waypoint interpretation reproduces the curve that was
+  // meant all along. Legacy keys carrying the exact old array are rewritten
+  // by migrateLegacyCurves below.
+  var DEFAULT_CURVE = [{ x: 0, y: 0 }, { x: 0.25, y: 0.156 }, { x: 0.5, y: 0.5 }, { x: 0.75, y: 0.844 }, { x: 1, y: 1 }];
+  var LEGACY_STEP_CURVE = [{ x: 0, y: 0 }, { x: 0.42, y: 0 }, { x: 0.58, y: 1 }, { x: 1, y: 1 }];
+  // A key still carrying the broken default bit-for-bit was never touched by
+  // hand, so replacing it restores the intended motion without overwriting
+  // any real edit. Anything dragged even slightly fails the equality test and
+  // is left exactly as the user tuned it.
+  function isLegacyStepCurve(pts) {
+    if (!pts || pts.length !== LEGACY_STEP_CURVE.length) return false;
+    for (var i = 0; i < pts.length; i++) {
+      if (typeof pts[i].tx === 'number') return false; // hand-dragged tangent
+      if (Math.abs(pts[i].x - LEGACY_STEP_CURVE[i].x) > 1e-9) return false;
+      if (Math.abs(pts[i].y - LEGACY_STEP_CURVE[i].y) > 1e-9) return false;
+    }
+    return true;
+  }
+  // ---- keyframe interpolation presets (After Effects parity) ----
+  // All three are expressed in the same on-curve-waypoint model as
+  // DEFAULT_CURVE, so they round-trip through the existing ease editor and
+  // through save/load with no new field. LINEAR is two waypoints (constant
+  // velocity); EASE_BOTH is the smoothstep default; the one-sided pair eases
+  // only the end it names and stays straight at the other, which is what AE's
+  // Easy Ease In / Easy Ease Out do.
+  var CURVE_LINEAR = [{ x: 0, y: 0 }, { x: 1, y: 1 }];
+  // F9's ease is deliberately STRONGER than DEFAULT_CURVE. AE can make Easy
+  // Ease identical to "the ease" because its own default is linear, so F9
+  // always changes something. This app's default is already a gentle
+  // ease-in-out (the original intent, kept), so an F9 that applied the same
+  // shape would be a silent no-op on every fresh keyframe — which is exactly
+  // how it first tested. A more pronounced curve keeps F9 meaningful and
+  // still reads as "ease this", matching AE's own fairly strong 33% influence.
+  var CURVE_EASE = [{ x: 0, y: 0 }, { x: 0.25, y: 0.09 }, { x: 0.5, y: 0.5 }, { x: 0.75, y: 0.91 }, { x: 1, y: 1 }];
+  // One-sided: straight through the half it does not name, eased at the half
+  // it does. easeIn decelerates ARRIVING at the key, easeOut accelerates
+  // leaving it — AE's Easy Ease In / Easy Ease Out.
+  var CURVE_EASE_IN = [{ x: 0, y: 0 }, { x: 0.25, y: 0.25 }, { x: 0.5, y: 0.5 }, { x: 0.75, y: 0.91 }, { x: 1, y: 1 }];
+  var CURVE_EASE_OUT = [{ x: 0, y: 0 }, { x: 0.25, y: 0.09 }, { x: 0.5, y: 0.5 }, { x: 0.75, y: 0.75 }, { x: 1, y: 1 }];
+  // A key's curvePoints govern the segment LEAVING it (valueAtFrame reads the
+  // left key's curve), so "ease at this key" means: ease the outgoing segment,
+  // and ease the incoming one by touching the previous key's curve. Applying
+  // to both is what makes F9 on a middle key feel symmetric, exactly as in AE.
+  function prevKeyOf(track, key) {
+    var i = track.keys.indexOf(key);
+    return i > 0 ? track.keys[i - 1] : null;
+  }
+  function applyCurveToSelection(kind) {
+    var sel = _motionKeySel;
+    if (!sel || !sel.length) return 0;
+    pushUndo();
+    var n = 0;
+    sel.forEach(function (s) {
+      var track = s.holder && s.holder.motion && s.holder.motion[s.prop];
+      if (!track) return;
+      if (kind === 'hold') { s.key.hold = !s.key.hold; n++; return; }
+      var outPts = kind === 'linear' ? CURVE_LINEAR : (kind === 'easeIn' ? CURVE_EASE_IN : (kind === 'easeOut' ? CURVE_EASE_OUT : CURVE_EASE));
+      // easeIn shapes the segment ARRIVING at this key, so it belongs on the
+      // previous key; the others shape the outgoing segment.
+      if (kind === 'easeIn') {
+        var pk = prevKeyOf(track, s.key);
+        if (pk) { pk.curvePoints = cloneCurvePts(CURVE_EASE_IN); n++; }
+      } else if (kind === 'easeOut') {
+        s.key.curvePoints = cloneCurvePts(CURVE_EASE_OUT); n++;
+      } else {
+        s.key.curvePoints = cloneCurvePts(outPts);
+        var pk2 = prevKeyOf(track, s.key);
+        if (pk2) pk2.curvePoints = cloneCurvePts(outPts);
+        n++;
+      }
+    });
+    if (n) { renderLayerList(); renderTimeline(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow(); }
+    return n;
+  }
+  function setKeyInterp(kind) { return applyCurveToSelection(kind); }
+  function applyEasyEase(which) { return applyCurveToSelection(which || 'ease'); }
+  // Shift every selected keyframe in time. Guards the whole move against
+  // collisions and against running off frame 0 BEFORE applying any of it, so a
+  // nudge either happens for the whole selection or not at all — a partial
+  // shift would silently change the spacing the user was preserving.
+  function nudgeSelectedKeys(delta) {
+    var sel = _motionKeySel;
+    if (!sel || !sel.length || !delta) return 0;
+    var groups = {};
+    sel.forEach(function (s) {
+      var track = s.holder && s.holder.motion && s.holder.motion[s.prop];
+      if (!track) return;
+      var id = (s.holder.uid || state.layers.indexOf(s.holder)) + '|' + s.prop;
+      (groups[id] || (groups[id] = { track: track, keys: [] })).keys.push(s.key);
+    });
+    var ok = true;
+    Object.keys(groups).forEach(function (id) {
+      var g = groups[id];
+      g.keys.forEach(function (k) {
+        var nf = k.frame + delta;
+        if (nf < 0 || nf > state.totalFrames - 1) ok = false;
+        var occupant = g.track.keys.find(function (o) { return o.frame === nf; });
+        if (occupant && g.keys.indexOf(occupant) < 0) ok = false;
+      });
+    });
+    if (!ok) return 0;
+    pushUndo();
+    var n = 0;
+    Object.keys(groups).forEach(function (id) {
+      var g = groups[id];
+      g.keys.forEach(function (k) { k.frame += delta; n++; });
+      sortKeys(g.track);
+    });
+    renderLayerList(); renderTimeline();
+    if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+    return n;
+  }
+  function deleteSelectedKeys() {
+    var sel = _motionKeySel;
+    if (!sel || !sel.length) return 0;
+    pushUndo();
+    var n = 0;
+    sel.forEach(function (s) {
+      var track = s.holder && s.holder.motion && s.holder.motion[s.prop];
+      if (!track) return;
+      var i = track.keys.indexOf(s.key);
+      if (i >= 0) { track.keys.splice(i, 1); n++; }
+    });
+    if (n) { setKeySel([]); renderLayerList(); renderTimeline(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow(); }
+    return n;
+  }
+  // Copy/paste keeps frames RELATIVE to the earliest key copied, so pasting at
+  // the playhead reproduces the selection's own rhythm wherever it lands —
+  // AE's behaviour, and the reason this stores offsets rather than frames.
+  var _keyClip = null;
+  function copySelectedKeys() {
+    var sel = _motionKeySel;
+    if (!sel || !sel.length) return 0;
+    var base = Math.min.apply(null, sel.map(function (s) { return s.key.frame; }));
+    _keyClip = sel.map(function (s) {
+      return { prop: s.prop, dt: s.key.frame - base, v: s.key.v.slice(), hold: !!s.key.hold, curvePoints: cloneCurvePts(s.key.curvePoints || DEFAULT_CURVE) };
+    });
+    return _keyClip.length;
+  }
+  function pasteKeys() {
+    if (!_keyClip || !_keyClip.length) return 0;
+    var ld = state.layers[state.activeLayerIdx];
+    if (!ld) return 0;
+    pushUndo();
+    var n = 0;
+    _keyClip.forEach(function (c) {
+      var f = state.currentFrame + c.dt;
+      if (f < 0 || f > state.totalFrames - 1) return;
+      var track = ensureTrack(ld, c.prop);
+      var ex = track.keys.find(function (k) { return k.frame === f; });
+      if (ex) { ex.v = c.v.slice(); ex.hold = c.hold; ex.curvePoints = cloneCurvePts(c.curvePoints); }
+      else track.keys.push({ frame: f, v: c.v.slice(), hold: c.hold, curvePoints: cloneCurvePts(c.curvePoints), hOut: [0, 0], hIn: [0, 0] });
+      sortKeys(track); n++;
+    });
+    if (n) { renderLayerList(); renderTimeline(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow(); }
+    return n;
+  }
+  function hasKeySelection() { return !!(_motionKeySel && _motionKeySel.length); }
+  function hasKeyClipboard() { return !!(_keyClip && _keyClip.length); }
+  function migrateLegacyCurves() {
+    var n = 0;
+    (state.layers || []).forEach(function (ld) {
+      if (!ld || !ld.motion) return;
+      Object.keys(ld.motion).forEach(function (prop) {
+        var trk = ld.motion[prop];
+        if (!trk || !trk.keys) return;
+        trk.keys.forEach(function (k) {
+          if (isLegacyStepCurve(k.curvePoints)) { k.curvePoints = cloneCurvePts(DEFAULT_CURVE); n++; }
+        });
+      });
+    });
+    return n;
+  }
   // tx/ty preserved: a point's manual tangent override (draggable Alt-
   // handles in the shared curve editor, ui.js) — stripping them here
   // reset hand-tuned tangents on every key clone.
@@ -2129,6 +2322,19 @@
             // reached. Renders as a square (see the .hold class above).
             menu.push({ label: key.hold ? 'Retirer le maintien (hold)' : 'Maintenir (hold)', action: function () { pushUndo(); key.hold = !key.hold; renderLayerList(); renderTimeline(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow(); } });
           }
+          // Interpolation presets, mirroring the keyboard layer added
+          // alongside them (timeline.js onKeyDown) so neither is the only way
+          // in — the keyboard is faster once known, the menu is how it gets
+          // known. They act on the whole selection, so right-clicking a key
+          // that isn't selected yet selects it first (the mousedown handler
+          // above already did that by the time this fires).
+          if (_motionKeySel.length) {
+            menu.push({ sep: true });
+            menu.push({ label: 'Easy Ease  (F9)', action: function () { applyEasyEase('ease'); } });
+            menu.push({ label: 'Easy Ease In  (Maj+F9)', action: function () { applyEasyEase('easeIn'); } });
+            menu.push({ label: 'Easy Ease Out  (Cmd+Maj+F9)', action: function () { applyEasyEase('easeOut'); } });
+            menu.push({ label: 'Linéaire  (Cmd+Alt+K)', action: function () { setKeyInterp('linear'); } });
+          }
           // Batch ops act on the WHOLE current multi-selection, offered
           // regardless of which key/cell was right-clicked. No Align here
           // (unlike layer bars) — a keyframe has no duration, "align"
@@ -2830,5 +3036,14 @@
     // changed; the panel's scrub field too, if the playhead sits inside
     // the segment being reshaped.
     onEaseSegChanged: function () { renderLayerList(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow(); },
+    migrateLegacyCurves: migrateLegacyCurves,
+    setKeyInterp: setKeyInterp,
+    applyEasyEase: applyEasyEase,
+    nudgeSelectedKeys: nudgeSelectedKeys,
+    deleteSelectedKeys: deleteSelectedKeys,
+    copySelectedKeys: copySelectedKeys,
+    pasteKeys: pasteKeys,
+    hasKeySelection: hasKeySelection,
+    hasKeyClipboard: hasKeyClipboard,
   };
 })();

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1204,6 +1204,10 @@ window.SM={
     state.symmetryEnabled=d.symmetryEnabled||false;state.symmetryMode=d.symmetryMode||'y';state.symmetryAxis=d.symmetryAxis||null;state.symmetryRadialCenter=d.symmetryRadialCenter||null;state.symmetryRadialSectors=d.symmetryRadialSectors||6;state.symmetryExtend=d.symmetryExtend!==undefined?d.symmetryExtend:true;
     if(window.renderPaletteGrid)window.renderPaletteGrid();
     if(d.resamplePts)state.resamplePts=d.resamplePts;if(d.tweenStep)state.tweenStep=d.tweenStep;
+    // Repair motion keyframes saved with the step-shaped default ease before
+    // 2026-07-25 — see DEFAULT_CURVE in motion.js. Only keys still carrying
+    // that exact array are touched, so a hand-tuned curve is never rewritten.
+    if(window.SMMotion&&SMMotion.migrateLegacyCurves)SMMotion.migrateLegacyCurves();
     state.currentFrame=0;state.activeLayerIdx=0;activateUL(0);drawStage();loadFrame(0);renderOS();renderArcs();updateUI();renderSymbolTabs();
     syncDocFields();
     if(!silent)showToast('Projet chargé');}catch(e){showToast('Erreur: '+e.message);}},
@@ -4529,9 +4533,16 @@ function onKeyDown(event){
   // clipboard was filled most recently (2026-07, "vérifie que copier/
   // couper/coller existe pour tous les éléments... les keyframes" — canvas
   // shapes had NO copy/cut/paste at all before this, only keyframes did).
-  if((event.metaKey||event.ctrlKey)&&event.key==='c'){if(inField)return;event.preventDefault();if(selectedPaths.length)copySelection();else window.SM.copyFrames();return;}
+  // A Motion keyframe selection is the most specific thing ⌘C can mean, so it
+  // wins over shapes and frame cells — same "more specific selection wins"
+  // rule the shape-vs-frame split below already follows. Gated on there BEING
+  // a keyframe selection, so ⌘C is unchanged everywhere else.
+  if((event.metaKey||event.ctrlKey)&&event.key==='c'){if(inField)return;event.preventDefault();
+    if(state.appMode==='motion'&&window.SMMotion&&SMMotion.hasKeySelection&&SMMotion.hasKeySelection()){SMMotion.copySelectedKeys();return;}
+    if(selectedPaths.length)copySelection();else window.SM.copyFrames();return;}
   if((event.metaKey||event.ctrlKey)&&event.key==='x'){if(inField)return;event.preventDefault();if(selectedPaths.length)cutSelection();else window.SM.cutFrames();return;}
   if((event.metaKey||event.ctrlKey)&&event.key==='v'){if(inField)return;event.preventDefault();
+    if(state.appMode==='motion'&&window.SMMotion&&SMMotion.hasKeyClipboard&&SMMotion.hasKeyClipboard()){SMMotion.pasteKeys();return;}
     if(window._lastClipKind==='canvas'&&_canvasClip&&_canvasClip.snaps.length)pasteSelection();
     else if(window._lastClipKind==='frames'&&_sel.clipboard&&_sel.clipboard.length)window.SM.pasteFrames();
     else if(_canvasClip&&_canvasClip.snaps.length)pasteSelection();
@@ -4644,6 +4655,33 @@ function onKeyDown(event){
   // ('u' is otherwise bound to the Line tool, TOOL_SHORTCUTS) — only inside
   // Motion mode, the Line tool shortcut is untouched everywhere else.
   if((k==='u'||k==='U')&&state.appMode==='motion'&&window.SMMotion&&SMMotion.revealAnimated()){event.preventDefault();return;}
+  // ---- Motion keyframe keyboard layer (2026-07-25) ----
+  // The Motion timeline already had drag-retime, marquee multi-select, hold,
+  // distribute/flip/select-every-2nd and a per-segment ease editor — but every
+  // one of them was reachable ONLY by right-click. After Effects is
+  // keyboard-first for exactly these operations, which is most of what "a real
+  // AE timeline" means in daily use, so they get the AE bindings here.
+  //
+  // Every branch is gated on an actual keyframe selection, so with nothing
+  // selected these keys keep their existing meanings untouched — Delete still
+  // deletes canvas objects, arrows still step the playhead, Cmd+C/V still route
+  // to shapes or frame cells.
+  if(state.appMode==='motion'&&window.SMMotion&&SMMotion.hasKeySelection&&SMMotion.hasKeySelection()){
+    // F9 / Shift+F9 / Cmd+Shift+F9 — Easy Ease, Easy Ease In, Easy Ease Out.
+    if(k==='F9'){event.preventDefault();SMMotion.applyEasyEase(event.shiftKey?((event.metaKey||event.ctrlKey)?'easeOut':'easeIn'):'ease');return;}
+    // Ctrl/Cmd+Alt+K — linear (AE has no single default binding for this; K is
+    // free here and reads as "keyframe interpolation").
+    if((event.metaKey||event.ctrlKey)&&event.altKey&&(k==='k'||k==='K')){event.preventDefault();SMMotion.setKeyInterp('linear');return;}
+    // Ctrl/Cmd+Alt+H — toggle hold, AE's own binding.
+    if((event.metaKey||event.ctrlKey)&&event.altKey&&(k==='h'||k==='H')){event.preventDefault();SMMotion.setKeyInterp('hold');return;}
+    if(k==='Delete'||k==='Backspace'){event.preventDefault();SMMotion.deleteSelectedKeys();return;}
+    // Alt+Left/Right nudges the SELECTED KEYS in time; bare arrows keep moving
+    // the playhead, which is the distinction AE draws too.
+    if(event.altKey&&(k==='ArrowLeft'||k==='ArrowRight')){event.preventDefault();SMMotion.nudgeSelectedKeys(k==='ArrowRight'?1:-1);return;}
+    // ⌘C/⌘V are claimed much earlier in this handler (they must be, to sit
+    // alongside the shape and frame-cell clipboards) — the Motion branch lives
+    // there, not here.
+  }
   // AE's B/N — "Set Work Area Start/End" at the current frame. See the
   // _pointerOverTimeline comment above this function for why this is
   // hover-scoped rather than global (unlike real AE, these letters are

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -44,7 +44,10 @@
   // with camera mode (editMotionSeg/editCameraSeg each clear the other).
   var motionEaseSeg=null,motionEaseLabel='';
   function isMotionMode(){return !!motionEaseSeg;}
-  var MOTION_DEFAULT_CURVE=[{x:0,y:0},{x:.42,y:0},{x:.58,y:1},{x:1,y:1}];
+  // MUST stay identical to DEFAULT_CURVE in motion.js (CLAUDE.md §3 duplicate
+  // pair) — see that copy for why the old CSS-cubic-bezier numbers produced a
+  // step instead of an ease once read as on-curve waypoints.
+  var MOTION_DEFAULT_CURVE=[{x:0,y:0},{x:.25,y:.156},{x:.5,y:.5},{x:.75,y:.844},{x:1,y:1}];
   function motionCurve(){return motionEaseSeg.curvePoints||(motionEaseSeg.curvePoints=clonePts(MOTION_DEFAULT_CURVE));}
   // Brush pressure-response curve (2026-07 — audit gap "aucun éditeur de
   // courbe de pression dédié"): same on-curve-waypoint model as the other


### PR DESCRIPTION
Deux choses, trouvées en **pilotant** la timeline Motion plutôt qu'en la lisant.

## 1. L'ease par défaut des clés était un escalier, pas un ease

`DEFAULT_CURVE` valait `[{0,0},{.42,0},{.58,1},{1,1}]` — les quatre nombres du `cubic-bezier(.42,0,.58,1)` CSS, c'est-à-dire `ease-in-out`, où `.42`/`.58` sont des **poignées de contrôle** vers lesquelles la courbe se penche.

Mais le modèle de courbe de ce codebase est un modèle de **nœuds sur la courbe** — `ui.js` le dit explicitement, et son défaut de pression `[{0,0},{1,1}]` est écrit correctement pour ce modèle. Lus comme des nœuds, ces nombres **épinglent** la valeur à 0 jusqu'à 42% du segment et à 1 dès 58%.

Mesuré sur deux clés de position distantes de 12 frames, x allant de 0 à 120 :

| | valeurs |
|---|---|
| **legacy** | `0 0 0 0 0 0 60 120 120 120 120 120 120` |
| linéaire | `0 10 20 30 40 50 60 70 80 90 100 110 120` |
| **corrigé** | `0 5 11 19 31 45 60 75 89 101 109 115 120` |

Chaque paire de clés par défaut dans Motion restait immobile, sautait en deux frames, puis restait immobile.

Corrigé en exprimant **la même intention** (un ease-in-out doux) correctement pour ce modèle : les échantillons de `smoothstep 3t²−2t³` aux quarts.

`migrateLegacyCurves` répare les projets existants au chargement, mais **uniquement** les clés portant le tableau cassé au bit près — toute courbe déplacée ne serait-ce qu'un peu, ou portant une tangente manuelle, échoue au test d'égalité et reste exactement telle que réglée. Vérifié : 1 clé sur 2 migrée, celle réglée à la main intacte.

## 2. La timeline était clic-droit uniquement

Retiming par glisser, sélection multiple au marquee, hold, distribuer/flip/1-sur-2 et l'éditeur d'ease par segment existaient **déjà** — mais aucun n'avait de touche. After Effects est clavier-first précisément sur ces opérations, ce qui constitue l'essentiel de « une vraie timeline à la After Effects » à l'usage.

| raccourci | action |
|---|---|
| `F9` / `Maj+F9` / `Cmd+Maj+F9` | Easy Ease / Ease In / Ease Out |
| `Cmd+Alt+K` | linéaire |
| `Cmd+Alt+H` | bascule hold *(le raccourci d'AE)* |
| `Suppr` / `Retour` | supprimer les clés sélectionnées |
| `Alt+←` / `Alt+→` | décaler les clés dans le temps |
| `Cmd+C` / `Cmd+V` | copier, coller à la tête de lecture |

### Pourquoi F9 est plus marqué que le défaut

AE peut donner la même forme aux deux parce que **son** défaut est linéaire — F9 fait donc toujours quelque chose. Ici le défaut est déjà un ease, et un F9 appliquant cette même forme était un **no-op silencieux** sur toute clé fraîche — c'est exactement comme ça qu'il a testé la première fois. Après correction, défaut / F9 / linéaire donnent trois courbes visiblement distinctes.

## Rien n'est volé ailleurs

Chaque binding est conditionné à une vraie sélection de clés. Sans sélection, tout garde son sens : `Suppr` supprime les objets du canvas, les flèches nues déplacent la tête de lecture (ou l'objet sélectionné), `Cmd+C`/`V` vont aux formes ou aux cellules de frame.

`Cmd+C`/`Cmd+V` ont dû être branchés **à leur emplacement existant** en haut de `onKeyDown` plutôt que dans le nouveau bloc : ils sortent en `return`, donc une branche plus tardive n'aurait jamais été atteinte.

## Détails de conception

- **Coller** stocke les frames **relatives** à la clé la plus précoce copiée, donc coller à la tête de lecture reproduit le rythme propre de la sélection où qu'elle atterrisse.
- **Décaler** valide **tout** le mouvement contre les collisions et les bornes *avant* d'en appliquer la moindre partie : un décalage a lieu en entier ou pas du tout — un décalage partiel changerait silencieusement l'espacement que l'utilisateur préservait.
- Les quatre presets d'interpolation sont **aussi** dans le menu contextuel des clés, avec leur raccourci affiché : le clavier est plus rapide une fois connu, le menu est comment on l'apprend.

## Vérification

11 étapes vertes dans l'app, undo compris, plus les garde-fous : sélection, F9, linéaire, hold, décalage, refus de collision, copier/coller, suppression, `Cmd+Z`, migration, et non-vol hors Motion.

`MOTION_DEFAULT_CURVE` dans `ui.js` mis à jour en parallèle (§3 du CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)