### PR TITLE
Restore Fill Brush same-color merge, preserving the source contours

### DIFF
--- a/src/js/draw-bridge.js
+++ b/src/js/draw-bridge.js
@@ -806,20 +806,26 @@
         // silently operating on the stale, already-removed original instead
         // of the real merged result.
         path = applyFillBrushPlacement(path, userLayers[state.activeLayerIdx]);
-        // 2026-08 feedback reversal: the 2026-07 change below called
-        // fillMergeSameColor unconditionally so consecutive same-color
-        // strokes fused into one shape — but fillMergeSameColor unions via
-        // Paper.js's .unite(), which re-emits a BRAND NEW point set for the
-        // WHOLE resulting boundary (see that function's own comment). That
-        // silently reshaped the FIRST stroke's own anchors the moment a
-        // second same-color stroke merely overlapped it. Reported: "je veux
-        // merge mais que les formes se conservent, pas que les path
-        // changent" — same-color strokes should read as one continuous
-        // filled area (they already do, visually, as opaque same-color
-        // fills with no stroke) WITHOUT a boolean op ever touching either
-        // shape's own geometry. Left as independent, unmodified paths.
-        // (Placement's own explicit 'merge' mode, just above, is a
-        // different, deliberately-named opt-in and keeps its real union.)
+        // Same-color Fill Brush strokes fuse into one shape.
+        //
+        // History worth keeping, because this flipped twice. It was added in
+        // 2026-07 ("plusieurs coups de pinceau avec la même couleur doivent
+        // merger automatiquement"), then removed in 2026-08 on the report
+        // that a second stroke reshaped the first — the reasoning being that
+        // .unite() re-emits a brand new point set for the whole boundary, so
+        // it must be distorting the untouched side.
+        //
+        // That reasoning was wrong, and measured wrong: sampling 380 points
+        // along the first shape's outline OUTSIDE the overlap, before and
+        // after the union, the maximum deviation is 0.000px — on two bars,
+        // on two opposed arcs, on two near-coincident wavy strokes, and on a
+        // shape unioned with its exact clone. unite() does re-emit the point
+        // set, but the curve it lands on is the same one.
+        //
+        // Removing it had a real cost that only shows below 100% opacity:
+        // two 50% shapes overlapping composite to 75%, so the overlap reads
+        // as a visibly darker seam — exactly "ça ne merge pas". Restored.
+        if (path) path = fillMergeSameColor(userLayers[state.activeLayerIdx], path, true) || path;
       }
     } else if (state.vectorBrush && !state.strokeEnabled) {
       // Stroke eye OFF + Fill ON: the pressure ribbon IS the stroke, so

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -2660,8 +2660,8 @@ function fillMergeSameColor(layer,newFill,allowFillShapeAbsorb){
   // else (insertBooleanResult below, or a FUTURE merge/regeneration pass
   // that would otherwise unite() this already-messy result again and
   // compound the degeneracy) — see _eraseDegenerateSelfLoops' own comment.
-  if(acc instanceof CompoundPath)acc.children.forEach(function(ch){_eraseDegenerateSelfLoops(ch);});
-  else _eraseDegenerateSelfLoops(acc);
+  if(acc instanceof CompoundPath)acc.children.forEach(function(ch){_eraseDegenerateSelfLoops(ch,true);});
+  else _eraseDegenerateSelfLoops(acc,true);
   var op=newFill.opacity;
   // Highest stacking position among the participants, adjusted for the
   // removals below it — the union visually replaces ALL of them, so it
@@ -2670,7 +2670,7 @@ function fillMergeSameColor(layer,newFill,allowFillShapeAbsorb){
   var topIdx=Math.max.apply(null,idxs);
   var removedBelow=idxs.filter(function(i){return i<topIdx;}).length;
   newFill.remove();absorbed.forEach(function(c){c.remove();});
-  var parts=insertBooleanResult(layer,Math.min(topIdx-removedBelow,layer.children.length),acc,newFill.fillColor,op,null,newFill.data);
+  var parts=insertBooleanResult(layer,Math.min(topIdx-removedBelow,layer.children.length),acc,newFill.fillColor,op,null,newFill.data,true);
   if(mergedSeeds.length){
     parts.forEach(function(part){
       part.data.fillSeeds=mergedSeeds;
@@ -5553,7 +5553,7 @@ function _mergeHoleIntoExterior(extSegs,holeSegs){
 // repeat until no repeats remain) recovers the true minimal boundary.
 // Verified live: 292 points -> 48, zero repeats left, shape area unchanged
 // to within 0.3% (the removed loops really were negligible slivers).
-function _eraseDegenerateSelfLoops(path){
+function _eraseDegenerateSelfLoops(path,skipRefit){
   if(!path||!path.segments)return;
   // Distance-based (not rounded-key) revisit detection: two of Paper's own
   // union() outputs from the SAME real junction routinely land a fraction
@@ -5656,7 +5656,15 @@ function _eraseDegenerateSelfLoops(path){
   // neighboring segments assuming at least a real closed triangle to work
   // with, and throws a bare TypeError instead of a catchable error on
   // fewer. Nothing to simplify below that anyway.
-  if(!keptRevisit&&path.segments.length>=3)path.simplify(2.5);
+  // `skipRefit` (2026-08, Fill Brush same-color merge): the refit below
+  // REPLACES the boundary's own anchors with a fresh Douglas-Peucker fit —
+  // measured on a two-stroke merge, 174 anchors in, 31 out, and 1.25% of
+  // sampled silhouette pixels moved versus the exact union (which is itself
+  // 0.000px from the source outlines: every anchor of a unite() result IS a
+  // source anchor or a true intersection). For a merge whose whole point is
+  // "the shapes must keep their contours" that trade is wrong, so the caller
+  // can keep the degenerate-loop splice above while declining the refit.
+  if(!skipRefit&&!keptRevisit&&path.segments.length>=3)path.simplify(2.5);
 }
 // strokeInfo (optional, 2026-07 — "l'eraser supprime le stroke entier"):
 // every branch below used to hardcode strokeColor=null on its island(s),
@@ -5685,7 +5693,13 @@ function _eraseDegenerateSelfLoops(path){
 // all describe how to REBUILD the outline, and a notched outline no longer
 // has a valid centerline to rebuild from (see eraseAtPoint's own comment on
 // origStrokeInfo — that tradeoff is intentional and predates this).
-var BOOL_KEEP_DATA_ALL=['groupId','ownerId','ownerName','ownerColor','channelTag','shadowSwatchId','tweenOn','boxAngle','xformAnchorKey','xformAnchorCustom','effects','fillGradient'];
+// isFillShape added 2026-08 (CLAUDE.md §1 family): pen-bridge's close-path/
+// endpoint-snap exclusion and vector-sculpt's sculptables filter both read it,
+// but every boolean fusion (same-color Fill Brush merge included) silently
+// dropped it — the merged shape then behaved subtly differently from the
+// strokes it was built from. Conditional copy, so a non-fill source is
+// unaffected.
+var BOOL_KEEP_DATA_ALL=['groupId','ownerId','ownerName','ownerColor','channelTag','shadowSwatchId','tweenOn','boxAngle','xformAnchorKey','xformAnchorCustom','effects','fillGradient','isFillShape'];
 // Keys that must stay UNIQUE across the layer: strokeId is a lookup map key
 // (motion.js:1413 scans for the first data.strokeId match), so copying it
 // onto every island of a split would make all but one unreachable. The
@@ -5725,11 +5739,11 @@ function carryBooleanData(isl,srcData,isFirst){
 // styling + real layer insertion. Hoisted out unchanged from what used to be
 // inline in insertBooleanResult — see that function's own history for why
 // hole-merging/degenerate-loop cleanup work the way they do.
-function flattenBooleanResult(result){
+function flattenBooleanResult(result,preserveGeometry){
   if(!(result instanceof CompoundPath)){
     // The op produced one seamless Path, no holes or islands at all (e.g.
     // two same-color fills merging into a single continuous outline).
-    _eraseDegenerateSelfLoops(result);
+    _eraseDegenerateSelfLoops(result,preserveGeometry);
     return[result];
   }
   var children=result.children.slice();
@@ -5772,7 +5786,7 @@ function flattenBooleanResult(result){
     // slit anchor — every extra hole compounds another revisit of that one
     // coordinate, same degenerate-loop shape _eraseDegenerateSelfLoops
     // already fixes after Paper's own unite() (see that function's comment).
-    _eraseDegenerateSelfLoops(merged);
+    _eraseDegenerateSelfLoops(merged,preserveGeometry);
     return merged;
   });
   result.remove();
@@ -6035,12 +6049,12 @@ function applyParamShapeRect(path){
   built.remove();
 }
 window.applyParamShapeRect=applyParamShapeRect;
-function insertBooleanResult(layer,insertAt,result,fillColor,opacity,strokeInfo,srcData){
+function insertBooleanResult(layer,insertAt,result,fillColor,opacity,strokeInfo,srcData,preserveGeometry){
   function applyStroke(isl){
     if(strokeInfo&&strokeInfo.color){isl.strokeColor=strokeInfo.color;isl.strokeWidth=strokeInfo.width;isl.strokeCap=strokeInfo.cap;isl.strokeJoin=strokeInfo.join;}
     else isl.strokeColor=null;
   }
-  var flat=flattenBooleanResult(result);
+  var flat=flattenBooleanResult(result,preserveGeometry);
   flat.forEach(function(isl,k){
     if(fillColor!==undefined)isl.fillColor=fillColor;
     applyStroke(isl);
@@ -7010,14 +7024,12 @@ function onMouseUp(event){
         // Placement (Above/Below/Merge) — see applyFillBrushPlacement's own
         // comment; replaces the old unconditional "always at the back".
         currentPath=applyFillBrushPlacement(currentPath,userLayers[state.activeLayerIdx]);
-        // 2026-08 feedback reversal — mirrors draw-bridge.js's own commit
-        // path (CLAUDE.md §3, keep these two in sync): calling
-        // fillMergeSameColor here unconditionally reshaped the FIRST
-        // stroke's own anchors via Paper.js's .unite() the moment a second
-        // same-color stroke merely overlapped it. Reported: "je veux merge
-        // mais que les formes se conservent, pas que les path changent" —
-        // left as independent, unmodified paths instead (Placement's own
-        // explicit 'merge' mode, just above, is unaffected).
+        // Same-color Fill Brush strokes fuse into one shape. Mirrors
+        // draw-bridge.js's own commit path (CLAUDE.md §3) — see its longer
+        // comment for why this was removed in 2026-08 and restored: the
+        // "unite() distorts the first shape" reasoning was never measured,
+        // and measuring it gives 0.000px deviation outside the overlap.
+        if(currentPath)currentPath=fillMergeSameColor(userLayers[state.activeLayerIdx],currentPath,true)||currentPath;
       }
       if(currentPath)tagOwner(currentPath);
     }


### PR DESCRIPTION
> **Not merged — yours to review.**

## What this settles
The user's question was: *"why can't the merge just keep the coordinates of both contours and stitch them at the intersections?"* — and the answer is: **it can, and that is exactly what `unite()` does.** The distortion that got the merge removed in #259 was never the union; it was the cleanup pass after it.

## The two measurements
**1. `unite()` is exact.** 380 points sampled along the first shape's outline *outside* the overlap, before/after union: max deviation **0.000px** — on bars, opposed arcs, near-coincident wavy strokes, and a shape unioned with its own clone. Every anchor of a unite() result is a source anchor or a true intersection.

**2. The distortion came from `_eraseDegenerateSelfLoops`' final `path.simplify(2.5)`** — an unconditional Douglas-Peucker refit that replaces the anchors wholesale. Measured: **174 anchors in, 31 out**, 1.25% of sampled silhouette pixels moved vs the exact union.

## The fix
A `preserveGeometry` flag threads from `fillMergeSameColor` through `insertBooleanResult` / `flattenBooleanResult` into `_eraseDegenerateSelfLoops`, skipping **only the final refit**. The degenerate-loop splice (clipper-noise removal) and the hole-merge stay active. Every other caller — boolean tool, eraser, group combine — passes nothing and is byte-for-byte unchanged.

Also, `isFillShape` joins `BOOL_KEEP_DATA_ALL` (CLAUDE.md §1 family): pen-bridge's endpoint-snap exclusion and vector-sculpt's `sculptables` filter both read it, but every boolean fusion silently dropped it. Conditional copy; non-fill sources unaffected.

## Why restore the merge at all
Leaving strokes unmerged (the #259 state) has a cost that only shows below 100% opacity: two 50% shapes overlapping composite to **75%** — a visibly darker seam. Reported as "ça ne merge pas".

## Verification (driven in the app, pressure neutralised so both passes draw identical geometry)
| test | result |
|---|---|
| merge vs exact-union reference | **0** of 10 948 sampled points differ (was 1.9% with the refit); 174 segments preserved |
| 50% opacity overlap | one shape, one opacity — seam gone |
| two half-rings fusing into a ring | hole survives (centre empty, ring filled), `isFillShape` present |
| eraser through a merged shape (non-preserved path) | no exception, output intact |

## Honest note on method
Three wrong claims were made and corrected along the way in-session: "geometry loss" in `insertBooleanResult` (was the slit's area accounting — 0 of 4096 sampled points actually lost), "0.000px through the pipeline" (measured on a path that bypassed the real pipeline), and a 5.2% figure (uncontrolled pressure between passes). The numbers above are from the controlled reruns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)