### PR TITLE
fix: beforeBuildCommand path — the guard runs from the project root

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "build": {
     "frontendDist": "../src",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "python3 ../scripts/assert-no-private-labs.py"
+    "beforeBuildCommand": "python3 scripts/assert-no-private-labs.py"
   },
   "app": {
     "withGlobalTauri": true,


### PR DESCRIPTION
Tauri exécute `beforeBuildCommand` depuis le répertoire contenant `package.json`, pas depuis `src-tauri/`. `../scripts/` remontait donc d'un niveau de trop et le garde-fou **cassait toutes les builds** sur son propre chemin manquant.

Trouvé en lançant réellement une build plutôt qu'en supposant le câblage correct.

**Le sens de l'échec était le bon** : le garde-fou a échoué **fermé** (aucune build) plutôt qu'ouvert (une build sans contrôle).

## Vérification après correction

- le garde-fou passe, la build se termine
- **analyse des chaînes du binaire livré** : `0` occurrence de `aescript-host`, `__adobe_cep__` ou `SMAEScript`
- le scripting Nemo (`nemo-script.js`, `SMPanelUI`) est bien présent

Le front étant compilé dans le binaire Tauri, c'est cette analyse — et non l'inspection du dossier `Resources` — qui constitue la preuve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)