### PR TITLE
Coalesce curve-editor drag commits to one per animation frame (feedback #91)

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -343,6 +343,32 @@
     if(isPressureMode())return;
     if(window.SM)window.SM.setCurve(clonePts(cs.points));upP();
   }
+  // Feedback #91 ("des lenteurs dans l'édition de curves"): pushCurve() ran
+  // on every raw mousemove tick, unthrottled — in tween-pair mode that's a
+  // full generateTweens() re-bake (every intermediate frame's interpolated
+  // geometry) per tick, not just a cheap state write, and a mouse/stylet
+  // firing well above 60 events/s made a single drag call it far more often
+  // than the screen could ever show a new result. Same rAF-coalescing
+  // pattern already proven for the scrub inputs (dispatchLiveChange, below
+  // in this file) — draw() stays synchronous every tick (cheap: one canvas
+  // repaint) so the point still tracks the cursor with no visible lag, only
+  // the expensive regeneration is capped at one call per animation frame.
+  var pushCurveRaf=0,pushCurveDirty=false;
+  function pushCurveLive(){
+    pushCurveDirty=true;
+    if(pushCurveRaf)return;
+    pushCurveRaf=requestAnimationFrame(function(){
+      pushCurveRaf=0;
+      if(pushCurveDirty){pushCurveDirty=false;pushCurve();}
+    });
+  }
+  // Called on mouseup — a still-pending coalesced call must fire synchronously
+  // right away, or the final point position (the one the user actually let go
+  // on) would never get its own generateTweens/setCurve commit.
+  function flushPushCurve(){
+    if(pushCurveRaf){cancelAnimationFrame(pushCurveRaf);pushCurveRaf=0;}
+    if(pushCurveDirty){pushCurveDirty=false;pushCurve();}
+  }
 
   // Camera-mode drag state — which control handle (0 or 1) is being moved.
   var camDragWhich=null;
@@ -434,7 +460,7 @@
       // itself in x, which has no meaning on a timing axis.
       var ntx=dragTangent.dir*3*(fX(tmx)-tp.x),nty=dragTangent.dir*3*(fY(tmy,yrt)-tp.y);
       tp.tx=Math.max(0.001,ntx);tp.ty=nty;
-      draw();pushCurve();
+      draw();pushCurveLive();
       return;
     }
     if(dragging==null)return;
@@ -451,16 +477,15 @@
       p.x=Math.max(lo,Math.min(hi,nx));
     }
     p.y=Math.max(-1,Math.min(2,ny));
-    draw();pushCurve();
+    draw();pushCurveLive();
   });
   window.addEventListener('mouseup',function(){
-    // No extra commit needed here (verified live, 2026-07-30 — an earlier
-    // version of this fix added one and it double-pushed): mousemove above
-    // already calls pushCurve() on EVERY tick, including the last one right
-    // before mouseup, so the final point position and its generateTweens
-    // re-bake are already applied by the time this fires. All this needs to
-    // do is close out the gesture — clearing _scrubLiveActive is what lets
-    // the NEXT unrelated pushUndoLayers() call through again.
+    // pushCurveLive() (feedback #91) coalesces to one call per animation
+    // frame — the tick for the very last mousemove before release may still
+    // be a pending, unfired rAF at this point, so it must be flushed
+    // synchronously here or the final point position (the one actually let
+    // go on) would never get its own generateTweens/setCurve commit.
+    if(dragging!=null||dragTangent)flushPushCurve();
     dragging=null;camDragWhich=null;dragTangent=null;
     window._scrubLiveActive=false;
   });


### PR DESCRIPTION
## Résumé
"des lenteurs dans l'édition de curves" — glisser un point (ou une poignée de tangente) dans l'éditeur de courbe d'accélération appelait \`pushCurve()\` à chaque tick brut de \`mousemove\`, sans aucun throttle. En mode courbe par-paire de tween, c'est un \`generateTweens()\` complet (re-bake de toutes les frames intermédiaires interpolées) À CHAQUE tick — pas une simple écriture d'état — et une souris/tablette qui envoie largement plus de 60 \`mousemove\`/s appelait ça bien plus souvent que l'écran ne peut jamais afficher de nouveau résultat.

## Fix
Même schéma de coalescence par requestAnimationFrame déjà éprouvé ailleurs dans ce fichier (\`dispatchLiveChange\`, pour les champs numériques scrub) : \`draw()\` (léger : un repaint canvas) reste synchrone à chaque tick pour que le point suive le curseur sans latence visible, seul le commit coûteux est plafonné à un appel par frame d'animation. Le \`mouseup\` force un commit en attente au cas où, pour ne jamais perdre la position finale (celle effectivement relâchée).

## Vérification (pilotage réel)
- Simulé un drag de 30 ticks sur le point de la courbe par défaut : avant ce fix, chaque tick aurait commité séparément ; après, un seul commit réel s'est déclenché pendant le drag (vérifié via un compteur enveloppant \`window.SM.setCurve\`).
- L'état final de la courbe correspond bien à la dernière position simulée, pas à un état intermédiaire périmé.
- Aucune erreur console.

## Test plan
- [x] Vérifié en pilotant (drag simulé multi-tick + compteur d'appels réels)
- [x] Position finale du point vérifiée correcte
- [ ] Pas testé en build Tauri natif (uniquement preview navigateur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)