### PR TITLE
Add "propagate this fill" to the frame right-click menu (feedback #117)

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -4367,6 +4367,34 @@ document.getElementById('frame-grid').addEventListener('contextmenu',function(e)
     // already exists (e.g. after editing an endpoint's content).
     {label:'Générer / refaire le tween',shortcut:'T',action:function(){window.SM.generateTweens();}},
     {sep:true},
+    // Feedback #117 ("où est la propagation de la couleur aux autres
+    // frames, il la faudrait au clic droit sur la frame") — the command
+    // already existed (fillPropagateAcrossFrames, tools.js, wired to
+    // #btn-fill-propagate in Tool Options while the Fill tool is active),
+    // just not reachable from here. Mirrors onPropagateClick's own logic
+    // exactly (fill-bridge.js) — same "most recently added fill on this
+    // frame" target heuristic, same toasts — rather than looping it over
+    // EVERY fill on the frame: that function's own comment measures
+    // ~3.5s per call on a 120-frame project, so a bulk multi-fill version
+    // needs its own progress/cost story, not a silent loop here.
+    {
+      label:'Propager ce remplissage → toutes les frames',
+      disabled:!(userLayers[li]&&userLayers[li].children.some(function(c){return c.data&&c.data.fillSeed;})),
+      action:function(){
+        var layer=userLayers[li];
+        var fills=layer.children.filter(function(c){return c.data&&c.data.fillSeed;});
+        if(!fills.length)return;
+        var target=fills[fills.length-1];
+        pushUndo();
+        var res=null;
+        try{res=fillPropagateAcrossFrames(target);}catch(err){console.warn('[fill] propagate failed',err);}
+        updateUI();
+        if(window.SMEngineBridge)SMEngineBridge.renderNow();
+        if(!res){if(window.showToast)showToast(SM.t('toastPropagateFailed'));return;}
+        if(window.showToast)showToast(SM.t('toastPropagateDone').replace('{filled}',res.filled).replace('{skipped}',res.skipped));
+      }
+    },
+    {sep:true},
     {label:'Supprimer les images',action:function(){window.SM.removeFrameSpan();}},
   ]));
 });


### PR DESCRIPTION
## Summary
- Feedback #117: "où est la propagation de la couleurs aux autres frames, il la faudrait au clic droit sur la frame dans animation 2D"
- The command already existed: `fillPropagateAcrossFrames` (tools.js), wired to a "Propager sur toutes les frames" button that only shows in Tool Options while the Fill tool is active. The user's own action trail confirms they were using the Fill (bucket) tool but never found that button.
- Added the same operation as a new entry in the frame-cell right-click menu (`#frame-grid`'s `contextmenu` handler, timeline.js) — reuses `onPropagateClick`'s exact logic and toasts (fill-bridge.js), targeting the most recently added fill on the right-clicked frame.
- Deliberately scoped to ONE fill (not a bulk loop over every fill on the frame) — `fillPropagateAcrossFrames`'s own comment measures ~3.5s per call on a 120-frame project, so looping it over N fills needs its own progress/cost design, not a silent loop added here.

## Test plan
- [x] Drew a rectangle (stroke only), filled it on frame 1 with the Fill tool
- [x] Inserted a keyframe at frame 6 (duplicates the unfilled rectangle)
- [x] Right-click on frame 6 (no fill yet) → confirmed the new menu entry is correctly **disabled**
- [x] Right-click on frame 1 (has the fill) → confirmed it's **enabled**, clicked it
- [x] Toast: "Propagated: 1 frame(s) filled, 0 left untouched"
- [x] Verified frame 6 now has the fill (`fillSeed` present, `fillColor:#ff0000`), renders correctly
- [x] Zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)