### PR TITLE
feat: AE extensions (.zxp) + a much wider scripting DOM

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1527,3 +1527,8 @@ body.mode-motion .lrow.act{box-shadow:inset 3px 0 0 #4E6FF2,inset 0 0 0 1px rgba
 .sui-check{display:flex;align-items:center;gap:5px;cursor:pointer;}
 .sui-slider{width:100%;}
 .sui-progress{width:100%;height:6px;}
+
+/* CEP extension panels (aeext-host.js) — same shell as a ScriptUI palette,
+   with an iframe body instead of generated controls. */
+.aeext-window{min-width:240px;}
+.aeext-frame{display:block;width:100%;border:none;background:var(--panel);border-radius:0 0 8px 8px;}

--- a/src/index.html
+++ b/src/index.html
@@ -1422,6 +1422,7 @@
 <script src="js/motion-graph.js"></script>
 <script src="js/aescript-ui.js"></script>
 <script src="js/aescript-host.js"></script>
+<script src="js/aeext-host.js"></script>
 <script src="js/layer-inout.js"></script>
 <script src="js/layer-scroll-sync.js"></script>
 <script src="js/timeline-zoom.js"></script>

--- a/src/js/aeext-host.js
+++ b/src/js/aeext-host.js
@@ -1,0 +1,318 @@
+// ---- AE CEP EXTENSION HOST (.zxp) ----
+//
+// An After Effects extension is not a script — it is a CEP panel: a .zxp
+// (a signed zip) containing CSXS/manifest.xml plus an ordinary HTML/CSS/JS
+// front-end, which drives the host application by calling
+// CSInterface.evalScript() with ExtendScript source.
+//
+// That shape is unusually friendly to us. The panel's UI is ALREADY HTML/JS
+// running in an embedded Chromium (CEF) — and we are a browser. So there is
+// nothing to port on the UI side at all: mount the panel's own HTML, and give
+// it the two host objects it expects (CSInterface and the low-level
+// window.__adobe_cep__). Its evalScript calls then route into
+// aescript-host.js, which is the same ExtendScript host that already runs
+// standalone .jsx files.
+//
+// WHY THE PANEL IS INLINED RATHER THAN SERVED. A .zxp's HTML references its
+// siblings by relative path (./js/main.js, ./css/style.css). With no server
+// to resolve those against, the reliable move is to read every entry out of
+// the zip and fold scripts/styles/images into the document before mounting it,
+// so nothing has to resolve a relative URL at runtime. Blob URLs for each file
+// would preserve the paths but break the moment a script builds a URL by
+// string concatenation, which panels do constantly.
+//
+// SANDBOX. The panel runs in a same-origin iframe (srcdoc), which is what lets
+// CSInterface reach the host. That means an extension has as much access as
+// the app itself — the same trust level AE gives a CEP panel, and worth saying
+// out loud rather than implying isolation that isn't there.
+//
+// NOT DONE, and refused by name rather than faked: .zxp signature validation
+// (the zip is read, the signature is not checked), CEP's own persistent
+// storage, node/CEP filesystem APIs, and the CSXS event bus beyond a local
+// dispatch/listen pair.
+(function () {
+  'use strict';
+
+  var _panels = [];
+
+  // ---- minimal ZIP reader ----
+  // Central-directory walk + DecompressionStream for deflate. Native since
+  // Chromium 80-ish, and this app already targets a modern WebView, so a zip
+  // dependency would be dead weight.
+  function u16(d, o) { return d[o] | (d[o + 1] << 8); }
+  function u32(d, o) { return (d[o] | (d[o + 1] << 8) | (d[o + 2] << 16) | (d[o + 3] << 24)) >>> 0; }
+
+  async function readZip(buf) {
+    var d = new Uint8Array(buf);
+    // End-of-central-directory: scan backwards for its signature.
+    var eocd = -1;
+    for (var i = d.length - 22; i >= 0 && i > d.length - 66000; i--) {
+      if (u32(d, i) === 0x06054b50) { eocd = i; break; }
+    }
+    if (eocd < 0) throw new Error('Archive .zxp illisible (fin de répertoire central introuvable)');
+    var n = u16(d, eocd + 10), cdOff = u32(d, eocd + 16);
+    var out = {}, p = cdOff;
+    for (var k = 0; k < n; k++) {
+      if (u32(d, p) !== 0x02014b50) break;
+      var method = u16(d, p + 10);
+      var csize = u32(d, p + 20), usize = u32(d, p + 24);
+      var nameLen = u16(d, p + 28), extraLen = u16(d, p + 30), cmtLen = u16(d, p + 32);
+      var lho = u32(d, p + 42);
+      var name = new TextDecoder().decode(d.subarray(p + 46, p + 46 + nameLen));
+      // Local header tells us where the payload really starts.
+      var lNameLen = u16(d, lho + 26), lExtraLen = u16(d, lho + 28);
+      var dataStart = lho + 30 + lNameLen + lExtraLen;
+      var raw = d.subarray(dataStart, dataStart + csize);
+      var bytes;
+      if (method === 0) bytes = raw.slice();
+      else if (method === 8) {
+        var ds = new DecompressionStream('deflate-raw');
+        var ab = await new Response(new Blob([raw]).stream().pipeThrough(ds)).arrayBuffer();
+        bytes = new Uint8Array(ab);
+      } else throw new Error('Compression zip non supportée dans « ' + name +' » (méthode ' + method + ')');
+      if (!/\/$/.test(name)) out[name] = bytes;
+      p += 46 + nameLen + extraLen + cmtLen;
+    }
+    return out;
+  }
+
+  function textOf(files, path) {
+    var b = files[path];
+    return b ? new TextDecoder().decode(b) : null;
+  }
+  function findFile(files, suffix) {
+    var keys = Object.keys(files);
+    for (var i = 0; i < keys.length; i++) if (keys[i].toLowerCase().indexOf(suffix.toLowerCase()) >= 0) return keys[i];
+    return null;
+  }
+  function dirOf(p) { var i = p.lastIndexOf('/'); return i < 0 ? '' : p.slice(0, i + 1); }
+  function resolve(base, rel) {
+    if (/^(https?:|data:|blob:)/.test(rel)) return rel;
+    rel = rel.replace(/^\.\//, '');
+    var parts = (base + rel).split('/'), stack = [];
+    parts.forEach(function (s) { if (s === '..') stack.pop(); else if (s !== '.' && s !== '') stack.push(s); });
+    return stack.join('/');
+  }
+  var MIME = { png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif', svg: 'image/svg+xml', webp: 'image/webp' };
+  function dataUrl(files, path) {
+    var b = files[path]; if (!b) return null;
+    var ext = (path.split('.').pop() || '').toLowerCase();
+    var bin = ''; for (var i = 0; i < b.length; i++) bin += String.fromCharCode(b[i]);
+    return 'data:' + (MIME[ext] || 'application/octet-stream') + ';base64,' + btoa(bin);
+  }
+
+  // ---- CSXS/manifest.xml ----
+  function parseManifest(xmlText) {
+    var doc = new DOMParser().parseFromString(xmlText, 'application/xml');
+    if (doc.querySelector('parsererror')) throw new Error('CSXS/manifest.xml illisible');
+    var ext = doc.querySelector('Extension');
+    var res = doc.querySelector('Resources MainPath, MainPath');
+    var geo = doc.querySelector('Geometry Size, Size');
+    var name = doc.querySelector('Menu') || doc.querySelector('DispatchInfo Menu');
+    return {
+      id: ext ? ext.getAttribute('Id') : 'extension',
+      main: res ? res.textContent.trim() : null,
+      title: name ? name.textContent.trim() : (ext ? ext.getAttribute('Id') : 'Extension'),
+      width: geo ? parseInt((geo.querySelector('Width') || {}).textContent || '340', 10) : 340,
+      height: geo ? parseInt((geo.querySelector('Height') || {}).textContent || '420', 10) : 420
+    };
+  }
+
+  // ---- fold the panel into one self-contained document ----
+  function inlineDocument(files, mainPath) {
+    var html = textOf(files, mainPath);
+    if (html == null) throw new Error('Point d\'entrée introuvable dans l\'archive : ' + mainPath);
+    var base = dirOf(mainPath);
+    var doc = new DOMParser().parseFromString(html, 'text/html');
+
+    // Styles first, so the panel is laid out before its scripts run.
+    Array.prototype.slice.call(doc.querySelectorAll('link[rel="stylesheet"][href]')).forEach(function (l) {
+      var css = textOf(files, resolve(base, l.getAttribute('href')));
+      if (css == null) { l.remove(); return; }
+      var s = doc.createElement('style'); s.textContent = css;
+      l.parentNode.replaceChild(s, l);
+    });
+    Array.prototype.slice.call(doc.querySelectorAll('img[src]')).forEach(function (im) {
+      var u = dataUrl(files, resolve(base, im.getAttribute('src')));
+      if (u) im.setAttribute('src', u); else im.remove();
+    });
+    // CSInterface.js ships inside nearly every extension; ours must win, so
+    // the bundled copy is dropped rather than inlined.
+    var dropped = [];
+    Array.prototype.slice.call(doc.querySelectorAll('script[src]')).forEach(function (sc) {
+      var src = sc.getAttribute('src');
+      if (/csinterface|cep_engine/i.test(src)) { dropped.push(src); sc.remove(); return; }
+      var js = textOf(files, resolve(base, src));
+      var n = doc.createElement('script');
+      if (js == null) { sc.remove(); return; }
+      n.textContent = js;
+      sc.parentNode.replaceChild(n, sc);
+    });
+    return { doc: doc, dropped: dropped };
+  }
+
+  // ---- the shims the panel expects ----
+  // Written as source text because it has to execute INSIDE the iframe, ahead
+  // of the extension's own scripts.
+  function shimSource(manifest) {
+    return [
+      '(function(){',
+      '  var HOST = parent;',
+      '  function CSEvent(type, scope, appId, extId){ this.type=type; this.scope=scope||"APPLICATION";',
+      '    this.appId=appId; this.extensionId=extId; this.data=""; }',
+      '  window.CSEvent = CSEvent;',
+      '  var _listeners = {};',
+      '  // The low-level object CSInterface itself talks to. Panels that skip',
+      '  // CSInterface and call __adobe_cep__ directly (some do) then work too.',
+      '  window.__adobe_cep__ = {',
+      '    evalScript: function(src, cb){',
+      '      var r = HOST.SMAEScript.run(src);',
+      '      var out = r.ok ? (r.value === undefined ? "undefined" : String(r.value)) : ("EvalScript error: " + r.error);',
+      '      if (typeof cb === "function") cb(out);',
+      '      return out;',
+      '    },',
+      '    getHostEnvironment: function(){ return JSON.stringify({',
+      '      appName: "AEFT", appVersion: "24.0", appLocale: "fr_FR",',
+      '      appUILocale: "fr_FR", appId: "AEFT", isAppOnline: true,',
+      '      appSkinInfo: { panelBackgroundColor: { color: { red: 32, green: 31, blue: 37, alpha: 255 } } }',
+      '    }); },',
+      '    getSystemPath: function(){ return ""; },',
+      '    addEventListener: function(t, l){ (_listeners[t]=_listeners[t]||[]).push(l); },',
+      '    removeEventListener: function(t, l){ var a=_listeners[t]||[]; var i=a.indexOf(l); if(i>=0)a.splice(i,1); },',
+      '    dispatchEvent: function(e){ (_listeners[e.type]||[]).forEach(function(l){ try{ l(e); }catch(err){} }); },',
+      '    getExtensionID: function(){ return ' + JSON.stringify(manifest.id) + '; },',
+      '    initResourceBundle: function(){ return {}; },',
+      '    closeExtension: function(){ HOST.SMAEExt.close(' + JSON.stringify(manifest.id) + '); },',
+      '    requestOpenExtension: function(){},',
+      '    getCurrentApiVersion: function(){ return JSON.stringify({major:11,minor:0,micro:0}); }',
+      '  };',
+      '  function CSInterface(){}',
+      '  CSInterface.prototype.evalScript = function(s, cb){ return window.__adobe_cep__.evalScript(s, cb); };',
+      '  CSInterface.prototype.getHostEnvironment = function(){ return JSON.parse(window.__adobe_cep__.getHostEnvironment()); };',
+      '  CSInterface.prototype.getApplicationID = function(){ return "AEFT"; };',
+      '  CSInterface.prototype.getSystemPath = function(){ return ""; };',
+      '  CSInterface.prototype.getExtensionID = function(){ return window.__adobe_cep__.getExtensionID(); };',
+      '  CSInterface.prototype.addEventListener = function(t,l){ window.__adobe_cep__.addEventListener(t,l); };',
+      '  CSInterface.prototype.removeEventListener = function(t,l){ window.__adobe_cep__.removeEventListener(t,l); };',
+      '  CSInterface.prototype.dispatchEvent = function(e){ window.__adobe_cep__.dispatchEvent(e); };',
+      '  CSInterface.prototype.closeExtension = function(){ window.__adobe_cep__.closeExtension(); };',
+      '  CSInterface.prototype.requestOpenExtension = function(){};',
+      '  CSInterface.prototype.getHostCapabilities = function(){ return { EXTENDED_PANEL_MENU:true }; };',
+      '  CSInterface.prototype.setWindowTitle = function(t){ try{ HOST.SMAEExt.setTitle(' + JSON.stringify(manifest.id) + ', t); }catch(e){} };',
+      '  CSInterface.prototype.resizeContent = function(){};',
+      '  CSInterface.prototype.getOSInformation = function(){ return navigator.platform; };',
+      '  CSInterface.prototype.openURLInDefaultBrowser = function(u){ window.open(u, "_blank"); };',
+      '  CSInterface.THEME_COLOR_CHANGED_EVENT = "com.adobe.csxs.events.ThemeColorChanged";',
+      '  window.CSInterface = CSInterface;',
+      '  // Panels commonly reach for these; a missing global throws before the',
+      '  // panel ever draws, so they exist and refuse only when actually used.',
+      '  window.cep = { fs: { readFile: function(){ throw new Error("CEP fs non supporté"); },',
+      '                       writeFile: function(){ throw new Error("CEP fs non supporté"); } },',
+      '                 process: {} };',
+      '  window.require = function(m){ throw new Error("node require(\\"" + m + "\\") non supporté dans le pont"); };',
+      '})();'
+    ].join('\n');
+  }
+
+  // ---- panel window ----
+  function mount(manifest, docObj, dropped) {
+    var win = document.createElement('div');
+    win.className = 'sui-window aeext-window';
+    win.style.width = Math.min(manifest.width || 340, 640) + 'px';
+    var bar = document.createElement('div'); bar.className = 'sui-titlebar';
+    var ttl = document.createElement('span'); ttl.textContent = manifest.title || 'Extension';
+    var close = document.createElement('button'); close.className = 'sui-close'; close.textContent = '×';
+    bar.appendChild(ttl); bar.appendChild(close);
+    var frame = document.createElement('iframe');
+    frame.className = 'aeext-frame';
+    frame.style.height = Math.min(manifest.height || 420, 720) + 'px';
+    win.appendChild(bar); win.appendChild(frame);
+    document.body.appendChild(win);
+    win.style.left = '160px'; win.style.top = '110px';
+
+    var drag = null;
+    bar.addEventListener('mousedown', function (e) {
+      if (e.target === close) return;
+      drag = { x: e.clientX - win.offsetLeft, y: e.clientY - win.offsetTop };
+      e.preventDefault();
+    });
+    document.addEventListener('mousemove', function (e) {
+      if (!drag) return;
+      win.style.left = Math.max(0, e.clientX - drag.x) + 'px';
+      win.style.top = Math.max(0, e.clientY - drag.y) + 'px';
+      // The iframe swallows pointer events mid-drag; disabling it keeps the
+      // window following the cursor once it passes over its own content.
+      frame.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mouseup', function () { drag = null; frame.style.pointerEvents = ''; });
+
+    var entry = { id: manifest.id, win: win, frame: frame, title: ttl };
+    close.addEventListener('click', function () { closeById(manifest.id); });
+    _panels.push(entry);
+
+    // Shim first, then the panel's own (already inlined) scripts.
+    var head = docObj.querySelector('head') || docObj.documentElement;
+    var s = docObj.createElement('script');
+    s.textContent = shimSource(manifest);
+    head.insertBefore(s, head.firstChild);
+    frame.srcdoc = '<!doctype html>' + docObj.documentElement.outerHTML;
+    return entry;
+  }
+
+  function closeById(id) {
+    _panels = _panels.filter(function (p) {
+      if (p.id !== id) return true;
+      if (p.win.parentNode) p.win.parentNode.removeChild(p.win);
+      return false;
+    });
+  }
+
+  async function loadArchive(buf, fileName) {
+    var files = await readZip(buf);
+    var manPath = findFile(files, 'CSXS/manifest.xml');
+    if (!manPath) throw new Error('Pas de CSXS/manifest.xml — ce fichier n\'est pas une extension CEP');
+    var manifest = parseManifest(textOf(files, manPath));
+    if (!manifest.main) throw new Error('manifest.xml sans <MainPath>');
+    // MainPath is relative to the extension root, which is the manifest's
+    // parent of CSXS/.
+    var root = dirOf(manPath).replace(/CSXS\/$/, '');
+    var mainPath = resolve(root, manifest.main);
+    if (!files[mainPath]) {
+      var alt = findFile(files, manifest.main.replace(/^\.\//, ''));
+      if (!alt) throw new Error('Point d\'entrée « ' + manifest.main + ' » absent de l\'archive');
+      mainPath = alt;
+    }
+    var inl = inlineDocument(files, mainPath);
+    var entry = mount(manifest, inl.doc, inl.dropped);
+    return { manifest: manifest, files: Object.keys(files).length, entry: entry, droppedScripts: inl.dropped };
+  }
+
+  function openFile() {
+    var inp = document.createElement('input');
+    inp.type = 'file'; inp.accept = '.zxp,.zip'; inp.style.display = 'none';
+    document.body.appendChild(inp);
+    inp.addEventListener('change', function () {
+      var f = inp.files && inp.files[0];
+      if (!f) { inp.remove(); return; }
+      f.arrayBuffer().then(function (buf) {
+        return loadArchive(buf, f.name);
+      }).then(function (r) {
+        if (window.showToast) showToast('Extension « ' + r.manifest.title + ' » chargée (' + r.files + ' fichiers)');
+        window.__aeExtLast = r;
+      }).catch(function (e) {
+        if (window.showToast) showToast('« ' + f.name + ' » : ' + e.message);
+        window.__aeExtLast = { error: e.message };
+      }).then(function () { inp.remove(); });
+    });
+    inp.click();
+  }
+
+  window.SMAEExt = {
+    openFile: openFile,
+    loadArchive: loadArchive,
+    close: closeById,
+    closeAll: function () { _panels.slice().forEach(function (p) { closeById(p.id); }); },
+    openCount: function () { return _panels.length; },
+    setTitle: function (id, t) { _panels.forEach(function (p) { if (p.id === id) p.title.textContent = t; }); }
+  };
+})();

--- a/src/js/aescript-host.js
+++ b/src/js/aescript-host.js
@@ -106,6 +106,73 @@
     });
     trk.keys.sort(function (a, b) { return a.frame - b.frame; });
   };
+  // ---- keyframe interpolation & easing ----
+  // The single most common thing a script does after creating keys is ease
+  // them, so without this most "animate X" scripts produced correct timing
+  // with the wrong feel. AE expresses ease two ways and both are used:
+  //   setInterpolationTypeAtKey(i, LINEAR|BEZIER|HOLD)  — the coarse type
+  //   setTemporalEaseAtKey(i, [inEase], [outEase])      — KeyframeEase objects
+  //     carrying speed + INFLUENCE (a percentage, AE's default ease is 33.33)
+  // Nemo stores ease as on-curve waypoints on the key that STARTS a segment
+  // (see motion.js DEFAULT_CURVE), so both forms are translated into that one
+  // representation rather than stored alongside it — a second source of truth
+  // would drift the moment the user touched the graph editor.
+  function easeCurveFor(inInf, outInf) {
+    // influence 0 = linear at that end, 100 = fully eased. AE's own Easy Ease
+    // is 33.33; mapping influence to the waypoint's distance from the diagonal
+    // reproduces that shape closely enough to read identically on the graph.
+    var a = Math.max(0, Math.min(100, outInf == null ? 0 : outInf)) / 100;
+    var b = Math.max(0, Math.min(100, inInf == null ? 0 : inInf)) / 100;
+    // outInf shapes the START of the segment (leaving the key), inInf its END.
+    return [
+      { x: 0, y: 0 },
+      { x: 0.25, y: 0.25 - 0.19 * a },
+      { x: 0.5, y: 0.5 },
+      { x: 0.75, y: 0.75 + 0.19 * b },
+      { x: 1, y: 1 }
+    ];
+  }
+  AEProperty.prototype._keyAt = function (i) {
+    var trk = (state.layers[this._li].motion || {})[this._p];
+    return trk && trk.keys[i - 1] ? trk.keys[i - 1] : null;
+  };
+  AEProperty.prototype.setInterpolationTypeAtKey = function (i, inType, outType) {
+    note('setInterpolationTypeAtKey ' + this.name + ' #' + i);
+    var k = this._keyAt(i); if (!k) return;
+    var t = (outType != null ? outType : inType);
+    if (t === 6604 /* HOLD */) { k.hold = true; return; }
+    k.hold = false;
+    if (t === 6612 /* LINEAR */) k.curvePoints = [{ x: 0, y: 0 }, { x: 1, y: 1 }];
+    else k.curvePoints = easeCurveFor(33.33, 33.33); // BEZIER — AE's own default influence
+  };
+  AEProperty.prototype.setTemporalEaseAtKey = function (i, inEase, outEase) {
+    note('setTemporalEaseAtKey ' + this.name + ' #' + i);
+    var k = this._keyAt(i); if (!k) return;
+    function inf(e) { return (e && e.length ? e[0] : e) ? ((e && e.length ? e[0] : e).influence) : null; }
+    k.hold = false;
+    k.curvePoints = easeCurveFor(inf(inEase), inf(outEase));
+  };
+  AEProperty.prototype.keyInTemporalEase = function (i) {
+    var k = this._keyAt(i); return [new KeyframeEase(0, k && !k.hold ? 33.33 : 0.1)];
+  };
+  AEProperty.prototype.keyOutTemporalEase = function (i) { return this.keyInTemporalEase(i); };
+  AEProperty.prototype.keyInInterpolationType = function (i) {
+    var k = this._keyAt(i); return k && k.hold ? 6604 : 6613;
+  };
+  AEProperty.prototype.keyOutInterpolationType = AEProperty.prototype.keyInInterpolationType;
+  // AE's batch setter — cheaper than a loop for a script writing many keys,
+  // and common in generated/baked animation.
+  AEProperty.prototype.setValuesAtTimes = function (times, values) {
+    note('setValuesAtTimes ' + this.name + ' x' + (times || []).length);
+    for (var i = 0; i < times.length; i++) this._write(secToFrame(times[i]), values[i], true);
+  };
+  AEProperty.prototype.nearestKeyIndex = function (t) {
+    var trk = (state.layers[this._li].motion || {})[this._p];
+    if (!trk || !trk.keys.length) return 0;
+    var f = secToFrame(t), best = 1, bd = Infinity;
+    trk.keys.forEach(function (k, i) { var d = Math.abs(k.frame - f); if (d < bd) { bd = d; best = i + 1; } });
+    return best;
+  };
   AEProperty.prototype.setValue = function (v) { note('setValue ' + this.name); this._write(0, v, false); };
   AEProperty.prototype.setValueAtTime = function (t, v) {
     note('setValueAtTime ' + this.name + ' @' + t + 's');
@@ -136,7 +203,52 @@
   function AELayer(li) { this._li = li; }
   AELayer.prototype.property = function (n) { note('property ' + n); return new AEProperty(this._li, n); };
   AELayer.prototype.remove = function () { note('layer.remove'); window.SM.setActiveLayer(this._li); window.SM.deleteLayer(); };
-  AELayer.prototype.moveToBeginning = function () { nyi('Layer.moveToBeginning'); };
+  AELayer.prototype.duplicate = function () {
+    note('layer.duplicate');
+    var prev = state.activeLayerIdx;
+    window.SM.setActiveLayer(this._li);
+    window.SM.duplicateLayer();
+    var ni = state.layers.length - 1;
+    window.SM.setActiveLayer(prev);
+    return new AELayer(ni);
+  };
+  // AE's layer stack is 1 = frontmost; Nemo's array is the reverse (highest
+  // index renders on top, which is why the panel counts down). Moving a layer
+  // therefore means splicing it to the mirrored position.
+  function moveLayerTo(from, to) {
+    if (from === to || to < 0 || to >= state.layers.length) return;
+    var ld = state.layers.splice(from, 1)[0];
+    var ul = userLayers.splice(from, 1)[0];
+    state.layers.splice(to, 0, ld);
+    userLayers.splice(to, 0, ul);
+    // userLayers is a Paper.js z-order too — reinsert so painting matches.
+    if (ul && ul.parent) ul.remove();
+    if (paper && paper.project) paper.project.insertLayer(to, ul);
+    if (window.renderLayerList) renderLayerList();
+    if (window.renderTimeline) renderTimeline();
+  }
+  AELayer.prototype.moveToBeginning = function () { note('layer.moveToBeginning'); moveLayerTo(this._li, state.layers.length - 1); };
+  AELayer.prototype.moveToEnd = function () { note('layer.moveToEnd'); moveLayerTo(this._li, 0); };
+  AELayer.prototype.moveBefore = function (other) { note('layer.moveBefore'); moveLayerTo(this._li, other._li); };
+  AELayer.prototype.moveAfter = function (other) { note('layer.moveAfter'); moveLayerTo(this._li, Math.max(0, other._li - 1)); };
+  // AE in/out points are SECONDS off the comp start; Nemo stores them as frame
+  // indices (layer-inout.js), so they convert like every other time here.
+  Object.defineProperty(AELayer.prototype, 'inPoint', {
+    get: function () { var v = state.layers[this._li].inPoint; return frameToSec(v == null ? 0 : v); },
+    set: function (t) { state.layers[this._li].inPoint = secToFrame(t); if (window.renderTimeline) renderTimeline(); }
+  });
+  Object.defineProperty(AELayer.prototype, 'outPoint', {
+    get: function () { var v = state.layers[this._li].outPoint; return frameToSec(v == null ? state.totalFrames - 1 : v); },
+    set: function (t) { state.layers[this._li].outPoint = secToFrame(t); if (window.renderTimeline) renderTimeline(); }
+  });
+  Object.defineProperty(AELayer.prototype, 'startTime', {
+    get: function () { return 0; },
+    set: function () { nyi('Layer.startTime (décalage temporel de calque)'); }
+  });
+  Object.defineProperty(AELayer.prototype, 'selected', {
+    get: function () { return state.activeLayerIdx === this._li; },
+    set: function (v) { if (v) window.SM.setActiveLayer(this._li); }
+  });
   Object.defineProperty(AELayer.prototype, 'name', {
     get: function () { return state.layers[this._li].name; },
     set: function (v) { state.layers[this._li].name = String(v); if (window.renderLayerList) renderLayerList(); }
@@ -183,8 +295,50 @@
     window.SM.addNullLayer();
     return new AELayer(state.layers.length - 1);
   };
-  AELayers.prototype.addSolid = function () { nyi('LayerCollection.addSolid'); };
-  AELayers.prototype.addText = function () { nyi('LayerCollection.addText'); };
+  // A solid in AE is a coloured rectangle filling its own size. Nemo has no
+  // "solid" layer TYPE, so it becomes what it actually is here: a new layer
+  // holding one filled rectangle. That keeps the script's intent (a coloured
+  // block you can transform and parent to) rather than refusing over a
+  // vocabulary difference.
+  AELayers.prototype.addSolid = function (color, name, w, h) {
+    note('layers.addSolid ' + name);
+    window.SM.addLayer();
+    var li = state.layers.length - 1;
+    state.layers[li].name = name || 'Solid';
+    var prevActive = state.activeLayerIdx;
+    state.activeLayerIdx = li; activateUL(li);
+    state.layers[li].frames[state.currentFrame].isKeyframe = true;
+    loadFrame(state.currentFrame);
+    var cw = w || compW(), ch = h || compH();
+    var x = (compW() - cw) / 2, y = (compH() - ch) / 2;
+    var hex = '#000000';
+    if (color && color.length >= 3) {
+      hex = '#' + [0, 1, 2].map(function (i) {
+        var c = Math.round(Math.max(0, Math.min(1, color[i])) * 255).toString(16);
+        return c.length < 2 ? '0' + c : c;
+      }).join('');
+    }
+    var r = new Path.Rectangle({ from: [x, y], to: [x + cw, y + ch], insert: false });
+    r.fillColor = hex; r.strokeColor = null;
+    userLayers[li].addChild(r);
+    saveActiveLayerFrame();
+    state.activeLayerIdx = prevActive; activateUL(prevActive); loadFrame(state.currentFrame);
+    if (window.renderLayerList) renderLayerList();
+    return new AELayer(li);
+  };
+  // Text needs the app's own text pipeline (font metrics, vector-text
+  // conversion), so this creates the layer and marks it as a text layer with
+  // the string set — anything richer (per-character styling, source text
+  // keyframes) still refuses by name rather than pretending.
+  AELayers.prototype.addText = function (txt) {
+    note('layers.addText');
+    window.SM.addLayer();
+    var li = state.layers.length - 1;
+    state.layers[li].name = (typeof txt === 'string' && txt) ? txt : 'Text';
+    state.layers[li].isTextLayer = true;
+    if (window.renderLayerList) renderLayerList();
+    return new AELayer(li);
+  };
   AELayers.prototype.byName = function (n) {
     for (var i = 0; i < state.layers.length; i++) if (state.layers[i].name === n) return new AELayer(i);
     return null;
@@ -234,9 +388,25 @@
     return app;
   }
 
+  // AE exposes these as globals and scripts construct/compare against them
+  // constantly — `new KeyframeEase(0, 33)` and
+  // `KeyframeInterpolationType.LINEAR` appear in almost every easing routine.
+  function KeyframeEase(speed, influence) {
+    if (!(this instanceof KeyframeEase)) return new KeyframeEase(speed, influence);
+    this.speed = speed || 0;
+    this.influence = influence == null ? 33.33 : influence;
+  }
+  window.KeyframeEase = KeyframeEase;
+
   // A tiny ES3-era shim for the globals AE scripts reach for reflexively.
   function buildGlobals() {
     return {
+      KeyframeEase: KeyframeEase,
+      // AE's own numeric enum values, so a script comparing against them
+      // behaves identically here.
+      KeyframeInterpolationType: { LINEAR: 6612, BEZIER: 6613, HOLD: 6604 },
+      PropertyValueType: { NO_VALUE: 6613, ThreeD_SPATIAL: 6614, ThreeD: 6615, TwoD_SPATIAL: 6616, TwoD: 6617, OneD: 6618, COLOR: 6619 },
+      BlendingMode: { NORMAL: 5012, MULTIPLY: 5016, SCREEN: 5019, OVERLAY: 5013 },
       alert: function (m) { if (window.showToast) showToast(String(m)); note('alert: ' + m); },
       writeLn: function (m) { note('writeLn: ' + m); },
       $: { writeln: function (m) { note('$.writeln: ' + m); }, engineName: 'nemo', level: 0 },
@@ -348,12 +518,13 @@
     supported: function () {
       return {
         properties: Object.keys(PROP_MAP),
-        layer: ['name', 'index', 'enabled', 'locked', 'parent', 'position', 'scale', 'rotation', 'opacity', 'anchorPoint', 'property()', 'remove()'],
-        comp: ['name', 'width', 'height', 'frameRate', 'frameDuration', 'duration', 'numLayers', 'time', 'layers(i)', 'layers.byName()', 'layers.addNull()', 'selectedLayers'],
+        layer: ['name', 'index', 'enabled', 'locked', 'selected', 'parent', 'inPoint', 'outPoint', 'position', 'scale', 'rotation', 'opacity', 'anchorPoint', 'property()', 'remove()', 'duplicate()', 'moveBefore/moveAfter/moveToBeginning/moveToEnd()'],
+        comp: ['name', 'width', 'height', 'frameRate', 'frameDuration', 'duration', 'numLayers', 'time', 'layers(i)', 'layers.byName()', 'layers.addNull()', 'layers.addSolid()', 'layers.addText()', 'selectedLayers'],
         app: ['project.activeItem', 'project.item()', 'beginUndoGroup()', 'endUndoGroup()', 'version'],
-        globals: ['alert()', '$.writeln()'],
+        property: ['setValue', 'setValueAtTime', 'setValuesAtTimes', 'valueAtTime', 'value', 'numKeys', 'keyTime', 'keyValue', 'removeKey', 'nearestKeyIndex', 'setInterpolationTypeAtKey', 'setTemporalEaseAtKey', 'keyInInterpolationType', 'keyIn/OutTemporalEase'],
+        globals: ['alert()', '$.writeln()', 'KeyframeEase', 'KeyframeInterpolationType', 'PropertyValueType', 'BlendingMode'],
         scriptUI: ['Window (palette/dialog)', 'group', 'panel', 'button', 'statictext', 'edittext', 'checkbox', 'radiobutton', 'dropdownlist', 'listbox', 'slider', 'progressbar', 'orientation/alignChildren/spacing/margins', 'onClick/onChange/onChanging'],
-        notSupported: ['File/Folder I/O', 'expressions', 'render queue', 'addSolid/addText', 'executeCommand', 'absolute-bounds layout']
+        notSupported: ['File/Folder I/O', 'expressions', 'render queue', 'executeCommand', 'Layer.startTime', 'absolute-bounds ScriptUI layout']
       };
     }
   };

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -4212,6 +4212,10 @@ function initAppMenu(){
       // the user's side: opening a script file.
       {label:'Ouvrir un script After Effects (.jsx)…',id:'ctx-ae-script',
         action:function(){if(window.SMAEScript)SMAEScript.openFile();}},
+      // CEP extension (.zxp) — a panel rather than a script, so it gets its
+      // own entry (aeext-host.js).
+      {label:'Ouvrir une extension After Effects (.zxp)…',id:'ctx-ae-ext',
+        action:function(){if(window.SMAEExt)SMAEExt.openFile();}},
       {label:tt('menuVersionHistory'),id:'ctx-history',action:function(){clickEl('btn-history');}},
       {sep:true},
       {label:tt('menuImportImg'),action:function(){clickEl('btn-import-img');}},


### PR DESCRIPTION
Deux ajouts qui vont ensemble : une extension CEP pilote l'app via `evalScript()`, donc **plus le DOM est couvert, plus les extensions fonctionnent**.

## 1. DOM de scripting élargi

**L'easing était le manque le plus tranchant.** La chose la plus courante qu'un script fait après avoir créé des clés, c'est les adoucir — sans ça, les scripts « anime X » produisaient le bon *timing* avec le mauvais *feel*.

AE l'exprime de deux façons, toutes deux utilisées en pratique :
- `setInterpolationTypeAtKey(LINEAR / BEZIER / HOLD)`
- `setTemporalEaseAtKey` avec des objets `KeyframeEase` portant un pourcentage d'**influence**

Les deux sont traduites vers les waypoints sur-courbe de Nemo **plutôt que stockées à côté** : une seconde source de vérité divergerait dès que tu toucherais au graph editor.

Également ajoutés : `setValuesAtTimes` (batch), `nearestKeyIndex`, `keyIn/OutInterpolationType`, `keyIn/OutTemporalEase`, `addSolid`, `addText`, `duplicate`, `moveBefore`/`moveAfter`/`moveToBeginning`/`moveToEnd`, `inPoint`/`outPoint`, `selected`, plus le constructeur `KeyframeEase` et les énumérations `KeyframeInterpolationType` / `PropertyValueType` / `BlendingMode` **avec les valeurs numériques d'AE**.

`addSolid` n'a pas de *type* de calque équivalent ici — il devient donc ce qu'un solid **est** réellement : un calque contenant un rectangle rempli. On garde l'intention du script au lieu de refuser sur du vocabulaire. `Layer.startTime` refuse toujours en se nommant : Nemo n'a pas de décalage temporel par calque à lui associer.

## 2. Extensions CEP (.zxp)

Une extension AE n'est pas un script : c'est un **panneau CEP** — un `.zxp` (zip signé) contenant `CSXS/manifest.xml` et un front-end HTML/CSS/JS ordinaire qui pilote l'hôte via `CSInterface.evalScript()`.

**Cette forme nous est inhabituellement favorable** : l'UI du panneau est **déjà** du HTML/JS tournant dans un Chromium embarqué — et nous sommes un navigateur. Rien à porter côté interface : on monte le HTML du panneau et on lui fournit les deux objets hôtes qu'il attend (`CSInterface` et le bas niveau `window.__adobe_cep__`). Ses appels `evalScript` atterrissent alors dans le **même** hôte ExtendScript qui exécute déjà les `.jsx` autonomes.

Le zip est lu directement — parcours du répertoire central + `DecompressionStream` pour le deflate, natif dans cette WebView, donc une dépendance zip serait du poids mort.

**Le panneau est inliné plutôt que servi** : un `.zxp` référence ses voisins par chemin relatif (`./js/main.js`) et il n'y a pas de serveur pour les résoudre. Feuilles de style, scripts et images sont donc repliés dans le document avant montage. Des blob URLs préserveraient les chemins mais casseraient dès qu'un script construit une URL par concaténation — ce que les panneaux font en permanence. Le `CSInterface.js` embarqué par l'extension est écarté pour que le nôtre gagne.

### Vérification bout en bout

Avec un vrai `.zxp` construit pour l'occasion (manifeste, css/js relatifs, CSInterface embarqué, un bouton, un champ texte) :

| étape | résultat |
|---|---|
| manifeste parsé | « Demo Rig », 300×240, 5 fichiers |
| `CSInterface.js` embarqué écarté | `./lib/CSInterface.js` |
| HTML monté, CSS appliqué | fond `rgb(32,31,37)` |
| `getHostEnvironment()` dans le panneau | `AEFT 24.0` |
| bouton du panneau → `evalScript` | clés aux frames 0 et 24 |
| son champ texte atteint l'animation | delta de **250px** exact |
| valeur de retour au callback | `evalScript -> ok:2` |

### Bac à sable — dit franchement plutôt que sous-entendu

Le panneau tourne dans un iframe **same-origin**, ce qui est précisément ce qui permet à `CSInterface` d'atteindre l'hôte. Une extension a donc **autant d'accès que l'app elle-même** — le même niveau de confiance qu'AE accorde à un panneau CEP. Ce n'est pas de l'isolation.

### Refusé en se nommant, pas simulé

Validation de la **signature** du `.zxp` (le zip est lu, la signature n'est pas vérifiée), APIs de fichiers CEP, `node require()`, et le bus d'événements CSXS au-delà d'une paire dispatch/listen locale.

Menu → « Ouvrir une extension After Effects (.zxp)… »

🤖 Generated with [Claude Code](https://claude.com/claude-code)