### PR TITLE
Show brush-size hover cursor for Fill Brush and Bitmap Brush

### DIFF
--- a/src/js/draw-bridge.js
+++ b/src/js/draw-bridge.js
@@ -686,8 +686,18 @@
   // while `dragging` so it never fights onMove's live pressure-driven size
   // during an actual stroke).
   function onHoverMove(e) {
-    if (dragging || !window.SMEngineBridge || !window.SMEngineBridge.isEnabled()) return;
-    if (state.tool !== 'draw' || !state.vectorBrush || state.playing) return;
+    if (dragging || !window.SMEngineBridge || !window.SMEngineBridge.isEnabled() || state.playing) return;
+    // Feedback ("une vraie sensation de dessin comme sur Flash/Animate"):
+    // this brush-footprint preview used to be vectorBrush-only — Fill
+    // Brush and Bitmap Brush fell through to a plain crosshair instead,
+    // with no way to gauge the brush's actual size before the first
+    // stroke (Flash/Animate always show it, for every brush mode).
+    // widthFor() already resolves the right size field per mode
+    // (fillBrushSize vs brushSize) — this only widens WHEN the circle
+    // shows, not how big it is.
+    var isDraw = state.tool === 'draw';
+    if (!isDraw && !isFillBrush()) return;
+    if (isDraw && !state.vectorBrush && !(state.bitmapBrushOn && state.strokeEnabled)) return;
     var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
     window.SMEngineBridge.setPressureCursor(w, widthFor(0.5) / 2);
     window.SMEngineBridge.renderNow();

--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2980,7 +2980,18 @@
   // this function silently swallowed it via the same gate.
   function setPressureCursor(worldPt, radius, forced) { pressureCursorWorld = worldPt; pressureCursorRadius = radius; pressureCursorForced = !!forced; }
   function buildPressureCursorItems() {
-    if (state.tool !== 'draw' || !pressureCursorWorld || !(state.vectorBrush || pressureCursorForced)) return [];
+    if (!pressureCursorWorld) return [];
+    if (!pressureCursorForced) {
+      // Mirrors draw-bridge.js's onHoverMove gate exactly (feedback: "une
+      // vraie sensation de dessin comme sur Flash/Animate" — Fill Brush and
+      // Bitmap Brush now call setPressureCursor on hover too, but this was
+      // the one place that still only ever built the circle for tool==='draw'
+      // + vectorBrush, silently swallowing the other two modes' calls).
+      var isDraw = state.tool === 'draw';
+      var isFillBrush = state.tool === 'fillbrush';
+      if (!isDraw && !isFillBrush) return [];
+      if (isDraw && !state.vectorBrush && !(state.bitmapBrushOn && state.strokeEnabled)) return [];
+    }
     // Rim was pure white — invisible against a white canvas background
     // (reported). The app's own blue accent stays visible on any bg.
     return [circleItem(pressureCursorWorld[0], pressureCursorWorld[1], pressureCursorRadius, [255, 255, 255, 40], [74, 158, 255, 220], 1 / view.zoom)];


### PR DESCRIPTION
## Summary
- The always-on brush-footprint hover circle (shows the brush size/position before the first stroke, like Flash/Animate) only ever worked for the Draw tool's vector-brush mode.
- Fill Brush and Bitmap Brush hovers silently showed nothing — two separate gates needed widening: `draw-bridge.js`'s `onHoverMove` (which decides whether to call `setPressureCursor`) and `engine-bridge.js`'s `buildPressureCursorItems` (which decides whether to actually render the stored cursor as a visible overlay circle).

## Test plan
- [x] Verified in-browser: hover with Fill Brush active shows a correctly-sized/positioned circle tracking the cursor.
- [x] Verified in-browser: hover with Bitmap Brush active (vectorBrush off) shows the circle too.
- [x] Verified existing Draw + vector-brush hover behavior is unchanged.
- [x] Verified alt-drag brush-resize preview (the `forced` bypass) still works for every mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)