### PR TITLE
Fix Text Animator being unreachable for any real text (feedback #87)

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -6639,7 +6639,20 @@ function updateTextActionsPanel(){
   if(!sec)return;
   var p=(state.tool==='select'&&selectedPaths.length===1)?selectedPaths[0]:null;
   var isWholeText=!!(p&&p.data&&p.data.isText&&!p.data.isTextChar&&!p.data.isVectorText);
-  var animGroupId=window.SMTextAnimator?window.SMTextAnimator.groupIdForItem(p):null;
+  // Multi-glyph selection (feedback #87, "je n'ai toujours pas d'option
+  // pour animer le texte") — groupIdForItem(p) above only ever fired for
+  // an EXACT single-Path selection, but a plain click on vector text (or
+  // an already-split raster block) selects every glyph sharing its
+  // groupId — one Path per character, so any real word/sentence is
+  // ALREADY more than one selected Path the instant you click it. "Animer
+  // le texte…" was reachable only for a one-character block, effectively
+  // never in practice. Same "whole selection matches one group" contract
+  // textPropsRoot() already enforces for the Typography panel a bit
+  // further down this file — one mismatched member (a partial/mixed
+  // pick) still hides the button rather than animating the wrong set.
+  var SMTA=window.SMTextAnimator;
+  var animGroupId=(SMTA&&state.tool==='select'&&selectedPaths.length)?SMTA.groupIdForItem(selectedPaths[0]):null;
+  if(animGroupId&&!selectedPaths.every(function(sp){return SMTA.groupIdForItem(sp)===animGroupId;}))animGroupId=null;
   sec.style.display=(isWholeText||animGroupId)?'':'none';
   document.getElementById('text-split-desc').style.display=isWholeText?'':'none';
   document.getElementById('btn-text-split-chars').parentElement.style.display=isWholeText?'':'none';


### PR DESCRIPTION
## Summary
Partially addresses feedback #87 — the "unreachable" bug, not "on a path" (see note below).

`updateTextActionsPanel()` only derived the animate group from an EXACT single selected Path, but clicking vector text (or split raster text) selects one Path PER GLYPH — so any real word/sentence was already multi-selected the instant you clicked it, and the "Animer le texte…" button never showed. The underlying Text Animator (text-animator.js) already has char/word/line grouping and a stagger/delay field — it was just unreachable.

Now derives the group from the first selected path, requiring the whole selection to share it (same contract `textPropsRoot()` already uses for the Typography panel).

**Not addressed**: "sur un path ou non" (text following an arbitrary curve) is a separate, substantially bigger feature — genuinely not built. Worth a separate ticket/discussion on scope before attempting it.

## Test plan
- [x] Verified live: a 17-glyph "Hello World" vector text block now shows the button, opens the panel with Lettres/Mots/Lignes + stagger intact, and Apply writes real per-glyph elementMotion keyframes
- [ ] Manual smoke test in the real app

🤖 Generated with [Claude Code](https://claude.com/claude-code)