### PR TITLE
Add Graphite-style skew handles to the Animation 2D transform box

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2668,6 +2668,32 @@
       var isDistortHover = state.xformDistortHoverDir === k;
       items.push(rectItem(p[0], p[1], (isDistortHover ? 4.5 : 3.5) * zs, [255, 255, 255, 255], isDistortHover ? [255, 159, 10, 255] : [74, 158, 255, 255], 1.2 * zs));
     });
+    // Skew tick marks (2026-08, Graphite-style skew-on-hover — user
+    // reference) — two short marks flanking each edge-midpoint handle,
+    // running PARALLEL to that edge: dragging from here shears the grabbed
+    // edge ALONG its own direction (matching the EW/NS-resize cursor
+    // select-bridge.js shows for it), relative to the fixed opposite edge.
+    // Hidden on an edge too short to grab both ticks cleanly.
+    // SKEW_MIN_EDGE_PX/INNER/OUTER must match select-bridge.js's own
+    // hitTestHandles thresholds exactly (same duplication-with-agreement
+    // shape as ringRadius above) — a mark drawn where a click wouldn't be
+    // recognized (or vice versa) would be a UI lie.
+    var SKEW_MIN_EDGE_PX = 48, SKEW_INNER_PX = 9, SKEW_OUTER_PX = 20;
+    var EDGE_PAIRS = { n: ['nw', 'ne'], s: ['sw', 'se'], w: ['nw', 'sw'], e: ['ne', 'se'] };
+    Object.keys(EDGE_PAIRS).forEach(function (k) {
+      var a = corners[EDGE_PAIRS[k][0]], b2 = corners[EDGE_PAIRS[k][1]];
+      var ex = b2[0] - a[0], ey = b2[1] - a[1];
+      var edgeLen = Math.sqrt(ex * ex + ey * ey);
+      if (edgeLen * view.zoom < SKEW_MIN_EDGE_PX) return;
+      var dx = ex / edgeLen, dy = ey / edgeLen;
+      var mid = corners[k];
+      var isSkewHover = state.xformSkewHoverEdge === k;
+      var col = isSkewHover ? [255, 159, 10, 255] : [74, 158, 255, 255];
+      [-1, 1].forEach(function (side) {
+        var c0 = side * SKEW_INNER_PX * zs, c1 = side * SKEW_OUTER_PX * zs;
+        items.push(lineItem([mid[0] + dx * c0, mid[1] + dy * c0], [mid[0] + dx * c1, mid[1] + dy * c1], col, 1.6 * zs));
+      });
+    });
     // Anchor/pivot marker (redesign 2026-07-09, AE-style anchor point) — a
     // small ringed crosshair AT the point rotation actually pivots around
     // (tools.js xformAnchorPoint), so a non-center anchor is visible on the

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -347,6 +347,14 @@
   var _multiLayerDrag = null;
   var xformDir = null, xformAnchor = null, xformOrigHandlePos = null, xformLastSx = 1, xformLastSy = 1;
   var xformMap = null; // geometry<->rendered-world mapper when the active layer has a Motion transform
+  // Skew-on-hover (2026-08, Graphite-style — user reference: the edge
+  // midpoints of the transform box, past the plain resize handle's own
+  // hit radius, grab a single-axis shear instead of a resize). Shear
+  // composes ADDITIVELY for a fixed axis+anchor (unlike scale, which is
+  // multiplicative) — xformLastShx/Shy track the cumulative shear applied
+  // so far so onMove can apply just the per-tick DELTA, same incremental-
+  // step pattern xformLastSx/Sy already use for scale.
+  var xformSkewEdge = null, xformSkewPerp = 1, xformLastShx = 0, xformLastShy = 0;
   // Ctrl+drag corner = free-transform DISTORT pins (2026-07, "avec l'outil
   // de sélection si on fait ctrl il ne faudrait pas le menu droit mais des
   // pin de transformation libre pour modifier la sélection" — confirmed
@@ -538,7 +546,44 @@
       var d = pt.getDistance(h.corners[k]);
       if (d < bestD) { bestD = d; best = { type: 'scale', dir: k }; }
     });
