### PR TITLE
Fix Motion not moving a brush stroke's fill companion (feedback #103)

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -999,6 +999,20 @@
       // own start/end convention.
       var brushGroupDabs = null;
       var brushAnchorItem = null;
+      // Linked-fill companion (feedback #103: "y a juste le stroke qui se
+      // déplace et pas le fill") — same shape as brushAnchorStrokeId just
+      // above, one pre-pass building linkedFillId -> ANCHOR's strokeId. A
+      // fill companion carries its OWN strokeId (draw-bridge.js stamps it
+      // independently, see motion.js's layerElements comment on
+      // __linkedFillStrokeId), never the anchor's — but the Elements panel
+      // folds the companion OUT of the list entirely (motion.js:
+      // "isLinkedFillCompanion: return // folded into its owning stroke
+      // below"), so per-element Motion (position/scale/rotation drags,
+      // keyframes) is only ever RECORDED under the anchor's strokeId. Below,
+      // cStrokeId fell through to the companion's own (different) strokeId
+      // for every OTHER lookup keyed by cStrokeId, so elementMotionAt found
+      // no entry for it and the fill silently never moved with its stroke.
+      var fillAnchorStrokeId = null;
       for (var bi = 0; bi < children.length; bi++) {
         var bc = children[bi];
         if (bc.data && bc.data.brushGroupId) {
@@ -1016,6 +1030,10 @@
             if (!brushAnchorItem) brushAnchorItem = {};
             brushAnchorItem[bc.data.brushGroupId] = bc;
           }
+        }
+        if (bc.data && bc.data.linkedFillId && !bc.data.isLinkedFillCompanion && bc.data.strokeId) {
+          if (!fillAnchorStrokeId) fillAnchorStrokeId = {};
+          fillAnchorStrokeId[bc.data.linkedFillId] = bc.data.strokeId;
         }
       }
       var dabOrdinal = null;
@@ -1308,7 +1326,9 @@
         // around this item's OWN bounds (never the whole layer's), matching
         // AE's shape-group-inside-a-layer composition. null in the common
         // case (this item has no per-element motion of its own).
-        var cStrokeId = c.data && ((c.data.isBrushTextureCopy && brushAnchorStrokeId && brushAnchorStrokeId[c.data.brushGroupId]) || c.data.strokeId);
+        var cStrokeId = c.data && ((c.data.isBrushTextureCopy && brushAnchorStrokeId && brushAnchorStrokeId[c.data.brushGroupId])
+          || (c.data.isLinkedFillCompanion && fillAnchorStrokeId && fillAnchorStrokeId[c.data.linkedFillId])
+          || c.data.strokeId);
         // Path-CONTENT mutations (Trim, per-vertex offsets, animated corner
         // radii, path-vertex-follow, text-bounds-follow) must never run on a
         // texture-copy dab's own tiny stamp geometry (isBrushTextureCopy,


### PR DESCRIPTION
## Résumé
"si je fait une shape avec brush avec stroke + fill et que je deplace shape dans le layer dans la partie motion, y a juste le stroke qui se deplace et pas le fill" — un trait dessiné avec Fill activé est en réalité DEUX items Paper.js : le ruban (l'ancre, avec son propre \`data.strokeId\`) et un fond de remplissage séparé (\`data.isLinkedFillCompanion\`, partageant \`data.linkedFillId\` avec l'ancre mais ayant son PROPRE \`data.strokeId\` différent). Le panneau Elements de Motion exclut le compagnon de la liste (replié dans la ligne de son ancre), donc le mouvement par-élément (drag position/scale/rotation, keyframes) n'est enregistré QUE sous le \`strokeId\` de l'ancre.

## Cause racine
Le \`cStrokeId\` d'engine-bridge.js (l'id que tout lookup \`elementMotionAt\`/\`elementFillColorAt\`/etc. utilise) avait déjà exactement ce même cas spécial "résoudre via l'ancre" pour \`isBrushTextureCopy\` (via \`brushGroupId\`) — mais \`isLinkedFillCompanion\` n'avait pas d'équivalent : il retombait sur le \`strokeId\` du compagnon lui-même, qui n'a jamais d'entrée \`elementMotion\`, donc \`elementMotionAt\` ne trouvait rien et le fill ne bougeait jamais avec son trait.

## Fix
Ajout du même pré-passage (linkedFillId → strokeId de l'ancre, \`fillAnchorStrokeId\`) que celui déjà existant pour les dabs de texture, câblé dans \`cStrokeId\` exactement de la même façon.

## Vérification
- Posé \`state.layers[li].elementMotion[anchorStrokeId] = {motionStatic:{position:[100,50]}}\`.
- Confirmé \`SMMotion.elementMotionAt(li, anchorStrokeId, frame)\` renvoie \`{dx:100,dy:50,...}\`.
- Confirmé \`elementMotionAt(li, strokeId PROPRE du compagnon, frame)\` renvoie \`null\` — reproduisant exactement la cause racine.
- Confirmé \`anchor.data.linkedFillId === companion.data.linkedFillId\` — exactement la clé que le nouveau lookup \`fillAnchorStrokeId\` utilise pour rediriger le compagnon vers l'entrée de mouvement (correcte) de l'ancre.
- Aucune erreur console.

## Test plan
- [x] Vérifié en pilotant (trait pinceau+fill réel dessiné, chaîne de résolution confirmée bout en bout)
- [ ] Pas testé en build Tauri natif (uniquement preview navigateur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)