### PR TITLE
fix(brush): custom brush editor unreachable + p5.brush grain/noise

### DIFF
--- a/src/js/brush-editor.js
+++ b/src/js/brush-editor.js
@@ -13,6 +13,11 @@
     { key: 'roundness', label: 'Rondeur', min: 0.1, max: 1, step: 0.05 },
     { key: 'spacing', label: 'Espacement', min: 0.05, max: 1.5, step: 0.05 },
     { key: 'spaceJitter', label: 'Var. espacement', min: 0, max: 1, step: 0.05 },
+    // Grain (p5.brush, feedback #61) — module l'espacement effectif dans le
+    // sens INVERSE : plus haut = plus dense/continu (comme un grain fin),
+    // plus bas = dabs plus espacés/visibles individuellement (texture
+    // granuleuse). 1 = neutre, comportement identique à avant.
+    { key: 'grain', label: 'Grain (densité texture)', min: 0.2, max: 2, step: 0.1 },
     { key: 'rotationJitter', label: 'Var. rotation (°)', min: 0, max: 180, step: 5 },
     { key: 'sizeJitter', label: 'Var. taille', min: 0, max: 1, step: 0.05 },
     // Pression start/milieu/fin (p5.brush, feedback #61) — un multiplicateur
@@ -26,6 +31,10 @@
     { key: 'pressureEnd', label: 'Pression fin', min: 0.1, max: 2.5, step: 0.05 },
     { key: 'opacity', label: 'Opacité', min: 0.05, max: 1, step: 0.05 },
     { key: 'opacityJitter', label: 'Var. opacité', min: 0, max: 1, step: 0.05 },
+    // Noise (p5.brush, feedback #61) — variation d'opacité PAR TRAIT ENTIER
+    // (échantillonnée une seule fois au tracé), distincte d'opacityJitter
+    // ci-dessus qui varie PAR TAMPON — les deux se cumulent. 0 = neutre.
+    { key: 'noise', label: 'Var. opacité par trait', min: 0, max: 1, step: 0.05 },
     { key: 'scatter', label: 'Dispersion', min: 0, max: 1, step: 0.05 },
     { key: 'dashGap', label: 'Trous (bord cassé)', min: 0, max: 0.6, step: 0.02 },
     { key: 'edgeNoise', label: 'Bord irrégulier', min: 0, max: 0.4, step: 0.02 },
@@ -57,7 +66,7 @@
     { value: 'scribble', label: 'Gribouillis (graphite/fusain)' },
     { value: 'custom', label: 'Personnalisé (dessiné)…' },
   ];
