### PR TITLE
fix: the timeline's second markers were one frame early

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1876,7 +1876,20 @@ function renderTimeline(){
     // Second-boundary ticks (Animate-style ruler: "1s"/"2s" labels take
     // priority over the plain every-5-frames tick when they land on the
     // same cell) — gives a time-based read of the timeline, not just frames.
-    if((i+1)%fps===0){c.classList.add('sec');c.textContent=Math.round((i+1)/fps)+'s';}
+    // `i` is the 0-BASED frame index, and frame index 0 is time zero — so one
+    // second is at index `fps`, not `fps-1` (2026-07-25). The old
+    // `(i+1)%fps===0` marked one frame early at every boundary: at 24fps "1s"
+    // sat on index 23, which is 23/24 = 0.958s.
+    //
+    // It was the only place in the app that read time that way. Every other
+    // frame-to-seconds conversion — the camera export, video import, and
+    // reference-bridge's own video seek — uses frame/fps, so the ruler was
+    // announcing "1s" at the exact frame where the reference video would be
+    // parked at 0.958s. Anyone timing to that reference was off by a frame.
+    //
+    // The plain every-5 tick keeps showing the 1-based frame NUMBER (i+1),
+    // which is what the rest of the UI displays — that part was never wrong.
+    if(i>0&&i%fps===0){c.classList.add('sec');c.textContent=Math.round(i/fps)+'s';}
     else if((i+1)%5===0)c.textContent=i+1;
     hdr.appendChild(c);
   }


### PR DESCRIPTION
Demandé : vérifier que la lecture est en temps réel et cohérente avec le fps et le guide de temps.

**La lecture elle-même est saine** — accumulateur rAF sur horloge murale :

| fps demandé | fps réel mesuré | écart |
|---|---|---|
| 24 | 23.88 | −0.5% |
| 12 | 11.66 | −2.8% |
| 60 | 59.39 | −1.0% |

Tous **sous une frame** de quantification sur la fenêtre de mesure.

**C'est le ruler qui était faux.**

## La cause

`i` est l'index de frame **0-basé**, et la frame d'index 0 est l'instant zéro — une seconde se situe donc à l'index `fps`. Le test était `(i+1)%fps===0`, qui se déclenche à `fps-1` :

| fps | « 1s » placé sur l'index | temps réel |
|---|---|---|
| 24 | 23 | 23/24 = **0.958 s** |
| 12 | 11 | 11/12 = **0.917 s** |
| 25 | 24 | 24/25 = **0.960 s** |

À chaque repère, à chaque cadence, **une frame trop tôt**.

## Pourquoi ce n'est pas cosmétique

C'était le **seul endroit de l'app** qui lisait le temps ainsi. L'export caméra (`k.frame/state.fps`), l'import vidéo (`i/fps`), la lecture audio et la synchro de `reference-bridge` utilisent tous `frame/fps`.

Le ruler annonçait donc « 1s » **exactement à la frame où la vidéo de référence est positionnée à 0.958 s**. Quiconque calait un dessin sur cette référence — ou sur la waveform audio juste en dessous — était décalé d'une frame à chaque repère de seconde.

Les graduations tous les 5 continuent d'afficher le **numéro** de frame 1-basé (`i+1`), ce que montre le reste de l'UI : cette partie n'a jamais été fausse et ne change pas.

## Vérification

À 24/12/25/30 fps : chaque étiquette « Ns » tombe exactement sur l'index `N*fps`, le premier repère se convertit en **1.000 s** pile, le ruler s'accorde avec le `frame/fps` utilisé par la synchro de référence, et les graduations de frame lisent toujours 5/10/15/20 aux index 4/9/14/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)