### PR TITLE
motion: add the graph editor

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1468,3 +1468,19 @@ body.mode-motion .lrow.act{box-shadow:inset 3px 0 0 #4E6FF2,inset 0 0 0 1px rgba
 .sb-ruler{position:absolute;height:14px;background:repeating-linear-gradient(90deg,var(--border2) 0 1px,transparent 1px 8px),var(--panel2);border:1px solid var(--border);border-radius:4px 4px 0 0;cursor:ew-resize;overflow:visible;}
 .sb-ruler .sb-ph{top:0;bottom:-4px;}
 .sb-ruler-lbl{position:absolute;right:4px;top:0;font-size:8px;color:var(--text-dim);pointer-events:none;line-height:14px;}
+
+/* ---- Motion graph editor (motion-graph.js) ----
+   Absolutely positioned INSIDE #fg-wrap (the scroller) so it inherits
+   horizontal scroll and the live FC frame width without participating in the
+   panel/grid row-alignment invariant motion.js depends on. */
+#motion-graph{position:absolute;left:0;top:42px;z-index:3;display:none;
+  background:var(--panel);border-top:1px solid var(--border);}
+#motion-graph svg{display:block;}
+#motion-graph .mg-key{cursor:ns-resize;}
+#motion-graph .mg-ease{cursor:move;}
+/* Pinned to the visible scroll window (left is updated on scroll) rather than
+   to the graph's own origin, so the legend stays readable at any scroll x. */
+#motion-graph .mg-legend{position:absolute;top:4px;font-size:9px;
+  background:color-mix(in srgb,var(--panel) 88%,transparent);
+  padding:2px 6px;border-radius:3px;pointer-events:none;white-space:nowrap;}
+#btn-mgraph.on{color:var(--accent);}

--- a/src/index.html
+++ b/src/index.html
@@ -1283,6 +1283,9 @@
     <button class="tb" id="btn-revision-view" data-i18n-title="btnRevisionViewTitle" title="Vue de révision — cycle Tout / Mes traits / Corrections" style="margin-left:4px;width:auto;padding:0 8px;font-size:10px" data-i18n="revisionViewAll">Tout</button>
     <button class="tb" id="btn-cycle" data-i18n-title="btnCycleTitle" title="Cycle — repete N fois la plage de frames selectionnee (walk cycles)" style="margin-left:4px"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 2l4 4-4 4"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><path d="M7 22l-4-4 4-4"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></svg></button>
     <button class="tb" id="btn-tween-curves" data-i18n-title="btnTweenCurvesTitle" title="Afficher/masquer les courbes d'easing sous les calques avec tween — clic sur un segment pour l'éditer individuellement" style="margin-left:4px"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 17c3 0 3-10 6-10s3 10 6 10 3-8 6-8"/></svg></button>
+    <!-- Graph editor (Motion mode only — shown/hidden by setAppMode). Clic
+         droit bascule valeur/vitesse, Alt+clic fige l'échelle verticale. -->
+    <button class="tb" id="btn-mgraph" title="Éditeur de courbes (Maj+F3) — clic droit : valeur/vitesse · Alt+clic : figer l'échelle" style="margin-left:4px;display:none"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 20V4"/><path d="M3 20h18"/><path d="M6 16c4 0 3-9 7-9 3 0 3 5 6 5"/><circle cx="6" cy="16" r="1.6" fill="currentColor"/><circle cx="19" cy="12" r="1.6" fill="currentColor"/></svg></button>
   </div>
   <div id="tl-content">
     <div id="layer-panel">
@@ -1416,6 +1419,7 @@
 <script src="js/i18n.js"></script>
 <script src="js/camera.js"></script>
 <script src="js/motion.js"></script>
+<script src="js/motion-graph.js"></script>
 <script src="js/layer-inout.js"></script>
 <script src="js/layer-scroll-sync.js"></script>
 <script src="js/timeline-zoom.js"></script>

