### PR TITLE
Skip held frames when propagating a fill

### DIFF
--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -2883,7 +2883,14 @@ function fillPropagateAcrossFrames(fillPath){
   for(var fi=0;fi<ld.frames.length;fi++){
     if(fi===srcFrame)continue;
     var f=ld.frames[fi];
-    if(!f||!f.strokes)continue; // inherits from a keyframe — nothing of its own
+    // Only frames that OWN content. A held frame (neither keyframe nor
+    // interpolated) carries an empty strokes array and renders the keyframe it
+    // inherits from — so it already shows that keyframe's propagated fill, and
+    // writing to it is a no-op that saveActiveLayerFrame refuses anyway.
+    // Measured before this guard: ~100 of 119 frames on a real project were
+    // held, so the pass spent most of its time producing nothing and reported
+    // them as "filled".
+    if(!f||!f.strokes||!(f.isKeyframe||f.isInterpolated))continue;
     frames++;
     goToFrame(fi);
     var lyr=userLayers[li];


### PR DESCRIPTION
## Why
The propagation pass walked every frame with a `strokes` array — but a **held** frame (neither keyframe nor interpolated) carries an *empty* array and renders the keyframe it inherits from. It therefore already shows that keyframe's propagated fill, and writing to it is a no-op `saveActiveLayerFrame` refuses anyway.

Measured on a real 120-frame project: **100 of the 119 candidate frames were held**, so the pass spent most of its time producing nothing — and reported them as filled. The toast claimed *107 frames* when only 7 frames that own content actually changed.

## After
- Honest report: *"7 frame(s) filled, 12 left untouched"* — out of the 19 frames that own content (3 keyframes + 17 interpolated, minus the source).
- 3.6s → **2.6s**.
- **Visible result unchanged**: 108 of 120 frames still show the fill, identical areas (54421–56972), because held frames inherit it.

## Verification
Full export → import round trip on the reporter's project: same 108 frames showing the fill, same areas, 5 closing lines present on every frame, and **0** closing lines resurrected as a visible stroke (CLAUDE.md §1's `'#ffffff'` fallback trap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)