### PR TITLE
Investigate feedback #104 (dab-render-drop): no fix — extensive repro attempts failed

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -36,6 +36,12 @@
       "runtimeExecutable": "python3",
       "runtimeArgs": ["-m", "http.server", "33871", "-d", "src"],
       "port": 33871
+    },
+    {
+      "name": "nemo-fb104-dab-render",
+      "runtimeExecutable": "python3",
+      "runtimeArgs": ["-m", "http.server", "48213", "-d", "src"],
+      "port": 48213
     }
   ]
 }

--- a/geometry-wasm/Cargo.lock
+++ b/geometry-wasm/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
  "geo-types",
  "log",
  "naga",
+ "pollster",
  "serde",
  "serde_json",
  "vello",
@@ -800,6 +801,12 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "pollster"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 
 [[package]]
 name = "polycool"

--- a/geometry-wasm/Cargo.toml
+++ b/geometry-wasm/Cargo.toml
@@ -50,6 +50,22 @@ web-sys = { version = "0.3", features = ["HtmlCanvasElement", "console"] }
 
 [dev-dependencies]
 naga = { version = "29.0.4", features = ["wgsl-in"] }
+# Native (non-wasm32) diagnostic test only (feedback #104 dab-render-drop
+# repro, tests/dab_dense_overlap_repro.rs) — blocks on the async wgpu
+# device/adapter negotiation and buffer readback outside a browser event
+# loop. Never touches the wasm32 release build (dev-dependency only).
+pollster = "0.3"
+# Diagnostic-only feature flip on vello: exposes Scene::bump_estimate(), a
+# CPU-side estimate of GPU bump-allocator demand for a built scene, purely
+# for the feedback #104 repro test to compare against vello's fixed,
+# hand-picked buffer sizes (vello_encoding::config::BufferSizes::new) —
+# never consulted by render_to_texture itself (checked: not referenced
+# anywhere in vello's render.rs/config.rs), so this does NOT change
+# render() or render_to_pixels() behavior, only adds a diagnostic method
+# available to `cargo test`. Cargo unifies dev-dependency features into the
+# `cargo test` build only — the wasm32 release build (wasm-pack build,
+# which never touches dev-dependencies) is unaffected.
+vello = { version = "0.9", features = ["bump_estimate"] }
 
 [profile.release]
 opt-level = "s"

