### PR TITLE
Fix Null layer marker never actually moving on canvas drag (#59)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -3774,7 +3774,22 @@
       // Skipped entirely for a 3D layer — the box isn't drawn there (see
       // buildOverlayItems' is3DTargetForBox), so it must not still be a
       // live (invisible) hit-target either.
-      var boxHit = (t.li != null && state.layers[t.li] && state.layers[t.li].threeD && !t.strokeId) ? null : hitMotionBoxHandle(event.point, t);
+      // Also skipped for a Null layer (feedback #59, "un petit bounding box
+      // que l'on peu déplacer" never actually moved on drag): motionBoxGeom
+      // gives a Null a fixed tiny 24px-equivalent box (hs=12/zoom) so
+      // ringRadius (30% of that) collapses to ~7.2px — right on top of
+      // hitMotionBoxHandle's own ±7px ring tolerance. The tolerance band
+      // then swallows the ENTIRE clickable marker, so every click matched
+      // 'rotate' and the correctly-working move handler in select-bridge.js
+      // (mode:'null-drag', a few lines below this file's own onDown return)
+      // never got a chance to run — confirmed live, dragging always rotated,
+      // position never budged. A Null has no real use for a canvas
+      // rotate/scale drag anyway (both properties stay reachable from the
+      // panel) — skip the box gizmo outright so a plain click always falls
+      // through to the dedicated move handler instead of chasing a
+      // per-layer-type ring-radius tune.
+      var isNullTarget = t.li != null && state.layers[t.li] && state.layers[t.li].isNullLayer;
+      var boxHit = (isNullTarget || (t.li != null && state.layers[t.li] && state.layers[t.li].threeD && !t.strokeId)) ? null : hitMotionBoxHandle(event.point, t);
       if (boxHit) {
         pushUndo();
         var g = motionBoxGeom(t);


### PR DESCRIPTION
## Summary
Feedback #59 demandait un calque Null avec petit bounding box déplaçable au canvas. Le marqueur existait déjà (branche `null-layer-canvas`, mergée) avec un dropdown Shape, mais le déplacement par glisser ne marchait jamais — chaque drag pivotait le Null au lieu de le déplacer.

**Cause** : `motionBoxGeom` donne au Null une box fixe minuscule (24px-équivalent), donc le rayon de l'anneau de rotation (30% de cette box) s'écrase à ~7.2px — pile dans sa propre tolérance de ±7px. Cette bande avale tout le marqueur cliquable : chaque drag matchait "rotate" avant que le move-handler déjà correct (select-bridge.js, mode `null-drag`) ait sa chance.

**Fix** : exclure les calques Null du gizmo générique boîte/anneau, comme c'est déjà fait pour les calques 3D — un Null n'a pas vraiment d'usage pour rotate/scale au canvas (les deux restent accessibles depuis le panneau), donc un simple clic tombe directement dans le move-handler dédié.

## Test plan
- [x] Testé en pilotant : drag sur le marqueur Null → Position bouge, marqueur suit visuellement, Rotation reste à 0
- [x] Confirmé AVANT le fix : même geste → Rotation bougeait, Position à 0 (reproduction du bug)
- [x] Zéro erreur console

🤖 Generated with [Claude Code](https://claude.com/claude-code)