### PR TITLE
Stop Fill Brush same-color auto-merge from reshaping strokes

### DIFF
--- a/src/js/draw-bridge.js
+++ b/src/js/draw-bridge.js
@@ -806,15 +806,20 @@
         // silently operating on the stale, already-removed original instead
         // of the real merged result.
         path = applyFillBrushPlacement(path, userLayers[state.activeLayerIdx]);
-        // 2026-07 feedback ("plusieurs coup de pinceau avec la même couleur
-        // doivent merger automatiquement") — Placement's own 'merge' option
-        // unions with whatever fill it happens to overlap regardless of
-        // color; genuine same-color fusion already exists
-        // (fillMergeSameColor, used by the paint bucket) but was never
-        // called from the Fill Brush's own commit. Wired in here
-        // unconditionally so consecutive same-color strokes merge into one
-        // shape no matter which Placement mode is active.
-        if (path) path = fillMergeSameColor(userLayers[state.activeLayerIdx], path, true) || path;
+        // 2026-08 feedback reversal: the 2026-07 change below called
+        // fillMergeSameColor unconditionally so consecutive same-color
+        // strokes fused into one shape — but fillMergeSameColor unions via
+        // Paper.js's .unite(), which re-emits a BRAND NEW point set for the
+        // WHOLE resulting boundary (see that function's own comment). That
+        // silently reshaped the FIRST stroke's own anchors the moment a
+        // second same-color stroke merely overlapped it. Reported: "je veux
+        // merge mais que les formes se conservent, pas que les path
+        // changent" — same-color strokes should read as one continuous
+        // filled area (they already do, visually, as opaque same-color
+        // fills with no stroke) WITHOUT a boolean op ever touching either
+        // shape's own geometry. Left as independent, unmodified paths.
+        // (Placement's own explicit 'merge' mode, just above, is a
+        // different, deliberately-named opt-in and keeps its real union.)
       }
     } else if (state.vectorBrush && !state.strokeEnabled) {
       // Stroke eye OFF + Fill ON: the pressure ribbon IS the stroke, so

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -6606,15 +6606,14 @@ function onMouseUp(event){
         // Placement (Above/Below/Merge) — see applyFillBrushPlacement's own
         // comment; replaces the old unconditional "always at the back".
         currentPath=applyFillBrushPlacement(currentPath,userLayers[state.activeLayerIdx]);
-        // 2026-07 feedback ("plusieurs coup de pinceau avec la même couleur
-        // doivent merger automatiquement") — Placement's own 'merge' option
-        // unions with whatever fill it happens to overlap regardless of
-        // color (see applyFillBrushPlacement); genuine same-color fusion
-        // already exists (fillMergeSameColor, used by the paint bucket) but
-        // was never called from the Fill Brush's own commit. Wired in here
-        // unconditionally so consecutive same-color strokes merge into one
-        // shape no matter which Placement mode is active.
-        if(currentPath)currentPath=fillMergeSameColor(userLayers[state.activeLayerIdx],currentPath,true)||currentPath;
+        // 2026-08 feedback reversal — mirrors draw-bridge.js's own commit
+        // path (CLAUDE.md §3, keep these two in sync): calling
+        // fillMergeSameColor here unconditionally reshaped the FIRST
+        // stroke's own anchors via Paper.js's .unite() the moment a second
+        // same-color stroke merely overlapped it. Reported: "je veux merge
+        // mais que les formes se conservent, pas que les path changent" —
+        // left as independent, unmodified paths instead (Placement's own
+        // explicit 'merge' mode, just above, is unaffected).
       }
       if(currentPath)tagOwner(currentPath);
     }


### PR DESCRIPTION
## Summary
- Two overlapping same-color Fill Brush strokes were auto-unioned (`fillMergeSameColor` → Paper.js `.unite()`), which re-tessellates the whole resulting boundary — so the first stroke's own anchors silently reshaped every time a second same-color stroke merely overlapped it.
- Feedback: strokes should still read as one merged area, but the underlying paths must not change. Same-color opaque fills with no stroke already look seamless when left as separate overlapping paths, so this removes the union call from Fill Brush's own automatic commit path (both the Rust-engine path in `draw-bridge.js` and its Paper-native fallback twin in `tools.js`) and just lets each stroke keep its own geometry.
- Placement's explicit "Merge" mode (which unions with any overlapping fill regardless of color) is untouched — that's a different, deliberately opt-in mode. The paint bucket's own use of `fillMergeSameColor` is also untouched.

## Test plan
- [x] Verified in-browser: two overlapping same-color Fill Brush strokes — first stroke's object identity, segment count, and anchor positions are all unchanged after drawing the second.
- [x] Verified the two strokes render as separate `Path` objects, both correctly `isFillShape`/closed/fill-only (no stroke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)