--- a/src/js/motion-graph.js
+++ b/src/js/motion-graph.js
@@ -1,0 +1,333 @@
+// ---- MOTION GRAPH EDITOR (2026-07-25) ----
+// After Effects' Graph Editor: the interpolation itself, drawn and edited as a
+// curve over time, instead of inferred from diamonds on a track.
+//
+// Lives in its own file because motion.js is already 2900 lines and this needs
+// none of its internals — it reads through the SMMotion API and writes back
+// through the same key objects the track view already renders.
+//
+// WHY AN OVERLAY, NOT A ROW MODE. motion.js's panel/grid split rests on one
+// invariant its comments return to over and over: every .lrow in #layer-list
+// must line up with a .frow in #frame-grid, and any render path that emits a
+// different number of rows on one side silently shifts every track below it.
+// A graph editor built as rows would have to participate in that invariant on
+// every zoom, expand and filter change. Instead this is one absolutely
+// positioned box inside #fg-wrap — the scroller — so it inherits horizontal
+// scroll and the live FC (frame column width) for free, and the row machinery
+// never has to know it exists.
+(function () {
+  'use strict';
+
+  var HDR_OFFSET = 42;      // #frame-hdr (20) + #bars-row (22), same constant index.html documents
+  var PAD_T = 26, PAD_B = 22;
+  var MIN_H = 180;
+  var HANDLE_R = 4;
+
+  var _on = false;
+  var _mode = 'value';      // 'value' | 'speed'
+  var _fit = null;          // {min,max} locked range, or null to auto-fit
+  var _drag = null;
+  var _el = null, _svg = null;
+
+  // One colour per property/dimension. Position and Scale are 2D, so their two
+  // dimensions must stay distinguishable from each other AND from the other
+  // properties — otherwise a graph with four curves is unreadable.
+  var COLORS = {
+    'position.0': '#4fa3ff', 'position.1': '#7ee081',
+    'anchor.0': '#b48ead', 'anchor.1': '#d0a3c8',
+    'scale.0': '#ffb86c', 'scale.1': '#ff9f43',
+    'rotation.0': '#ff6b81',
+    'opacity.0': '#c9d1d9',
+  };
+  var DIM_SUFFIX = { position: ['X', 'Y'], anchor: ['X', 'Y'], scale: ['W', 'H'], rotation: [''], opacity: [''] };
+
+  function M() { return window.SMMotion; }
+  function fc() { return window.FC || 30; }
+  function xForFrame(f) { return f * fc() + fc() / 2; }
+  function frameForX(x) { return Math.round((x - fc() / 2) / fc()); }
+
+  // Which curves to show. AE scopes the graph to the SELECTED properties and
+  // falls back to everything animated on the layer — same rule here, because a
+  // graph showing all five properties at once is exactly as unreadable in this
+  // app as it is there.
+  function tracks() {
+    var out = [];
+    var sel = M() && M().getKeySelection ? M().getKeySelection() : [];
+    var wanted = null;
+    if (sel && sel.length) {
+      wanted = {};
+      sel.forEach(function (s) { wanted[(state.layers.indexOf(s.holder)) + '|' + s.prop] = true; });
+    }
+    state.layers.forEach(function (ld, li) {
+      if (!ld || !ld.motion) return;
+      var expanded = (window._motionExpandedLayer === li) ||
+        (window._motionRevealedLayers && window._motionRevealedLayers.indexOf(li) >= 0);
+      Object.keys(ld.motion).forEach(function (prop) {
+        var trk = ld.motion[prop];
+        if (!trk || !trk.keys || trk.keys.length < 1) return;
+        if (wanted) { if (!wanted[li + '|' + prop]) return; }
+        else if (!expanded) return;
+        var dims = (trk.keys[0].v || []).length || 1;
+        for (var d = 0; d < dims; d++) out.push({ ld: ld, li: li, prop: prop, dim: d, track: trk });
+      });
+    });
+    return out;
+  }
+
+  function sampleCurve(t) {
+    var pts = [];
+    var f0 = t.track.keys[0].frame, f1 = t.track.keys[t.track.keys.length - 1].frame;
+    if (f1 <= f0) f1 = f0 + 1;
+    for (var f = f0; f <= f1; f++) {
+      var v = M().valueAtFrame(t.ld, t.prop, f);
+      pts.push([f, Array.isArray(v) ? v[t.dim] : v]);
+    }
+    if (_mode === 'speed') {
+      // Speed = |dv/dframe|, the derivative animators actually read: a flat
+      // stretch is constant velocity, a dip to zero is a hold. Plotted at the
+      // midpoint of each frame pair so it lines up with the motion it
+      // describes rather than leading it by half a frame.
+      var sp = [];
+      for (var i = 1; i < pts.length; i++) sp.push([(pts[i][0] + pts[i - 1][0]) / 2, Math.abs(pts[i][1] - pts[i - 1][1])]);
+      return sp;
+    }
+    return pts;
+  }
+
+  function rangeOf(all) {
+    if (_fit) return _fit;
+    var min = Infinity, max = -Infinity;
+    all.forEach(function (c) { c.pts.forEach(function (p) { if (p[1] < min) min = p[1]; if (p[1] > max) max = p[1]; }); });
+    if (!isFinite(min) || !isFinite(max)) { min = 0; max = 1; }
+    if (Math.abs(max - min) < 1e-6) { min -= 1; max += 1; }
+    var pad = (max - min) * 0.12;
+    return { min: min - pad, max: max + pad };
+  }
+
+  function host() { return document.getElementById('fg-wrap'); }
+
+  function ensureEl() {
+    if (_el && _el.parentNode) return _el;
+    var w = host(); if (!w) return null;
+    _el = document.createElement('div');
+    _el.id = 'motion-graph';
+    _el.addEventListener('contextmenu', function (e) { e.preventDefault(); e.stopPropagation(); });
+    w.appendChild(_el);
+    return _el;
+  }
+
+  function height() {
+    var w = host();
+    var h = w ? w.clientHeight - HDR_OFFSET : 0;
+    return Math.max(MIN_H, h);
+  }
+
+  function render() {
+    if (!_on) { if (_el) _el.style.display = 'none'; return; }
+    var el = ensureEl(); if (!el) return;
+    el.style.display = 'block';
+    var W = state.totalFrames * fc(), H = height();
+    el.style.top = HDR_OFFSET + 'px';
+    el.style.width = W + 'px';
+    el.style.height = H + 'px';
+
+    var all = tracks().map(function (t) { t.pts = sampleCurve(t); return t; });
+    var rg = rangeOf(all);
+    var innerH = H - PAD_T - PAD_B;
+    function yFor(v) { return PAD_T + innerH - ((v - rg.min) / (rg.max - rg.min)) * innerH; }
+    el._yFor = yFor; el._rg = rg; el._innerH = innerH;
+
+    var svg = '<svg width="' + W + '" height="' + H + '" style="display:block">';
+    // horizontal value gridlines, labelled — a graph without a scale is a
+    // shape, not a measurement
+    var STEPS = 4;
+    for (var g = 0; g <= STEPS; g++) {
+      var vv = rg.min + (rg.max - rg.min) * (g / STEPS), yy = yFor(vv);
+      svg += '<line x1="0" y1="' + yy + '" x2="' + W + '" y2="' + yy + '" stroke="var(--border)" stroke-width="1" opacity="0.5"/>';
+      svg += '<text x="4" y="' + (yy - 3) + '" font-size="9" fill="var(--text-dim)">' + (Math.round(vv * 10) / 10) + '</text>';
+    }
+    // playhead
+    var px = xForFrame(state.currentFrame);
+    svg += '<line x1="' + px + '" y1="0" x2="' + px + '" y2="' + H + '" stroke="var(--accent)" stroke-width="1" opacity="0.8"/>';
+
+    all.forEach(function (t, ti) {
+      var col = COLORS[t.prop + '.' + t.dim] || '#8ab4f8';
+      var d = t.pts.map(function (p, i) { return (i ? 'L' : 'M') + xForFrame(p[0]).toFixed(1) + ' ' + yFor(p[1]).toFixed(1); }).join(' ');
+      svg += '<path d="' + d + '" fill="none" stroke="' + col + '" stroke-width="1.8" stroke-linejoin="round"/>';
+      if (_mode === 'value') {
+        t.track.keys.forEach(function (k, ki) {
+          var v = Array.isArray(k.v) ? k.v[t.dim] : k.v;
+          var selNow = M().getKeySelection().some(function (s) { return s.key === k && s.prop === t.prop; });
+          svg += '<circle class="mg-key" data-t="' + ti + '" data-k="' + ki + '" cx="' + xForFrame(k.frame).toFixed(1) + '" cy="' + yFor(v).toFixed(1) +
+            '" r="' + (selNow ? HANDLE_R + 1.5 : HANDLE_R) + '" fill="' + (selNow ? '#fff' : col) + '" stroke="' + col + '" stroke-width="2"/>';
+        });
+        // Ease waypoints of each segment, placed ON the curve they shape —
+        // dragging one is the whole point of a graph editor, and putting them
+        // anywhere else would make the connection to the curve guesswork.
+        for (var s2 = 0; s2 < t.track.keys.length - 1; s2++) {
+          var a = t.track.keys[s2], b = t.track.keys[s2 + 1];
+          if (a.hold) continue;
+          var va = Array.isArray(a.v) ? a.v[t.dim] : a.v, vb = Array.isArray(b.v) ? b.v[t.dim] : b.v;
+          var cps = a.curvePoints || [];
+          for (var w2 = 1; w2 < cps.length - 1; w2++) {
+            var cx = xForFrame(a.frame + (b.frame - a.frame) * cps[w2].x);
+            var cy = yFor(va + (vb - va) * cps[w2].y);
+            svg += '<circle class="mg-ease" data-t="' + ti + '" data-s="' + s2 + '" data-w="' + w2 + '" cx="' + cx.toFixed(1) + '" cy="' + cy.toFixed(1) +
+              '" r="3" fill="var(--panel)" stroke="' + col + '" stroke-width="1.5" opacity="0.9"/>';
+          }
+        }
+      }
+    });
+    svg += '</svg>';
+
+    // legend + mode readout, pinned to the left of the visible scroll window so
+    // it stays readable however far along the timeline you are
+    var legend = all.map(function (t) {
+      var col = COLORS[t.prop + '.' + t.dim] || '#8ab4f8';
+      var suf = (DIM_SUFFIX[t.prop] || [''])[t.dim] || '';
+      return '<span style="color:' + col + ';margin-right:12px">&#9632;&nbsp;' + t.prop + (suf ? '&nbsp;' + suf : '') + '</span>';
+    }).join('');
+    el.innerHTML = svg +
+      '<div class="mg-legend" style="left:' + (host().scrollLeft + 8) + 'px">' + legend +
+      '<span style="color:var(--text-dim);margin-left:6px">' + (_mode === 'speed' ? 'vitesse' : 'valeur') + (_fit ? ' · figé' : '') + '</span></div>';
+    _svg = el.querySelector('svg');
+    el._tracks = all;
+  }
+
+  // ---- interaction ----
+  function localPt(e) {
+    var r = _svg.getBoundingClientRect();
+    return { x: e.clientX - r.left, y: e.clientY - r.top };
+  }
+  function onDown(e) {
+    if (!_on) return;
+    var tgt = e.target;
+    if (!tgt || !tgt.classList) return;
+    var all = _el._tracks || [];
+    if (tgt.classList.contains('mg-key')) {
+      var t = all[+tgt.dataset.t], k = t.track.keys[+tgt.dataset.k];
+      if (window.pushUndo) pushUndo();
+      // Share the track view's selection rather than keeping a private one:
+      // clicking a point here lights up its diamond, and F9 / Delete / copy
+      // then act on it exactly as they would from the track view. Shift adds,
+      // matching the track view's own multi-select.
+      if (M().selectKeys) {
+        var cur = M().getKeySelection();
+        var already = cur.some(function (s) { return s.key === k; });
+        if (e.shiftKey) { if (!already) M().selectKeys(cur.concat([{ holder: t.ld, prop: t.prop, key: k }])); }
+        else if (!already) M().selectKeys([{ holder: t.ld, prop: t.prop, key: k }]);
+      }
+      _drag = { kind: 'key', t: t, key: k, startFrame: k.frame, start: localPt(e), startV: (Array.isArray(k.v) ? k.v[t.dim] : k.v) };
+      e.preventDefault(); e.stopPropagation();
+    } else if (tgt.classList.contains('mg-ease')) {
+      var t2 = all[+tgt.dataset.t], seg = +tgt.dataset.s, wi = +tgt.dataset.w;
+      if (window.pushUndo) pushUndo();
+      _drag = { kind: 'ease', t: t2, seg: seg, wi: wi, start: localPt(e) };
+      e.preventDefault(); e.stopPropagation();
+    }
+  }
+  function onMove(e) {
+    if (!_drag) return;
+    var p = localPt(e), rg = _el._rg, innerH = _el._innerH;
+    var perPx = (rg.max - rg.min) / innerH;
+    if (_drag.kind === 'key') {
+      var t = _drag.t, k = _drag.key;
+      // vertical = value
+      var nv = _drag.startV - (p.y - _drag.start.y) * perPx;
+      if (Array.isArray(k.v)) k.v[t.dim] = nv; else k.v = nv;
+      // horizontal = time, refused rather than clamped when it would land on
+      // another key — same rule as the track view's nudge, so a drag can never
+      // silently merge two keyframes
+      var nf = _drag.startFrame + Math.round((p.x - _drag.start.x) / fc());
+      if (nf >= 0 && nf <= state.totalFrames - 1) {
+        var clash = t.track.keys.some(function (o) { return o !== k && o.frame === nf; });
+        if (!clash && nf !== k.frame) {
+          k.frame = nf;
+          t.track.keys.sort(function (a, b) { return a.frame - b.frame; });
+        }
+      }
+    } else {
+      var t3 = _drag.t, a = t3.track.keys[_drag.seg], b = t3.track.keys[_drag.seg + 1];
+      var va = Array.isArray(a.v) ? a.v[t3.dim] : a.v, vb = Array.isArray(b.v) ? b.v[t3.dim] : b.v;
+      var cps = a.curvePoints; if (!cps) return;
+      var span = (b.frame - a.frame) * fc();
+      var nx = (p.x - xForFrame(a.frame)) / (span || 1);
+      var vy = rg.min + (innerH - (p.y - PAD_T)) * perPx;
+      var ny = Math.abs(vb - va) > 1e-9 ? (vy - va) / (vb - va) : cps[_drag.wi].y;
+      // Waypoints must stay ordered in x, or evalCurvePoints' segment search
+      // walks past the point it wants and the ease inverts.
+      var lo = cps[_drag.wi - 1].x + 0.02, hi = cps[_drag.wi + 1].x - 0.02;
+      cps[_drag.wi].x = Math.max(lo, Math.min(hi, nx));
+      cps[_drag.wi].y = Math.max(-1, Math.min(2, ny));
+      delete cps[_drag.wi].tx; delete cps[_drag.wi].ty;
+    }
+    render();
+    if (window.renderLayerList) renderLayerList();
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+  }
+  function onUp() {
+    if (!_drag) return;
+    _drag = null;
+    if (window.renderTimeline) renderTimeline();
+    render();
+  }
+
+  function toggle(on) {
+    _on = (on === undefined) ? !_on : !!on;
+    var grid = document.getElementById('frame-grid');
+    // The track rows stay in the DOM (their geometry is what every other
+    // module measures) — they are only hidden, so toggling back is free and
+    // nothing downstream has to re-render.
+    if (grid) grid.style.visibility = _on ? 'hidden' : '';
+    var btn = document.getElementById('btn-mgraph');
+    if (btn) btn.classList.toggle('on', _on);
+    render();
+    return _on;
+  }
+  function setMode(m) { _mode = m; _fit = null; render(); }
+  function freezeRange() {
+    // Lock the current auto-fit so editing a value doesn't make the whole graph
+    // rescale under the cursor mid-drag — AE's own "lock zoom" affordance.
+    if (_fit) _fit = null; else if (_el && _el._rg) _fit = { min: _el._rg.min, max: _el._rg.max };
+    render();
+  }
+
+  // Toolbar button: plain click toggles, right-click swaps value/speed, Alt+
+  // click freezes the vertical scale. Three actions on one button rather than
+  // three buttons — the toolbar is already dense, and the two secondary ones
+  // are modifiers of the first, not peers of it.
+  document.addEventListener('DOMContentLoaded', function () {
+    var b = document.getElementById('btn-mgraph');
+    if (!b) return;
+    b.addEventListener('click', function (e) {
+      if (e.altKey) { if (_on) freezeRange(); return; }
+      toggle();
+    });
+    b.addEventListener('contextmenu', function (e) {
+      e.preventDefault();
+      if (!_on) toggle(true);
+      setMode(_mode === 'value' ? 'speed' : 'value');
+    });
+  });
+
+  document.addEventListener('mousedown', onDown, true);
+  document.addEventListener('mousemove', onMove);
+  document.addEventListener('mouseup', onUp);
+  window.addEventListener('resize', function () { if (_on) render(); });
+  document.addEventListener('scroll', function (e) {
+    if (_on && e.target && e.target.id === 'fg-wrap') {
+      var lg = _el && _el.querySelector('.mg-legend');
+      if (lg) lg.style.left = (e.target.scrollLeft + 8) + 'px';
+    }
+  }, true);
+
+  window.SMMotionGraph = {
+    isOn: function () { return _on; },
+    toggle: toggle,
+    render: render,
+    setMode: setMode,
+    mode: function () { return _mode; },
+    freezeRange: freezeRange,
+    isFrozen: function () { return !!_fit; },
+  };
+})();

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -2850,11 +2850,16 @@
       window._motionRevealedLayers = null;
       removeKeySelectionBox();
       removeLayerStaggerBox();
