### PR TITLE
Fix Delete key not deleting a layer in the timeline (feedback #107)

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -8154,6 +8154,17 @@ function onKeyDown(event){
       }
     }
     else if(state.tool==='select'&&selectedPaths.length>0)window.SM.deleteSelStrokes();
+    // Delete key on the Select tool with nothing on canvas selected — but a
+    // layer row IS (feedback #107: "la touche supprimer ne marche pas pour
+    // supprimer un calque dans la timeline"). Every branch above only ever
+    // deletes strokes/nodes/frames; a plain layer-row selection with no
+    // canvas selection fell all the way through to nothing (Shift+Delete
+    // hits removeFrame() below, which this must not shadow — hence the
+    // !event.shiftKey guard). Matches the same trash-button/context-menu
+    // action (window.SM.deleteLayer(), already scoped to _layerSel/
+    // activeLayerIdx with its own last-layer/camera-layer guards) rather
+    // than duplicating that logic here.
+    else if(state.tool==='select'&&!event.shiftKey&&state.layers.length){event.preventDefault();window.SM.deleteLayer();}
     else if(event.shiftKey)removeFrame();
   }
   else if(k==='F5'){event.preventDefault();insertFrame();}


### PR DESCRIPTION
## Summary
- feedback #107: "la touche supprimer ne marche pas pour supprimer un calque dans la timeline"
- Delete/Backspace in \`onKeyDown\` (timeline.js) handled canvas strokes, subselect nodes, fsselect, and selected frame cells — but nothing when a layer row is selected and none of those apply. Added a plain-Delete fallback (Select tool only, so it doesn't affect Draw/Eraser/etc.) that calls the existing \`window.SM.deleteLayer()\`.
- Shift+Delete's existing \"remove frame\" behavior is untouched (the new branch is gated on \`!event.shiftKey\`, checked before that fallback).

## Test plan
- [x] Added a 2nd layer, selected it, pressed Delete → layer removed, back to 1 layer
- [x] Drew a stroke, selected it (canvas selection, not layer), pressed Delete → stroke removed, layer count unchanged (no regression)
- [x] With only 1 layer left, pressed Delete → refused with the existing \"Impossible de supprimer le dernier calque\" toast (last-layer guard still holds)
- [x] \`node --check\` on timeline.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)