### PR TITLE
Export: supersampled effects export (2x/4x pro-quality)

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2906,10 +2906,13 @@
   // params are now zoom-scaled (see run_one_effect, engine.rs) and must
   // match the true document size to look right in the export.
   //
-  // Scope limitation: unlike exportFrameDataURL, this path doesn't support
-  // a supersampling `scale` factor — export.js only takes it for scale=1
-  // when routing through here. Revisit if higher-res effect exports are
-  // ever needed.
+  // Supersampled effects export (2026-08, feedback #60 — "il faudrait
+  // augmenter la résolution [du] rendu final pour avoir une qualité pro"):
+  // renderFrameToPixelsPNG now takes the same `scale` factor
+  // exportFrameDataURL always supported, rendering at cw*scale × ch*scale
+  // instead of native size. This is NOT a resize-then-blit upscale — the
+  // whole scene (vector geometry AND effect params) renders natively at
+  // the higher pixel density, via resizeEngineOffscreenAtScale below.
   var _fxExportSavedFrame = null, _fxExportSavedEngineW = 0, _fxExportSavedEngineH = 0;
   function beginEffectsExport() {
     if (!engine) return false;
@@ -2929,6 +2932,28 @@
   function resizeEngineOffscreen(w, h) {
     engine.resize(w, h);
     engine.set_viewport(0, 0, 1, 0, w / 2, h / 2, 1);
+  }
+  // Same idea as resizeEngineOffscreen, but for a render target that's a
+  // uniform SCALE factor of the document's own native size rather than an
+  // arbitrary independent w/h — the pivot must stay the NATIVE document
+  // center (nativeW/2, nativeH/2), not half of the scaled target, or the
+  // content renders at the wrong density/position the moment scale != 1.
+  // Exact same pan-compensation algebra as syncViewport's panAdjX/panAdjY
+  // (see that function's own derivation) with the "desired pan before
+  // pivot compensation" fixed at 0 (no on-screen pan concept applies to an
+  // offscreen export) and z fixed at `scale`: pan = pivot*(scale-1) is what
+  // keeps world (0,0) landing on pixel (0,0) instead of drifting by the
+  // pivot's own offset once zoom != 1. effect_zoom is set to the SAME
+  // `scale` (not 1) so effect radii — already expressed as document pixels,
+  // scaled by effect_zoom in engine.rs's run_one_effect — grow with the
+  // render density instead of looking relatively thinner at higher scale.
+  function resizeEngineOffscreenAtScale(nativeW, nativeH, scale) {
+    var w = Math.max(1, Math.round(nativeW * scale)), h = Math.max(1, Math.round(nativeH * scale));
+    engine.resize(w, h);
+    var pivotWX = nativeW / 2, pivotWY = nativeH / 2;
+    var panAdjX = pivotWX * (scale - 1), panAdjY = pivotWY * (scale - 1);
+    engine.set_viewport(panAdjX, panAdjY, scale, 0, pivotWX, pivotWY, scale);
+    return { w: w, h: h };
   }
   // Renders one frame and returns the raw RGBA8 pixels — the actual
   // GPU-readback call site, factored out so both the PNG-encoding export
@@ -2950,12 +2975,12 @@
     var bytes = await engine.render_to_pixels(json);
     return new Uint8ClampedArray(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   }
-  async function renderFrameToPixelsPNG(frameIdx) {
+  async function renderFrameToPixelsPNG(frameIdx, scale) {
     var cw = state.canvasW, ch = state.canvasH;
-    resizeEngineOffscreen(cw, ch);
+    var size = resizeEngineOffscreenAtScale(cw, ch, scale || 1);
     var pixels = await renderFrameRawPixels(frameIdx);
-    var imgData = new ImageData(pixels, cw, ch);
-    var off = document.createElement('canvas'); off.width = cw; off.height = ch;
+    var imgData = new ImageData(pixels, size.w, size.h);
+    var off = document.createElement('canvas'); off.width = size.w; off.height = size.h;
     off.getContext('2d').putImageData(imgData, 0, 0);
     return off.toDataURL('image/png');
   }

--- a/src/js/export.js
+++ b/src/js/export.js
@@ -364,13 +364,12 @@ async function exportRenderPNGsToDir(dir,start,end,scale,onProgress,alpha){
   // effect, route every frame through the engine instead so the export
   // matches what the user sees on screen — see engine-bridge.js's
   // beginEffectsExport/renderFrameToPixelsPNG/endEffectsExport.
-  // Scale>1 (supersampled export) isn't supported on this path yet, so it
-  // only kicks in at the default scale — see renderFrameToPixelsPNG's own
-  // comment for why.
-  var useFx=(scale===1||!scale)&&exportNeedsEngine()&&window.SMEngineBridge&&window.SMEngineBridge.beginEffectsExport();
+  // scale (supersampled export, 2026-08 feedback #60) renders natively at
+  // cw*scale x ch*scale through the engine too — see renderFrameToPixelsPNG.
+  var useFx=exportNeedsEngine()&&window.SMEngineBridge&&window.SMEngineBridge.beginEffectsExport();
   try{
     for(var f=start,i=1;f<=end;f++,i++){
-      var url=useFx?await SMEngineBridge.renderFrameToPixelsPNG(f):exportFrameDataURL(f,scale,alpha);
+      var url=useFx?await SMEngineBridge.renderFrameToPixelsPNG(f,scale):exportFrameDataURL(f,scale,alpha);
       var bytes=exportDataURLToBytes(url);
       await exportWriteBytes(dir+'/frame_'+pad4(i)+'.png',bytes);
       if(onProgress)onProgress(i,end-start+1);
@@ -445,12 +444,12 @@ async function exportVideoBrowser(opts){
   rec.ondataavailable=function(e){if(e.data&&e.data.size)chunks.push(e.data);};
   var stopped=new Promise(function(resolve){rec.onstop=resolve;});
   rec.start();
-  var useFx=(scale===1||!scale)&&exportNeedsEngine()&&window.SMEngineBridge&&window.SMEngineBridge.beginEffectsExport();
+  var useFx=exportNeedsEngine()&&window.SMEngineBridge&&window.SMEngineBridge.beginEffectsExport();
   try{
     var frameMs=1000/fps;
     for(var f=r.start,i=1;f<=r.end;f++,i++){
       var t0=performance.now();
-      var url=useFx?await SMEngineBridge.renderFrameToPixelsPNG(f):exportFrameDataURL(f,scale,false);
+      var url=useFx?await SMEngineBridge.renderFrameToPixelsPNG(f,scale):exportFrameDataURL(f,scale,false);
       var img=await exportLoadImage(url);
       ctx.clearRect(0,0,cw,ch);
       ctx.drawImage(img,0,0,cw,ch);
@@ -573,7 +572,7 @@ async function exportGifBrowser(opts){
   var cw=Math.max(1,Math.round(state.canvasW*scale)),ch=Math.max(1,Math.round(state.canvasH*scale));
   var canvas=document.createElement('canvas');canvas.width=cw;canvas.height=ch;
   var ctx=canvas.getContext('2d',{willReadFrequently:true});
-  var useFx=(scale===1||!scale)&&exportNeedsEngine()&&window.SMEngineBridge&&window.SMEngineBridge.beginEffectsExport();
+  var useFx=exportNeedsEngine()&&window.SMEngineBridge&&window.SMEngineBridge.beginEffectsExport();
   var frameCount=r.end-r.start+1;
   var framePixels=[];
   try{
@@ -584,7 +583,7 @@ async function exportGifBrowser(opts){
     // introduced later.
     var samples=[];
     for(var f=r.start,i=1;f<=r.end;f++,i++){
-      var url=useFx?await SMEngineBridge.renderFrameToPixelsPNG(f):exportFrameDataURL(f,scale,false);
+      var url=useFx?await SMEngineBridge.renderFrameToPixelsPNG(f,scale):exportFrameDataURL(f,scale,false);
       var img=await exportLoadImage(url);
       ctx.clearRect(0,0,cw,ch);ctx.drawImage(img,0,0,cw,ch);
       var data=ctx.getImageData(0,0,cw,ch).data;


### PR DESCRIPTION
## Summary
Feedback #60 (part 1/2) — "il faudrait travailler l'échantillonnage pour la preview... et celle du rendu final dont on doit augmenter la résolution pour avoir une qualité pro à la fin."

Effect-bearing exports (blur/vignette/glow/matte/track-composite/...) were hard-capped to the project's native resolution — `export.js` silently fell back to the non-engine Paper.js rasterizer for any `scale > 1`, which never runs effects at all, so a 2x/4x export of a project using effects silently dropped them.

- `renderFrameToPixelsPNG` now accepts the same `scale` factor `exportFrameDataURL` always supported.
- `resizeEngineOffscreenAtScale` renders the whole scene **natively** at `cw*scale × ch*scale` (not a resize-then-blit upscale) — reuses the exact pan/pivot algebra `syncViewport` already uses, so vector geometry and effect radii (already zoom-scaled in `engine.rs`) grow together correctly.
- Removed the `scale===1` gate on all 3 export call sites (PNG sequence, WebM/video, GIF).

Part 2 (adaptive live-preview sampling quality) needs an internal render-resolution/coordinate-mapping split in `engine.rs` so `screen_to_world`/hit-testing (which read `engineW`/`engineH` throughout the JS codebase) stay correct while the GPU surface shrinks for weaker hardware — bigger, riskier change to the shared on-screen render path, left for a dedicated follow-up.

## Test plan
- [x] `node --check` on both touched files
- [x] Live-verified in browser: scale=2 export is exactly 2x pixel dimensions (1920×1080 → 3840×2160); a shape's edge lands at exactly `world_x*scale`; a blur's edge falloff width scales by exactly 2x between scale=1/2 exports (pixel-sampled scanline comparison); scale=1 behavior mathematically unchanged (same viewport formula reduces to identical values); 4x (8K, 7680×4320) export completes in ~350ms/frame with no console errors; on-screen viewport correctly restored after export

🤖 Generated with [Claude Code](https://claude.com/claude-code)