### PR TITLE
ui: put the gradient toggle on the fill row, where it is looked for

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1526,3 +1526,15 @@ body.mode-motion .lrow.act{box-shadow:inset 3px 0 0 #4E6FF2,inset 0 0 0 1px rgba
 .npanel-check{display:flex;align-items:center;gap:5px;cursor:pointer;}
 .npanel-slider{flex:1;}
 .nplugin-frame{display:block;width:100%;border:none;background:var(--panel);border-radius:0 0 8px 8px;}
+
+/* Bouton dégradé sur la ligne Fill (timeline.js initFillGradientButton).
+   Une rampe miniature plutôt qu'une icône abstraite : le contrôle montre ce
+   qu'il fait, ce qui est tout l'objet de l'avoir déplacé ici. */
+.fill-grad-btn{padding:0;width:22px;height:20px;flex:0 0 auto;display:flex;
+  align-items:center;justify-content:center;}
+.fill-grad-ramp{display:block;width:14px;height:12px;border-radius:2px;
+  border:1px solid var(--border2);
+  background:linear-gradient(90deg,var(--text) 0%,transparent 100%);}
+.fill-grad-btn.on{border-color:var(--accent);}
+.fill-grad-btn.on .fill-grad-ramp{border-color:var(--accent);}
+.fill-grad-btn.off{opacity:.4;}

--- a/src/index.html
+++ b/src/index.html
@@ -587,6 +587,14 @@
           <input type="text" class="pi color-hex-input" id="p-fill-hex" value="FF0000" maxlength="9" spellcheck="false" data-i18n-title="hexInputTitle" title="Code hex — tape pour changer">
           <input type="number" class="pi scrub color-opacity-input" id="p-opacity" value="100" min="5" max="100" data-step="1">
           <span class="color-pct">%</span>
+          <!-- Gradient toggle, ON THE FILL ROW (2026-07-25). The control it
+               drives (#p-grad-on) already existed but lived inside the section
+               headed "Effects" — a mislabelled neighbour of the real effects
+               stack (see #effects-stack-sec's own ID-collision note) — so a
+               gradient fill was unfindable unless you already knew. Every
+               comparable app puts the fill TYPE next to the fill swatch, which
+               is what this is. Wired in timeline.js's initFillGradientButton. -->
+          <button class="pbtn fill-grad-btn" id="p-fill-grad-btn" title="Dégradé de fill — sélectionne une seule forme avec l'outil Sélection"><span class="fill-grad-ramp"></span></button>
           <div class="lico color-eye-toggle" id="fill-enable-toggle" data-i18n-title="fillEnableTitle" title="Enable/disable fill"></div>
         </div>
         <!-- "Propager la couleur…" button removed (feedback 2026-07: "pas

--- a/src/js/gradient-bridge.js
+++ b/src/js/gradient-bridge.js
@@ -54,6 +54,7 @@
     if (!target) {
       onCb.checked = false; onCb.disabled = true;
       kindRow.style.display = stopsList.style.display = addRow.style.display = hintRow.style.display = 'none';
+      if (window.syncFillGradientButton) syncFillGradientButton();
       return;
     }
     onCb.disabled = false;
@@ -63,6 +64,10 @@
     kindRow.style.display = show; addRow.style.display = show; hintRow.style.display = grad ? 'block' : 'none';
     stopsList.style.display = grad ? 'block' : 'none';
     stopsList.innerHTML = '';
+    // Le bouton dégradé de la ligne Fill (timeline.js) reflète cet état —
+    // resynchronisé ici parce que c'est le seul endroit qui sait ce que porte
+    // réellement la sélection courante.
+    if (window.syncFillGradientButton) syncFillGradientButton();
     if (!grad) return;
     document.getElementById('p-grad-kind').value = grad.kind;
     var stops = sortedStops(grad);

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -4083,6 +4083,49 @@ function updateTextActionsPanel(){
 // separate #effect-layer-sec-specific rendering that used to live here
 // has been replaced by that file's unified updateEffectsPanel(), shared
 // with ordinary layers.
+// Gradient toggle on the fill row (2026-07-25, "les gradient et blur ont été
+// travaillé mais non implémenté dans l'ui"). The feature was fully working —
+// verified applying, editing and surviving save/load — but its only entry
+// point was a checkbox inside a section headed "Effects", which is a
+// mislabelled neighbour of the real effects stack. Unfindable unless you
+// already knew where to look.
+//
+// This drives that SAME checkbox rather than duplicating its logic: dispatching
+// a real 'change' means gradient-bridge.js's own handler does all the work, so
+// there is one implementation and no second path to keep in sync.
+function initFillGradientButton(){
+  var btn=document.getElementById('p-fill-grad-btn');
+  var cb=document.getElementById('p-grad-on');
+  if(!btn||!cb)return;
+  btn.addEventListener('click',function(e){
+    e.preventDefault();e.stopPropagation();
+    if(cb.disabled){
+      // The checkbox disables itself when there is no single shape selected —
+      // say why instead of looking broken (same rule as the rest of this file).
+      showToast('Sélectionne une seule forme avec l\'outil Sélection pour lui appliquer un dégradé');
+      return;
+    }
+    cb.checked=!cb.checked;
+    cb.dispatchEvent(new Event('change',{bubbles:true}));
+    syncFillGradientButton();
+  });
+  syncFillGradientButton();
+}
+// Reflects the selection's real state, so the button reads as ON when the
+// selected shape actually carries a gradient.
+function syncFillGradientButton(){
+  var btn=document.getElementById('p-fill-grad-btn');
+  var cb=document.getElementById('p-grad-on');
+  if(!btn||!cb)return;
+  btn.classList.toggle('on',!!cb.checked);
+  btn.classList.toggle('off',!!cb.disabled);
+  btn.title=cb.disabled
+    ? 'Dégradé de fill — sélectionne une seule forme avec l\'outil Sélection'
+    : (cb.checked?'Dégradé de fill actif — cliquer pour revenir en aplat'
+                 :'Appliquer un dégradé au fill de la forme sélectionnée');
+}
+if(document.readyState==='loading')document.addEventListener('DOMContentLoaded',initFillGradientButton);
+else initFillGradientButton();
 function initCycleAndPropagate(){
   var cyc=document.getElementById('btn-cycle');
   if(cyc)cyc.addEventListener('click',function(){


### PR DESCRIPTION
Signalé ainsi : *« les gradient et blur ont été travaillé mais non implémenté dans l'ui »*.

Le dégradé s'est révélé **pleinement fonctionnel** — vérifié : il s'applique, ses stops s'éditent, il survit au save/load. Le signalement portait donc sur **l'accès**, pas sur le câblage.

Et l'accès était réellement mauvais : son unique point d'entrée était une case à cocher **dans la section intitulée « Effects »** — voisine **mal nommée** de la vraie pile d'effets (cf. la note de collision d'ID de `#effects-stack-sec`, qui consigne que `#effects-sec` était déjà pris par cette section dégradé).

Une option de **fill** rangée sous **Effets** est introuvable si on ne sait pas déjà.

## Déplacé là où toutes les apps comparables mettent le type de fill

Sur la **ligne Fill**, juste après la pastille, l'hexa et l'opacité. Une **rampe de dégradé miniature** plutôt qu'une icône abstraite : le contrôle montre ce qu'il fait, ce qui est tout l'objet du déplacement.

## Une seule implémentation

Le bouton pilote **la même case à cocher** au lieu de dupliquer la logique : le clic émet un vrai `change`, donc c'est le handler de `gradient-bridge.js` qui fait tout le travail. Aucun second chemin à maintenir synchronisé.

Il reflète aussi **la réalité** plutôt que son propre dernier clic — `renderGradientPanel` le resynchronise, donc resélectionner une forme qui porte déjà un dégradé affiche le bouton **actif**.

Et sans forme unique sélectionnée, il **s'estompe et explique** au lieu de sembler cassé (même règle que les autres refus du fichier).

## Vérification

| test | résultat |
|---|---|
| le bouton est sur la ligne Fill | ✅ |
| sans sélection : estompé + explique | ✅ |
| avec une forme : s'active | ✅ |
| clic : dégradé linéaire 2 stops + éditeur ouvert | ✅ |
| re-clic : retour à l'aplat | ✅ |
| resélection d'une forme à dégradé : affiche actif | ✅ |

Le blur n'avait pas besoin d'équivalent — il est accessible via le `+` de la section Effects, qui porte désormais un compteur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)