### PR TITLE
Fix uncaught SM.t crash on every fresh load (Labs floating panel)

### DIFF
--- a/src/js/labs/labs-float-panel.js
+++ b/src/js/labs/labs-float-panel.js
@@ -308,7 +308,16 @@
     function addBtn(n) {
       var btn = document.createElement('button');
       btn.className = 'labs-float-btn' + (registered[n] ? ' active' : '');
-      btn.title = SM.t(SHORT_NAME[n]) || n;
+      // Guarded (found live testing feedback #110's fill fix, unrelated to
+      // it): this file's own init() (below) calls renderLabsFloatPanel()
+      // on DOMContentLoaded — which fires BEFORE timeline.js's wholesale
+      // `window.SM={...}` reassignment defines SM.t (see this file's own
+      // 'load'-deferred afterI18n registration below, whose comment
+      // documents the same ordering) — so the very first paint threw
+      // "SM.t is not a function" on every fresh load. The afterI18n
+      // requeue already repaints with real titles moments later; this
+      // guard just stops that first paint from throwing uncaught.
+      btn.title = (window.SM && SM.t ? SM.t(SHORT_NAME[n]) : null) || n;
       btn.innerHTML = ICONS[n] || '';
       btn.addEventListener('click', function () {
         // ACTIONS entries manage their own re-render (BrushMenu.toggle


### PR DESCRIPTION
## Summary
Found while deep-verifying the paint-bucket fix from feedback #110 (unrelated bug, surfaced in the same testing pass).

- `labs-float-panel.js`'s `init()` calls `renderLabsFloatPanel()` on `DOMContentLoaded`, which fires **before** `timeline.js`'s wholesale `window.SM={...}` reassignment defines `SM.t` — the file's own comment already documents this exact ordering (it's why the `afterI18n` re-render registration a few lines down is deliberately deferred to the `'load'` event instead of parse time).
- `addBtn()`'s `btn.title = SM.t(SHORT_NAME[n]) || n;` call had no guard against this, so **every fresh page load threw `TypeError: SM.t is not a function` uncaught** — the `afterI18n` requeue silently repaints the panel correctly moments later, so it's not a lasting functional bug, but it's an avoidable uncaught error on every single load.
- Fix: guarded with the same `window.SM && SM.t` check already used elsewhere in this codebase for the identical race (`timeline.js`'s `syncPropsPanelCollapseTitle`, `media-library.js`).

## Test plan
- [x] `node --check` on the touched file
- [x] Live in the browser: confirmed the error fired on every fresh tab load (verified via a genuinely fresh tab, not a stale console buffer) before the fix, zero console errors after — checked `renderLabsFloatPanel.toString()` in the live page to confirm the fix was actually the code executing, not just served

🤖 Generated with [Claude Code](https://claude.com/claude-code)