### PR TITLE
fix: stop destroying the hole in every boolean result

### DIFF
--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -4214,13 +4214,56 @@ function _eraseDegenerateSelfLoops(path){
   // entirely. 1.5px is well under anything a real drawn detail would ever
   // need two distinct anchors that close together for.
   var REVISIT_TOL=1.5;
-  var changed=true,guard=0;
+  // AREA GUARD (2026-07-25). The splice below rests on the assumption stated
+  // in the header comment — "by construction that sub-loop's own closed shape
+  // is degenerate/near-zero-area clipper noise, never real geometry". That
+  // holds for unite()'s re-processed touch points, but NOT for the one
+  // deliberate revisit _mergeHoleIntoExterior creates: a hole merged into its
+  // exterior through a zero-width slit revisits the slit anchor on purpose,
+  // and the sub-loop bracketed by that revisit IS the hole.
+  //
+  // Without this guard the two passes fought each other, and the hole always
+  // lost. Measured on a 200x200 square minus a 50px circle, straight through
+  // insertBooleanResult:
+  //
+  //                        segments   area    bounds
+  //   after hole merge        10      35000   100,100 200x200   (correct)
+  //   after this function      3      61980    56, 56 279x279   (destroyed)
+  //
+  // The hole was spliced out entirely, and simplify() below then refit curves
+  // through the three survivors, ballooning the outline past the original
+  // shape. Every path that reaches insertBooleanResult with a hole was
+  // affected: the boolean subtract/exclude tool, fill merge, and the eraser
+  // piercing the middle of a filled shape.
+  //
+  // Scale-invariant threshold rather than an absolute one, so it behaves the
+  // same on a thumbnail and a full-canvas shape. The two populations are ~3
+  // orders of magnitude apart — the real hole above is 12.5% of its bounding
+  // box, while the clipper slivers this function was written for measured
+  // ~0.3% of shape area TOTAL across ~40 loops — so 0.2% sits far from either
+  // edge rather than between them.
+  var MIN_LOOP_FRAC=0.002;
+  function _subLoopArea(segs,from,to){
+    // Shoelace over the anchor ring segs[from..to]; handles ignored on
+    // purpose, since this only has to separate "essentially nothing" from
+    // "a real enclosed region".
+    var a=0;
+    for(var k=from;k<=to;k++){
+      var p=segs[k].point,q=segs[k===to?from:k+1].point;
+      a+=p.x*q.y-q.x*p.y;
+    }
+    return Math.abs(a)/2;
+  }
+  var bb=path.bounds, bbArea=Math.max(1,bb.width*bb.height);
+  var minLoopArea=Math.max(1,bbArea*MIN_LOOP_FRAC);
+  var changed=true,guard=0,keptRevisit=false;
   while(changed&&guard<5000){
     changed=false;guard++;
     var segs=path.segments,n=segs.length;
     for(var i=0;i<n;i++){
       for(var j=0;j<i;j++){
         if(segs[i].point.getDistance(segs[j].point)<=REVISIT_TOL){
+          if(_subLoopArea(segs,j,i)>minLoopArea){keptRevisit=true;continue;} // real geometry (a hole), not clipper noise
           path.removeSegments(j+1,i+1);
           changed=true;
           break;
@@ -4244,7 +4287,17 @@ function _eraseDegenerateSelfLoops(path){
   // unconditionally (safe/idempotent on an already-clean shape too, not
   // gated on whether a revisit was actually spliced like the old
   // smooth()-only pass was).
-  path.simplify(2.5);
+  // ...but NOT on a path that legitimately returns along its own slit
+  // (2026-07-25). Douglas-Peucker + a least-squares bezier refit both assume a
+  // simple, non-self-touching curve. Fed a hole merged through a zero-width
+  // seam, the refit pulls the two coincident anchors apart into a bulge:
+  // measured on a square-minus-circle donut, area 32972 (ideal 32146) and
+  // bounds 100,100 200x200 going in, area 54286 and bounds 68,65 267x265
+  // coming out. The area guard above having preserved a revisit is exactly the
+  // signal that this path is one of those, so the refit is skipped for it —
+  // and only for it, leaving the ordinary unite()-output case this pass was
+  // written for untouched.
+  if(!keptRevisit)path.simplify(2.5);
 }
 // strokeInfo (optional, 2026-07 — "l'eraser supprime le stroke entier"):
 // every branch below used to hardcode strokeColor=null on its island(s),
@@ -4300,18 +4353,25 @@ function insertBooleanResult(layer,insertAt,result,fillColor,opacity,strokeInfo)
     return flat;
   }
   var islands=exteriors.map(function(ext){
-    var extSegs=ext.segments.map(function(s){return{point:[s.point.x,s.point.y],handleIn:[0,0],handleOut:[0,0]};});
+    // Handles carried through, not zeroed (2026-07-25). This merge was written
+    // for insertBooleanResult's straight WASM polygons, where every handle is
+    // [0,0] anyway — but Paper's own subtract()/exclude() feed the SAME
+    // function, and their output is curved. Zeroing turned a circular hole cut
+    // by the boolean tool into a 4-corner diamond, and any curved exterior
+    // into a polygon. Measured on a 50px-radius circular hole: area 5000
+    // (diamond) instead of 7854 (circle).
+    var extSegs=ext.segments.map(function(s){return{point:[s.point.x,s.point.y],handleIn:[s.handleIn.x,s.handleIn.y],handleOut:[s.handleOut.x,s.handleOut.y]};});
     // Bounds-containment pairs each hole with the exterior it sits inside
     // — good enough since a hole can only ever nest inside the ONE
     // exterior it was cut from (_polygonsToPaperItem builds one hole list
     // per source polygon, never shared across exteriors).
     var myHoles=holes.filter(function(h){return ext.bounds.contains(h.bounds);});
     myHoles.forEach(function(h){
-      var holeSegs=h.segments.map(function(s){return{point:[s.point.x,s.point.y],handleIn:[0,0],handleOut:[0,0]};});
+      var holeSegs=h.segments.map(function(s){return{point:[s.point.x,s.point.y],handleIn:[s.handleIn.x,s.handleIn.y],handleOut:[s.handleOut.x,s.handleOut.y]};});
       extSegs=_mergeHoleIntoExterior(extSegs,holeSegs);
     });
     var merged=new Path({insert:false});
-    extSegs.forEach(function(s){merged.add(new Segment(new Point(s.point[0],s.point[1])));});
+    extSegs.forEach(function(s){merged.add(new Segment(new Point(s.point[0],s.point[1]),new Point(s.handleIn[0],s.handleIn[1]),new Point(s.handleOut[0],s.handleOut[1])));});
     merged.closed=true;
     // Multiple holes merged into the same exterior can each independently
     // pick the SAME closest exterior point (_polyClosestPair) as their own


### PR DESCRIPTION
Percer un trou dans une forme remplie produisait une géométrie corrompue. **Deux passes de `insertBooleanResult` se combattaient**, et le trou perdait à tous les coups.

Mesuré sur un carré 200×200 moins un cercle de 50px, via le vrai chemin de code :

| étape | segments | aire | bounds |
|---|---|---|---|
| après la fusion du trou | 10 | 35 000 | 100,100 · 200×200 |
| après `_eraseDegenerateSelfLoops` | **3** | **61 980** | **56,56 · 279×279** |
| donut idéal | — | 32 146 | 100,100 · 200×200 |

Tous les chemins arrivant à `insertBooleanResult` avec un trou étaient touchés : l'outil booléen soustraire/exclure (dont le commentaire dit lui-même qu'il produit « couramment » des trous), la fusion de remplissage, et la gomme perçant le milieu d'une forme remplie.

## Trois causes, dans la même chaîne

### 1. Le découpage

`_mergeHoleIntoExterior` raccorde un trou à son extérieur par une **fente de largeur nulle**, qui revisite son point d'ancrage **volontairement**. `_eraseDegenerateSelfLoops` — appelée juste après — existe pour supprimer exactement ce motif dans la sortie de `unite()` de Paper. Elle supprimait donc le trou entier.

Son propre commentaire se justifie ainsi : *« par construction ce sous-contour est du bruit de clipper d'aire quasi nulle, jamais de la géométrie réelle dessinée par l'artiste »*. Vrai pour `unite()`, **faux** pour un trou volontaire.

Le correctif applique cette hypothèse littéralement : un sous-contour n'est supprimé que si son aire (shoelace) est **sous 0.2% de sa boîte englobante**. Les deux populations sont à ~3 ordres de grandeur d'écart — le trou ci-dessus fait 12.5% de sa bbox, tandis que les échardes de clipper visées à l'origine représentaient ~0.3% de l'aire **au total sur ~40 contours**. Le seuil n'est proche d'aucun des deux bords.

### 2. Le refit

`path.simplify(2.5)` termine la même fonction. Douglas-Peucker et un refit bézier par moindres carrés supposent **une courbe simple, sans auto-contact**. Sur un chemin qui revient par sa propre fente, le refit écarte les deux ancres coïncidentes en une boursouflure :

| | aire | bounds |
|---|---|---|
| entrée | 32 972 | 100,100 · 200×200 |
| sortie | 54 286 | 68,65 · 267×265 |

Désactivé **uniquement** quand le garde-fou d'aire a réellement préservé une revisite — ce qui est précisément le signal que le chemin est de ce type. La sortie `unite()` ordinaire garde son refit, inchangée.

### 3. Les poignées perdues

La fusion mettait `handleIn`/`handleOut` à zéro des deux côtés. Elle avait été écrite pour les polygones droits du WASM, où ils valent `[0,0]` de toute façon — mais les `subtract()`/`exclude()` de Paper alimentent **la même fonction** et leur sortie est courbe. Un trou circulaire ressortait en losange à 4 coins (aire 5000 au lieu de 7854). Les poignées sont désormais transmises.

## Vérification dans l'app

| cas | résultat |
|---|---|
| carré moins petit cercle | aire 32 972 (idéal 32 146, +2.6%), bounds exacts |
| carré 400px, trou 100px | aire 131 889 (idéal 128 584, +2.6%), bounds exacts |
| **deux trous** dans un extérieur | aire 71 535 (idéal 69 947, +2.3%), bounds exacts |
| pic en cheveu | toujours supprimé |
| deux îlots disjoints | toujours séparés en 2 paths |
| chemin ordinaire de 40 points | toujours simplifié à 6 |

Le résidu de ~2.5% est la fente elle-même, qui ajoute une écharde par construction — attendu, et de même nature qu'avant.

**Aller-retour vérifié** : le donut réparé survit à `saveActiveLayerFrame` + `exportJSON` + `importJSON` avec 10 segments, aire et bounds identiques.

## Contexte

Trouvé en auditant la fidélité sauvegarde/rechargement selon le §1 du CLAUDE.md. **Cet audit-là était propre** — 10 contrôles verts sur les champs de traits, les flags de calque, le contenu multi-frames, les pistes Motion, les `curvePoints` réglés à la main et les flags `hold`. Aucun bug de persistance ; celui-ci était en amont, dans la géométrie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)