### PR TITLE
Snap Alt-drag closing strokes to the centerline, not the ribbon outline

### DIFF
--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -2014,7 +2014,20 @@ function fillMaterializeTempCloseStrokes(layer){
     // fillVectorFind then traced wrong. Same exclusion as fillCollectWalls.
     if(c.data&&(c.data.isLinkedFillCompanion||c.data.isBrushTextureCopy))return false;
     return c instanceof Path&&(c.strokeColor||c.fillColor||(c.data&&c.data.isVectorBrush))&&!(c.data&&c.data.isFillTempClose)&&c.segments.length>=2;
-  });
+  // Snap against the same geometry the FILL GRAPH uses — fillWallPath, i.e.
+  // a pressure/brush stroke's CENTERLINE, not the ribbon outline stored on
+  // the item (CLAUDE.md §1: fillWallPath is the shared "what counts as a
+  // wall" transform and this function was the one wall-consumer that never
+  // called it). Snapping to the raw item pulled each closing-stroke end onto
+  // the ribbon's OUTER EDGE, half a brush-width away from the centerline the
+  // graph then traces — so a closing stroke the user drew exactly end-to-end
+  // still left a systematic ~half-brush-width hole at BOTH ends and could
+  // not close at gapThr 0. Reproduced minimally: two 6px vertical brush
+  // strokes 220px apart, bridged top and bottom, found nothing at gapThr 0
+  // or 10 and only closed at 24 (the snapped ends sat at x=855.0/1065.0
+  // against centerlines at x=850/1070). This is the "je ferme tous les
+  // bouts proprement et il ne comprend pas la forme" report.
+  }).map(fillWallPath).filter(function(w){return w.segments.length>=2;});
   // Two cheap rejects before the expensive call (CLAUDE.md §5bis(a)):
   // getNearestPoint runs a numeric search over every curve of the wall,
   // measured at ~0.33ms on a real 15-segment brush stroke — so the naive


### PR DESCRIPTION
## Summary
`fillMaterializeTempCloseStrokes` snapped each closing-stroke point onto the **raw layer item**, but the fill graph traces `fillWallPath(item)` — a brush stroke's **centerline**, not the ribbon outline the item stores.

So every closing stroke was pulled onto the ribbon's *outer edge*, half a brush-width away from the wall the graph actually uses — leaving a systematic hole at **both** ends of a closing stroke the user drew exactly end-to-end.

CLAUDE.md §1 exactly: `fillWallPath` is the shared "what counts as a wall" transform, and this was the one wall-consumer that never called it.

## Reproduction (minimal, decisive)
Two 6px-wide vertical brush strokes at `x=850` and `x=1070`, bridged top and bottom with real Alt+drag closing strokes, fill clicked in the middle:

| | snapped ends | gapThr 0 | 10 | 24 |
|---|---|---|---|---|
| **before** | x=855.0 / 1065.0 | ✗ | ✗ | ✓ |
| **after** | x=850.0 / 1070.0 | ✓ | ✓ | ✓ |

After the fix it closes at `gapThr=0` with the exact expected geometry — area `66000` = 220×300, bounds `850,400 220×300`.

This is the "je ferme tous les bouts proprement et il ne comprend pas la forme" report: needing a large `gapThr` is what makes the tracer bridge long straight chords that visibly cut across the drawing.

## Notes
- Centerlines carry fewer segments than ribbon outlines, so the snap search touched here gets slightly **cheaper**, not dearer — the #261 guards are unaffected.
- Not yet re-verified against the reporter's own project file (I deleted my working copy during cleanup before finding this). The minimal case above is exact and unambiguous; a re-check on the real drawing is still worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)