### PR TITLE
Fix Fill Brush lag: scope undo snapshot to current frame (feedback #111)

### DIFF
--- a/src/js/fill-bridge.js
+++ b/src/js/fill-bridge.js
@@ -49,7 +49,16 @@
     // AND whatever this click does, as one step. Doing it lazily per-branch
     // also left a "Aucune zone fermée ici" miss's keyframe promotion
     // permanently un-undoable.
-    pushUndo();
+    // pushUndoActiveFrame() (tweens.js), not the full pushUndo() — measured
+    // on a real 120-keyframe project: the fill click itself only ever
+    // mutates state.currentFrame (across possibly-linked layers via
+    // ensureKeyframe's syncLinkedKeyframeFolder fan-out, still covered since
+    // this snapshots every layer's copy of just that one frame), so cloning
+    // the other 119 frames on every click was 166-298ms of dead weight —
+    // 80%+ of the whole click's cost. Fill Brush/paint bucket propagation
+    // (onPropagateClick, below) legitimately touches OTHER frames and keeps
+    // the full pushUndo().
+    pushUndoActiveFrame();
     ensureKeyframe();
     var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
     var pt = new Point(w[0], w[1]);
@@ -152,7 +161,9 @@
     // as one step with whatever fill follows it.
     var committed = null;
     if (_fillCloseDrag.points.length >= 2) {
-      pushUndo();
+      // Same reasoning as the click handler above — a closing-line commit
+      // only ever touches the current frame.
+      pushUndoActiveFrame();
       ensureKeyframe();
       committed = fillCommitCloseLine(userLayers[state.activeLayerIdx], _fillCloseDrag.points);
       if (committed) saveActiveLayerFrame();

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -6681,7 +6681,9 @@ function onMouseDown(event){
     // pushUndo() BEFORE ensureKeyframe(), and unconditionally — see
     // draw-bridge.js's commitStroke comment: one undo must revert both the
     // frame's auto-promotion to keyframe and whatever this click does.
-    pushUndo();ensureKeyframe();
+    // pushUndoActiveFrame() (tweens.js) — mirrors fill-bridge.js's own
+    // click handler (CLAUDE.md §3): this only ever mutates the current frame.
+    pushUndoActiveFrame();ensureKeyframe();
     if(event.modifiers.shift){
       var hitRm=layer.hitTest(event.point,{fill:true,tolerance:12/view.zoom});
       if(hitRm&&hitRm.item instanceof Path&&hitRm.item.fillColor){hitRm.item.fillColor=null;saveActiveLayerFrame();updateUI();showToast(SM.t('toastFillRemoved'));}

--- a/src/js/tweens.js
+++ b/src/js/tweens.js
@@ -4363,6 +4363,61 @@ function _walkStrokes(layers,fn){
 // The live tree is briefly mutated (heavy fields nulled) — synchronous, with
 // no call-out in between, and restored in a `finally` so a throw inside
 // JSON.stringify cannot leave it stripped.
+// Same detach-heavy-fields-then-native-stringify technique as
+// _cloneLayersForUndo just below, scoped to ONE frame's own strokes array
+// instead of walking every layer's every frame. Exists because pushUndoLayers
+// (the only thing that ever pushed onto state.undoStack until now) always
+// snapshots the WHOLE animation — measured on a real 120-keyframe, one-layer,
+// 67052-item project: 298ms per undo-able click, ~80% of the paint bucket's
+// whole per-click cost, and NOT specific to the Fill tool — any undoable
+// action on a project this size pays it. undo()/redo() (below) already had a
+// matching lightweight RESTORE path for a non-'layers'-typed snapshot
+// ({frame, layers:[{strokes,isKeyframe,isInterpolated}]}) — nothing ever
+// PUSHED one, so that branch was dead code until this function.
+function _cloneStrokesForUndo(strokes){
+  if(!strokes)return strokes;
+  var HEAVY=(window._HEAVY_STROKE_FIELDS)||['src','bitmapPressureProfile'];
+  var saved=[];
+  strokes.forEach(function(s){
+    var e=null;
+    for(var i=0;i<HEAVY.length;i++){var k=HEAVY[i];
+      if(typeof s[k]==='string'){(e||(e={}))[k]=s[k];s[k]=null;}}
+    saved.push(e);
+  });
+  var c;
+  try{ c=JSON.parse(JSON.stringify(strokes)); }
+  finally{ strokes.forEach(function(s,j){var e=saved[j];if(e)for(var k in e)s[k]=e[k];}); }
+  c.forEach(function(s,j){var e=saved[j];if(e)for(var k in e)s[k]=e[k];});
+  return c;
+}
+// Frame-scoped undo entry — deliberately NOT type:'layers', so it lands in
+// undo()/redo()'s existing lightweight branch. Captures every layer's copy of
+// ONE frame (not layersSnapshotNow's whole animation), which is exactly what
+// that branch already restores. Correct as long as the guarded mutation never
+// touches a DIFFERENT frame index than state.currentFrame — true for the
+// Fill tool: ensureKeyframe() only ever promotes curF (the current frame),
+// and its cross-layer fan-out (syncLinkedKeyframeFolder, for linked-layer
+// groups) only ever writes the SAME frame index on sibling layers — both
+// captured here since this snapshots ALL layers, just the one frame.
+// Anything whose mutation could reach beyond the current frame (or that
+// calls saveAllLayerFrames() rather than saveActiveLayerFrame()) must keep
+// using the full pushUndo() instead.
+function pushUndoActiveFrame(){
+  if(window._scrubLiveActive)return;
+  if(typeof saveActiveLayerFrame==='function')saveActiveLayerFrame();
+  var frame=state.currentFrame;
+  var snap={frame:frame,layers:state.layers.map(function(ld){
+    var f=ld.frames[frame]||{};
+    return{strokes:_cloneStrokesForUndo(f.strokes),isKeyframe:f.isKeyframe,isInterpolated:f.isInterpolated};
+  })};
+  state.undoStack.push(snap);state.undoLabels.push(_actionLabelNow());
+  if(state.undoStack.length>state.maxUndo){state.undoStack.shift();state.undoLabels.shift();}
+  state.redoStack=[];state.redoLabels=[];
+  if(window.SMFeedback)SMFeedback.logAction();
+  if(window.renderHistoryPanelIfOpen)renderHistoryPanelIfOpen();
+  if(window.SMPlaybackCache)SMPlaybackCache.invalidateAll();
+  window._tweenFrameDirty=true;
+}
 function _cloneLayersForUndo(layers){
   var HEAVY=(window._HEAVY_STROKE_FIELDS)||['src','bitmapPressureProfile'];
   var saved=[],c;


### PR DESCRIPTION
## Résumé
- `pushUndo()` clonait TOUTE l'animation (toutes frames, tous calques) à chaque clic annulable. Sur le projet réel du testeur (120 keyframes, 67052 strokes) : 166-298ms par clic, ~80% du coût total — alors que le Fill (clic, fermeture de trait, fallback Paper-natif) ne touche jamais que `state.currentFrame`.
- Ajoute `pushUndoActiveFrame()` (tweens.js) : snapshot d'UNE seule frame à travers tous les calques (couvre bien le fan-out cross-calque de `syncLinkedKeyframeFolder` via `ensureKeyframe`), tombe dans la branche de restauration légère déjà existante et jusqu'ici morte dans `undo()`/`redo()`.
- `fillPropagateAcrossFrames` (propagation multi-frames) garde volontairement le `pushUndo()` complet, car il touche légitimement plusieurs frames.

## Vérification (pilotage live, projet réel du testeur, port isolé)
- Timing réel : 5 gestes de fermeture = 93ms au total (était ~970ms) ; clic de fill final = 61ms (était ~200ms).
- Correction du résultat inchangée (aire/gap identiques).
- Les autres frames (1, 5, 20, 60, 119) restent **identiques bit à bit** avant/après un cycle undo/redo.
- Cas le plus sensible testé : une frame maintenue promue en keyframe par `ensureKeyframe()` revient exactement à son état d'origine (`isKeyframe:false`, tableau vide) après `undo()`.
- Déroulement complet de la pile (6 `undo()` successifs) : retrait propre et dans l'ordre des 5 traits de fermeture + le fill, `undoStackLeft` termine à 0, nombre d'items final identique à l'état de départ.
- Aucune erreur console sur toute la séquence de test.

## Test plan
- [x] Vérifié en pilotant le navigateur sur le fichier projet réel du testeur (63.9MB, 120 frames, 1 calque)
- [x] Timing avant/après mesuré
- [x] Intégrité undo/redo vérifiée sur plusieurs frames + cas de promotion de keyframe
- [x] Déroulement complet de la pile d'undo vérifié
- [ ] Pas encore testé en build Tauri natif (uniquement preview navigateur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)