### PR TITLE
Fix inline tween-curve strip clipping overshoot control points (feedback #99)

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -3618,9 +3618,23 @@ function buildTweenCurveSVG(li,fA,fB,svgW,svgH){
 
   var ipad=6;
   function toSX(px){return ipad+px*(svgW-2*ipad);}
-  function toSY(py){return svgH-ipad-py*(svgH-2*ipad);}
+  // Feedback #99: "il faudrait pouvoir resize vers le bas les graph editor
+  // car sinon on a pas accès aux poignées du haut" — toSY used to map plain
+  // [0,1] to the strip's full height, but fromSY (the drag input side, just
+  // below) already clamps to [-0.3,1.3] for overshoot easing (back/elastic
+  // curves routinely place a point above y=1 or below y=0). A point at
+  // y=1.2 mapped through the OLD toSY landed above the SVG's own y=0 —
+  // genuinely off-canvas, not just visually cramped, so no resize would
+  // have helped reach it; the coordinate space itself didn't cover where
+  // the point could legally be. Mapping the SAME [-0.3,1.3] domain toSY
+  // already clamps to guarantees every point fromSY can ever produce has a
+  // toSY position inside the strip, at every width — this fixes the actual
+  // reachability instead of trading one fixed height for another fixed
+  // (still eventually cramped) height.
+  var Y_LO=-0.3,Y_HI=1.3,Y_SPAN=Y_HI-Y_LO;
+  function toSY(py){return ipad+(Y_HI-py)/Y_SPAN*(svgH-2*ipad);}
   function fromSX(sx){return Math.max(0,Math.min(1,(sx-ipad)/(svgW-2*ipad)));}
-  function fromSY(sy){return Math.max(-0.3,Math.min(1.3,(svgH-ipad-sy)/(svgH-2*ipad)));}
+  function fromSY(sy){return Math.max(Y_LO,Math.min(Y_HI,Y_HI-(sy-ipad)/(svgH-2*ipad)*Y_SPAN));}
 
   function redraw(){
     while(svg.firstChild)svg.removeChild(svg.firstChild);


### PR DESCRIPTION
## Résumé
"pour les graph de tween dans animation 2D il faudrait pouvoir resize vers le bas les graph editor car sinon on a pas accés aux poignées du haut" — \`buildTweenCurveSVG\`'s \`toSY\` mappait y∈[0,1] sur toute la hauteur de la bande, mais \`fromSY\` (le côté saisie du glisser, dans la MÊME fonction) autorise déjà [-0.3,1.3] — les courbes avec rebond (back/elastic) placent volontairement un point au-dessus de y=1 ou en dessous de y=0. Un point à y=1.15 atterrissait à cy=-4.2 avec l'ancien \`toSY\` — vraiment AU-DESSUS de l'origine du SVG, pas juste visuellement à l'étroit près d'un bord. Aucun redimensionnement de la bande n'aurait aidé : c'est l'espace de coordonnées lui-même qui ne couvrait pas où le point pouvait légalement se trouver.

## Fix
\`toSY\`/\`fromSY\` remappés ensemble sur le MÊME domaine [-0.3,1.3] que \`fromSY\` autorise déjà en entrée — donc tout point que le modèle de courbe peut contenir a une position \`toSY\` garantie À L'INTÉRIEUR de la bande, quelle que soit sa hauteur. Partagé par la bande persistante ET le popup flottant (même implémentation), donc corrige les deux d'un coup.

## Vérification (pilotage réel)
- Construit un vrai tween 0→10, réglé son easing sur une courbe façon \"back-out\" avec un point de rebond y=1.15.
- Lu le SVG réellement rendu : cy=12.4 dans une bande de height=80 (avant : hors-canvas).
- Confirmé visuellement par capture d'écran (le point de contrôle du pic est bien visible dans la bande).
- Aucune erreur console.

## Test plan
- [x] Vérifié en pilotant (tween réel + easing à rebond + lecture SVG)
- [x] Confirmé visuellement
- [ ] Pas testé en build Tauri natif (uniquement preview navigateur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)