### PR TITLE
Discoverable "Convert stroke to fill" command (feedback #102)

### DIFF
--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -2524,6 +2524,18 @@
     var profilable = (window.selectedPaths || []).some(function (p) { return p && p.segments && p.segments.length >= 2; });
     if (profilable) {
       items.push({ sep: true });
+      // Feedback #102 ("comme dans Animate... convertir les lines en fill,
+      // pour le confort de dessin"): the underlying conversion already
+      // existed as the "even" stroke profile below (a constant-width
+      // profile turns a stroke into a same-width filled ribbon, in place —
+      // same machinery, zero new geometry code), but nothing in the menu
+      // read as "convert to fill" to someone looking for that specific,
+      // named Animate command. Adding the Animate-style label as its own
+      // top-level entry rather than renaming the profile option — a
+      // constant-width profile and "convert to fill" are the same operation
+      // here, but users coming from the tapering submenu still want that
+      // wording, so both stay.
+      items.push({ label: 'Convertir le trait en remplissage (Fill)', action: function () { window.SM.applyStrokeProfile('even'); } });
       items.push({ label: 'Profil de contour :', disabled: true, action: function () {} });
       [['taper-both', '   • effilé aux deux bouts'],
        ['taper-in', '   • effilé au début'],


### PR DESCRIPTION
## Summary
- Feedback #102: "ca vaudrait le coup d avoir comme dans animate la possibilité de convertir les lines en fill, pour le confort de dessin"
- The underlying conversion already existed: the "even" stroke profile (`applyStrokeProfileToPath(path,'even')`, tools.js) turns a plain stroked path into a same-width filled ribbon **in place** (preserves `strokeId`/other `data.*` tags, no new item — CLAUDE.md §1-safe by construction), already reachable via the right-click "Profil de contour → épaisseur constante (ruban)" submenu.
- Verified live: nothing in that submenu reads as "convert to fill" to someone looking for that specific, named command — same shape of gap as feedback #78 (lasso discoverability) earlier this sweep.
- Fix: one new top-level context-menu entry, "Convertir le trait en remplissage (Fill)", calling the exact same existing handler (`window.SM.applyStrokeProfile('even')`). Zero new geometry code, tapering submenu untouched.

## Test plan
- [x] Drew a plain black-stroked open path with the Pen tool (no fill), selected it with Select tool
- [x] Right-click → confirmed the new entry appears above "Profil de contour :"
- [x] Clicked it — confirmed `isVectorBrush:true`, `fillColor` = the former stroke color, `strokeColor:null`, rendered correctly on canvas
- [x] Zero console errors
- [x] Caught and fixed a stale-browser-cache false negative during testing (CLAUDE.md §4) by restarting the preview on a fresh port before concluding

🤖 Generated with [Claude Code](https://claude.com/claude-code)