### PR TITLE
Add an examples menu to the expression editor (feedback #113)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -5412,6 +5412,39 @@
       window.SMMotion.setExprGlobals(v);
     });
     row.appendChild(glob);
+    // Examples menu (feedback #113, "les expressions ne sont pas encore
+    // très clair à utilisé il faudrait un menu... qui permettent d'avoir
+    // des exemples d'expression commune et basique à utiliser"). Every
+    // snippet below uses ONLY names actually present in compiledFnFor's
+    // sandbox arg list above (time/frame/value/layer/wiggle/loopOut/key/
+    // nearestKey/numKeys) — copy-pasteable by construction, nothing here
+    // can ever reference a variable that doesn't really exist. Reuses
+    // window.showContextMenu (ui.js), the same generic dropdown already
+    // used elsewhere off a plain button click, not just right-click.
+    var examplesBtn = document.createElement('button');
+    examplesBtn.className = 'motion-expr-glob';
+    examplesBtn.textContent = 'Exemples ▾';
+    examplesBtn.title = 'Insérer un exemple d’expression courante';
+    examplesBtn.addEventListener('click', function (e) {
+      e.preventDefault(); e.stopPropagation();
+      if (!window.showContextMenu) return;
+      var followProp = (prop === 'rotation' || prop === 'opacity' || prop === 'scale' || prop === 'anchor') ? prop : 'position';
+      function insert(code) {
+        ta.value = code;
+        paintGutter();
+        commit();
+        ta.focus();
+      }
+      window.showContextMenu(e.clientX, e.clientY, [
+        { label: 'value — pas de changement', action: function () { insert('value'); } },
+        { label: 'value + wiggle(2, 10) — tremblement aléatoire', action: function () { insert('value + wiggle(2, 10)'); } },
+        { label: 'value + Math.sin(time * 3) * 10 — oscillation régulière', action: function () { insert('value + Math.sin(time * 3) * 10'); } },
+        { label: 'loopOut() — boucle en continu après la dernière clé', action: function () { insert('loopOut()'); } },
+        { label: 'key(1).value — reste sur la valeur de la 1ère clé', action: function () { insert('key(1).value'); } },
+        { label: 'layer(\'Nom du calque\').' + followProp + ' — suivre un autre calque', action: function () { insert('layer(\'Nom du calque\').' + followProp); } },
+      ]);
+    });
+    row.appendChild(examplesBtn);
     // ---- code pane (Van Dijk 7.5) ------------------------------------
     // A 3-row bare textarea was fine when an expression was one line; it
     // stops being fine the moment people actually write in it, which is his


### PR DESCRIPTION
## Summary
- Feedback #113: "Les expressions ne sont pas encore très clair à utilisé il faudrait un menu dans le fenêtre d'expression qui permettent d'avoir des exemples d'expression commune et basique à utiliser"
- New "Exemples ▾" button next to the existing "Variables globales…" button in the per-property expression editor (`buildExprEditorRow`, motion.js), reusing `window.showContextMenu` — the same generic dropdown already used elsewhere in the app off a plain click.
- 6 curated snippets, all using only names actually present in the expression sandbox (`time`/`frame`/`value`/`layer`/`wiggle`/`loopOut`/`key`/`nearestKey`/`numKeys` — the real arg list `compiledFnFor` compiles against), so every example is guaranteed to run: identity, wiggle, manual sine oscillation, loopOut, first-keyframe lock, and a layer-follow example whose property name adapts to whichever property's editor is open (`.position`/`.rotation`/`.scale`/`.opacity`/`.anchor`).

## Test plan
- [x] Opened the Position expression editor on a real layer in Motion mode
- [x] Clicked "Exemples ▾" — confirmed all 6 items render with the layer-follow example correctly showing `.position`
- [x] Clicked "loopOut()" — confirmed it lands in the textarea AND commits to `ld.expressions.position.code` (not just a visual insert)
- [x] Zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)