### PR TITLE
Fix stray M glyph + add resize handle to in-place text box (#83)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -31,6 +31,14 @@
 @font-face{font-family:'Nemo Vector Text';font-weight:700;src:url('../fonts/Roboto-Bold.ttf') format('truetype');}
 #tp-inplace-editor{position:fixed;z-index:210;background:transparent;border:none;outline:none;resize:none;
   overflow:hidden;padding:0;margin:0;font-family:'Nemo Vector Text',sans-serif;white-space:pre;}
+/* Resize handle for the orange in-place text box (feedback #83, "la box de
+   texte orange n'est pas resizable") — resize:none above is deliberate (a
+   native textarea resize handle has no way to feed back into d.fixedWidth
+   or reflow world-space glyph geometry), so this is the custom stand-in:
+   a small square pinned to the box's bottom-right corner, dragged in
+   timeline.js's openInPlaceTextEditor. */
+#tp-inplace-resize-handle{position:fixed;z-index:211;width:10px;height:10px;margin:-5px 0 0 -5px;
+  background:#ffb86c;border:1.5px solid #1a1a1a;border-radius:2px;cursor:nwse-resize;}
 html,body{width:100%;height:100%;overflow:hidden;background:var(--gutter);color:var(--text);
   font-family:'Manrope',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
   /* -webkit-user-select alongside the unprefixed property (2026-07,

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -6262,7 +6262,7 @@ function closeTextPopover(){var pop=document.getElementById('text-popover');if(p
 // (style.css, 'Nemo Vector Text') loads the SAME bundled Roboto TTFs
 // vector-text-bridge.js parses for glyph outlines, so the overlay LOOKS
 // like the vector result it's about to become, not a generic stand-in.
-var _inplaceTa=null,_inplaceRoot=null,_inplaceHidden=null,_inplaceIsNew=false;
+var _inplaceTa=null,_inplaceRoot=null,_inplaceHidden=null,_inplaceIsNew=false,_inplaceHandle=null;
 // Area-text creation (2026-08-17, same ask as openInPlaceTextEditor above:
 // "comme AI ou Figma" also means the INITIAL drag-a-box placement, not just
 // re-editing) — builds a throwaway single-glyph vector-text root (needed
@@ -6304,7 +6304,16 @@ function openInPlaceTextEditor(root,isNew){
   // re-edit (reported 2026-08-27, feedback #79, with a screenshot).
   var groupBounds=members.reduce(function(b,p){return b?b.unite(p.bounds):p.bounds.clone();},null);
   var bounds=d.anchorTopLeft?new Rectangle(new Point(d.anchorTopLeft.x,d.anchorTopLeft.y),new Size(groupBounds.width,groupBounds.height)):groupBounds;
-  members.forEach(function(p){p.visible=false;});
+  // opacity, not .visible (feedback #83, "un M apparait décalé alors que de
+  // devrait avoir une barre de texte clignotante") — the Rust engine's
+  // buildSceneJson never reads a Path's .visible flag (only layer-level
+  // visibility is checked anywhere in it, CLAUDE.md §5's "view.autoUpdate=
+  // false quand le moteur Rust est actif": Paper's own raster is disabled
+  // entirely, so .visible has nothing left to affect), but it DOES read
+  // c.opacity — same field buildSceneJson already uses for a normal fade.
+  // Stashed per-glyph rather than forced to 1 on restore, in case a glyph
+  // ever legitimately had non-1 opacity to begin with.
+  members.forEach(function(p){p.data.__inplacePrevOpacity=p.opacity;p.opacity=0;});
   _inplaceHidden=members;_inplaceRoot=root;
   var ta=document.createElement('textarea');
   ta.id='tp-inplace-editor';
@@ -6312,6 +6321,35 @@ function openInPlaceTextEditor(root,isNew){
   ta.spellcheck=false;
   document.body.appendChild(ta);
   _inplaceTa=ta;
+  // Resize handle (feedback #83, "la box de texte orange n'est pas
+  // resizable") — the orange box itself is just a Rust-rendered overlay
+  // rectangle (buildTextDragBoxItems, engine-bridge.js) with no hit-testing
+  // of its own, so this is a real DOM element pinned to its bottom-right
+  // corner instead of trying to hit-test the engine's canvas.
+  var handle=document.createElement('div');
+  handle.id='tp-inplace-resize-handle';
+  document.body.appendChild(handle);
+  _inplaceHandle=handle;
+  var resizing=false,resizeStartX=0,resizeStartWidth=0;
+  handle.addEventListener('pointerdown',function(e){
+    e.preventDefault();e.stopPropagation();
+    resizing=true;resizeStartX=e.clientX;
+    // First drag on a not-yet-fixed-width (auto-grow) box starts from its
+    // CURRENT rendered width, not an arbitrary default — so the box doesn't
+    // visibly jump the instant you grab the handle.
+    resizeStartWidth=d.fixedWidth||(parseFloat(ta.style.width)/view.zoom);
+    handle.setPointerCapture(e.pointerId);
+  });
+  handle.addEventListener('pointermove',function(e){
+    if(!resizing)return;
+    e.preventDefault();e.stopPropagation();
+    var deltaWorld=(e.clientX-resizeStartX)/view.zoom;
+    d.fixedWidth=Math.max(20,resizeStartWidth+deltaWorld);
+    reposition();
+  });
+  function endResize(e){if(!resizing)return;resizing=false;try{handle.releasePointerCapture(e.pointerId);}catch(err){}}
+  handle.addEventListener('pointerup',endResize);
+  handle.addEventListener('pointercancel',endResize);
   function reposition(){
     var topLeftView=view.projectToView(bounds.topLeft);
     var canvasEl=document.getElementById('drawing-canvas');
@@ -6340,6 +6378,8 @@ function openInPlaceTextEditor(root,isNew){
       right:bounds.left+parseFloat(ta.style.width)/view.zoom,
       bottom:bounds.top+parseFloat(ta.style.height)/view.zoom,
     };
+    handle.style.left=(cr.left+topLeftView.x+parseFloat(ta.style.width))+'px';
+    handle.style.top=(cr.top+topLeftView.y+parseFloat(ta.style.height))+'px';
     if(window.SMEngineBridge)SMEngineBridge.renderNow();
   }
   reposition();
@@ -6353,9 +6393,10 @@ function openInPlaceTextEditor(root,isNew){
   ta.focus();ta.select();
 }
 function closeInPlaceTextEditor(cancel){
-  var ta=_inplaceTa,root=_inplaceRoot,hidden=_inplaceHidden,isNew=_inplaceIsNew;
+  var ta=_inplaceTa,root=_inplaceRoot,hidden=_inplaceHidden,isNew=_inplaceIsNew,handle=_inplaceHandle;
   if(!ta)return;
-  _inplaceTa=null;_inplaceRoot=null;_inplaceHidden=null;_inplaceIsNew=false;
+  if(handle)handle.remove();
+  _inplaceTa=null;_inplaceRoot=null;_inplaceHidden=null;_inplaceIsNew=false;_inplaceHandle=null;
   window._inplaceTextBoxBounds=null;
   if(window.SMEngineBridge)SMEngineBridge.renderNow();
   var newText=ta.value;
@@ -6365,7 +6406,7 @@ function closeInPlaceTextEditor(cancel){
   // it outright instead of restoring its visibility (unlike a discarded
   // re-edit, which restores the real pre-existing glyphs untouched).
   var discardNew=function(){if(hidden)hidden.forEach(function(p){if(p&&!p.removed)p.remove();});if(window.SMEngineBridge)SMEngineBridge.renderNow();};
-  var restore=function(){if(hidden)hidden.forEach(function(p){if(p&&!p.removed)p.visible=true;});};
+  var restore=function(){if(hidden)hidden.forEach(function(p){if(p&&!p.removed)p.opacity=p.data.__inplacePrevOpacity!==undefined?p.data.__inplacePrevOpacity:1;});};
   if(cancel||!root||!root.data||!newText.trim()||(!isNew&&newText===root.data.text)){if(isNew)discardNew();else{restore();if(window.SMEngineBridge)SMEngineBridge.renderNow();}return;}
   var d=root.data;
   var opts={bold:d.bold,italic:d.italic,underline:d.underline,strike:d.strike,letterSpacing:d.letterSpacing,wordSpacing:d.wordSpacing,lineHeightMult:d.lineHeightMult,textCase:d.textCase};


### PR DESCRIPTION
## Summary
Closes feedback #83.

- The placeholder/pre-existing glyphs in the in-place text editor were hidden via `p.visible=false`, but the Rust engine's `buildSceneJson` never checks a Path's `.visible` flag — only layer-level visibility. The glyph stayed fully rendered, offset from the blinking-cursor textarea overlay. Switched to `p.opacity`, which the engine's main render loop does read.
- Added a real resize handle pinned to the orange text box's bottom-right corner, dragging it sets `d.fixedWidth` live and reflows the textarea.

## Test plan
- [x] Verified live: no stray glyph while typing, drag-resize works without closing the editor, committed text rebuilds at the new width
- [ ] Manual smoke test in the real app

🤖 Generated with [Claude Code](https://claude.com/claude-code)