### PR TITLE
feat: keyframe navigator on animated effect parameters

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1546,3 +1546,14 @@ body.mode-motion .lrow.act{box-shadow:inset 3px 0 0 #4E6FF2,inset 0 0 0 1px rgba
   display:flex;align-items:center;justify-content:center;}
 .fx-stopwatch:hover{color:var(--text);}
 .fx-stopwatch.on{color:var(--accent);}
+
+/* Navigateur de clés d'un paramètre d'effet (effects-panel.js) — le triple
+   précédent / poser-supprimer / suivant qu'AE place à côté d'une propriété
+   animée, plus le nombre de clés. */
+.fx-keynav{display:flex;align-items:center;gap:2px;margin-left:auto;flex:0 0 auto;}
+.fx-keynav-btn{cursor:pointer;color:var(--text-dim);font-size:9px;line-height:1;
+  padding:2px 3px;border-radius:3px;user-select:none;}
+.fx-keynav-btn:hover{color:var(--text);background:rgba(255,255,255,.06);}
+.fx-keynav-btn.off{opacity:.25;cursor:default;}
+.fx-keynav-btn.off:hover{color:var(--text-dim);background:none;}
+.fx-keynav-count{font-size:8px;color:var(--text-dark);margin-left:2px;min-width:8px;text-align:center;}

--- a/src/js/effects-panel.js
+++ b/src/js/effects-panel.js
@@ -351,6 +351,53 @@
     saveActiveLayerFrame(); renderEffectsList();
     if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
   }
+  // ---- keyframe navigator ----
+  // Keying a parameter without a way to reach or remove its keys is only half
+  // a feature: a key could be created at the playhead and then never moved or
+  // deleted. The natural home would be a track in the Motion timeline, but
+  // that side rests on a panel/grid row-count invariant this file has no
+  // business touching (see motion.js's ROW_H header), so the navigator lives
+  // on the parameter row itself — the same prev/toggle/next triple AE puts
+  // beside an animated property, and enough to reach every key.
+  function paramKeysOf(eff, key) {
+    return (eff.keys && eff.keys[key] && eff.keys[key].keys) ? eff.keys[key].keys : [];
+  }
+  function keyAtFrame(eff, key, frame) {
+    return paramKeysOf(eff, key).filter(function (k) { return k.frame === frame; })[0] || null;
+  }
+  function gotoAdjacentKey(eff, key, dir) {
+    var ks = paramKeysOf(eff, key), f = state.currentFrame, best = null;
+    ks.forEach(function (k) {
+      if (dir < 0 ? k.frame < f : k.frame > f) {
+        if (best === null || (dir < 0 ? k.frame > best : k.frame < best)) best = k.frame;
+      }
+    });
+    if (best !== null) goToFrame(best);
+    return best !== null;
+  }
+  function toggleKeyHere(idx, key) {
+    var t = effectsTarget(); if (!t || !t.obj.effects || !t.obj.effects[idx]) return;
+    var eff = t.obj.effects[idx];
+    if (!paramKeyed(eff, key)) return;
+    var ks = paramKeysOf(eff, key);
+    var here = keyAtFrame(eff, key, state.currentFrame);
+    pushUndo();
+    if (here) {
+      // Removing the LAST key would leave an empty track that still reads as
+      // "animated" — collapse back to a static value instead, freezing what
+      // the animation showed. Same choice the stopwatch makes when turned off.
+      if (ks.length === 1) {
+        eff[key] = here.v[0];
+        delete eff.keys[key];
+      } else {
+        ks.splice(ks.indexOf(here), 1);
+      }
+    } else {
+      setParamKey(idx, key, state.currentFrame, paramValueAt(eff, key, state.currentFrame));
+    }
+    saveActiveLayerFrame(); renderEffectsList();
+    if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+  }
   function setParam(idx, key, raw) {
     var t = effectsTarget(); if (!t || !t.obj.effects || !t.obj.effects[idx]) return;
     var eff = t.obj.effects[idx];
@@ -399,6 +446,33 @@
       input.addEventListener('input', function () { setParam(idx, p.key, (parseFloat(this.value) || 0) / (p.scale || 1)); });
       input.addEventListener('click', function (e) { e.stopPropagation(); });
       line.appendChild(sw); line.appendChild(label); line.appendChild(input); line.appendChild(unit);
+      // Navigator, only once the parameter is actually animated — an unkeyed
+      // parameter has nothing to navigate, and three inert arrows would read
+      // as broken controls.
+      if (keyed) {
+        var ks = paramKeysOf(eff, p.key);
+        var nav = document.createElement('div'); nav.className = 'fx-keynav';
+        var hasPrev = ks.some(function (k) { return k.frame < state.currentFrame; });
+        var hasNext = ks.some(function (k) { return k.frame > state.currentFrame; });
+        var onKey = !!keyAtFrame(eff, p.key, state.currentFrame);
+        function navBtn(txt, on, title, fn) {
+          var b = document.createElement('span');
+          b.className = 'fx-keynav-btn' + (on ? '' : ' off');
+          b.textContent = txt; b.title = title;
+          if (on) b.addEventListener('click', function (e) { e.stopPropagation(); fn(); });
+          nav.appendChild(b);
+        }
+        navBtn('◀', hasPrev, 'Clé précédente', function () { gotoAdjacentKey(eff, p.key, -1); renderEffectsList(); });
+        navBtn(onKey ? '◆' : '◇', true,
+               onKey ? 'Supprimer la clé à cette frame' : 'Poser une clé à cette frame',
+               function () { toggleKeyHere(idx, p.key); });
+        navBtn('▶', hasNext, 'Clé suivante', function () { gotoAdjacentKey(eff, p.key, 1); renderEffectsList(); });
+        var count = document.createElement('span');
+        count.className = 'fx-keynav-count'; count.textContent = ks.length;
+        count.title = ks.length + ' clé(s)';
+        nav.appendChild(count);
+        line.appendChild(nav);
+      }
       wrap.appendChild(line);
     });
     row.parentNode.insertBefore(wrap, row.nextSibling);