+      // The graph editor hides #frame-grid while it's open — leaving Motion
+      // with it still on would strand the 2D timeline invisible.
+      if (window.SMMotionGraph && SMMotionGraph.isOn()) SMMotionGraph.toggle(false);
     }
     state.appMode = mode;
     document.querySelectorAll('.app-mode-btn').forEach(function (b) { b.classList.toggle('active', b.dataset.mode === mode); });
     document.body.classList.toggle('mode-motion', mode === 'motion');
     document.body.classList.toggle('mode-storyboard', mode === 'storyboard');
+    var mgBtn = document.getElementById('btn-mgraph');
+    if (mgBtn) mgBtn.style.display = (mode === 'motion') ? '' : 'none';
     // StoryBoard swaps the whole timeline area for the node space —
     // renderLayerList/renderTimeline still run (their targets are hidden,
     // harmless) so switching BACK lands on an up-to-date grid.
@@ -3030,6 +3035,11 @@
     elementLabel: elementLabel,
     distributeKeys: distributeKeys, flipKeys: flipKeys, selectEveryNthKey: selectEveryNthKey, invertKeySelection: invertKeySelection,
     getKeySelection: function () { return _motionKeySel.slice(); },
+    // Lets the graph editor drive the SAME selection the track view uses, so
+    // clicking a point on a curve lights up its diamond and makes F9 / Delete
+    // / copy behave identically from either view. Without this the two views
+    // would each hold their own idea of what is selected.
+    selectKeys: function (sel) { setKeySel(sel || []); },
     // ui.js's shared curve widget calls this after a motion segment's
     // curvePoints change (drag/preset/add/delete point) — the canvas needs
     // a repaint since the eased value at the current frame may have

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -2021,6 +2021,13 @@ function renderTimeline(){
   document.getElementById('playhead').style.left=(state.currentFrame*FC)+'px';document.getElementById('playhead').style.height=Math.max(30+rowCount*ROW_H+camGridRowOffset(),awrap?awrap.clientHeight:0)+'px';document.getElementById('playhead-flag').textContent=state.currentFrame+1;
   if(window.SMAudio)SMAudio.renderStrip();
   renderTweenCurveStrips();
+  // renderTimeline() wipes #frame-grid, so the graph editor — which hides that
+  // grid and draws over the same box — has to be re-applied after every
+  // rebuild, or toggling zoom/frames silently drops it.
+  if(window.SMMotionGraph&&SMMotionGraph.isOn()){
+    document.getElementById('frame-grid').style.visibility='hidden';
+    SMMotionGraph.render();
+  }
 }
 // ---- TWEEN EASING CURVE STRIPS (toggle: btn-tween-curves) ----
 // Purely additive display, complements the global/per-pair easing system —
