### PR TITLE
feat: Nemo's own scripting and plugin API

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1502,3 +1502,27 @@ body.mode-motion .lrow.act{box-shadow:inset 3px 0 0 #4E6FF2,inset 0 0 0 1px rgba
   min-width:15px;height:15px;line-height:15px;text-align:center;font-size:9px;
   font-weight:700;padding:0 4px;}
 
+
+/* ---- Nemo script panels & HTML plugins (nemo-panel.js / nemo-plugin.js) ---- */
+.npanel{position:fixed;z-index:400;background:var(--panel2);border:1px solid var(--border2);
+  border-radius:8px;box-shadow:0 12px 40px rgba(0,0,0,.55);min-width:190px;font-size:11px;color:var(--text);}
+.npanel-bar{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:6px 8px;
+  border-bottom:1px solid var(--border);cursor:move;font-weight:600;user-select:none;}
+.npanel-close{background:none;border:none;color:var(--text-dim);font-size:15px;line-height:1;cursor:pointer;padding:0 2px;}
+.npanel-close:hover{color:var(--text);}
+.npanel-body{display:flex;flex-direction:column;gap:6px;padding:8px;}
+.npanel-row{display:flex;align-items:center;gap:6px;}
+.npanel-label{color:var(--text-dim);min-width:64px;}
+.npanel-text{color:var(--text-dim);}
+.npanel-group{display:flex;flex-direction:column;gap:6px;padding:8px;border:1px solid var(--border);border-radius:6px;}
+.npanel-group-title{font-size:9px;color:var(--text-dim);text-transform:uppercase;letter-spacing:.4px;}
+.npanel-btn{background:var(--panel);border:1px solid var(--border2);color:var(--text);
+  border-radius:5px;padding:5px 10px;cursor:pointer;font-size:11px;}
+.npanel-btn:hover{border-color:var(--accent);color:#fff;}
+.npanel-input{background:var(--panel);border:1px solid var(--border);color:var(--text);
+  border-radius:4px;padding:4px 6px;font-size:11px;flex:1;min-width:50px;}
+.npanel-select{background:var(--panel);border:1px solid var(--border);color:var(--text);
+  border-radius:4px;padding:4px 6px;font-size:11px;flex:1;}
+.npanel-check{display:flex;align-items:center;gap:5px;cursor:pointer;}
+.npanel-slider{flex:1;}
+.nplugin-frame{display:block;width:100%;border:none;background:var(--panel);border-radius:0 0 8px 8px;}

--- a/src/index.html
+++ b/src/index.html
@@ -1420,6 +1420,9 @@
 <script src="js/camera.js"></script>
 <script src="js/motion.js"></script>
 <script src="js/motion-graph.js"></script>
+<script src="js/nemo-panel.js"></script>
+<script src="js/nemo-script.js"></script>
+<script src="js/nemo-plugin.js"></script>
 <script src="js/layer-inout.js"></script>
 <script src="js/layer-scroll-sync.js"></script>
 <script src="js/timeline-zoom.js"></script>

--- a/src/js/nemo-panel.js
+++ b/src/js/nemo-panel.js
@@ -1,0 +1,147 @@
+// ---- NEMO PANEL UI ----
+//
+// Lets a script put a real interface on screen: a floating, draggable panel of
+// controls, styled as one of the app's own panels.
+//
+// The API is a BUILDER — `p.button('Go', fn)` returns the panel so calls chain
+// — rather than the add(type, bounds, text, props) shape older scripting
+// toolkits use. That older shape exists because those toolkits had to describe
+// an absolute-pixel layout; we don't, so the vocabulary can just say what the
+// control is. Every control also returns a handle through `p.last()` for the
+// cases where a script needs to read or update it later.
+//
+// Nothing here is specific to any other application's toolkit — it is a small
+// generic widget set over DOM, which is why it can ship.
+(function () {
+  'use strict';
+
+  var _panels = [];
+
+  function el(tag, cls) { var e = document.createElement(tag); if (cls) e.className = cls; return e; }
+
+  function Panel(opts) {
+    var self = this;
+    this._handles = [];
+    var win = el('div', 'npanel');
+    var bar = el('div', 'npanel-bar');
+    var ttl = el('span'); ttl.textContent = opts.title || 'Panneau';
+    var close = el('button', 'npanel-close'); close.textContent = '×';
+    bar.appendChild(ttl); bar.appendChild(close);
+    var body = el('div', 'npanel-body');
+    win.appendChild(bar); win.appendChild(body);
+    if (opts.width) win.style.width = (opts.width | 0) + 'px';
+    document.body.appendChild(win);
+    win.style.left = (opts.x != null ? opts.x : 140) + 'px';
+    win.style.top = (opts.y != null ? opts.y : 100) + 'px';
+
+    // Draggable by its bar — a panel that can't move covers the canvas it acts on.
+    var drag = null;
+    bar.addEventListener('mousedown', function (e) {
+      if (e.target === close) return;
+      drag = { x: e.clientX - win.offsetLeft, y: e.clientY - win.offsetTop };
+      e.preventDefault();
+    });
+    document.addEventListener('mousemove', function (e) {
+      if (!drag) return;
+      win.style.left = Math.max(0, e.clientX - drag.x) + 'px';
+      win.style.top = Math.max(0, e.clientY - drag.y) + 'px';
+    });
+    document.addEventListener('mouseup', function () { drag = null; });
+    close.addEventListener('click', function () { self.close(); });
+
+    this._win = win; this._body = body; this._title = ttl;
+    this._target = body;
+    _panels.push(this);
+  }
+
+  function row(p) { var r = el('div', 'npanel-row'); p._target.appendChild(r); return r; }
+
+  Panel.prototype.text = function (s) {
+    var d = el('div', 'npanel-text'); d.textContent = s;
+    this._target.appendChild(d);
+    this._handles.push({ node: d, get: function () { return d.textContent; }, set: function (v) { d.textContent = v; } });
+    return this;
+  };
+  Panel.prototype.button = function (label, fn) {
+    var b = el('button', 'npanel-btn'); b.textContent = label;
+    b.addEventListener('click', function () { if (fn) fn(); });
+    this._target.appendChild(b);
+    this._handles.push({ node: b, get: function () { return b.textContent; }, set: function (v) { b.textContent = v; } });
+    return this;
+  };
+  Panel.prototype.field = function (label, value, fn) {
+    var r = row(this);
+    if (label) { var l = el('span', 'npanel-label'); l.textContent = label; r.appendChild(l); }
+    var i = el('input', 'npanel-input'); i.type = 'text'; i.value = value == null ? '' : value;
+    i.addEventListener('change', function () { if (fn) fn(i.value); });
+    r.appendChild(i);
+    this._handles.push({ node: i, get: function () { return i.value; }, set: function (v) { i.value = v; } });
+    return this;
+  };
+  Panel.prototype.number = function (label, value, fn) {
+    var r = row(this);
+    if (label) { var l = el('span', 'npanel-label'); l.textContent = label; r.appendChild(l); }
+    // `scrub` is this app's own convention for drag-to-change numeric fields
+    // (CLAUDE.md §10) — a scripted field behaves like every built-in one.
+    var i = el('input', 'npanel-input scrub'); i.type = 'number'; i.value = value == null ? 0 : value;
+    i.addEventListener('change', function () { if (fn) fn(parseFloat(i.value)); });
+    r.appendChild(i);
+    this._handles.push({ node: i, get: function () { return parseFloat(i.value); }, set: function (v) { i.value = v; } });
+    return this;
+  };
+  Panel.prototype.check = function (label, value, fn) {
+    var lab = el('label', 'npanel-check');
+    var c = el('input'); c.type = 'checkbox'; c.checked = !!value;
+    c.addEventListener('change', function () { if (fn) fn(c.checked); });
+    lab.appendChild(c); lab.appendChild(document.createTextNode(' ' + label));
+    this._target.appendChild(lab);
+    this._handles.push({ node: c, get: function () { return c.checked; }, set: function (v) { c.checked = !!v; } });
+    return this;
+  };
+  Panel.prototype.select = function (label, items, fn) {
+    var r = row(this);
+    if (label) { var l = el('span', 'npanel-label'); l.textContent = label; r.appendChild(l); }
+    var s = el('select', 'npanel-select');
+    (items || []).forEach(function (it) { var o = el('option'); o.textContent = it; s.appendChild(o); });
+    s.addEventListener('change', function () { if (fn) fn(s.value, s.selectedIndex); });
+    r.appendChild(s);
+    this._handles.push({ node: s, get: function () { return s.value; }, set: function (v) { s.value = v; } });
+    return this;
+  };
+  Panel.prototype.slider = function (label, value, min, max, fn) {
+    var r = row(this);
+    if (label) { var l = el('span', 'npanel-label'); l.textContent = label; r.appendChild(l); }
+    var s = el('input', 'npanel-slider'); s.type = 'range';
+    s.min = min == null ? 0 : min; s.max = max == null ? 100 : max; s.value = value == null ? s.min : value;
+    s.addEventListener('input', function () { if (fn) fn(parseFloat(s.value)); });
+    r.appendChild(s);
+    this._handles.push({ node: s, get: function () { return parseFloat(s.value); }, set: function (v) { s.value = v; } });
+    return this;
+  };
+  // A titled box that following controls go into, until group(null) ends it.
+  Panel.prototype.group = function (title) {
+    if (title == null) { this._target = this._body; return this; }
+    var g = el('div', 'npanel-group');
+    var t = el('div', 'npanel-group-title'); t.textContent = title;
+    g.appendChild(t);
+    this._body.appendChild(g);
+    this._target = g;
+    return this;
+  };
+  Panel.prototype.last = function () { return this._handles[this._handles.length - 1]; };
+  Panel.prototype.handle = function (i) { return this._handles[i]; };
+  Object.defineProperty(Panel.prototype, 'title', {
+    get: function () { return this._title.textContent; },
+    set: function (v) { this._title.textContent = v; }
+  });
+  Panel.prototype.close = function () {
+    if (this._win.parentNode) this._win.parentNode.removeChild(this._win);
+    var i = _panels.indexOf(this); if (i >= 0) _panels.splice(i, 1);
+  };
+
+  window.SMPanelUI = {
+    create: function (opts) { return new Panel(opts || {}); },
+    closeAll: function () { _panels.slice().forEach(function (p) { p.close(); }); },
+    openCount: function () { return _panels.length; }
+  };
+})();

--- a/src/js/nemo-plugin.js
+++ b/src/js/nemo-plugin.js
@@ -1,0 +1,220 @@
+// ---- NEMO HTML PLUGINS ----
+//
+// A plugin is an ordinary HTML page in a zip, plus a small JSON manifest. It
+// opens as a panel inside the app and drives it through the same `nemo` API
+// scripts use (nemo-script.js), reached from the panel as `window.nemo`.
+//
+// Being HTML is barely a design choice — the app runs in a WebView, so a
+// plugin's interface can simply BE a web page, with no toolkit to learn and no
+// build step. Anyone who can write a small page can extend Nemo.
+//
+// PACKAGE FORMAT — deliberately minimal, and ours:
+//
+//   my-plugin.zip
+//     nemo-plugin.json     { "name": "...", "main": "index.html",
+//                            "width": 320, "height": 380, "version": "1.0" }
+//     index.html
+//     ...css/js/images referenced relatively
+//
+// A plain folder works too via loadFiles(), so development needs no packaging
+// step at all.
+//
+// WHY THE PAGE IS INLINED RATHER THAN SERVED. The HTML references its siblings
+// by relative path and there is no server to resolve those against, so every
+// stylesheet, script and image is folded into the document before mounting.
+// Blob URLs would preserve the paths but break the moment a script builds a
+// URL by concatenation.
+//
+// TRUST, said plainly: the panel runs in a same-origin iframe, which is what
+// lets it reach `nemo`. A plugin therefore has the app's own access — it is
+// not sandboxed. Only install plugins you trust, exactly as with any editor's
+// extensions.
+(function () {
+  'use strict';
+
+  var _open = [];
+
+  function u16(d, o) { return d[o] | (d[o + 1] << 8); }
+  function u32(d, o) { return (d[o] | (d[o + 1] << 8) | (d[o + 2] << 16) | (d[o + 3] << 24)) >>> 0; }
+
+  // Central-directory walk + DecompressionStream for deflate — both native
+  // here, so a zip dependency would be dead weight.
+  async function readZip(buf) {
+    var d = new Uint8Array(buf), eocd = -1;
+    for (var i = d.length - 22; i >= 0 && i > d.length - 66000; i--) {
+      if (u32(d, i) === 0x06054b50) { eocd = i; break; }
+    }
+    if (eocd < 0) throw new Error('Archive illisible (fin de répertoire central introuvable)');
+    var n = u16(d, eocd + 10), p = u32(d, eocd + 16), out = {};
+    for (var k = 0; k < n; k++) {
+      if (u32(d, p) !== 0x02014b50) break;
+      var method = u16(d, p + 10), csize = u32(d, p + 20);
+      var nameLen = u16(d, p + 28), extraLen = u16(d, p + 30), cmtLen = u16(d, p + 32);
+      var lho = u32(d, p + 42);
+      var name = new TextDecoder().decode(d.subarray(p + 46, p + 46 + nameLen));
+      var start = lho + 30 + u16(d, lho + 26) + u16(d, lho + 28);
+      var raw = d.subarray(start, start + csize), bytes;
+      if (method === 0) bytes = raw.slice();
+      else if (method === 8) {
+        var ab = await new Response(new Blob([raw]).stream()
+          .pipeThrough(new DecompressionStream('deflate-raw'))).arrayBuffer();
+        bytes = new Uint8Array(ab);
+      } else throw new Error('Compression non supportée dans « ' + name +' »');
+      if (!/\/$/.test(name)) out[name] = bytes;
+      p += 46 + nameLen + extraLen + cmtLen;
+    }
+    return out;
+  }
+
+  function text(files, path) { var b = files[path]; return b ? new TextDecoder().decode(b) : null; }
+  function dirOf(p) { var i = p.lastIndexOf('/'); return i < 0 ? '' : p.slice(0, i + 1); }
+  function resolve(base, rel) {
+    if (/^(https?:|data:|blob:)/.test(rel)) return rel;
+    var parts = (base + rel.replace(/^\.\//, '')).split('/'), st = [];
+    parts.forEach(function (s) { if (s === '..') st.pop(); else if (s && s !== '.') st.push(s); });
+    return st.join('/');
+  }
+  var MIME = { png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif', svg: 'image/svg+xml', webp: 'image/webp' };
+  function dataUrl(files, path) {
+    var b = files[path]; if (!b) return null;
+    var bin = ''; for (var i = 0; i < b.length; i++) bin += String.fromCharCode(b[i]);
+    return 'data:' + (MIME[(path.split('.').pop() || '').toLowerCase()] || 'application/octet-stream') + ';base64,' + btoa(bin);
+  }
+  function findManifest(files) {
+    var keys = Object.keys(files);
+    for (var i = 0; i < keys.length; i++) if (/(^|\/)nemo-plugin\.json$/.test(keys[i])) return keys[i];
+    return null;
+  }
+
+  function inlineDocument(files, mainPath) {
+    var html = text(files, mainPath);
+    if (html == null) throw new Error('Point d\'entrée introuvable : ' + mainPath);
+    var base = dirOf(mainPath);
+    var doc = new DOMParser().parseFromString(html, 'text/html');
+    Array.prototype.slice.call(doc.querySelectorAll('link[rel="stylesheet"][href]')).forEach(function (l) {
+      var css = text(files, resolve(base, l.getAttribute('href')));
+      if (css == null) { l.remove(); return; }
+      var s = doc.createElement('style'); s.textContent = css;
+      l.parentNode.replaceChild(s, l);
+    });
+    Array.prototype.slice.call(doc.querySelectorAll('img[src]')).forEach(function (im) {
+      var u = dataUrl(files, resolve(base, im.getAttribute('src')));
+      if (u) im.setAttribute('src', u); else im.remove();
+    });
+    Array.prototype.slice.call(doc.querySelectorAll('script[src]')).forEach(function (sc) {
+      var js = text(files, resolve(base, sc.getAttribute('src')));
+      if (js == null) { sc.remove(); return; }
+      var n = doc.createElement('script'); n.textContent = js;
+      sc.parentNode.replaceChild(n, sc);
+    });
+    return doc;
+  }
+
+  // Injected ahead of the plugin's own scripts so `nemo` exists before they
+  // run. The parent's API object is handed over directly rather than proxied:
+  // a proxy would have to enumerate the surface and would silently rot as the
+  // API grows.
+  function bridgeSource(id) {
+    return [
+      '(function(){',
+      '  window.nemo = parent.SMScript.api();',
+      '  window.nemo.close = function(){ parent.SMPlugin.close(' + JSON.stringify(id) + '); };',
+      '  window.nemo.setTitle = function(t){ parent.SMPlugin.setTitle(' + JSON.stringify(id) + ', t); };',
+      '})();'
+    ].join('\n');
+  }
+
+  function mount(manifest, doc) {
+    var id = manifest.id;
+    var win = document.createElement('div'); win.className = 'npanel nplugin';
+    if (manifest.width) win.style.width = Math.min(manifest.width | 0, 640) + 'px';
+    var bar = document.createElement('div'); bar.className = 'npanel-bar';
+    var ttl = document.createElement('span'); ttl.textContent = manifest.name || 'Plugin';
+    var close = document.createElement('button'); close.className = 'npanel-close'; close.textContent = '×';
+    bar.appendChild(ttl); bar.appendChild(close);
+    var frame = document.createElement('iframe'); frame.className = 'nplugin-frame';
+    frame.style.height = Math.min(manifest.height | 0 || 380, 720) + 'px';
+    win.appendChild(bar); win.appendChild(frame);
+    document.body.appendChild(win);
+    win.style.left = '180px'; win.style.top = '120px';
+
+    var drag = null;
+    bar.addEventListener('mousedown', function (e) {
+      if (e.target === close) return;
+      drag = { x: e.clientX - win.offsetLeft, y: e.clientY - win.offsetTop };
+      e.preventDefault();
+    });
+    document.addEventListener('mousemove', function (e) {
+      if (!drag) return;
+      win.style.left = Math.max(0, e.clientX - drag.x) + 'px';
+      win.style.top = Math.max(0, e.clientY - drag.y) + 'px';
+      // The iframe swallows pointer events mid-drag; disabling it keeps the
+      // window following the cursor once it passes over its own content.
+      frame.style.pointerEvents = 'none';
+    });
+    document.addEventListener('mouseup', function () { drag = null; frame.style.pointerEvents = ''; });
+    close.addEventListener('click', function () { closeById(id); });
+
+    var head = doc.querySelector('head') || doc.documentElement;
+    var s = doc.createElement('script'); s.textContent = bridgeSource(id);
+    head.insertBefore(s, head.firstChild);
+    frame.srcdoc = '<!doctype html>' + doc.documentElement.outerHTML;
+
+    var entry = { id: id, win: win, title: ttl };
+    _open.push(entry);
+    return entry;
+  }
+
+  function closeById(id) {
+    _open = _open.filter(function (p) {
+      if (p.id !== id) return true;
+      if (p.win.parentNode) p.win.parentNode.removeChild(p.win);
+      return false;
+    });
+  }
+
+  function loadFiles(files) {
+    var manPath = findManifest(files);
+    if (!manPath) throw new Error('Pas de nemo-plugin.json — ce n\'est pas un plugin Nemo');
+    var man;
+    try { man = JSON.parse(text(files, manPath)); }
+    catch (e) { throw new Error('nemo-plugin.json illisible : ' + e.message); }
+    if (!man.main) throw new Error('nemo-plugin.json sans « main »');
+    man.id = man.id || man.name || ('plugin-' + Object.keys(files).length);
+    var root = dirOf(manPath);
+    var mainPath = resolve(root, man.main);
+    if (!files[mainPath]) throw new Error('Point d\'entrée « ' + man.main + ' » absent du paquet');
+    var entry = mount(man, inlineDocument(files, mainPath));
+    return { manifest: man, files: Object.keys(files).length, entry: entry };
+  }
+
+  async function loadArchive(buf) { return loadFiles(await readZip(buf)); }
+
+  function openFile() {
+    var inp = document.createElement('input');
+    inp.type = 'file'; inp.accept = '.zip,.nemoplug'; inp.style.display = 'none';
+    document.body.appendChild(inp);
+    inp.addEventListener('change', function () {
+      var f = inp.files && inp.files[0];
+      if (!f) { inp.remove(); return; }
+      f.arrayBuffer().then(loadArchive).then(function (r) {
+        if (window.showToast) showToast('Plugin « ' + r.manifest.name + ' » chargé');
+        window.__nemoPluginLast = r;
+      }).catch(function (e) {
+        if (window.showToast) showToast('« ' + f.name + ' » : ' + e.message);
+        window.__nemoPluginLast = { error: e.message };
+      }).then(function () { inp.remove(); });
+    });
+    inp.click();
+  }
+
+  window.SMPlugin = {
+    openFile: openFile,
+    loadArchive: loadArchive,
+    loadFiles: loadFiles,
+    close: closeById,
+    closeAll: function () { _open.slice().forEach(function (p) { closeById(p.id); }); },
+    openCount: function () { return _open.length; },
+    setTitle: function (id, t) { _open.forEach(function (p) { if (p.id === id) p.title.textContent = t; }); }
+  };
+})();

--- a/src/js/nemo-script.js
+++ b/src/js/nemo-script.js
@@ -1,0 +1,291 @@
+// ---- NEMO SCRIPTING API ----
+//
+// Nemo's own extensibility: a `nemo` object exposing this app's model in this
+// app's vocabulary, plus a panel builder so a script can put a real interface
+// on screen.
+//
+// WHY THIS EXISTS RATHER THAN THE OTHER THING. An earlier experiment ran
+// After Effects scripts by emulating Adobe's DOM. It worked, but a legal audit
+// put the exposure squarely on ADOBE'S VOCABULARY — the object graph, the SDK
+// constants, claiming to be "AEFT" — and not on the capability itself. So the
+// capability stays and the vocabulary goes: everything here is named after
+// Nemo's own concepts (layers, frames, keys, strokes), and nothing in this
+// file or its plugin loader refers to another company's API.
+//
+// The design still borrows the two SHAPES that make script tooling pleasant,
+// because those are generic and not anyone's property: a script can open a
+// floating panel of controls, and a plugin can be an ordinary HTML page. The
+// second is barely a design decision at all — we run in a browser.
+//
+// UNITS. Everything is in FRAMES, because that is what this app is. No
+// seconds-to-frames translation layer, no rounding surprises. `nemo.fps` is
+// there for a script that wants to compute one.
+(function () {
+  'use strict';
+
+  var _log = [];
+  function note(w) { _log.push(w); }
+  function fail(msg) { throw new Error('nemo: ' + msg); }
+
+  // ---- helpers over the app's own state ----
+  function layerAt(i) {
+    var ld = state.layers[i];
+    if (!ld) fail('aucun calque à l\'index ' + i);
+    return ld;
+  }
+  function indexOfName(name) {
+    for (var i = 0; i < state.layers.length; i++) if (state.layers[i].name === name) return i;
+    return -1;
+  }
+  var PROPS = ['position', 'anchor', 'scale', 'rotation', 'opacity'];
+  function checkProp(p) {
+    if (PROPS.indexOf(p) < 0) fail('propriété inconnue « ' + p + ' » (attendu : ' + PROPS.join(', ') + ')');
+    return p;
+  }
+
+  // ---- Layer ----
+  function Layer(i) { this.index = i; }
+  Layer.prototype._ld = function () { return layerAt(this.index); };
+  Object.defineProperty(Layer.prototype, 'name', {
+    get: function () { return this._ld().name; },
+    set: function (v) { this._ld().name = String(v); if (window.renderLayerList) renderLayerList(); }
+  });
+  Object.defineProperty(Layer.prototype, 'visible', {
+    get: function () { return this._ld().visible !== false; },
+    set: function (v) { this._ld().visible = !!v; if (window.renderLayerList) renderLayerList(); }
+  });
+  Object.defineProperty(Layer.prototype, 'locked', {
+    get: function () { return !!this._ld().locked; },
+    set: function (v) { this._ld().locked = !!v; if (window.renderLayerList) renderLayerList(); }
+  });
+  Object.defineProperty(Layer.prototype, 'parent', {
+    get: function () {
+      var uid = this._ld().parentLayerUid;
+      var pi = uid && window.SMMotion ? SMMotion.findLayerIndexByUid(uid) : -1;
+      return pi >= 0 ? new Layer(pi) : null;
+    },
+    set: function (l) {
+      if (!window.SMMotion) return;
+      SMMotion.setLayerParent(this.index, l ? SMMotion.ensureLayerUid(layerAt(l.index)) : null);
+      if (window.renderLayerList) renderLayerList();
+    }
+  });
+  // Frame range the layer is present for. Named in/out like the timeline UI
+  // calls them, and in frames like everything else.
+  Object.defineProperty(Layer.prototype, 'inFrame', {
+    get: function () { var v = this._ld().inPoint; return v == null ? 0 : v; },
+    set: function (f) { this._ld().inPoint = f | 0; if (window.renderTimeline) renderTimeline(); }
+  });
+  Object.defineProperty(Layer.prototype, 'outFrame', {
+    get: function () { var v = this._ld().outPoint; return v == null ? state.totalFrames - 1 : v; },
+    set: function (f) { this._ld().outPoint = f | 0; if (window.renderTimeline) renderTimeline(); }
+  });
+
+  // Static (unkeyed) transform value. Reading falls back to the property's
+  // neutral value so a script never has to special-case "never touched".
+  Layer.prototype.get = function (prop, frame) {
+    checkProp(prop);
+    var ld = this._ld();
+    var f = frame == null ? state.currentFrame : frame;
+    var v = window.SMMotion ? SMMotion.valueAtFrame(ld, prop, f) : null;
+    if (v == null) v = (ld.motionStatic && ld.motionStatic[prop]) ||
+      (prop === 'scale' ? [100, 100] : prop === 'opacity' ? [100] : [0, 0]);
+    return Array.isArray(v) ? v.slice() : [v];
+  };
+  Layer.prototype.set = function (prop, value) {
+    checkProp(prop); note('set ' + prop);
+    var ld = this._ld();
+    if (!ld.motionStatic) ld.motionStatic = {};
+    ld.motionStatic[prop] = Array.isArray(value) ? value.slice() : [value];
+    return this;
+  };
+  // Keyframing. `ease` is one of the names the app's own UI uses, so a script
+  // and the graph editor describe the same thing.
+  var EASES = {
+    linear: [{ x: 0, y: 0 }, { x: 1, y: 1 }],
+    smooth: [{ x: 0, y: 0 }, { x: 0.25, y: 0.156 }, { x: 0.5, y: 0.5 }, { x: 0.75, y: 0.844 }, { x: 1, y: 1 }],
+    strong: [{ x: 0, y: 0 }, { x: 0.25, y: 0.09 }, { x: 0.5, y: 0.5 }, { x: 0.75, y: 0.91 }, { x: 1, y: 1 }],
+    easeIn: [{ x: 0, y: 0 }, { x: 0.25, y: 0.25 }, { x: 0.5, y: 0.5 }, { x: 0.75, y: 0.91 }, { x: 1, y: 1 }],
+    easeOut: [{ x: 0, y: 0 }, { x: 0.25, y: 0.09 }, { x: 0.5, y: 0.5 }, { x: 0.75, y: 0.75 }, { x: 1, y: 1 }]
+  };
+  Layer.prototype.key = function (prop, frame, value, ease) {
+    checkProp(prop); note('key ' + prop + ' @' + frame);
+    var ld = this._ld();
+    if (!ld.motion) ld.motion = {};
+    if (!ld.motion[prop]) ld.motion[prop] = { keys: [] };
+    var trk = ld.motion[prop];
+    var arr = Array.isArray(value) ? value.slice() : [value];
+    var curve = EASES[ease || 'smooth'];
+    if (!curve) fail('ease inconnu « ' + ease + ' » (attendu : ' + Object.keys(EASES).join(', ') + ')');
+    var ex = trk.keys.filter(function (k) { return k.frame === frame; })[0];
+    if (ex) { ex.v = arr; ex.curvePoints = JSON.parse(JSON.stringify(curve)); ex.hold = false; }
+    else {
+      trk.keys.push({ frame: frame | 0, v: arr, curvePoints: JSON.parse(JSON.stringify(curve)), hOut: [0, 0], hIn: [0, 0] });
+      trk.keys.sort(function (a, b) { return a.frame - b.frame; });
+    }
+    return this;
+  };
+  Layer.prototype.hold = function (prop, frame) {
+    checkProp(prop);
+    var trk = (this._ld().motion || {})[prop];
+    var k = trk && trk.keys.filter(function (x) { return x.frame === frame; })[0];
+    if (k) k.hold = true;
+    return this;
+  };
+  Layer.prototype.keys = function (prop) {
+    checkProp(prop);
+    var trk = (this._ld().motion || {})[prop];
+    return trk ? trk.keys.map(function (k) { return { frame: k.frame, value: k.v.slice(), hold: !!k.hold }; }) : [];
+  };
+  Layer.prototype.clearKeys = function (prop) {
+    checkProp(prop);
+    var ld = this._ld();
+    if (ld.motion && ld.motion[prop]) delete ld.motion[prop];
+    return this;
+  };
+  // Strokes drawn on this layer at a given frame — read-only introspection, so
+  // a script can count, measure or report on artwork.
+  Layer.prototype.strokes = function (frame) {
+    var f = frame == null ? state.currentFrame : frame;
+    var fr = this._ld().frames[f];
+    return (fr && fr.strokes ? fr.strokes : []).map(function (s) {
+      return { id: s.strokeId || null, points: (s.segments || []).length, closed: !!s.closed,
+               strokeColor: s.strokeColor || null, fillColor: s.fillColor || null };
+    });
+  };
+  Layer.prototype.select = function () { window.SM.setActiveLayer(this.index); return this; };
+  Layer.prototype.remove = function () { window.SM.setActiveLayer(this.index); window.SM.deleteLayer(); };
+  Layer.prototype.duplicate = function () {
+    var prev = state.activeLayerIdx;
+    window.SM.setActiveLayer(this.index); window.SM.duplicateLayer();
+    var ni = state.layers.length - 1;
+    window.SM.setActiveLayer(prev);
+    return new Layer(ni);
+  };
+
+  // ---- the nemo object ----
+  function buildApi() {
+    var api = {
+      version: 1,
+      get fps() { return state.fps; },
+      get width() { return state.canvasW; },
+      get height() { return state.canvasH; },
+      get frameCount() { return state.totalFrames; },
+      get frame() { return state.currentFrame; },
+      set frame(f) { goToFrame(f | 0); },
+      get layerCount() { return state.layers.length; },
+
+      layer: function (which) {
+        if (typeof which === 'string') {
+          var i = indexOfName(which);
+          if (i < 0) fail('aucun calque nommé « ' + which + ' »');
+          return new Layer(i);
+        }
+        return new Layer(which | 0);
+      },
+      layers: function () { return state.layers.map(function (_l, i) { return new Layer(i); }); },
+      activeLayer: function () { return new Layer(state.activeLayerIdx); },
+      addLayer: function (name) {
+        window.SM.addLayer();
+        var i = state.layers.length - 1;
+        if (name) state.layers[i].name = String(name);
+        if (window.renderLayerList) renderLayerList();
+        return new Layer(i);
+      },
+      // A layer that never renders, meant to be parented to — the app already
+      // has the concept, this just names it for scripts.
+      addPivot: function (name) {
+        window.SM.addNullLayer();
+        var i = state.layers.length - 1;
+        if (name) state.layers[i].name = String(name);
+        if (window.renderLayerList) renderLayerList();
+        return new Layer(i);
+      },
+
+      // Frames
+      goToFrame: function (f) { goToFrame(f | 0); return api; },
+      isKeyframe: function (li, f) {
+        var fr = layerAt(li).frames[f == null ? state.currentFrame : f];
+        return !!(fr && fr.isKeyframe);
+      },
+
+      // Feedback + undo. One undo entry per script run is the sane default, so
+      // `undoGroup` wraps a whole routine rather than each edit.
+      toast: function (m) { if (window.showToast) showToast(String(m)); note('toast'); return api; },
+      undoGroup: function (fn) {
+        if (window.pushUndo) pushUndo();
+        return fn();
+      },
+      log: function () { return _log.slice(); },
+
+      // Everything a script can name, so `nemo.help()` answers "what can I do"
+      // without leaving the app.
+      help: function () {
+        return {
+          properties: PROPS,
+          eases: Object.keys(EASES),
+          layer: ['name', 'visible', 'locked', 'parent', 'inFrame', 'outFrame',
+                  'get(prop,frame)', 'set(prop,value)', 'key(prop,frame,value,ease)',
+                  'hold(prop,frame)', 'keys(prop)', 'clearKeys(prop)', 'strokes(frame)',
+                  'select()', 'duplicate()', 'remove()'],
+          nemo: ['fps', 'width', 'height', 'frameCount', 'frame', 'layerCount',
+                 'layer(nameOrIndex)', 'layers()', 'activeLayer()', 'addLayer(name)',
+                 'addPivot(name)', 'goToFrame(f)', 'isKeyframe(li,f)', 'toast(msg)',
+                 'undoGroup(fn)', 'ui.panel(opts)'],
+          units: 'tout est en FRAMES (nemo.fps pour convertir)'
+        };
+      }
+    };
+    api.ui = { panel: function (opts) { return window.SMPanelUI.create(opts || {}); } };
+    return api;
+  }
+
+  // ---- runner ----
+  function run(source, opts) {
+    opts = opts || {};
+    _log = [];
+    var api = buildApi();
+    var fn;
+    try {
+      // The last expression is the script's result, which is what a console-
+      // style tool wants; eval's completion value gives that, and "use strict"
+      // keeps the script's own vars out of the page.
+      fn = new Function('nemo', '__src', '"use strict";\nreturn eval(__src);');
+    } catch (e) {
+      return { ok: false, error: 'Erreur de syntaxe : ' + e.message, log: [] };
+    }
+    try {
+      var v = fn(api, source);
+      if (window.saveActiveLayerFrame) saveActiveLayerFrame();
+      if (window.renderLayerList) renderLayerList();
+      if (window.renderTimeline) renderTimeline();
+      if (window.updateUI) updateUI();
+      if (window.SMEngineBridge) SMEngineBridge.renderNow();
+      return { ok: true, value: v, log: _log.slice() };
+    } catch (e) {
+      var isSyntax = (e instanceof SyntaxError);
+      return { ok: false, error: (isSyntax ? 'Erreur de syntaxe : ' : '') + e.message, log: _log.slice() };
+    }
+  }
+
+  function openFile() {
+    var inp = document.createElement('input');
+    inp.type = 'file'; inp.accept = '.js,.nemo'; inp.style.display = 'none';
+    document.body.appendChild(inp);
+    inp.addEventListener('change', function () {
+      var f = inp.files && inp.files[0];
+      if (!f) { inp.remove(); return; }
+      var rd = new FileReader();
+      rd.onload = function () {
+        var r = run(String(rd.result), { name: f.name });
+        if (window.showToast) showToast(r.ok ? ('Script « ' + f.name + ' » exécuté') : ('« ' + f.name + ' » : ' + r.error));
+        window.__nemoScriptLast = r;
+        inp.remove();
+      };
+      rd.readAsText(f);
+    });
+    inp.click();
+  }
+
+  window.SMScript = { run: run, openFile: openFile, api: buildApi, help: function () { return buildApi().help(); } };
+})();

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -4207,6 +4207,12 @@ function initAppMenu(){
       {label:tt('menuSave'),shortcut:'⌘S',action:function(){if(window.SMProject)window.SMProject.save();}},
       {label:tt('menuSaveAs'),shortcut:'⇧⌘S',action:function(){if(window.SMProject)window.SMProject.saveAs();}},
       {label:tt('menuFromKitsu'),id:'ctx-kitsu-open',action:function(){clickEl('btn-kitsu-open');}},
+      // Nemo's own extensibility (nemo-script.js / nemo-plugin.js) — this
+      // app's model in this app's vocabulary, so it ships.
+      {label:'Ouvrir un script Nemo (.js)…',id:'ctx-nemo-script',
+        action:function(){if(window.SMScript)SMScript.openFile();}},
+      {label:'Ouvrir un plugin Nemo (.zip)…',id:'ctx-nemo-plugin',
+        action:function(){if(window.SMPlugin)SMPlugin.openFile();}},
       {label:tt('menuVersionHistory'),id:'ctx-history',action:function(){clickEl('btn-history');}},
       {sep:true},
       {label:tt('menuImportImg'),action:function(){clickEl('btn-import-img');}},


### PR DESCRIPTION
L'audit juridique a placé l'exposition du pont AE entièrement sur le **vocabulaire d'Adobe** — le graphe d'objets, les constantes SDK, la revendication `appName:"AEFT"` — et **pas sur la capacité**.

Donc la capacité reste, le vocabulaire part : même classe d'extensibilité, nommée d'après les concepts de Nemo, sans rien qui renvoie à l'API d'une autre société.

## Trois pièces

### `nemo-script.js` — l'API

Un objet `nemo` sur le modèle de l'app : calques par nom ou index, `get`/`set`/`key`/`hold`/`clearKeys` sur les cinq propriétés de transformation, parentage, frames d'entrée/sortie, introspection des traits, `addLayer`/`duplicate`/`remove`, `undoGroup`, `toast`.

**Tout est en FRAMES**, parce que c'est ce qu'est cette app : pas de couche de traduction en secondes, pas de surprise d'arrondi — `nemo.fps` est là pour qui veut convertir.

Les eases portent les noms de l'UI (`linear` / `smooth` / `strong` / `easeIn` / `easeOut`), donc un script et le graph editor décrivent la même chose.

`nemo.help()` énumère toute la surface depuis l'intérieur de l'app.

### `nemo-panel.js` — les panneaux

Un constructeur de panneau flottant : `text`, `button`, `field`, `number`, `check`, `select`, `slider`, `group`.

C'est un **builder** (`p.button(...)` renvoie le panneau) plutôt que la forme `add(type, bounds, text, props)` des vieux toolkits — cette forme-là existe pour décrire une mise en page en pixels absolus, dont nous n'avons pas besoin, donc le vocabulaire peut simplement dire **ce qu'est** le contrôle.

Les champs numériques portent la classe `scrub` de l'app (§10 du CLAUDE.md) : un champ scripté se drague comme tous les autres.

### `nemo-plugin.js` — les plugins HTML

Un plugin est **une page HTML ordinaire dans un zip**, plus un petit `nemo-plugin.json`.

C'est à peine une décision de conception : l'app tourne dans une WebView, donc l'interface d'un plugin peut simplement **être** une page web — aucun toolkit à apprendre, aucune étape de build. La page est inlinée plutôt que servie parce qu'elle référence ses voisins par chemin relatif et qu'il n'y a pas de serveur pour les résoudre.

## Refuse en se nommant, n'approxime jamais

| appel | réponse |
|---|---|
| propriété inconnue | `propriété inconnue « wobble » (attendu : position, anchor, scale, rotation, opacity)` |
| calque inconnu | nomme le calque cherché |
| ease inconnu | liste les valides |

## Confiance — dit franchement

Un panneau de plugin tourne dans un iframe **same-origin**, ce qui est précisément ce qui lui permet d'atteindre `nemo`. Il a donc **l'accès de l'app elle-même** — ce n'est pas un bac à sable, exactement comme les extensions de n'importe quel éditeur.

## Vérification — 12 contrôles

- un script pose 3 clés de position et 2 de rotation avec les bonnes formes de courbe selon l'ease nommé, parente un calque, et relit
- propriété / calque / ease inconnus refusent chacun en se nommant
- un script construit un panneau avec tous les types de contrôle, son bouton se déclenche et met à jour le panneau, `closeAll` nettoie
- un plugin HTML se charge depuis son propre manifeste, lit l'API (« 6 calques · 24 fps · 1920×1080 »), peuple une liste déroulante depuis les vrais calques, et son bouton écrit exactement la clé de **430px** demandée par son champ

Menu → « Ouvrir un script Nemo (.js)… » et « Ouvrir un plugin Nemo (.zip)… »

🤖 Generated with [Claude Code](https://claude.com/claude-code)