### PR TITLE
fix: the Parent column was missing on first paint

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -3040,17 +3040,30 @@ function parentDescendants(li){
   });
   return out;
 }
+// Resolved locally rather than through SMMotion.findLayerIndexByUid, because
+// this runs at RENDER time and renderLayerList fires during boot BEFORE
+// motion.js has defined SMMotion. An early return on a missing SMMotion made
+// the whole column vanish on first paint and never come back until something
+// else happened to re-render the list — silently, which is how it survived
+// testing (every test called renderLayerList itself, long after load). The
+// lookup is two lines; the dependency was not worth it.
+function _layerIndexByUid(uid){
+  if(!uid)return -1;
+  for(var i=0;i<state.layers.length;i++)if(state.layers[i].layerUid===uid)return i;
+  return -1;
+}
 function buildParentCell(row,ld,li){
-  var M=window.SMMotion; if(!M||!M.setLayerParent)return;
   var cell=document.createElement('div');
   cell.className='lparent';
-  var pIdx=ld.parentLayerUid&&M.findLayerIndexByUid?M.findLayerIndexByUid(ld.parentLayerUid):-1;
+  var pIdx=_layerIndexByUid(ld.parentLayerUid);
   var pName=(pIdx>=0&&state.layers[pIdx])?(state.layers[pIdx].name||('Layer '+(pIdx+1))):null;
   cell.textContent=pName||'—';
   cell.classList.toggle('none',!pName);
   cell.title=pName?('Parent : '+pName+' — cliquer pour changer'):'Aucun parent — cliquer pour en choisir un';
   function open(e){
     e.stopPropagation(); e.preventDefault();
+    var M=window.SMMotion;
+    if(!M||!M.setLayerParent){showToast('Parentage indisponible');return;}
     var bad=parentDescendants(li);
     var items=[{label:'Aucun (parentage libre)',disabled:!ld.parentLayerUid,action:function(){
       pushUndo(); M.setLayerParent(li,null); renderLayerList(); renderTimeline();


### PR DESCRIPTION
Trouvé par une **passe de non-régression** sur les changements de la journée, pas par un signalement — et c'est la seule raison pour laquelle il a été trouvé, parce qu'il était **silencieux**.

## La cause

`renderLayerList()` s'exécute au démarrage, **avant** que `motion.js` n'ait défini `SMMotion`. `buildParentCell` commençait par :

```js
var M=window.SMMotion; if(!M||!M.setLayerParent)return;
```

Au premier rendu, la colonne **n'existait donc tout simplement pas**, et rien ne la ramenait tant qu'une action ultérieure ne re-rendait pas la liste.

## Pourquoi ça a survécu à ses propres tests

Chacun d'eux appelait `renderLayerList()` lui-même, longtemps après le chargement. **Les tests ne voyaient que le second rendu.**

## Le correctif

Supprimer la dépendance au moment du rendu plutôt que la contourner : résoudre le nom d'un parent ne demande que de comparer un uid à `state.layers` — une recherche locale de deux lignes.

`SMMotion` reste utilisé par le gestionnaire de clic, où il est certainement chargé à ce moment-là, et ce chemin **refuse maintenant avec un message** au lieu de lever une exception si jamais il ne l'était pas.

## Vérification

- la colonne est présente au **premier** rendu, une cellule par ligne
- le menu liste toujours les candidats
- le parentage s'applique toujours et **reste résolu après rechargement du projet, au premier rendu**
- le garde-fou de cycle désactive toujours les descendants

## Une note sur le test lui-même

Le premier essai cliquait l'entrée de menu « qui commence par A » et tombait sur **« Aucun (parentage libre) »** au lieu du calque nommé `A`. C'était **l'assertion** qui était fausse, pas le code. Correspondance exacte désormais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)