-    return best;
+    if (best) return best;
+    // Skew zones (2026-08) — checked only once no corner/edge scale handle
+    // matched, so a resize handle always wins a tie. Two small hit-zones
+    // flank each edge's midpoint handle, running ALONG that edge, starting
+    // just past the scale handle's own tolerance (SKEW_INNER) so the two
+    // never overlap. Mirrors buildTransformBoxItems' (engine-bridge.js) own
+    // tick-mark geometry exactly — the two must agree, or a mark could be
+    // drawn somewhere a click here won't recognize.
+    var skewHit = skewZoneHitTest(h, pt);
+    if (skewHit) return skewHit;
+    return null;
+  }
+  var SKEW_MIN_EDGE_PX = 48, SKEW_INNER_PX = 9, SKEW_OUTER_PX = 20;
+  var EDGE_ENDPOINTS = { n: ['nw', 'ne'], s: ['sw', 'se'], w: ['nw', 'sw'], e: ['ne', 'se'] };
+  function skewZoneHitTest(h, pt) {
+    var zs = 1 / view.zoom;
+    var found = null;
+    Object.keys(EDGE_ENDPOINTS).forEach(function (k) {
+      if (found) return;
+      var ep = EDGE_ENDPOINTS[k];
+      var a = h.corners[ep[0]], b2 = h.corners[ep[1]];
+      var edgeVec = b2.subtract(a);
+      var edgeLenPx = edgeVec.length * view.zoom;
+      if (edgeLenPx < SKEW_MIN_EDGE_PX) return;
+      var dir = edgeVec.normalize();
+      var mid = h.corners[k];
+      [-1, 1].forEach(function (side) {
+        if (found) return;
+        var base = mid.add(dir.multiply(side * (SKEW_INNER_PX + SKEW_OUTER_PX) / 2 * zs));
+        var ext = pt.subtract(base);
+        var along = ext.dot(dir);
+        var perp = ext.subtract(dir.multiply(along)).length;
+        if (Math.abs(along) <= (SKEW_OUTER_PX - SKEW_INNER_PX) / 2 * zs && perp <= SKEW_INNER_PX * zs) {
+          found = { type: 'skew', edge: k };
+        }
+      });
+    });
+    return found;
   }
 
   // ---- Free-transform distort (Ctrl+drag a corner pin) ----
@@ -840,6 +885,21 @@
         var ptg0 = xformMap ? (function () { var g = xformMap.inv(pt.x, pt.y); return new Point(g[0], g[1]); })() : pt;
         rotStartAngle = Math.atan2(ptg0.y - rotCenter.y, ptg0.x - rotCenter.x) * 180 / Math.PI;
         rotLastAngle = 0;
+      } else if (hh.type === 'skew') {
+        mode = 'xform-skew';
+        xformSkewEdge = hh.edge;
+        // Same opposite-edge anchor convention as scale's ANCHOR_MAP (the
+        // edge you DIDN'T grab stays fixed) — geometry-space, since the
+        // gesture mutates raw Paper geometry directly.
+        xformAnchor = h.gCorners[ANCHOR_MAP[hh.edge]].clone();
+        xformOrigHandlePos = h.gCorners[hh.edge].clone();
+        xformMap = h.map;
+        // Perpendicular box dimension normalizes the shear amount (Graphite
+        // convention) so the visual skew angle stays consistent regardless
+        // of box size — a drag of N px always skews by the same ANGLE, not
+        // the same absolute offset.
+        xformSkewPerp = Math.abs((hh.edge === 'n' || hh.edge === 's') ? h.bounds.height : h.bounds.width) || 1;
+        xformLastShx = 0; xformLastShy = 0;
       } else {
         mode = 'xform-scale';
         xformDir = hh.dir;
@@ -1379,10 +1439,23 @@
         var hoverHit = e.altKey ? null : hitTestHandles(hpt, false);
         var nextCursor = hoverHit && hoverHit.type === 'scale' ? (HANDLE_CURSORS[hoverHit.dir] || 'default')
           : hoverHit && hoverHit.type === 'rotate' ? ROTATE_CURSOR
+          // Skew cursor (2026-08): top/bottom edge shears horizontally (the
+          // handle slides left/right) so it gets the EW cursor; left/right
+          // shears vertically so it gets NS — matches Graphite's own mapping.
+          : hoverHit && hoverHit.type === 'skew' ? ((hoverHit.edge === 'n' || hoverHit.edge === 's') ? 'ew-resize' : 'ns-resize')
           : 'default';
         if (canvasEl.dataset.xformCursor !== nextCursor) {
           canvasEl.style.cursor = nextCursor;
           canvasEl.dataset.xformCursor = nextCursor;
+        }
+        // Skew tick-mark hover highlight (2026-08) — same passive-hover
+        // pattern as xformDistortHoverDir just below: engine-bridge.js's
+        // buildTransformBoxItems reads this to recolor the hovered edge's
+        // ticks before any drag starts.
+        var skewHoverEdge = (hoverHit && hoverHit.type === 'skew') ? hoverHit.edge : null;
+        if (skewHoverEdge !== (state.xformSkewHoverEdge || null)) {
+          state.xformSkewHoverEdge = skewHoverEdge;
+          window.SMEngineBridge.renderNow();
         }
         // Rotate-ring hover grow (2026-07, "le rond de rotation peut un peu
         // grossir au roll hover") — same light "you can grab this" pattern
@@ -1409,6 +1482,7 @@
           delete canvasEl.dataset.xformCursor;
         }
         if (state.xformDistortHoverDir) { state.xformDistortHoverDir = null; window.SMEngineBridge.renderNow(); }