--- a/geometry-wasm/tests/dab_dense_overlap_repro.rs
+++ b/geometry-wasm/tests/dab_dense_overlap_repro.rs
@@ -1,0 +1,267 @@
+// Feedback #104 ("le smooth sur une stroke... ça casse la courbe") root-
+// cause repro. The user-visible symptom traces back to a Rust/vello render
+// bug, NOT the smoothing/geometry code — see the linked GitHub issue and
+// CLAUDE.md §3. This test isolates the failure at the vello layer: does
+// `Renderer::render_to_texture` (the EXACT call `composite_scene`/
+// `paint_layer_items` in src/engine.rs use — same params, same AA config,
+// no push_layer/clip groups) silently drop part of a scene made of many
+// small overlapping semi-transparent filled paths — the shape a densely-
+// dabbed textured brush stroke takes (hundreds of small companion Path
+// items stamped along an invisible anchor, see CLAUDE.md §1)?
+//
+// Two checks, cheapest first:
+//   1. CPU-only, no GPU: vello's own `Scene::bump_estimate` (feature
+//      "bump_estimate", dev-dependency-only override in Cargo.toml — see
+//      the comment there) against the FIXED buffer sizes
+//      `vello_encoding::config::BufferSizes::new` hard-codes. That file's
+//      own comment: "these buffer sizes have been hand picked to
+//      accommodate the vello test scenes... should instead get derived
+//      from the scene layout using reasonable heuristics" — i.e. vello
+//      admits these are NOT adaptive. `Renderer::render_to_texture` (via
+//      `render_encoding_full`) always passes `robust: false`, so there is
+//      no readback/detection/retry when a scene's actual demand exceeds
+//      these fixed sizes — an overflow is silently truncated, and nothing
+//      gets logged (the ONLY warning vello emits, `render.rs`'s "Trying to
+//      paint too large image", fires on canvas width×height, not path/tile
+//      count — confirmed by reading render.rs directly).
+//   2. GPU pixel readback: render the same scene for real, read back
+//      pixels, and check whether dabs past some point in paint order are
+//      visibly missing while earlier ones render fine — the actual visual
+//      symptom from the issue ("only the top portion of the curve
+//      renders").
+//
+// Run: cd geometry-wasm && cargo test --test dab_dense_overlap_repro -- --nocapture
+
+use vello::kurbo::{Affine, Circle};
+use vello::peniko::{Color, Fill};
+use vello::{AaConfig, AaSupport, RenderParams, Renderer, RendererOptions, Scene, wgpu};
+
+/// Mirrors `paint_layer_items`'s per-item fill call in src/engine.rs — one
+/// filled circle per "dab", semi-transparent (~0.45 alpha, matching the
+/// opacity range the user measured on real dab companions), packed far
+/// closer together than their radius so they heavily overlap along a
+/// vertical S-curve — exactly the shape a densely-dabbed brush stroke
+/// takes. No push_layer/clip groups (geometry-wasm never uses vello's own
+/// layer mechanism — see the blend.wgsl comment in engine.rs), so this
+/// isolates the plain fill path, nothing else.
+fn build_dab_scene(count: usize, canvas_w: f64, canvas_h: f64, radius: f64) -> (Scene, Vec<(f64, f64)>) {
+    let mut scene = Scene::new();
+    let mut centers = Vec::with_capacity(count);
+    let margin = radius * 2.0;
+    let y0 = margin;
+    let y1 = canvas_h - margin;
+    let cx = canvas_w / 2.0;
+    let amp = (canvas_w / 2.0 - margin).max(0.0).min(80.0);
+    let color = Color::from_rgba8(60, 40, 30, 115);
+    for i in 0..count {
+        let t = if count > 1 { i as f64 / (count - 1) as f64 } else { 0.0 };
+        let y = y0 + t * (y1 - y0);
+        let x = cx + amp * (t * std::f64::consts::PI * 3.0).sin();
+        let circle = Circle::new((x, y), radius);
+        scene.fill(Fill::NonZero, Affine::IDENTITY, color, None, &circle);
+        centers.push((x, y));
+    }
+    (scene, centers)
+}
+
+struct GpuCtx {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    renderer: Renderer,
+}
+
+fn setup_gpu() -> GpuCtx {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::PRIMARY,
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
+        });
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions::default())
+            .await
+            .expect("no native GPU adapter available for this diagnostic test");
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                required_limits: adapter.limits(),
+                ..Default::default()
+            })
+            .await
+            .expect("request_device failed");
+        let renderer = Renderer::new(
+            &device,
+            RendererOptions { antialiasing_support: AaSupport::area_only(), ..Default::default() },
+        )
+        .expect("renderer creation failed");
+        GpuCtx { device, queue, renderer }
+    })
+}
+
+/// Renders `scene` via the SAME entry point engine.rs uses
+/// (`render_to_texture`, robust=false internally, `AaConfig::Area`) and
+/// reads back straight-alpha RGBA8 pixels — same padded-row-copy technique
+/// as `render_to_pixels` in src/engine.rs.
+fn render_and_readback(ctx: &mut GpuCtx, scene: &Scene, width: u32, height: u32) -> Vec<u8> {
+    let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("dab-repro-offscreen"),
+        size: wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::STORAGE_BINDING
+            | wgpu::TextureUsages::TEXTURE_BINDING
+            | wgpu::TextureUsages::COPY_SRC,
+        view_formats: &[],
+    });
+    let view = tex.create_view(&wgpu::TextureViewDescriptor::default());
+    let params = RenderParams { base_color: Color::TRANSPARENT, width, height, antialiasing_method: AaConfig::Area };
+    ctx.renderer
+        .render_to_texture(&ctx.device, &ctx.queue, scene, &view, &params)
+        .expect("render_to_texture failed");
+
+    let unpadded = width as usize * 4;
+    let padded = unpadded.div_ceil(256) * 256;
+    let buf_size = (padded * height as usize) as u64;
+    let readback = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("dab-repro-readback"),
+        size: buf_size,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = ctx.device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+    encoder.copy_texture_to_buffer(
+        wgpu::TexelCopyTextureInfo { texture: &tex, mip_level: 0, origin: wgpu::Origin3d::ZERO, aspect: wgpu::TextureAspect::All },
+        wgpu::TexelCopyBufferInfo {
+            buffer: &readback,
+            layout: wgpu::TexelCopyBufferLayout { offset: 0, bytes_per_row: Some(padded as u32), rows_per_image: Some(height) },
+        },
+        wgpu::Extent3d { width, height, depth_or_array_layers: 1 },
+    );
+    ctx.queue.submit(Some(encoder.finish()));
+
+    let slice = readback.slice(..);
+    let (tx, rx) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |res| {
+        let _ = tx.send(res);
+    });
+    ctx.device.poll(wgpu::PollType::wait_indefinitely()).expect("device poll failed");
+    rx.recv().expect("map channel dropped").expect("buffer map failed");
+    let mapped = slice.get_mapped_range();
+    let mut out = Vec::with_capacity(unpadded * height as usize);
+    for row in 0..height as usize {
+        let start = row * padded;
+        out.extend_from_slice(&mapped[start..start + unpadded]);
+    }
+    drop(mapped);
+    readback.unmap();
+    out
+}
+
+fn alpha_at(pixels: &[u8], width: u32, x: f64, y: f64) -> u8 {
+    let xi = (x.round() as i64).clamp(0, width as i64 - 1) as usize;
+    let yi = (y.round() as i64).clamp(0, i64::MAX) as usize;
+    let idx = (yi * width as usize + xi) * 4 + 3;
+    pixels[idx]
+}
+
+/// Check 1 — CPU-only. Prints vello's own bump-allocator estimate for a
+/// 756-dab scene (the exact count from the issue's repro) against the
+/// fixed sizes `BufferSizes::new` hard-codes, so there's no ambiguity
+/// about which (if any) buffer the scene's real demand exceeds.
+#[test]
+fn bump_estimate_vs_fixed_vello_buffers() {
+    // vello_encoding::config::BufferSizes::new (vello 0.9.0, not derived
+    // from the scene — literal constants, see that file):
+    const BIN_DATA: u32 = 1 << 18; // 262_144 u32 elements
+    const TILES: u32 = 1 << 21; // 2_097_152 Tile elements
+    const LINES: u32 = 1 << 21;
+    const SEG_COUNTS: u32 = 1 << 21;
+    const SEGMENTS: u32 = 1 << 21;
+    const BLEND_SPILL: u32 = 1 << 20;
+    const PTCL: u32 = 1 << 23; // 8_388_608 u32 elements
+
+    let (canvas_w, canvas_h) = (1200.0, 1200.0);
+    for &count in &[756usize, 2000, 5000] {
+        let (scene, _) = build_dab_scene(count, canvas_w, canvas_h, 15.0);
+        let est = scene.bump_estimate(None);
+        println!(
+            "dabs={count:>5}  est.binning={:>10} (cap {BIN_DATA})  est.tile={:>10} (cap {TILES})  \
+             est.seg_counts={:>10} (cap {SEG_COUNTS})  est.segments={:>10} (cap {SEGMENTS})  \
+             est.lines={:>10} (cap {LINES})  est.ptcl={:>10} (cap {PTCL})",
+            est.binning.len(),
+            est.tile.len(),
+            est.seg_counts.len(),
+            est.segments.len(),
+            est.lines.len(),
+            est.ptcl.len(),
+        );
+        let over = est.binning.len() > BIN_DATA
+            || est.tile.len() > TILES
+            || est.seg_counts.len() > SEG_COUNTS
+            || est.segments.len() > SEGMENTS
+            || est.lines.len() > LINES
+            || est.ptcl.len() > PTCL;
+        println!("  -> exceeds a fixed buffer: {over}");
+        let _ = BLEND_SPILL; // not populated by bump_estimate (clip-group-only, unused here)
+    }
+}
+
+/// Check 2 — real GPU render + pixel readback, same call engine.rs makes.
+/// Renders the 756-dab scene and samples the pixel at every dab's own
+/// center, reporting the first missing dab (if any) and whether the
+/// missing set is a clean "everything past index K" suffix — which is
+/// exactly the "top of the curve renders, bottom doesn't" symptom from the
+/// issue.
+#[test]
+fn dense_dab_stroke_render_gap_repro() {
+    let mut ctx = setup_gpu();
+    // Sweep count/radius/canvas size well past the issue's own numbers
+    // (756 dabs, y 225..1045) to find whether ANY plain-overlapping-fill
+    // scene at plausible-or-generous scale trips a render gap — including
+    // radii large enough to simulate a heavily zoomed-in view (a bigger
+    // on-screen dab bbox spans far more GPU tiles per item than at 100%).
+    let scenarios: &[(usize, f64, f64, f64)] = &[
+        // (count, radius, canvas_w, canvas_h)
+        (756, 15.0, 1200.0, 1200.0),
+        (756, 60.0, 1200.0, 1200.0),
+        (756, 150.0, 2400.0, 2400.0),
+        (5_000, 60.0, 2400.0, 2400.0),
+        (20_000, 30.0, 2400.0, 2400.0),
+        (50_000, 15.0, 2400.0, 2400.0),
+        (100_000, 15.0, 2400.0, 2400.0),
+    ];
+
+    for &(count, radius, canvas_w, canvas_h) in scenarios {
+        let (scene, centers) = build_dab_scene(count, canvas_w, canvas_h, radius);
+        let pixels = render_and_readback(&mut ctx, &scene, canvas_w as u32, canvas_h as u32);
+
+        let mut missing = Vec::new();
+        let mut present = 0usize;
+        for (i, &(x, y)) in centers.iter().enumerate() {
+            let a = alpha_at(&pixels, canvas_w as u32, x, y);
+            if a == 0 {
+                missing.push(i);
+            } else {
+                present += 1;
+            }
+        }
+        print!(
+            "count={count:>7} radius={radius:>5} canvas={canvas_w}x{canvas_h}  present={present:>7} missing={:>7}",
+            missing.len()
+        );
+        if let Some(&first_missing) = missing.first() {
+            let suffix_from_first = missing.iter().enumerate().all(|(k, &idx)| idx == first_missing + k);
+            println!(
+                "  <-- GAP first_missing={first_missing} (y={:.1}) clean_suffix={suffix_from_first}",
+                centers[first_missing].1
+            );
+        } else {
+            println!();
+        }
+    }
+
+    // Not an assert(!) — this test's job is to report ground truth for the
+    // investigation, not to gate CI on a still-being-diagnosed vello
+    // behavior. See the accompanying report for the conclusion drawn from
+    // this output.
+}


