### PR TITLE
ux: make the three silently-refusing actions say why

### DIFF
--- a/src/js/group-bridge.js
+++ b/src/js/group-bridge.js
@@ -37,9 +37,18 @@
     if (window.showToast) showToast('Groupe créé (' + selectedPaths.length + ' éléments)');
   }
   function ungroupSelection() {
-    if (!window.selectedPaths || !selectedPaths.length) return;
+    // Both refusals were silent while groupSelection's own ("Sélectionnez au
+    // moins 2 calques") is not — so Cmd+Shift+G read as a broken shortcut
+    // rather than an inapplicable one (2026-07-25 UX audit).
+    if (!window.selectedPaths || !selectedPaths.length) {
+      if (window.showToast) showToast('Sélectionnez d\'abord un groupe à dissocier');
+      return;
+    }
     var hasGroup = selectedPaths.some(function (p) { return p.data && p.data.groupId; });
-    if (!hasGroup) return;
+    if (!hasGroup) {
+      if (window.showToast) showToast('La sélection ne contient aucun groupe');
+      return;
+    }
     pushUndo();
     selectedPaths.forEach(function (p) { if (p.data) delete p.data.groupId; });
     saveActiveLayerFrame(); updateUI();

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -601,7 +601,12 @@ window.SM={
       showToast('Calque caméra supprimé');
       return;
     }
-    if(state.layers.length<=1)return;saveAllLayerFrames();
+    // Refusing to delete the last layer is right — a document with no layer
+    // has nowhere to draw — but it was silent, so the trash button just
+    // appeared broken (2026-07-25 UX audit). Every other refusal in this file
+    // says why; this one now does too.
+    if(state.layers.length<=1){showToast('Impossible de supprimer le dernier calque');return;}
+    saveAllLayerFrames();
     pushUndoLayers();
     var sel=(_layerSel.length?_layerSel.slice():[state.activeLayerIdx]).sort(function(a,b){return b-a;});
     sel.forEach(function(idx){
@@ -3968,6 +3973,17 @@ function updateTextActionsPanel(){
 function initCycleAndPropagate(){
   var cyc=document.getElementById('btn-cycle');
   if(cyc)cyc.addEventListener('click',function(){
+    // Check the precondition BEFORE asking the question (2026-07-25 UX audit).
+    // repeatSelection already refuses with a clear message when no frame range
+    // is selected — but the prompt ran first, so the user typed a count, hit
+    // OK, and only then learned they needed a selection. Worse, cancelling the
+    // prompt returned before repeatSelection ever ran, so clicking this button
+    // with nothing selected was completely silent. Same message, raised to the
+    // point where it's actually useful.
+    if(typeof selBounds==='function'&&!selBounds()){
+      showToast('Sélectionne d\'abord une plage de frames dans la timeline');
+      return;
+    }
     var n=prompt('Repeter la plage selectionnee combien de fois ?','2');
     if(n===null)return;
     window.SM.repeatSelection(n);


### PR DESCRIPTION
J'ai déclenché **chaque action ayant une condition préalable** dans un état où cette condition échoue, et vérifié si l'app s'explique.

La plupart le fait déjà très bien — *« Il faut au moins 2 keyframes dessinées »*, *« Sélectionnez au moins 2 formes »*, *« Rien à coller »*, *« Aucune sélection »*, *« Rien à dupliquer »*. **Trois** ne le faisaient pas, et chacune se lisait simplement comme un bouton cassé.

## 1. Cycle, sans plage de frames sélectionnée

`repeatSelection` **a déjà** un message clair. Mais le bouton lançait `prompt("combien de fois ?")` **avant** de l'appeler : l'utilisateur saisissait un nombre, validait, et découvrait seulement ensuite qu'il fallait une sélection.

Pire : annuler le prompt sortait **avant** que `repeatSelection` ne s'exécute — le clic était donc totalement silencieux.

La vérification précède désormais la question. Vérifié : le prompt n'est plus atteint sur le chemin d'échec, et s'affiche toujours sur le chemin nominal.

## 2. Supprimer le calque, quand il n'en reste qu'un

Refuser est **correct** — un document sans calque n'a nulle part où dessiner — mais `if(len<=1)return;` était muet, donc le bouton corbeille semblait cassé.

## 3. Dissocier (Cmd+Maj+G)

Ses deux refus sortaient en silence alors que `groupSelection` dit *« Sélectionnez au moins 2 calques »* — le raccourci se lisait donc comme cassé plutôt qu'inapplicable. Distingue maintenant « rien de sélectionné » de « la sélection ne contient aucun groupe ».

## Délibérément **non** touché

Un message y serait du bruit, pas de l'aide :

| cas | pourquoi le silence est correct |
|---|---|
| `Suppr` sans sélection | comportement universel dans tous les éditeurs |
| pelure d'oignon / ghost-all / courbes de tween / boucle | **vérifié** : ces bascules donnent déjà leur retour de la bonne façon, par la classe `active` du bouton — c'est un **état**, pas un événement |
| Flip preview avec une seule clé | une bascule qui lance un vrai intervalle, pas un refus |

## Vérification

10 contrôles dans l'app : les quatre refus réparés produisent chacun leur message, les trois cas silencieux **restent** silencieux (pas de spam de toasts), les deux chemins nominaux fonctionnent toujours, et Cycle demande bien le nombre quand une plage **est** sélectionnée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)