@@ -4655,6 +4662,9 @@ function onKeyDown(event){
   // ('u' is otherwise bound to the Line tool, TOOL_SHORTCUTS) — only inside
   // Motion mode, the Line tool shortcut is untouched everywhere else.
   if((k==='u'||k==='U')&&state.appMode==='motion'&&window.SMMotion&&SMMotion.revealAnimated()){event.preventDefault();return;}
+  // Shift+F3 — AE's own Graph Editor toggle. Motion-only, like every other
+  // binding in this block.
+  if(k==='F3'&&event.shiftKey&&state.appMode==='motion'&&window.SMMotionGraph){event.preventDefault();SMMotionGraph.toggle();return;}
   // ---- Motion keyframe keyboard layer (2026-07-25) ----
   // The Motion timeline already had drag-retime, marquee multi-select, hold,
   // distribute/flip/select-every-2nd and a per-segment ease editor — but every


### PR DESCRIPTION
Le dernier vrai manque face à After Effects : l'interpolation pouvait être **éditée** (éditeur d'ease par segment, hold, presets F9) mais jamais **vue**. Une courbe qu'on ne peut que déduire de l'espacement des losanges est une courbe qu'on règle à l'aveugle.

`Maj+F3`, ou le bouton de la toolbar, remplace la zone de pistes par les courbes de valeur elles-mêmes — une par propriété et par dimension animée, échantillonnées frame par frame via le **même** `valueAtFrame` que le rendu. Ce qui est dessiné est donc ce qui sera joué.