### PR DESCRIPTION
## Summary

This is **not a fix** — it's a documented, negative-result investigation into [strokemotion-feedback#104](https://github.com/mysteropodes/nemo/issues/554) ("le smooth sur une stroke... ça casse la courbe"), whose real cause was suspected to be a Rust/vello rendering bug (only part of a densely-dabbed textured stroke rendering, the rest silently dropped) rather than the smoothing/geometry code.

I could not reproduce that symptom despite trying hard, from several independent angles. Opening this PR mainly to land the reusable diagnostic test (`geometry-wasm/tests/dab_dense_overlap_repro.rs`) and document what's been ruled out, so the next session (or Cyril) doesn't re-derive it.

## What I tested

**1. Pure-vello native Rust test** (`dab_dense_overlap_repro.rs`, `cargo test --test dab_dense_overlap_repro -- --nocapture`) — builds a synthetic scene of many small overlapping semi-transparent filled circles (mirroring `paint_layer_items`'s plain fill call, no push_layer/clip groups) and renders it via `Renderer::render_to_texture` — the exact call `composite_scene` in `engine.rs` uses (confirmed `render()`/`render_to_pixels()` both delegate to the shared `composite_scene`/`paint_layer_items`, so this isn't a CLAUDE.md §3 duplicated-pair issue — the draw loop is shared).
   - 756 dabs (the issue's own number) → 756/756 present, 0 missing.
   - Swept up to 50,000 dabs, various radii (15–150px, simulating heavy zoom) → still 0 missing.
   - Only at 100,000 dabs did anything break, and it wasn't a partial "top renders, bottom doesn't" — it was a **total** blackout (0/100,000 present), consistent with `vello`'s non-robust `render_to_texture` (confirmed: `render_encoding_full` always passes `robust: false`, so a GPU-side bump-allocator overflow — if it ever happens — is never detected/retried, and vello's *only* console warning, `render.rs`'s "Trying to paint too large image", fires on canvas width×height, not path/tile count). But this failure mode doesn't match the reported symptom, and it's ~100x past anything this app's own `BRUSH_MAX_DABS = 900` cap would ever produce.
   - A CPU-only cross-check via vello's `Scene::bump_estimate` (feature-flagped on as a dev-dependency override, doesn't touch the wasm32 release build) confirms even 5,000 dabs stay tiny relative to vello's fixed buffer sizes (`vello_encoding::config::BufferSizes::new` — hand-picked constants, not derived from the scene, per that file's own comment).

