### PR TITLE
Move tool shortcut letter to bottom-left, fill in shape tool icons (#85)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -243,7 +243,12 @@ body.tools-docked-away #tools-panel-resize{display:none;}
   position:relative;transition:background .15s,color .15s;}
 .tool-btn:hover{background:rgba(255,255,255,.06);color:var(--text);}
 .tool-btn.active{background:var(--accent-dim);color:var(--accent-hover);box-shadow:none;}
-.tool-btn .sk{position:absolute;bottom:0;right:1px;font-size:7px;color:var(--text-dark);pointer-events:none;font-family:monospace;}
+/* bottom-LEFT, not right (feedback #85, "le lettre de raccourcis doivent
+   être en bas à gauche... car elles cachent les submenu") — the submenu
+   hint triangle for a stacked shape tool (.tool-stack .stack-front::before,
+   just below) sits bottom-right, same corner this used to occupy, so the
+   shortcut letter was drawn right on top of it. */
+.tool-btn .sk{position:absolute;bottom:0;left:1px;font-size:7px;color:var(--text-dark);pointer-events:none;font-family:monospace;}
 .tool-btn.active .sk{color:rgba(255,255,255,.5);}
 .tool-sep{width:24px;height:1px;background:var(--border);margin:4px 0;}
 /* Shape-tool group (timeline.js, 2026-08) — Illustrator/Rive-style single
@@ -260,6 +265,19 @@ body.tools-docked-away #tools-panel-resize{display:none;}
   width:0;height:0;border-style:solid;border-width:0 0 4px 4px;
   border-color:transparent transparent rgba(236,234,231,.4) transparent;pointer-events:none;}
 .tool-stack .tool-btn.stack-front.active::before{border-bottom-color:rgba(255,255,255,.55);}
+/* Uniformize the shape-tool icons as solid/filled forms (feedback #85,
+   "pour les icons de shape uniformisé en formes pleine les icons") —
+   Speech bubble and Star are already solid custom SVGs (fill=currentColor),
+   but Rectangle/Line/Ellipse use Material Symbols Rounded glyphs, which
+   render OUTLINE-style by the app-wide default just above ('FILL' 0) —
+   the same 5-tool group mixed two icon styles. Scoped to just this group
+   (not the global .material-symbols-rounded rule) so every other Material
+   icon in the app keeps its intentional outline look. Two selectors: the
+   toolbar stack itself, and the long-press flyout, which clones the SAME
+   button markup (openFlyout, timeline.js) into a sibling DOM tree outside
+   .tool-stack — a rule scoped to only one of the two would leave the other
+   inconsistent.*/
+.tool-stack .material-symbols-rounded,.shape-tool-flyout-item .material-symbols-rounded{font-variation-settings:'FILL' 1,'wght' 300,'GRAD' 0,'opsz' 20;}
 .shape-tool-flyout{position:fixed;z-index:9999;display:flex;gap:2px;padding:4px;
   background:var(--panel,#2a2a2e);border:1px solid var(--border);border-radius:8px;
   box-shadow:0 4px 16px rgba(0,0,0,.4);}


### PR DESCRIPTION
## Summary
Closes feedback #85.

- `.tool-btn .sk` (shortcut letter) moved from bottom-right to bottom-left — it was drawing right on top of the stacked shape tool's submenu hint triangle, which occupies that same corner.
- Rectangle/Line/Ellipse icons now render solid/filled to match the already-solid Speech Bubble/Star icons, uniformizing the shape tool group. Scoped to just the shape-tool stack and its long-press flyout, not the global Material Symbols default.

## Test plan
- [x] Verified live via computed styles and visually
- [ ] Manual smoke test in the real app

🤖 Generated with [Claude Code](https://claude.com/claude-code)