### PR TITLE
Fix Width doing nothing on a textured vector brush (feedback #82)

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -525,6 +525,17 @@ window.SM={
             p.data.bitmapBrushSpec.size=v;
             SMBitmapBrush.regenerate(p,userLayers[state.activeLayerIdx]);
           }
+          // Same gap for a plain VECTOR texture preset (feedback #82, "si je
+          // select une brush avec texture vecto et que je change sa width
+          // cela n'agit pas") — the bitmap case above was fixed but this one
+          // never was: applyBrushTexture's dabs are stamped ONCE at apply
+          // time using the anchor's strokeWidth as baseWidth (tools.js), so
+          // just setting p.strokeWidth above only resizes the invisible
+          // anchor while the visible dabs stay at their old size.
+          // regenerateBrushTexture re-stamps from the NOW-updated strokeWidth.
+          else if(p.data&&p.data.brushTexturePreset&&p.data.brushGroupId){
+            regenerateBrushTexture(p,userLayers[state.activeLayerIdx]);
+          }
         }
       });
       saveActiveLayerFrame();updateUI();


### PR DESCRIPTION
## Summary
Addresses the Width half of feedback #82. See PR body / commit for the Smooth investigation — tested, no separate bug found, left open pending a repro.

- `setBrushSize` (timeline.js) already re-baked a Bitmap Brush's texture after a width change, but a plain vector texture preset had the same gap: `applyBrushTexture`'s dabs are stamped once using the anchor's `strokeWidth` at apply time, so setting `p.strokeWidth` alone only resized the (usually invisible) anchor, not the visible dabs.
- Now calls `regenerateBrushTexture` the same way the bitmap branch already does.

## Test plan
- [x] Verified live: dab count/size scale correctly with width changes (8→~34 dabs, 24→10 larger dabs, 4→68 smaller dabs)
- [x] Re-tested Smooth on a 61-segment wiggly textured stroke — `simplify(25)` reduced it to 7 segments while keeping the same bounding envelope, which reads as expected smoothing rather than the reported "shape completely changes." Left as-is pending more detail from the reporter.
- [ ] Manual smoke test in the real app

🤖 Generated with [Claude Code](https://claude.com/claude-code)