**2. Live in-app reproduction**, driving the actual editor end-to-end via synthetic pointer events (not just calling internal functions) in a browser session:
   - Drew a real pressure/vector-brush stroke with `chalk-round` texture live, producing 864–900 real `isBrushTextureCopy` dab companions (using the app's real `buildBrushDabs`/`applyBrushTexture`, not synthetic geometry) — structurally matching the issue's report (invisible `isVectorBrush` anchor + hundreds of dab companions, one unrelated item).
   - Tried a tight zigzag stroke to concentrate dab overlap locally (closer to a "virage serré") — hit the app's own `BRUSH_MAX_DABS = 900` ceiling — still full render, 0 gap.
   - Replicated the issue's exact reported workflow: draw + apply texture + `SM.smoothSelectedStroke()` 5× at varying amounts — still full render, 0 gap.
   - Forced `composite_scene`'s SLOW per-layer composite path (added a second layer with a non-normal blend mode, since that check spans every layer in the scene) — still full render, 0 gap.
   - Tested at 3× on-screen zoom (bigger per-dab screen footprint = more GPU tiles per dab) — still full render, 0 gap.
   - Verified via real pixel readback both ways: the on-screen `render()` path (canvas `toDataURL()`) and the export `render_to_pixels()` path (`window.SMEngineBridge.renderFrameToPixelsPNG`) — row-by-row scan for the stroke's red color, not eyeballing screenshots.
   - Directly tested (and ruled out) a JS-side stale-scene-cache theory: compared `window.__lastSceneJson` (what was actually last sent to `engine.render()`) against a fresh `buildSceneJsonForFrame()` call — item counts for the dab layer matched exactly.
   - No console errors, warnings, or the app's own "WASM trap, disabling" toast fired at any point (confirmed that catch path exists and would have surfaced a real Rust panic — didn't happen).