+        if (state.xformSkewHoverEdge) { state.xformSkewHoverEdge = null; window.SMEngineBridge.renderNow(); }
       }
       return;
     }
@@ -1767,6 +1841,58 @@
       });
       xformLastSx = sx; xformLastSy = sy;
       symGestureAccumulate(new Matrix().scale(stepSx, stepSy, anchor));
+    } else if (mode === 'xform-skew') {
+      // Graphite-style skew (2026-08): grabbing an edge midpoint's skew
+      // zone shears the box along that edge's own direction, anchored at
+      // the OPPOSITE edge (which stays fixed) — top/bottom shear
+      // horizontally (x as a function of y), left/right shear vertically
+      // (y as a function of x). Shear composes ADDITIVELY for a fixed
+      // axis+anchor (unlike scale's multiplicative ratio), so the total
+      // amount is recomputed fresh from the drag start every tick (same
+      // "total-from-anchor, then diff against last tick" shape as scale's
+      // sx/sy) and only the per-tick DELTA is actually applied.
+      var ptK = pt;
+      if (xformMap) { var ptgK = xformMap.inv(pt.x, pt.y); ptK = new Point(ptgK[0], ptgK[1]); }
+      var edgeK = xformSkewEdge;
+      var parallelToX = (edgeK === 'n' || edgeK === 's');
+      // Dragging the TOP/LEFT edge needs the opposite sign from BOTTOM/
+      // RIGHT for the same drag direction to read as the same visual skew
+      // (matches Graphite's own sign convention — verified against its
+      // source, not re-derived from scratch).
+      var signK = (edgeK === 'n' || edgeK === 'w') ? -1 : 1;
+      var dxK = ptK.x - xformOrigHandlePos.x, dyK = ptK.y - xformOrigHandlePos.y;
+      var shxTotal = 0, shyTotal = 0;
+      if (parallelToX) {
+        shxTotal = (signK * dxK) / xformSkewPerp;
+        // Ctrl = free/biaxial movement (Graphite convention): also lets the
+        // OTHER axis shear a little, instead of a pure single-axis shear.
+        if (e.ctrlKey) shyTotal = (signK * dyK) / xformSkewPerp;
+      } else {
+        shyTotal = (signK * dyK) / xformSkewPerp;
+        if (e.ctrlKey) shxTotal = (signK * dxK) / xformSkewPerp;
+      }
+      var stepShx = shxTotal - xformLastShx, stepShy = shyTotal - xformLastShy;
+      var anchorK = xformAnchor;
+      // Motion mode never reaches 'xform-skew' — hitTestHandles() (its only
+      // producer) is only consulted in Animation 2D (see onDown's `hh` gate
+      // above), so there's no per-mode branch to write here, unlike scale/
+      // rotate which are reachable from Motion's own separate hit-test.
+      selectedPaths.forEach(function (p) {
+        p.shear(stepShx, stepShy, anchorK);
+        transformFillGradient(p, function (gp) {
+          var lx = gp.x - anchorK.x, ly = gp.y - anchorK.y;
+          return new Point(anchorK.x + lx + stepShx * ly, anchorK.y + ly + stepShy * lx);
+        });
+        if (p.data && p.data.isVectorBrush && p.data.centerSegments) {
+          shearCenterSegments(p.data.centerSegments, stepShx, stepShy, anchorK.x, anchorK.y);
+          rebuildVectorBrushOutline(p);
+        }
+        if (p.data && p.data.brushCompanions) {
+          p.data.brushCompanions.forEach(function (c) { if (!c.removed) c.shear(stepShx, stepShy, anchorK); });
+        }
+      });
+      symGestureAccumulate(new Matrix().shear(stepShx, stepShy, anchorK));
+      xformLastShx = shxTotal; xformLastShy = shyTotal;
     } else if (mode === 'xform-distort') {
       var ptD = pt;
       if (xformMap) { var ptgD = xformMap.inv(pt.x, pt.y); ptD = new Point(ptgD[0], ptgD[1]); }
@@ -1907,7 +2033,7 @@
       draggingArc = null;
       arcDragCache = null;
       generateTweens();
-    } else if (mode === 'xform-scale' || mode === 'xform-rotate') {
+    } else if (mode === 'xform-scale' || mode === 'xform-rotate' || mode === 'xform-skew') {
       // Motion mode: geometry was never touched during this gesture (see
       // onMove's early-return) — none of the fork/regenerate/save-frame
       // work below applies to anything this drag actually changed, and

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -1313,6 +1313,15 @@ function rotateCenterSegments(segs,angleDeg,cx,cy){
     s.handleOut=rotVec(s.handleOut[0],s.handleOut[1]);
   });
 }
