### PR TITLE
Improve contrast: selected in/out bar + revealed Parent-in-Time dot (feedback #56, #108)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1473,9 +1473,17 @@ body.mode-motion .layer-inout-bar .layer-inout-handle{width:4px;border-radius:2p
    including free ones, while .is-child/.is-parent opt back into visibility
    unconditionally regardless of Alt, since an already-engaged point's role
    should never depend on a held key to be legible. */
-#frame-grid.timelink-alt .layer-inout-bar .timelink-anchor,
 .layer-inout-bar .timelink-anchor.is-child,
 .layer-inout-bar .timelink-anchor.is-parent{opacity:1;pointer-events:auto;}
+/* Feedback #108: "avec alt aucun petit rond n'apparait" — the dot DOES
+   reveal (opacity 0->1, confirmed live), but the base free-anchor color
+   (dim text-color border on a near-black --panel2 fill) barely registers
+   against a default/untrimmed bar, which is the near-transparent white
+   overlay .full-range style just above, not a bright custom color — a
+   near-black dot on a near-black bar is functionally invisible even at
+   opacity:1. Brighter border + fill specifically for the revealed state,
+   so it actually pops instead of just technically existing. */
+#frame-grid.timelink-alt .layer-inout-bar .timelink-anchor{opacity:1;pointer-events:auto;border-color:#fff;background:var(--accent,#3F6BF5);}
 .layer-inout-bar .timelink-anchor:hover{border-color:var(--accent,#5b6cff);box-shadow:0 0 0 2px rgba(91,108,255,.25);}
 .layer-inout-bar .timelink-anchor.in{left:0;}
 .layer-inout-bar .timelink-anchor.out{left:100%;}
@@ -1494,7 +1502,13 @@ body.mode-motion .layer-inout-bar .layer-inout-handle{width:4px;border-radius:2p
 
 /* Multi-select (marquee rect -> group-drag several layers' bars together,
    layer-inout.js) */
-.layer-inout-bar.sel{box-shadow:0 0 0 1.5px #fff;}
+/* Feedback #56: "les in et out point pas assez contrasté quand c'est
+   select" — a bare 1.5px white ring barely read against the bar's own
+   colored pill fill (see the reporter's screenshot: green/purple/orange
+   bars). Matches .layer-inout-handle.sel's own already-visible language
+   just above (white ring + accent glow) instead of a plain thin outline,
+   so bar-level and handle-level selection read as the same visual system. */
+.layer-inout-bar.sel{box-shadow:0 0 0 1.5px #fff,0 0 0 4px rgba(74,158,255,.55);}
 .layer-inout-marquee-rect{position:fixed;border:1px solid var(--accent);background:rgba(63,107,245,.15);pointer-events:none;z-index:50;}
 .fc.io-dim{background:rgba(0,0,0,.35);opacity:.4;}
 /* Per-keyframe tick marks inside the in/out bar (layer-inout.js


### PR DESCRIPTION
## Résumé
- **#56** : \`.layer-inout-bar.sel\` n'avait qu'un anneau blanc de 1.5px, difficile à voir contre le fond coloré du bar (capture du rapporteur : bars vert/violet/orange). Ajout du même halo accent que \`.layer-inout-handle.sel\` a déjà, pour une cohérence visuelle bar/poignée.
- **#108** : le mécanisme de révélation Alt fonctionne déjà correctement (vérifié : le listener keydown se déclenche, opacity passe bien de 0 à 1) — mais la couleur par défaut du point libre (bordure sombre sur fond quasi noir) est pratiquement invisible sur un bar \`.full-range\` par défaut (léger voile blanc, pas une couleur vive). L'état révélé par Alt a maintenant une bordure blanche + fond bleu accent au lieu d'hériter du style sombre de base.

## Vérification (pilotage réel)
- Sélection d'un bar : \`box-shadow\` confirmé via \`getComputedStyle\` (anneau blanc + halo bleu).
- Alt maintenu (keydown réel dispatché) : point confirmé opacity:1, bordure blanche, fond bleu accent — visible dans un screenshot.
- Aucune erreur console.

## Test plan
- [x] Vérifié en pilotant le navigateur (3 calques, mode Motion, sélection d'un bar + Alt maintenu)
- [x] Confirmé via getComputedStyle avant/après
- [ ] Pas testé en build Tauri natif (uniquement preview navigateur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)