## What this doesn't rule out

- Something specific to the reporter's actual GPU/OS/browser (this was tested against whatever WebGPU backend this sandboxed browser environment exposes — `adapter.info` came back empty, so backend identity is unconfirmed).
- Resource pressure/state accumulated over a long real editing session (many strokes, undo history, transient effects) — infeasible to simulate faithfully in a fresh test session.
- A narrow timing race around toggling `setEnabled()` exactly between a `_sceneVersion` bump and its corresponding render (traced the code path, couldn't construct a reliable repro for it).

## Files changed

- `geometry-wasm/tests/dab_dense_overlap_repro.rs` (new) — the native diagnostic test, reusable for future investigation.
- `geometry-wasm/Cargo.toml` / `Cargo.lock` — dev-dependency-only additions (`pollster` to block on wgpu's async setup in the test, vello's `bump_estimate` feature for the CPU-side estimate). Neither touches the wasm32 release build.
- `.claude/launch.json` — one preview-server entry used during this investigation.

## Test plan

- [x] `cd geometry-wasm && cargo test --test dab_dense_overlap_repro -- --nocapture` passes (reports numbers, no assertion failures — it's a diagnostic, not a regression guard).
- [ ] Cyril: decide whether to keep this test in the tree, or close without merging since there's no actual fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)