### PR TITLE
feat: effects through the scripting API

### DIFF
--- a/src/js/effects-panel.js
+++ b/src/js/effects-panel.js
@@ -317,6 +317,42 @@
     return window.SMMotion ? SMMotion.evalTrack(eff.keys[key], frame, stat) : stat;
   }
   window.effectParamValueAt = paramValueAt;
+  // Single writer for an effect parameter key, shared with the scripting API
+  // (nemo-script.js). A script building the key object itself would be a
+  // second definition of the shape, and the two would drift the first time it
+  // gains a field — the same reason evalTrack was factored out of motion.js
+  // rather than copied.
+  window.SMEffectKeys = {
+    valueAt: paramValueAt,
+    isKeyed: paramKeyed,
+    setKey: function (eff, key, frame, value, curvePoints) {
+      if (!eff.keys) eff.keys = {};
+      if (!eff.keys[key]) eff.keys[key] = { keys: [] };
+      var trk = eff.keys[key];
+      var curve = curvePoints || (window.SMMotion ? SMMotion.DEFAULT_CURVE() : [{ x: 0, y: 0 }, { x: 1, y: 1 }]);
+      var ex = trk.keys.filter(function (k) { return k.frame === frame; })[0];
+      if (ex) { ex.v = [value]; ex.curvePoints = curve; }
+      else {
+        trk.keys.push({ frame: frame | 0, v: [value], curvePoints: curve, hOut: [0, 0], hIn: [0, 0] });
+        trk.keys.sort(function (a, b) { return a.frame - b.frame; });
+      }
+      return trk;
+    },
+    // The valid type list, so a caller can refuse an unknown one BEFORE
+    // creating it. addEffect happily accepts any string and the renderer then
+    // receives an effect it cannot draw — silent nonsense rather than an
+    // error, which is exactly what this file's own rule forbids.
+    types: function () {
+      var t = Object.keys(EFFECT_PARAM_CONFIG);
+      (state.customEffects || []).forEach(function (c) { t.push('custom:' + c.id); });
+      return t;
+    },
+    paramNames: function (type) { return paramConfigFor(type).map(function (p) { return p.key; }); },
+    labelOf: function (type, key) {
+      var c = paramConfigFor(type).filter(function (p) { return p.key === key; })[0];
+      return c ? window.SM.t(c.label) : key;
+    }
+  };
   function ensureParamTrack(eff, key) {
     if (!eff.keys) eff.keys = {};
     if (!eff.keys[key]) eff.keys[key] = { keys: [] };

--- a/src/js/nemo-script.js
+++ b/src/js/nemo-script.js
@@ -153,6 +153,74 @@
                strokeColor: s.strokeColor || null, fillColor: s.fillColor || null };
     });
   };
