### PR TITLE
fix: in/out handle unreachable when a bar's inPoint is near 0

### DIFF
--- a/src/js/layer-inout.js
+++ b/src/js/layer-inout.js
@@ -448,7 +448,24 @@
   // left untouched by a Shift-click itself so a run of Shift-clicks grows
   // or shrinks the range from the SAME fixed end rather than drifting.
   var _barAnchorLi = null;
-  function onDown(li, row, type, e) {
+  // forceHandleEl (2026-08, feedback: "quand les calques sont calé au tout
+  // début c'est compliqué d'attraper le in point avec la souris") — the
+  // sticky reorder grip (installLayerReorderGrip, timeline.js) sits at
+  // z-index:9, ABOVE this bar's own z-index:2 stacking context, so the
+  // instant a bar's inPoint lands near frame 0 (or a scroll parks the
+  // viewport's left edge inside a bar), the in-handle physically
+  // coincides with the grip and every mousedown resolves to the grip
+  // first — the handle becomes literally unclickable, not just fiddly.
+  // Raising the WHOLE bar's z-index above the grip was rejected: the
+  // grip's sole reason to exist is staying reachable even while a long
+  // bar's BODY covers the viewport's left edge after scrolling — that
+  // would trade one unreachable target for another. Instead the grip's
+  // own handler (installLayerReorderGrip) hit-tests for a handle first
+  // and, when the click is really on one, calls this SAME onDown with
+  // the real handle element passed explicitly — forceHandleEl lets that
+  // caller's e.target (the grip, not the handle) not leak into the
+  // handle's own hover-lock behavior (.hot class below).
+  function onDown(li, row, type, e, forceHandleEl) {
     e.stopPropagation(); e.preventDefault();
     var ld = state.layers[li]; if (!ld) return;
     if (e.metaKey || e.ctrlKey) { // toggle one, no drag
@@ -491,7 +508,7 @@
     // drags past its small hitbox. Cleared at mouseup below. null for a
     // bar-BODY drag (type==='both' from the bar itself, not a handle) —
     // nothing to highlight there.
-    var handleEl = (type === 'in' || type === 'out') ? e.target : null;
+    var handleEl = forceHandleEl || ((type === 'in' || type === 'out') ? e.target : null);
     if (handleEl) handleEl.classList.add('hot');
     // Grabbing ANY part of an already-selected bar (body OR an edge handle)
     // moves/trims the whole group together — feedback: "je ne peux pas
@@ -1280,6 +1297,10 @@
 
   window.SMLayerInOut = {
     inPointOf: inPointOf, outPointOf: outPointOf, hasCustomRange: hasCustomRange, buildBar: buildBar, updateBar: updateBar,
+    // Exposed so the reorder grip (timeline.js) can hand off a mousedown
+    // that's really meant for an in/out handle it happens to be covering —
+    // see onDown's own forceHandleEl comment for why this exists.
+    onDown: onDown,
     alignBars: alignBars, distributeBars: distributeBars, flipBars: flipBars, staggerBars: staggerBars, selectEveryNth: selectEveryNth, invertBarSelection: invertBarSelection,
     // Exposed so Motion's own grid marquee can drive bar selection too —
     // it intercepts the mousedown in capture phase before this module's

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -5268,6 +5268,29 @@ function installLayerReorderGrip(row,li){
   grip.title='Glisser verticalement pour réordonner le calque';
   function begin(e){
     if(e.button!==0)return;
+    // Grip sits at z-index:9 (sticky, always reachable even while a long
+    // bar's body scrolls under it) — ABOVE the in/out bar's own z-index:2,
+    // so a bar whose inPoint lands near frame 0 puts its in-handle
+    // physically under this grip: every native click there resolves to
+    // the grip first, making the handle unclickable (feedback 2026-08:
+    // "quand les calques sont calé au tout début c'est compliqué
+    // d'attraper le in point"). Hit-test for a handle FIRST — same ±6px
+    // tolerance as the handle's own CSS ::before hitbox — and hand off to
+    // its real onDown instead of reordering when the click is really on
+    // one; native reordering is unaffected everywhere else, including the
+    // long-bar-scrolled-under-the-grip case this grip exists for (a
+    // handle is never physically there in that case).
+    if(window.SMLayerInOut&&window.SMLayerInOut.onDown){
+      var handles=row.querySelectorAll('.layer-inout-handle');
+      for(var hi=0;hi<handles.length;hi++){
+        var h=handles[hi],r=h.getBoundingClientRect();
+        if(e.clientX>=r.left-6&&e.clientX<=r.right+6&&e.clientY>=r.top-6&&e.clientY<=r.bottom+6){
+          e.preventDefault();e.stopPropagation();
+          window.SMLayerInOut.onDown(li,row,h.classList.contains('left')?'in':'out',e,h);
+          return;
+        }
+      }
+    }
     e.preventDefault();e.stopPropagation();
     armLayerReorder(e,li,'grid',row);
   }


### PR DESCRIPTION
## Summary
Suite au feedback : « quand les calques sont calé au tout début c'est compliqué d'attraper le in point avec la souris ». Ciblée sur la branche de Codex (#212) plutôt que `main` — la nouvelle poignée de réordonnancement (`installLayerReorderGrip`) qui cause ce bug n'existe que dans son travail P1, pas encore sur `main`.

La nouvelle poignée sticky de réordonnancement est à `z-index:9`, AU-DESSUS du contexte d'empilement de la barre in/out (`z-index:2`). Dès qu'un `inPoint` tombe près de la frame 0 (exactement le cas de la capture d'écran : plusieurs calques commençant tous à la frame 0), la poignée d'entrée se retrouve physiquement sous le grip — chaque clic natif à cet endroit résout d'abord vers le grip, rendant la poignée littéralement inatteignable, pas juste malcommode.

Augmenter le z-index de toute la barre a été écarté — la seule raison d'être du grip est de rester atteignable même quand le CORPS d'une longue barre défile sous le bord gauche du viewport, et ça aurait juste déplacé le problème.

À la place, le handler du grip teste d'abord géométriquement si le clic tombe sur une poignée in/out (même tolérance ±6px que le hitbox `::before` de la poignée), et délègue vers le vrai `onDown` de `layer-inout.js` (nouvellement exposé sur `window.SMLayerInOut`, avec un paramètre `forceHandleEl` pour que le hover-lock `.hot` de l'appel délégué tombe sur la vraie poignée, pas sur le grip qui a reçu le clic) — le réordonnancement natif est totalement inchangé partout ailleurs, y compris le cas (longue barre défilée sous le grip) pour lequel le grip existe.

## Test plan
- [x] `node --check` sur les 2 fichiers touchés
- [x] Vérifié en direct les deux cas : `inPoint=0` (scénario du bug) rogne maintenant correctement à travers la zone de chevauchement, calque actif inchangé (confirme que c'est un rognage, pas un réordonnancement) ; `inPoint=50` (cas normal, poignée loin du grip) laisse `onDown` non délégué, réordonnancement intact
- [x] `npm test` : 27/27 passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)