-  var DEFAULT_PARAMS = { nibSize: 1, roundness: 0.9, spacing: 0.4, spaceJitter: 0.2, rotationMode: 'tangent', rotationJitter: 20, sizeJitter: 0.2, opacity: 0.6, opacityJitter: 0.2, scatter: 0.15, dashGap: 0, tipShape: 'ellipse', edgeNoise: 0, polySides: 5, bristleCount: 5, tipCorner: 0.15, scribbleCount: 8, scribbleLen: 1.4, scribbleLenJitter: 0.4, scribbleWidth: 0.12, scribbleSpread: 0.6, scribbleAngleSpread: 70, pressureStart: 1, pressureMid: 1, pressureEnd: 1, sharpness: 1, markerTip: true };
+  var DEFAULT_PARAMS = { nibSize: 1, roundness: 0.9, spacing: 0.4, spaceJitter: 0.2, rotationMode: 'tangent', rotationJitter: 20, sizeJitter: 0.2, opacity: 0.6, opacityJitter: 0.2, scatter: 0.15, dashGap: 0, tipShape: 'ellipse', edgeNoise: 0, polySides: 5, bristleCount: 5, tipCorner: 0.15, scribbleCount: 8, scribbleLen: 1.4, scribbleLenJitter: 0.4, scribbleWidth: 0.12, scribbleSpread: 0.6, scribbleAngleSpread: 70, pressureStart: 1, pressureMid: 1, pressureEnd: 1, sharpness: 1, markerTip: true, grain: 1, noise: 0 };
 
   function closePopover() {
     if (!popover) return;

--- a/src/js/brush-menu-bridge.js
+++ b/src/js/brush-menu-bridge.js
@@ -204,6 +204,32 @@
     numRow(params, 'Lissage', state.smoothing || 0, 0, 60, 1, function (v) { driveOriginal('p-smooth', v, false, 'input'); }, SMOOTH_TITLE);
     checkRow(params, 'Pressure brush', !!state.vectorBrush, function (v) { driveOriginal('p-vecbrush', v, true, 'change'); });
     checkRow(params, 'Taper ends', !!state.taperEnds, function (v) { driveOriginal('p-taper', v, true, 'change'); });
+    // Créer/éditer un brush personnalisé (2026-08, feedback: "on a pas les
+    // brush personnalisé dans les brush panel flottant") — window.BrushEditor
+    // (le vrai Nib-panel façon Brush Maker de p5.brush, sliders pression/
+    // sharpness/etc.) était déjà entièrement construit mais n'avait plus
+    // AUCUN point d'entrée depuis l'UI réelle : le seul appelant existant
+    // (brush-preset-picker.js's `open()`, avec son propre bouton "Éditer /
+    // créer un brush…") n'est lui-même jamais déclenché nulle part dans le
+    // codebase — un panel mort, remplacé par CE fichier sans que le bouton
+    // ait jamais été porté. state.customBrushPresets restait donc
+    // structurellement toujours vide en usage normal, ce qui explique aussi
+    // pourquoi "Mes brushes" ne s'affichait jamais plus bas (ce groupe EST
+    // bien câblé, voir buildVectorGrid — il n'avait juste jamais rien à
+    // montrer).
+    var createRow = document.createElement('div'); createRow.className = 'pr';
+    var createLbl = document.createElement('span'); createLbl.className = 'pl';
+    var createBtn = document.createElement('button'); createBtn.className = 'pbtn'; createBtn.style.cssText = 'flex:1;font-size:10px'; createBtn.type = 'button'; createBtn.textContent = 'Créer un brush personnalisé…';
+    createBtn.addEventListener('click', function () {
+      if (!window.BrushEditor) return;
+      var startKey = state.brushPreset && state.brushPreset !== 'none' ? state.brushPreset : null;
+      window.BrushEditor.open(startKey, function (newKey) {
+        if (window.BrushPresetPicker) window.BrushPresetPicker.selectPreset(newKey);
+        if (popover) buildContent(popover); // rebuild header+grid so the new preset shows under "Mes brushes" and is highlighted active
+      });
+    });
+    createRow.appendChild(createLbl); createRow.appendChild(createBtn);
+    params.appendChild(createRow);
   }
   function buildBitmapParams(params) {
     // No manual Bitmap on/off switch here: choosing a bitmap tip activates
@@ -284,13 +310,13 @@
         // undoStack-length check, not just visually).
         window.BrushPresetPicker.selectPreset(key);
         buildVectorGrid(container);
-      })); });
+      }, true, function () { buildVectorGrid(container); })); });
       container.appendChild(cgrid);
     }
   }