+function shearCenterSegments(segs,shx,shy,cx,cy){
+  function shearVec(x,y){return[x+shx*y,shy*x+y];}
+  segs.forEach(function(s){
+    var r=shearVec(s.point[0]-cx,s.point[1]-cy);
+    s.point=[cx+r[0],cy+r[1]];
+    s.handleIn=shearVec(s.handleIn[0],s.handleIn[1]);
+    s.handleOut=shearVec(s.handleOut[0],s.handleOut[1]);
+  });
+}
 // Bug found live (2026-07, while testing the new subselect marquee-without-
 // pre-selection feature): clearSel() never cleared `nodeHandles` (the
 // module-level hit-test array renderNodeHandles() populates) — a stale


### PR DESCRIPTION
## Summary
- Requested by Cyril, reference: Graphite's transformation-cage skew UX (screenshot + `GraphiteEditor/Graphite`'s `transformation_cage.rs` on GitHub).
- Grabbing an edge midpoint of the Select-tool transform box, just past its plain resize handle, now shears the selection along that edge instead of resizing — anchored at the fixed opposite edge. Ctrl adds free/biaxial movement (matches Graphite's own convention).
- Small tick marks flank each edge-midpoint handle (only when the edge is long enough on screen — hidden on tiny selections), with a matching EW/NS hover cursor and orange hover highlight, same visual language as the existing corner/ring/anchor gizmo.

## Scope
Animation 2D's Select tool only (direct geometry edit, same as the existing scale/rotate handles). Motion mode's `hitTestHandles` path never fires (`state.appMode==='motion'` short-circuits it in onDown, same as it already does for scale/rotate/distort), and there's no existing keyable "skew" property on a Motion layer the way there is Scale/Rotation — adding one would be a separate, larger feature (new timeline property, keyframe UI, `computeMotionMat` support). Not built here.

## Test plan
- [x] Selected a stroke, confirmed tick marks render at the 4 edges, zoom-independent size, hidden below the min-edge-length threshold
- [x] Hover over a tick zone → cursor changes to `ew-resize` (top/bottom) or `ns-resize` (left/right — same code path, symmetric), tick turns orange
- [x] Dragged a top-edge tick → shape sheared horizontally, bottom (opposite) edge stayed fixed, top edge moved proportionally
- [x] Undo (Cmd+Z) correctly reverted the skew
- [x] Selection stayed intact through the whole gesture, no console errors
- [x] `node --check` on all 3 touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)