### PR TITLE
Fix Vector Sculpt getting stuck armed after a missed pointerup (feedback #94)

### DIFF
--- a/src/js/labs/vector-sculpt.js
+++ b/src/js/labs/vector-sculpt.js
@@ -238,6 +238,24 @@
   function onMove(e) {
     updateCursor(e);
     if (!isActive()) return;
+    // Feedback #94: "après avoir utilisé sculpt vector j'ai des lags sur
+    // l'affichage et les outils" — a pointerup/pointercancel can be missed
+    // by the browser (released outside the window, Alt-Tab mid-drag, a
+    // right-click interrupting) and this listener never resets dragging.
+    // With no safety net, EVERY subsequent mousemove — including ones that
+    // have nothing to do with sculpting, as long as Select/Subselect stays
+    // the active tool — silently re-ran the full applyPush/applySmooth
+    // pass (walk every sculptable path in the layer, distance-test every
+    // segment) forever, which reads exactly as "lag after using the tool"
+    // since nothing on screen hints sculpting is still armed. e.buttons is
+    // the actual live button state (unlike a stored flag it can't go
+    // stale) — bit 1 is the primary button; if it's not set the drag
+    // already ended somewhere this listener never heard about.
+    if ((dragging || resizing) && !(e.buttons & 1)) {
+      dragging = false; resizing = false; lastW = null; touched = [];
+      updateCursor(e);
+      return;
+    }
     if (resizing) {
       e.stopImmediatePropagation(); e.preventDefault();
       window.SMLabs.setSculptRadius(resizeStartRadius + (e.clientX - resizeStartX));


### PR DESCRIPTION
## Résumé
"après avoir utilisé sculpt vector dans labs j'ai des lags sur l'affichage et les outils" — \`onDown\` arme \`dragging\`/\`resizing\`, et seul \`onUp\` les désarme. Mais un \`pointerup\`/\`pointercancel\` peut être perdu par le navigateur (relâché hors de la fenêtre, Alt-Tab pendant le drag, un clic droit qui interrompt le geste). Sans filet de sécurité, CHAQUE \`mousemove\` suivant — même sans rapport avec le sculpt, tant que Select/Subselect reste l'outil actif — relançait silencieusement toute la passe applyPush/applySmooth (parcourir chaque forme sculptable du calque, tester la distance de chaque segment), ce qui se lit exactement comme un lag générique apparu \"après avoir utilisé l'outil\", puisque rien à l'écran n'indique que le sculpt est encore armé.

## Fix
\`e.buttons\` est l'état réel du bouton (contrairement aux flags stockés \`dragging\`/\`resizing\`, il ne peut pas devenir périmé) — si le bit du bouton principal n'est pas positionné alors qu'un des deux flags est actif, le drag s'est déjà terminé quelque part que ce listener n'a jamais vu. Réinitialise les deux flags et sort avant de faire quoi que ce soit.

## Vérification
- Aucune erreur console sur un vrai geste de drag ET sur une séquence simulant un pointerup manqué (pointerdown+move avec buttons=1, puis un move avec buttons=0 au lieu d'un pointerup, puis un move de suivi ailleurs).
- Le fix est une garde purement additive sur le cas exact \"buttons=0 alors qu'encore armé\" — le chemin bouton-maintenu (le seul qui existait avant) est inchangé.

## Test plan
- [x] Vérifié en pilotant (drag réel + séquence pointerup manqué simulée)
- [x] Aucune erreur console
- [ ] Pas testé en build Tauri natif (uniquement preview navigateur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)