-  function makeBrushItem(key, active, onSelect) {
+  function makeBrushItem(key, active, onSelect, isCustom, onRefresh) {
     var btn = document.createElement('button');
-    btn.className = 'bp-item' + (active ? ' active' : '');
+    btn.className = 'bp-item' + (active ? ' active' : '') + (isCustom ? ' bp-item-custom' : '');
     var canvas = document.createElement('canvas'); canvas.width = 150; canvas.height = 26;
     var span = document.createElement('span'); span.textContent = window.BrushPresetPicker.labelFor(key);
     btn.appendChild(canvas); btn.appendChild(span);
@@ -298,6 +324,29 @@
     btn.addEventListener('click', function () { onSelect(key); });
     btn.addEventListener('mouseenter', function () { previewVectorBrush(key); });
     btn.addEventListener('mouseleave', function () { revertBrushPreview(); });
+    if (isCustom) {
+      // Double-clic pour rouvrir le Nib panel (BrushEditor) pré-rempli sur
+      // ce preset — même flux que "Créer un brush…" mais en édition, pas de
+      // second bouton dédié : DOUBLE-CLIC sur une entrée personnalisée pour
+      // l'éditer est le même geste déjà établi ailleurs dans l'app pour
+      // "ouvrir/entrer dans" un élément (double-clic sur un Component).
+      btn.title = 'Cliquer pour sélectionner — double-clic pour éditer';
+      btn.addEventListener('dblclick', function (e) {
+        e.preventDefault(); e.stopPropagation();
+        if (window.BrushEditor) window.BrushEditor.open(key, function (newKey) {
+          window.BrushPresetPicker.selectPreset(newKey);
+          if (onRefresh) onRefresh();
+        });
+      });
+      var delBtn = document.createElement('span'); delBtn.className = 'bp-item-del'; delBtn.title = 'Supprimer'; delBtn.textContent = '×';
+      delBtn.addEventListener('click', function (e) {
+        e.preventDefault(); e.stopPropagation();
+        if (window.state && state.customBrushPresets) delete state.customBrushPresets[key];
+        if (state.brushPreset === key) { window.BrushPresetPicker.selectPreset('none'); }
+        if (onRefresh) onRefresh();
+      });
+      btn.appendChild(delBtn);
+    }
     return btn;
   }
 

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -3734,12 +3734,35 @@ function pressureCurveMul(preset,frac){
   if(frac<=.5)return s+(m-s)*(frac/.5);
   return m+(e-m)*((frac-.5)/.5);
 }
+// One Gaussian sample per STROKE (not per dab — see the "noise" preset
+// field below), Box-Muller, mirrors sampleAcrossWidth's own 'normal' case
+// above rather than a second RNG scheme.
+function sampleGaussian(rand){
+  var u1=Math.max(1e-12,rand()),u2=rand();
+  return Math.sqrt(-2*Math.log(u1))*Math.cos(2*Math.PI*u2);
+}
 function buildBrushDabs(pathLike,preset,baseWidth,rng,widthProfile){
   var rand=rng||Math.random;
   var len=pathLike.length;
   if(!(len>0))return[];
   var nibScale=preset.nibSize!==undefined?preset.nibSize:1;
-  var spacingFrac=preset.spacing!==undefined?preset.spacing:.35;
+  // grain (feedback #61, p5.brush's "grain" — "controls how dense the
+  // texture is, higher = smoother/more continuous line"): a MULTIPLIER on
+  // spacingFrac, inverted (higher grain = denser = SMALLER effective
+  // spacing) so 1 (default) reproduces today's spacing exactly, and
+  // lowering it opens up the gaps between dabs into a visibly grainier,
+  // more broken texture instead of a continuous line.
+  var grain=preset.grain!==undefined?preset.grain:1;
+  var spacingFrac=(preset.spacing!==undefined?preset.spacing:.35)*(grain<=0?4:1/Math.max(.1,grain));
+  // noise (p5.brush: "per-stroke opacity variation... samples a Gaussian to
+  // randomly shift the WHOLE STROKE slightly lighter or darker than its
+  // base alpha") — sampled ONCE per call (per stroke), not per dab like
+  // opacityJitter already is; the two are independent and stack (a preset
+  // can have per-dab flicker AND an overall per-stroke tint). 0 (default)
+  // reproduces the exact prior behavior — no allocation/branch cost beyond
+  // one extra multiply already folded into every dabOpacity computation.
+  var noiseAmt=preset.noise!==undefined?preset.noise:0;
+  var strokeNoiseMul=noiseAmt>0?Math.max(0,1+sampleGaussian(rand)*noiseAmt*.3):1;
   function localWidth(at){
     var base=(!widthProfile||!widthProfile.length)?baseWidth:widthAtFrac(widthProfile,len>0?at/len:0);
     return base*pressureCurveMul(preset,len>0?at/len:0);
@@ -3836,7 +3859,7 @@ function buildBrushDabs(pathLike,preset,baseWidth,rng,widthProfile){
           // real scribbling gets darker), not through each mark being
           // opaque on its own; a full-opacity mark here would read as one
           // solid stripe instead of a woven texture.
-          mark.data={dabOpacity:Math.max(0,Math.min(1,(preset.opacity!==undefined?preset.opacity:.5)*(1+(rand()*2-1)*(preset.opacityJitter||0))*.6))};
+          mark.data={dabOpacity:Math.max(0,Math.min(1,(preset.opacity!==undefined?preset.opacity:.5)*(1+(rand()*2-1)*(preset.opacityJitter||0))*.6*strokeNoiseMul))};
           dabs.push(mark);
         }
       }else if(preset.tipShape==='bristle'){
@@ -3856,7 +3879,7 @@ function buildBrushDabs(pathLike,preset,baseWidth,rng,widthProfile){
           var dab=buildDabShape(w,h,preset,rand);
           dab.rotate(angle);
           dab.position=center;
-          dab.data={dabOpacity:Math.max(0,Math.min(1,(preset.opacity!==undefined?preset.opacity:.5)*(1+(rand()*2-1)*(preset.opacityJitter||0))*.7))};
+          dab.data={dabOpacity:Math.max(0,Math.min(1,(preset.opacity!==undefined?preset.opacity:.5)*(1+(rand()*2-1)*(preset.opacityJitter||0))*.7*strokeNoiseMul))};
           dabs.push(dab);
         }
       }else{
@@ -3866,7 +3889,7 @@ function buildBrushDabs(pathLike,preset,baseWidth,rng,widthProfile){
         var w2=Math.max(.3,nibDiam*sizeMul2);
         var h2=Math.max(.3,w2*roundness);
         var angle2=angleBase+(rand()*2-1)*(preset.rotationJitter||0);
-        var baseOp=Math.max(0,Math.min(1,(preset.opacity!==undefined?preset.opacity:.5)*(1+(rand()*2-1)*(preset.opacityJitter||0))));
+        var baseOp=Math.max(0,Math.min(1,(preset.opacity!==undefined?preset.opacity:.5)*(1+(rand()*2-1)*(preset.opacityJitter||0))*strokeNoiseMul));
         if(sharpness>=1){
           var dab2=buildDabShape(w2,h2,preset,rand);
           dab2.rotate(angle2);
@@ -3921,7 +3944,7 @@ function buildBrushDabs(pathLike,preset,baseWidth,rng,widthProfile){
       var tan=pathLike.getTangentAt(endAt)||new Point(1,0);
       var localW=localWidth(endAt);
       var nibDiam=Math.max(.5,localW*nibScale);
-      var baseOp=Math.max(0,Math.min(1,preset.opacity!==undefined?preset.opacity:.5));
+      var baseOp=Math.max(0,Math.min(1,(preset.opacity!==undefined?preset.opacity:.5)*strokeNoiseMul));
       for(var bk=0;bk<2&&dabs.length<BRUSH_MAX_DABS;bk++){
         var bMul=.85+bk*.2;
         var buildDab=buildDabShape(nibDiam*bMul,nibDiam*roundness*bMul,preset,rand);


### PR DESCRIPTION
## Summary
Feedback : « pour les brush je trouve que l'on a pas encore les même brush que pour [Brush Maker de p5.brush] et même paramètre et d'ailleurs on a pas les brush personnalisé dans les brush panel flottant ».

**Bug critique trouvé en direct** — `window.BrushEditor` (le vrai panel Nib, sliders poids/dispersion/pression/netteté/etc., avec aperçu live) était entièrement construit mais **n'avait plus aucun point d'entrée dans l'UI**. Son seul appelant était la popover de `brush-preset-picker.js` (avec un bouton « Éditer / créer un brush… ») — mais cette popover n'est elle-même **jamais ouverte nulle part dans le code**, un panel mort laissé derrière quand `brush-menu-bridge.js` l'a remplacé, sans que le bouton n'ait jamais été porté. `state.customBrushPresets` restait donc toujours vide en usage normal — ce qui explique aussi pourquoi « Mes brushes » n'apparaissait jamais (ce groupe est correctement câblé, confirmé : il lit bien `customKeys()` — il n'avait juste jamais rien à montrer).

**Correctif** : `brush-menu-bridge.js` (le vrai panel flottant) a maintenant un bouton « Créer un brush personnalisé… » qui ouvre l'éditeur directement, plus un double-clic sur une entrée « Mes brushes » pour la rouvrir pré-remplie en édition, et un bouton × pour supprimer — cycle complet créer/sélectionner/éditer/supprimer, vérifié en direct de bout en bout.

**Deuxième partie** — deux réglages du Brush Maker de p5.brush qui manquaient encore :
- **grain** : multiplie l'espacement effectif des tampons de façon INVERSÉE (plus haut = plus dense/continu, plus bas = plus granuleux) — 1 (défaut) reproduit l'espacement d'avant à l'identique.
- **noise** : variation d'opacité PAR TRAIT (un seul échantillon gaussien par trait, appliqué uniformément à tous les tampons), distincte du `opacityJitter` PAR TAMPON déjà existant — les deux se cumulent plutôt que de se remplacer. 0 (défaut) = aucun effet.

## Test plan
- [x] `node --check` sur les 3 fichiers touchés
- [x] Vérifié en direct : créer un preset via le vrai bouton → apparaît sous « Mes brushes » → double-clic le rouvre pré-rempli → × le supprime et réinitialise le preset actif
- [x] `grain=0.5` divise exactement par 2 le nombre de tampons (espacement doublé) vs `grain=1`
- [x] `noise=1` donne à tous les tampons d'un même trait la même opacité (0.5557 pour opacity=0.5, RNG fixe) ; `noise=0` reproduit `opacity=0.5` exactement, bit à bit
- [x] Aucune erreur console

🤖 Generated with [Claude Code](https://claude.com/claude-code)