### PR TITLE
feat: effect parameters can be keyframed

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1538,3 +1538,11 @@ body.mode-motion .lrow.act{box-shadow:inset 3px 0 0 #4E6FF2,inset 0 0 0 1px rgba
 .fill-grad-btn.on{border-color:var(--accent);}
 .fill-grad-btn.on .fill-grad-ramp{border-color:var(--accent);}
 .fill-grad-btn.off{opacity:.4;}
+
+/* Stopwatch de paramètre d'effet (effects-panel.js) — même glyphe et même
+   position que celui du panneau Motion, pour que ce soit lu comme le même
+   geste des deux côtés. */
+.fx-stopwatch{cursor:pointer;color:var(--text-dark);flex:0 0 auto;width:16px;
+  display:flex;align-items:center;justify-content:center;}
+.fx-stopwatch:hover{color:var(--text);}
+.fx-stopwatch.on{color:var(--accent);}

--- a/src/js/effects-panel.js
+++ b/src/js/effects-panel.js
@@ -298,10 +298,67 @@
     if (expandedIdx === idx) expandedIdx = -1; else if (expandedIdx > idx) expandedIdx--;
     saveActiveLayerFrame(); renderEffectsSection(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
   }
+  // ---- keyable effect parameters (2026-07-25) ----
+  // An effect was a fixed number: a blur could be strong or weak but never
+  // came INTO focus. Each parameter can now carry its own key track, stored on
+  // the effect itself as `keys.p1 = {keys:[…]}` — the same shape a layer
+  // property uses, evaluated by the same SMMotion.evalTrack, so an eased blur
+  // and an eased Position behave identically and a hold means the same thing
+  // in both. It also rides along in save/load for free: the effects array is
+  // already serialised wholesale on both layers and shapes.
+  function paramKeyed(eff, key) {
+    return !!(eff.keys && eff.keys[key] && eff.keys[key].keys && eff.keys[key].keys.length);
+  }
+  // THE value getter — everything that needs a parameter goes through this, so
+  // keyed and static parameters are indistinguishable to callers.
+  function paramValueAt(eff, key, frame) {
+    var stat = eff[key];
+    if (!paramKeyed(eff, key)) return stat;
+    return window.SMMotion ? SMMotion.evalTrack(eff.keys[key], frame, stat) : stat;
+  }
+  window.effectParamValueAt = paramValueAt;
+  function ensureParamTrack(eff, key) {
+    if (!eff.keys) eff.keys = {};
+    if (!eff.keys[key]) eff.keys[key] = { keys: [] };
+    return eff.keys[key];
+  }
+  function setParamKey(idx, key, frame, value) {
+    var t = effectsTarget(); if (!t || !t.obj.effects || !t.obj.effects[idx]) return;
+    var eff = t.obj.effects[idx];
+    var trk = ensureParamTrack(eff, key);
+    var curve = window.SMMotion ? SMMotion.DEFAULT_CURVE() : [{ x: 0, y: 0 }, { x: 1, y: 1 }];
+    var ex = trk.keys.filter(function (k) { return k.frame === frame; })[0];
+    if (ex) ex.v = [value];
+    else {
+      trk.keys.push({ frame: frame, v: [value], curvePoints: curve, hOut: [0, 0], hIn: [0, 0] });
+      trk.keys.sort(function (a, b) { return a.frame - b.frame; });
+    }
+  }
+  // Stopwatch, matching the Motion panel's own convention: turning it ON keys
+  // the CURRENT value at the current frame so nothing jumps, turning it OFF
+  // freezes the value the animation had reached rather than snapping back to
+  // whatever the static field last held.
+  function toggleParamKeying(idx, key) {
+    var t = effectsTarget(); if (!t || !t.obj.effects || !t.obj.effects[idx]) return;
+    var eff = t.obj.effects[idx];
+    pushUndo();
+    if (paramKeyed(eff, key)) {
+      eff[key] = paramValueAt(eff, key, state.currentFrame);
+      delete eff.keys[key];
+    } else {
+      setParamKey(idx, key, state.currentFrame, eff[key]);
+    }
+    saveActiveLayerFrame(); renderEffectsList();
+    if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+  }
   function setParam(idx, key, raw) {
     var t = effectsTarget(); if (!t || !t.obj.effects || !t.obj.effects[idx]) return;
+    var eff = t.obj.effects[idx];
     pushUndo();
-    t.obj.effects[idx][key] = raw;
+    // While keying, editing the field writes a key at the current frame rather
+    // than the static value — same as dragging a keyed property in Motion.
+    if (paramKeyed(eff, key)) setParamKey(idx, key, state.currentFrame, raw);
+    else eff[key] = raw;
     saveActiveLayerFrame(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
   }
 
@@ -317,18 +374,31 @@
     }
     cfg.forEach(function (p) {
       var line = document.createElement('div'); line.className = 'fx-row-param';
+      // Stopwatch first, like the Motion panel puts it — same position, same
+      // glyph, so it reads as the same gesture in both places.
+      var keyed = paramKeyed(eff, p.key);
+      var sw = document.createElement('div');
+      sw.className = 'lico fx-stopwatch' + (keyed ? ' on' : '');
+      sw.innerHTML = '<span style="font-size:11px;line-height:1">' + (keyed ? '◈' : '◇') + '</span>';
+      sw.title = keyed ? 'Animé — cliquer pour figer la valeur actuelle'
+                       : 'Animer ce paramètre (pose une clé à la frame courante)';
+      sw.addEventListener('click', function (e) { e.stopPropagation(); toggleParamKeying(idx, p.key); });
       var label = document.createElement('span'); label.className = 'pl'; label.textContent = window.SM.t(p.label);
       var input = document.createElement('input');
       input.type = 'number'; input.className = 'pi scrub';
       input.min = p.min; input.max = p.max; input.dataset.step = p.step;
-      var stored = eff[p.key];
       var def = defaultsArrFor(eff.type)[{ p1: 0, p2: 1, p3: 2, p4: 3 }[p.key]];
-      input.value = Math.round(((stored !== undefined ? stored : def) * (p.scale || 1)) * 100) / 100;
+      var stored = eff[p.key] !== undefined ? eff[p.key] : def;
+      // Shows the value AT THE CURRENT FRAME once keyed, so scrubbing the
+      // timeline moves the field — the field is a readout of the animation,
+      // not a separate setting sitting beside it.
+      var shown = keyed ? paramValueAt(eff, p.key, state.currentFrame) : stored;
+      input.value = Math.round((shown * (p.scale || 1)) * 100) / 100;
       var unit = document.createElement('span');
       unit.style.cssText = 'font-size:9px;color:var(--text-dim)'; unit.textContent = p.unit || '';
       input.addEventListener('input', function () { setParam(idx, p.key, (parseFloat(this.value) || 0) / (p.scale || 1)); });
       input.addEventListener('click', function (e) { e.stopPropagation(); });
-      line.appendChild(label); line.appendChild(input); line.appendChild(unit);
+      line.appendChild(sw); line.appendChild(label); line.appendChild(input); line.appendChild(unit);
       wrap.appendChild(line);
     });
     row.parentNode.insertBefore(wrap, row.nextSibling);

--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -202,9 +202,26 @@
   // #[serde(rename_all = "camelCase")]). Shared by both the ordinary-layer
   // and effect/adjustment-layer push sites below — same stack, same wire
   // shape, only the SOURCE texture composite_scene runs it on differs.
-  function sceneEffectsOf(ld) {
+  // frameIdx (2026-07-25): effect parameters can be keyframed, so the value
+  // sent to the renderer is the one AT THIS FRAME, not the effect's static
+  // field. effectParamValueAt (effects-panel.js) returns the static value
+  // untouched when a parameter isn't keyed, so an unanimated effect is
+  // bit-identical to before. Defaults to the current frame, which is what the
+  // live view wants; export passes the frame it is writing.
+  // Export renders frame by frame through renderFrameToPixelsPNG, which calls
+  // loadFrame(f) — and loadFrame does NOT move state.currentFrame. Reading the
+  // current frame here would therefore have given EVERY exported image the
+  // effect value of whatever frame the editor happened to be sitting on, i.e.
+  // a frozen effect in the file and a moving one on screen. This override is
+  // set around the export's own buildSceneJson call.
+  var _fxFrameOverride = null;
+  function sceneEffectsOf(ld, frameIdx) {
+    var f = (frameIdx != null) ? frameIdx
+          : (_fxFrameOverride != null ? _fxFrameOverride : state.currentFrame);
+    var at = window.effectParamValueAt || function (e, k) { return e[k]; };
     return (ld.effects || []).map(function (e) {
-      return { effectType: e.type, enabled: !!e.enabled, p1: e.p1, p2: e.p2, p3: e.p3, p4: e.p4 };
+      return { effectType: e.type, enabled: !!e.enabled,
+               p1: at(e, 'p1', f), p2: at(e, 'p2', f), p3: at(e, 'p3', f), p4: at(e, 'p4', f) };
     });
   }
 
@@ -1587,7 +1604,9 @@
     engine.resize(cw, ch);
     engine.set_viewport(0, 0, 1, 0, cw / 2, ch / 2);
     loadFrame(frameIdx);
-    var json = buildSceneJson(true, true);
+    _fxFrameOverride = frameIdx;
+    var json;
+    try { json = buildSceneJson(true, true); } finally { _fxFrameOverride = null; }
     var bytes = await engine.render_to_pixels(json);
     var imgData = new ImageData(new Uint8ClampedArray(bytes.buffer, bytes.byteOffset, bytes.byteLength), cw, ch);
     var off = document.createElement('canvas'); off.width = cw; off.height = ch;

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -380,6 +380,31 @@
   // The value of `prop` on layer `ld` at `frame` — exact key, interpolated,
   // clamped outside the keyed range, the static override, or the neutral
   // default. Always returns an array (length 1 or 2, per PROP_DIM).
+  // Generic single-number track evaluator (2026-07-25, keyable effect
+  // parameters). Same key shape as a layer property track — {keys:[{frame, v,
+  // curvePoints, hold}]} — evaluated with the SAME curve code and the SAME
+  // hold semantics, so an effect's blur radius eases exactly like a Position
+  // key and a hold behaves identically. Deliberately shared rather than
+  // reimplemented next to the effects panel: a second copy of this maths would
+  // drift the first time either side gained a curve type (CLAUDE.md §3's
+  // duplicated-pair hazard, applied before it exists).
+  function evalTrack(track, frame, fallback) {
+    if (!track || !track.keys || !track.keys.length) return fallback;
+    var ks = track.keys;
+    if (frame <= ks[0].frame) return ks[0].v[0];
+    var last = ks[ks.length - 1];
+    if (frame >= last.frame) return last.v[0];
+    for (var i = 0; i < ks.length - 1; i++) {
+      var a = ks[i], b = ks[i + 1];
+      if (frame >= a.frame && frame < b.frame) {
+        if (a.hold) return a.v[0];
+        var t = (frame - a.frame) / (b.frame - a.frame);
+        var y = evalCurvePoints(a.curvePoints || DEFAULT_CURVE, t);
+        return a.v[0] + (b.v[0] - a.v[0]) * y;
+      }
+    }
+    return last.v[0];
+  }
   function rawValueAtFrame(ld, prop, frame) {
     var track = ld.motion && ld.motion[prop];
     if (!track || !track.keys.length) return staticValue(ld, prop);
@@ -2963,6 +2988,10 @@
 
   window.SMMotion = {
     valueAtFrame: valueAtFrame,
+    // Generic track evaluator — effects-panel.js keys its parameters with it
+    // so an effect eases exactly like a layer property (see evalTrack).
+    evalTrack: evalTrack,
+    DEFAULT_CURVE: function () { return JSON.parse(JSON.stringify(DEFAULT_CURVE)); },
     isAnimated: isAnimated,
     // Layer-level get/set for external gesture writers (select-bridge's
     // native-video footage drag) — same semantics as the Transform panel


### PR DESCRIPTION
Un effet était **un nombre fixe** : un blur pouvait être fort ou faible, mais jamais **entrer** dans la netteté. Chaque paramètre porte désormais sa propre piste de clés — blur, rayon de glow, vignette s'animent comme n'importe quelle propriété.

## Un seul évaluateur, pas deux

Les pistes de clés utilisent **la forme d'une propriété de calque** — `{keys:[{frame, v, curvePoints, hold}]}` — et sont évaluées par un nouveau `SMMotion.evalTrack`, **factorisé** depuis `rawValueAtFrame` plutôt que réimplémenté à côté du panneau d'effets.

Un blur adouci et une Position adoucie partagent donc le même code de courbe, un `hold` veut dire la même chose des deux côtés, et il n'existe **aucune seconde copie** de ces maths susceptible de diverger le jour où l'un des deux gagne un type de courbe (le piège des paires dupliquées du §3, désamorcé avant d'exister).

## Le stopwatch suit la convention du panneau Motion

- **ON** pose une clé sur la **valeur courante** — rien ne saute
- **OFF** fige la valeur que l'animation avait **atteinte**, au lieu de revenir à ce que le champ statique contenait
- **Pendant l'animation**, éditer le champ écrit une clé à la frame courante, et le champ affiche la valeur **à la tête de lecture** : c'est une lecture de l'animation, pas un réglage posé à côté

## Le bug que ça a failli embarquer

L'export rend image par image via `renderFrameToPixelsPNG`, qui appelle `loadFrame(f)` — et **`loadFrame` ne déplace pas `state.currentFrame`**.

Lire la frame courante au moment de construire la scène aurait donc donné à **chaque image exportée** la valeur d'effet de la frame où l'éditeur se trouvait : un effet **figé dans le fichier** et animé à l'écran.

Trouvé en allant vérifier ce que `loadFrame` fait réellement au lieu de le supposer. L'export pose maintenant un override de frame explicite autour de sa propre construction de scène.

## Vérification — 10 contrôles

**Le paramètre** : le stopwatch apparaît, pose la valeur courante, l'édition écrit une clé à la tête de lecture, la valeur anime `8 → 16 → 34 → 52 → 60` sur les frames 0-24 *(adouci, pas linéaire — le linéaire donnerait 21 à la frame 6)*, le champ suit la tête de lecture, et l'extinction du stopwatch fige 34.

**Persistance** : la piste fait l'aller-retour `exportJSON`/`importJSON`.

**Non-régression** : un effet non keyé renvoie sa valeur statique intacte — les effets non animés sont bit-identiques à avant.

**L'export, de bout en bout** : le **même dessin** copié sur les frames 0 et 24, l'éditeur **délibérément garé sur la frame 0**, rendu par le vrai chemin d'export d'effets — **112 Ko contre 301 Ko**. Des images identiques auraient signifié que l'override ne fonctionnait pas ; c'est exactement ce que ce test prouve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)