+  // ---- effects ----
+  // Reads and writes go through SMEffectKeys (effects-panel.js) rather than
+  // touching the key objects here: one definition of the shape, so a script
+  // and the effects panel can never disagree about what a key looks like.
+  function Effect(li, i) { this._li = li; this._i = i; }
+  Effect.prototype._e = function () {
+    var fx = (state.layers[this._li].effects || [])[this._i];
+    if (!fx) fail('aucun effet à l\'index ' + this._i);
+    return fx;
+  };
+  Object.defineProperty(Effect.prototype, 'type', { get: function () { return this._e().type; } });
+  Object.defineProperty(Effect.prototype, 'enabled', {
+    get: function () { return !!this._e().enabled; },
+    set: function (v) { this._e().enabled = !!v; if (window.updateEffectsPanel) updateEffectsPanel(); }
+  });
+  Effect.prototype.params = function () {
+    return window.SMEffectKeys ? SMEffectKeys.paramNames(this._e().type) : [];
+  };
+  Effect.prototype.get = function (param, frame) {
+    var f = frame == null ? state.currentFrame : frame;
+    return window.SMEffectKeys ? SMEffectKeys.valueAt(this._e(), param, f) : this._e()[param];
+  };
+  Effect.prototype.set = function (param, value) {
+    note('effect.set ' + param);
+    this._e()[param] = value;
+    return this;
+  };
+  Effect.prototype.key = function (param, frame, value, ease) {
+    note('effect.key ' + param + ' @' + frame);
+    var curve = EASES[ease || 'smooth'];
+    if (!curve) fail('ease inconnu « ' + ease + ' » (attendu : ' + Object.keys(EASES).join(', ') + ')');
+    if (!window.SMEffectKeys) fail('panneau d\'effets indisponible');
+    SMEffectKeys.setKey(this._e(), param, frame, value, JSON.parse(JSON.stringify(curve)));
+    return this;
+  };
+  Effect.prototype.keys = function (param) {
+    var trk = (this._e().keys || {})[param];
+    return trk ? trk.keys.map(function (k) { return { frame: k.frame, value: k.v[0] }; }) : [];
+  };
+  Effect.prototype.remove = function () {
+    var fx = state.layers[this._li].effects;
+    if (fx) fx.splice(this._i, 1);
+    if (window.updateEffectsPanel) updateEffectsPanel();
+  };
+  Layer.prototype.effects = function () {
+    var li = this.index;
+    return (this._ld().effects || []).map(function (_e, i) { return new Effect(li, i); });
+  };
+  Layer.prototype.addEffect = function (type) {
+    note('addEffect ' + type);
+    var ld = this._ld();
+    // Validate BEFORE creating: the panel's adder accepts any string, so an
+    // unknown type used to produce an effect the renderer cannot draw — silent
+    // nonsense instead of an error.
+    var valid = window.SMEffectKeys ? SMEffectKeys.types() : null;
+    if (valid && valid.indexOf(type) < 0) {
+      fail('type d\'effet inconnu « ' + type + ' » (attendu : ' + valid.join(', ') + ')');
+    }
+    var prev = state.activeLayerIdx;
+    // Goes through the panel's own adder so the effect gets its real defaults
+    // for its type, rather than a hand-built object that would be missing them.
+    window.SM.setActiveLayer(this.index);
+    if (!window.addEffectToActiveLayer) fail('panneau d\'effets indisponible');
+    addEffectToActiveLayer(type);
+    window.SM.setActiveLayer(prev);
+    if (!ld.effects || !ld.effects.length) fail('l\'effet « ' + type + ' » n\'a pas pu être créé');
+    return new Effect(this.index, ld.effects.length - 1);
+  };
   Layer.prototype.select = function () { window.SM.setActiveLayer(this.index); return this; };
   Layer.prototype.remove = function () { window.SM.setActiveLayer(this.index); window.SM.deleteLayer(); };
   Layer.prototype.duplicate = function () {
@@ -227,7 +295,9 @@
           layer: ['name', 'visible', 'locked', 'parent', 'inFrame', 'outFrame',
                   'get(prop,frame)', 'set(prop,value)', 'key(prop,frame,value,ease)',
                   'hold(prop,frame)', 'keys(prop)', 'clearKeys(prop)', 'strokes(frame)',
-                  'select()', 'duplicate()', 'remove()'],
+                  'effects()', 'addEffect(type)', 'select()', 'duplicate()', 'remove()'],
+          effect: ['type', 'enabled', 'params()', 'get(param,frame)', 'set(param,value)',
+                   'key(param,frame,value,ease)', 'keys(param)', 'remove()'],
           nemo: ['fps', 'width', 'height', 'frameCount', 'frame', 'layerCount',
                  'layer(nameOrIndex)', 'layers()', 'activeLayer()', 'addLayer(name)',
                  'addPivot(name)', 'goToFrame(f)', 'isKeyframe(li,f)', 'toast(msg)',


### PR DESCRIPTION
Ferme la boucle ouverte par les paramètres d'effets keyables : un script peut désormais **ajouter** un effet, **régler ou animer** ses paramètres, **lire** une valeur à n'importe quelle frame, et le **supprimer**.

```js
L.addEffect("blur")
 .key("p1", 0,  0,  "linear")
 .key("p1", 24, 90, "strong");
```

## Un seul écrivain pour la forme des clés

Lectures et écritures passent par un nouveau `SMEffectKeys` (`effects-panel.js`) plutôt que par une construction d'objets clés dans l'API. Une **seconde définition** de la forme divergerait dès qu'elle gagnerait un champ — la même raison qui a fait **factoriser** `SMMotion.evalTrack` au lieu de le copier.

Vérifié des deux côtés : le panneau et un script lisent **le même 45** à la frame 12 pour la même piste.

## Un vrai défaut que ça a fait remonter

`addEffectToActiveLayer` accepte **n'importe quelle chaîne** comme type d'effet — `addEffect("teleport")` créait donc un effet que le rendu ne sait pas dessiner. Du non-sens silencieux, c'est-à-dire exactement ce que la règle de ce codebase interdit.

Le type est désormais validé contre `SMEffectKeys.types()` **avant** toute création : un type inconnu refuse **en se nommant**, liste les valides, et **laisse le calque intact**.

Trouvé parce que le test affirmait le **refus**, pas seulement le chemin nominal.

## Vérification

Un script ajoute et anime un blur (`0 → 45 → 90` sur les frames 0/12/24, adouci), ajoute un second effet à côté, en supprime un, et relit via l'API ; un ease inconnu **et** un type d'effet inconnu refusent chacun en se nommant ; la liste des types valides est découvrable ; et `nemo.help()` documente désormais la surface des effets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)