### PR TITLE
Fix paint bucket freezing/crashing on a textured vector-brush stroke (feedback #110)

### DIFF
--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -2025,6 +2025,17 @@ function fillCollectWalls(layer,excludePath,onlyIds){
   var open=[],closed=[],openSrc=[],closedSrc=[];
   layer.children.forEach(function(c){
     if(c===excludePath||!(c instanceof Path))return;
+    // Feedback #110 (crash): a textured vector-brush stroke's dabs
+    // (data.isBrushTextureCopy — hundreds of small filled companion shapes
+    // stamped along the anchor, see buildBrushDabs/tools.js) each carry a
+    // real fillColor, so the check below alone let every one of them in as
+    // a SEPARATE wall candidate — same "dabs must never enter a matching/
+    // tracing algorithm" family of bug CLAUDE.md §1 already documents for
+    // tween matching (splitTweenables), just never fixed here. Hundreds of
+    // tiny overlapping closed candidates blew up the wall-graph/crossing
+    // pass. fillFindExistingMatch and fillMergeSameColor already exclude
+    // both tags below — this collector was the one gap.
+    if(c.data&&(c.data.isLinkedFillCompanion||c.data.isBrushTextureCopy))return;
     if(!(c.strokeColor||c.fillColor||(c.data&&c.data.isVectorBrush)))return;
     if(c.segments.length<2)return;
     var sid=ensureStrokeId(c);


### PR DESCRIPTION
## Summary
- feedback #110 (crash): "si j'utilise une brush texturé vector que je veux faire un fill en fermant la forme avec alt + glisser et que j'utilise le pot de peinture ça fait complément planté l'application"
- Root cause: `fillCollectWalls()` (`src/js/tools.js`) — the function that gathers candidate "walls" for the paint bucket's region-tracing graph — never excluded `data.isBrushTextureCopy` items (texture dabs). Each dab carries a real `fillColor`, so the existing guard (`if(!(c.strokeColor||c.fillColor||isVectorBrush))return;`) let every single one through as its own separate closed-loop wall candidate. A textured vector-brush stroke easily has 700+ of these small overlapping companion shapes (`buildBrushDabs`) — feeding all of them into the wall-tracing graph on top of the real stroke's own (correctly-extracted) centerline wall is exactly the same "dabs must never enter a matching/tracing algorithm" bug CLAUDE.md §1 already documents and fixed for tween matching, just never carried over here. The other two fill-side consumers (`fillFindExistingMatch`, `fillMergeSameColor`) already exclude both `isLinkedFillCompanion` and `isBrushTextureCopy` — this collector was the one gap.
- Fix: added the same exclusion at the top of `fillCollectWalls`'s per-item loop.

## Test plan
- [x] `node --check` on `tools.js`
- [x] Reproduced the exact reported scenario live in the browser: enabled the pressure/vector brush with the `chalk-round` texture preset, drew an open arc stroke (735 dab companions), Alt+dragged a closing stroke with the Fill tool, then plain-clicked to fill — **before this fix this scenario is what the tester reported as a full app freeze/crash**; with the fix it completes in ~90ms and produces a correct fill shape, no console errors
- [x] Regression check: a plain (non-textured) closed stroke filled normally still works correctly (fill shape created, expected area)

🤖 Generated with [Claude Code](https://claude.com/claude-code)