### PR TITLE
Fix fill/stroke color alpha never rendering + Fill opacity dimming stroke (feedback #48)

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -105,6 +105,18 @@
   // single-writer behavior a live preview during an intercepted drag needs.
   var suspended = false;
 
+  // Callers below MUST hand this colorHex8(color) — never color.toCSS(true).
+  // Paper.js's toCSS(true) hard-codes alpha=1 into the string it returns
+  // regardless of the Color object's actual .alpha (documented Paper.js
+  // quirk, CLAUDE.md §2's colorHex8 comment in app.js) — every one of these
+  // call sites used to pass toCSS(true), so a fill/stroke color's OWN alpha
+  // byte (#rrggbbaa, set via the Fill/Stroke opacity fields or the RGBA
+  // picker) silently never reached the renderer: only the item's separate
+  // opacity scalar (`op`/`op2` below) ever visibly dimmed anything, even
+  // though this function was already written to multiply BOTH together
+  // correctly (feedback #48, confirmed by sampling actual rendered pixels
+  // via renderFrameToPixelsPNG — a 40%-alpha fill and a 20%-alpha stroke
+  // both rendered fully opaque before this fix).
   function cssColorToRgba(css, opacity) {
     if (!css) return null;
     var h = String(css).replace('#', '');
@@ -1622,13 +1634,13 @@
           }
           var item;
           if (pathRef) {
-            item = { pathRef: pathRef, fillColor: cssColorToRgba(c.fillColor ? c.fillColor.toCSS(true) : null, op) };
+            item = { pathRef: pathRef, fillColor: cssColorToRgba(c.fillColor ? colorHex8(c.fillColor) : null, op) };
             if (pathTf) item.pathTransform = pathTf;
           } else {
             item = {
               segments: rounded,
               closed: !!sd.closed,
-              fillColor: cssColorToRgba(c.fillColor ? c.fillColor.toCSS(true) : null, op),
+              fillColor: cssColorToRgba(c.fillColor ? colorHex8(c.fillColor) : null, op),
             };
           }
           // Extended per-shape property: Fill color (2026-07) — overrides
@@ -1705,7 +1717,7 @@
             item.fillColor = null;
             delete item.fillGradient;
           }
-          var sc = cssColorToRgba(c.strokeColor ? c.strokeColor.toCSS(true) : null, op);
+          var sc = cssColorToRgba(c.strokeColor ? colorHex8(c.strokeColor) : null, op);
           if (sc) {
             item.strokeColor = sc;
             // With pathTransform the engine strokes THROUGH the affine, which
@@ -1897,9 +1909,9 @@
           var extraItem = {
             segments: roundSegs(exSegs),
             closed: !!ex.path.closed,
-            fillColor: cssColorToRgba(ex.path.fillColor ? ex.path.fillColor.toCSS(true) : null, op2),
+            fillColor: cssColorToRgba(ex.path.fillColor ? colorHex8(ex.path.fillColor) : null, op2),
           };
-          var exSc = cssColorToRgba(ex.path.strokeColor ? ex.path.strokeColor.toCSS(true) : null, op2);
+          var exSc = cssColorToRgba(ex.path.strokeColor ? colorHex8(ex.path.strokeColor) : null, op2);
           if (exSc) { extraItem.strokeColor = exSc; extraItem.strokeWidth = ex.path.strokeWidth || 1; }
           items.push(extraItem);
         });
@@ -2268,8 +2280,8 @@
           // outline mode would otherwise report closed:false and render with
           // a gap where the fill used to close the loop.
           closed: !!sub.closed,
-          fillColor: cssColorToRgba(c.fillColor ? c.fillColor.toCSS(true) : null, op),
-          strokeColor: cssColorToRgba(c.strokeColor ? c.strokeColor.toCSS(true) : null, op),
+          fillColor: cssColorToRgba(c.fillColor ? colorHex8(c.fillColor) : null, op),
+          strokeColor: cssColorToRgba(c.strokeColor ? colorHex8(c.strokeColor) : null, op),
           strokeWidth: c.strokeWidth || 1,
           // typeof-guarded — same Option<String> boundary as the main
           // per-item loop above (buildSceneJson).

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -755,7 +755,33 @@ window.SM={
     if((state.tool==='select'||state.tool==='subselect')&&selectedPaths.length){
       pushUndo();
       var op=Math.max(0,Math.min(100,parseInt(v)||0))/100;
-      selectedPaths.forEach(function(p){p.opacity=op;});
+      // Lives under the Fill header (#p-opacity, #fill-sec) — feedback #48:
+      // "la partie fill... s'applique au stroke". Writing whole-item opacity
+      // dimmed the stroke right along with the fill, which reads as "Fill
+      // opacity" doing the wrong thing for anyone coming from Figma's own
+      // convention (fill opacity is per-paint, separate from a layer's own
+      // opacity — mirrors how #p-stroke-alpha already only touches
+      // strokeColor's alpha, never the whole item). Only fall back to
+      // item.opacity when there's no fillColor to touch (rasters/images/
+      // video frames, or a shape with fill currently disabled) — keeps the
+      // fix this comment used to describe (opacity doing nothing on those).
+      // Reassign a brand-new hex8 STRING, not fillColor.alpha=op in place —
+      // mutating the existing live Color object left the retained-path
+      // engine cache (CLAUDE.md §5ter) unrefreshed on screen even though
+      // path.fillColor.alpha read back correctly afterward; every other
+      // color writer in this codebase (setFillColor/setStrokeColor/
+      // #p-stroke-alpha) already goes through a full string reassignment,
+      // which its `_changed` hook is proven to catch.
+      var touchedFillHex=null;
+      selectedPaths.forEach(function(p){
+        if(p.fillColor){
+          var rgb=colorHex8(p.fillColor).replace('#','').slice(0,6);
+          var a=Math.round(op*255).toString(16).padStart(2,'0').toUpperCase();
+          var hex8='#'+rgb+(op<1?a:'');
+          p.fillColor=hex8;touchedFillHex=hex8;
+        } else p.opacity=op;
+      });
+      if(touchedFillHex){state.fillColor=touchedFillHex;paintFillSwatches(touchedFillHex);}
       saveActiveLayerFrame();updateUI();
     }
   },
