### PR TITLE
ui: PageUp/PageDown step the active layer

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -4524,6 +4524,31 @@ var _pointerOverTimeline=false;
   wrap.addEventListener('pointerleave',function(){_pointerOverTimeline=false;});
 })();
 
+// Walks the layer list AS DISPLAYED, not state.layers order: the panel renders
+// highest index first (computeLayerRenderOrder counts down), and members of a
+// collapsed folder carry hidden:true and must be stepped over — otherwise
+// PageDown would appear to do nothing while it moved onto a row that isn't on
+// screen. dir -1 goes up the panel, +1 goes down.
+function stepActiveLayer(dir){
+  var idxs;
+  if(typeof computeLayerRenderOrder==='function'){
+    idxs=computeLayerRenderOrder()
+      .filter(function(e){return e.type==='layer'&&!e.hidden;})
+      .map(function(e){return e.idx;});
+  }else{
+    idxs=[];for(var i=state.layers.length-1;i>=0;i--)idxs.push(i);
+  }
+  if(idxs.length<2)return false;
+  var pos=idxs.indexOf(state.activeLayerIdx);
+  if(pos<0)pos=0;
+  var np=pos+dir;
+  if(np<0||np>=idxs.length)return false; // already at the end — stop, don't wrap
+  // Goes through the app's own layer-activation path rather than assigning
+  // activeLayerIdx directly: that one also saves the outgoing layer's frame,
+  // clears the selection, and unsticks the camera row (see setActiveLayer).
+  window.SM.setActiveLayer(idxs[np]);
+  return true;
+}
 function onKeyDown(event){
   // Editing a text/number field: leave Ctrl+Z/X/C/V to the BROWSER's own
   // in-field behavior (text undo, text cut/copy/paste) instead of
@@ -4812,6 +4837,14 @@ function onKeyDown(event){
   // Home/End "go to first/last frame" — a near-universal NLE/AE convention
   // (Home = start of composition, End = end) that had no binding here at
   // all (grepped: zero 'Home'/'End' handlers before this). AE audit, 2026-07.
+  // PageUp / PageDown — step the active layer up/down the panel (2026-07-25).
+  // Changing the active layer is one of the most frequent actions in any
+  // multi-layer drawing app (rough here, clean there, background below) and
+  // had NO keyboard path at all: Alt+arrows, Ctrl+arrows, PageUp/PageDown and
+  // Alt+[ ] were all verified inert for it. Alt+[ / Alt+] are taken (AE
+  // in/out-point trim) and plain [ ] are brush size, so PageUp/PageDown —
+  // entirely unclaimed here, and Krita's own binding for exactly this.
+  else if(k==='PageUp'||k==='PageDown'){event.preventDefault();stepActiveLayer(k==='PageUp'?-1:1);}
   else if(k==='Home'){if(state.playing)stopPlay();goToFrame(0);}
   else if(k==='End'){if(state.playing)stopPlay();goToFrame(state.totalFrames-1);}
   // Alt+[ / Alt+] "trim layer in/out point to current time" (AE convention)


### PR DESCRIPTION
Changer de calque actif est l'une des actions les plus fréquentes dans n'importe quelle app de dessin multi-calques — rough sur l'un, propre sur l'autre, décor en dessous — et il n'existait **aucun accès clavier**.

Vérifié inerte avant ce changement : `Alt+flèches`, `Ctrl+flèches`, `PageUp`/`PageDown`, `Maj+H`, `Maj+L`. Le seul moyen de changer de calque était de viser une ligne à la souris.

## Pourquoi PageUp/PageDown

Les candidats voisins sont tous pris :

| touche | déjà utilisée pour |
|---|---|
| `Alt+[` / `Alt+]` | trim des points in/out du calque (convention AE) |
| `[` / `]` | taille du pinceau et de la gomme |
| **`PageUp` / `PageDown`** | **rien** — et c'est le binding de Krita pour exactement ça |

## Parcours de la liste telle qu'affichée

Pas dans l'ordre de `state.layers`, ce qui compte deux fois :

- le panneau rend **l'index le plus haut en premier** (`computeLayerRenderOrder` décompte), donc « monter » = index **supérieur**, pas inférieur
- les membres d'un dossier **replié** portent `hidden:true` et sont **enjambés** — sinon `PageDown` semblerait ne rien faire alors qu'il aurait déplacé le calque actif sur une ligne absente de l'écran

## Réutilisation du chemin existant

Passe par `SM.setActiveLayer` plutôt que d'affecter `activeLayerIdx` directement : cela sauvegarde aussi la frame du calque sortant, vide la sélection et décroche la ligne caméra — exactement ce que fait un clic sur une ligne.

**S'arrête aux extrémités** au lieu de boucler : passer du calque du haut à celui du bas quand on maintient la touche est désorientant.

## Vérification

8 contrôles dans l'app : monte, redescend, se cale aux deux extrémités sans boucler, le surlignage du panneau suit, inerte pendant la saisie dans un champ, et — le cas pour lequel le parcours par ordre d'affichage existe — les membres d'un dossier replié sont sautés (`4 → 3 → 0`) puis atteignables une fois déplié (`4 → 3 → 2 → 1 → 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)