## Pourquoi un overlay, et pas un mode de lignes

Le découpage panneau/grille de `motion.js` repose sur un invariant que ses commentaires rappellent sans cesse : **chaque `.lrow` de `#layer-list` doit s'aligner avec une `.frow` de `#frame-grid`**, et tout chemin de rendu qui émet un nombre de lignes différent d'un côté décale silencieusement toutes les pistes en dessous.

Un graphe construit en lignes devrait tenir cet invariant à chaque zoom, chaque dépliage, chaque filtre. Celui-ci est **une seule boîte en position absolue dans `#fg-wrap`** — le scroller — donc il hérite gratuitement du défilement horizontal et du `FC` (largeur de colonne) en direct, et la machinerie de lignes n'apprend jamais son existence.

La bascule ne fait que changer la `visibility` de `#frame-grid` : la géométrie des pistes que tous les autres modules mesurent reste intacte, et revenir en arrière ne coûte rien.

## Ce qu'il fait

- **Courbes** par propriété/dimension animée du calque déplié, réduites aux propriétés **sélectionnées** quand il y a une sélection de clés (la règle d'AE — cinq propriétés à la fois est illisible ici aussi)
- **Glisser un point** verticalement change sa valeur, horizontalement le retime. Un retiming sur une frame occupée est **refusé** plutôt que clampé — même règle que le décalage de la vue piste, pour qu'un glisser ne puisse jamais fusionner deux clés en silence
- **Glisser un waypoint d'ease**, dessiné **sur** la courbe qu'il façonne. Les waypoints sont contraints à rester ordonnés en x, car la recherche de segment d'`evalCurvePoints` dépasse un point désordonné et l'ease s'inverse
- **Clic droit** sur le bouton : graphe de **vitesse** (`|dv/dframe|`, tracé au milieu de chaque paire de frames pour coïncider avec le mouvement qu'il décrit au lieu de le précéder d'une demi-frame)
- **Alt+clic** fige l'échelle verticale, pour qu'éditer une valeur ne fasse pas se remettre à l'échelle le graphe sous le curseur en plein glisser
- Lignes de valeur **graduées et étiquetées**, et légende épinglée à la fenêtre visible — un graphe sans échelle est une forme, pas une mesure

## Sélection partagée

La sélection est **partagée** avec la vue piste (nouveau `SMMotion.selectKeys`), pas une copie privée : cliquer un point allume son losange, et `F9` / `Suppr` / copier se comportent ensuite identiquement depuis l'une ou l'autre vue. Vérifié dans les deux sens.

## Deux pièges traités

- `renderTimeline()` vide `#frame-grid` — le graphe est donc ré-appliqué à sa fin. Sans ça, changer le zoom ou le nombre de frames le faisait disparaître silencieusement.
- Quitter le mode Motion **ferme** le graphe de force, puisqu'il masque la grille et laisserait sinon la timeline 2D invisible.

## Vérification

13 contrôles verts sur deux passes dans l'app : ouverture/fermeture au raccourci et au bouton, rendu courbes+points+waypoints, clic-pour-sélectionner partagé avec la vue piste, Maj+clic qui ajoute, `F9` et `Suppr` depuis le graphe, `Cmd+Z` après un glisser, glisser de valeur, glisser de retiming, refus de retiming sur collision, glisser de waypoint, ordonnancement en x des waypoints, bascule vitesse, gel d'échelle, survie à une reconstruction complète de `renderTimeline`, et grille restaurée à la fermeture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)