### PR DESCRIPTION
Comble un trou de la livraison précédente : une clé d'effet pouvait être **créée** à la tête de lecture, puis **jamais atteinte, déplacée ni supprimée**. Une demi-fonctionnalité.

L'emplacement naturel serait une piste dans la timeline Motion, mais ce côté repose sur un invariant de nombre de lignes panneau/grille que ce fichier n'a rien à faire de toucher (l'en-tête `ROW_H` de `motion.js` y revient sans cesse).

Le navigateur vit donc **sur la ligne du paramètre** — le même triple précédent / poser-supprimer / suivant qu'AE place à côté d'une propriété animée, plus le nombre de clés.

## Les détails qui comptent

- **Le losange central reflète la tête de lecture** : creux entre deux clés (cliquer en **ajoute** une, valorisée depuis l'animation pour que rien ne saute), plein quand on est sur une clé (cliquer la **supprime**)
- **Les flèches s'estompent** aux extrémités au lieu de rester là, apparemment actives
- Il **n'apparaît qu'une fois le paramètre réellement animé** : trois flèches mortes sur un paramètre statique se liraient comme des contrôles cassés
- **Supprimer la dernière clé** ramène le paramètre à une valeur statique **figée sur ce que l'animation affichait**, au lieu de laisser une piste vide qui se prétendrait encore « animée » — le même choix que fait le stopwatch qu'on éteint

## Vérification — 10 contrôles

Le navigateur s'affiche avec le bon compte ; le losange est creux entre les clés et plein sur une clé ; les flèches sautent à la clé précédente et suivante et s'estompent aux extrémités ; le losange plein supprime la clé de cette frame ; le creux en ajoute une valorisée depuis l'animation (**76** à la frame 18, entre 0 et 90) ; supprimer la dernière laisse `p1=33` et **aucune piste** ; et un paramètre statique n'affiche **aucun** navigateur.

## À noter pour la suite

Les lignes de paramètres n'existent que tant qu'une ligne d'effet est **dépliée** — un test qui affecte `ld.effects` directement ne voit **aucun** contrôle. Ça m'a coûté un run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)