@@ -5063,9 +5089,12 @@ function paintFillSwatches(v){
   var fw=document.getElementById('fill-well'); if(fw)fw.style.background=v;
   var pf=document.getElementById('pm-fill');   if(pf)pf.style.background=v;
   ['color-fill','pm-fill-c'].forEach(function(id){setHex8Input(document.getElementById(id),v);});
-  // No fill-side alpha field exists (only the stroke has one) — the fill's
-  // alpha rides in dataset.hex8 above.
   var fhex=document.getElementById('p-fill-hex');if(fhex&&document.activeElement!==fhex)fhex.value=hexDisplayValue(v);
+  // #p-opacity (feedback #48 fix) now IS the fill's own alpha field, same
+  // convention as #p-stroke-alpha just below for stroke — keep it in sync
+  // with whatever selection/color change just painted this swatch, instead
+  // of showing a stale percentage left over from a previous shape.
+  var fop=document.getElementById('p-opacity');if(fop&&document.activeElement!==fop)fop.value=alphaPctFromHex(v);
 }
 // `frameOnly` — same contract as updateUI's: nothing but state.currentFrame
 // changed. Animation 2D's rows are frame-INDEPENDENT (name, colour dot,


### PR DESCRIPTION
## Résumé
Deux bugs distincts derrière un seul symptôme rapporté ("la partie fill dans le panel droite s'applique au stroke et tout ne marche pas bien") :

1. **Bug moteur (le plus important)** : `engine-bridge.js` lisait chaque couleur fill/stroke via `color.toCSS(true)` avant de l'envoyer à `cssColorToRgba()`. `toCSS(true)` de Paper.js force TOUJOURS alpha=1 dans la chaîne retournée, quelle que soit la vraie valeur de `.alpha` — piège déjà documenté dans CLAUDE.md §2 (`colorHex8`), mais qui n'était pas respecté dans le pont moteur. Résultat : l'alpha propre d'une couleur (celui du champ %, ou de la pipette RGBA) n'atteignait JAMAIS le rendu — seule l'opacité globale de l'objet (`item.opacity`) avait un effet visuel. Corrigé aux 7 points d'appel (rendu principal, formes combinées booléennes, fantôme onion-skin) en remplaçant par `colorHex8(color)`, qui préserve l'alpha.
2. **Bug de câblage** : `#p-opacity` (le champ % du panneau Fill) écrivait l'opacité de TOUT l'objet, donc touchait aussi le stroke — surprenant pour un champ logé sous l'en-tête "Fill", qui devrait n'affecter QUE le fill (comme `#p-stroke-alpha` n'affecte QUE le stroke). Il écrit maintenant l'alpha du `fillColor` uniquement (retombe sur l'opacité de l'objet entier pour les rasters/images, qui n'ont pas de fillColor — préserve le fix précédent qui faisait marcher Opacity du tout sur une sélection).

## Vérification (pilotage réel, lecture de pixels)
`toDataURL()` ne fonctionne pas de façon fiable sur ce canvas WebGPU (retourne du transparent) — vérifié via `SMEngineBridge.renderFrameToPixelsPNG` (la méthode déjà établie dans ce repo pour ce genre de vérification) :
- **Avant fix** : fill à 40% d'alpha → pixel `[255,0,0,255]` (rouge plein, alpha ignoré). Stroke à 20% → `[0,0,0,255]` (noir plein).
- **Après fix** : fill à 40% → `[255,153,153,255]` (exactement le blend attendu rouge/blanc). Stroke à 20% → visiblement éclairci en dégradé (blend correct), plus du noir plein.
- Modifier le % du Fill ne touche plus `strokeColor` ni `item.opacity` (vérifié : `strokeAlpha` reste à sa valeur propre après un changement de Fill%).
- Resélection de la forme : le panneau réaffiche correctement 40%/20% (pas de valeur périmée).
- Aucune erreur console sur toute la séquence.

## Test plan
- [x] Vérifié en pilotant le navigateur (dessin d'une forme fill+stroke, édition des deux %, lecture de pixels réels via renderFrameToPixelsPNG)
- [x] Confirmé que Fill% n'affecte plus le stroke
- [x] Confirmé la resélection sans valeur périmée
- [ ] Pas testé en build Tauri natif (uniquement preview navigateur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)