### PR TITLE
Give anonymous testers a distinct default name + technical context (feedback #115)

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -275,7 +275,20 @@ function initUserProfile(){
     // never required anywhere it's read (feedback-bridge.js's issue body).
     if(saved&&saved.id){if(!saved.role)saved.role='animator';if(saved.email===undefined)saved.email='';state.userProfile=saved;return;}
   }catch(e){}
-  state.userProfile={id:'u_'+Date.now().toString(36)+'_'+Math.random().toString(36).slice(2,8),name:'Animateur',color:'#4a9eff',role:'animator',email:''};
+  // Default name (feedback #115, "attribuer un nom dynamique aux
+  // différents utilisateurs... si ils rentrent pas leurs noms"): every
+  // fresh install used to get the literal, IDENTICAL string 'Animateur' —
+  // harmless on one person's own machine, but on the public web build
+  // every anonymous tester who never opens Settings > Profil shows up as
+  // the exact same name in every GitHub feedback issue, with no way to
+  // tell two different people's reports apart short of the raw internal
+  // id (which the comment above says stays internal on purpose). A short
+  // uppercase slice of that SAME id, already being generated on the line
+  // below, gives each browser/session a distinct-but-still-recognizable
+  // default ("Animateur X7K2") at zero extra randomness/complexity — still
+  // freely overwritten the moment someone sets a real name in Settings.
+  var _uid='u_'+Date.now().toString(36)+'_'+Math.random().toString(36).slice(2,8);
+  state.userProfile={id:_uid,name:'Animateur '+_uid.slice(-4).toUpperCase(),color:'#4a9eff',role:'animator',email:''};
   try{localStorage.setItem('nemo-profile',JSON.stringify(state.userProfile));}catch(e){}
 }
 function saveUserProfile(){

--- a/src/js/feedback-bridge.js
+++ b/src/js/feedback-bridge.js
@@ -365,6 +365,20 @@
       '- Projet: ' + entry.projectKey,
       '- Enregistré précisément: ' + (entry.recorded ? 'oui' : 'non (dernières actions)'),
       '',
+      // Feedback #115 ("des infos non intrusive pour le debugguage et des
+      // rapports de connexion simple") — only values already sitting in
+      // the page (navigator/screen/document.title, the same source
+      // updater-bridge.js's showVersion() keeps in sync — CLAUDE.md §7's
+      // single-source-of-truth version display, so no new version-tracking
+      // needed here). No IP, no geolocation, no analytics SDK — this is
+      // the same privacy profile the click/action trail below already has.
+      '**Infos techniques**',
+      '- Plateforme: ' + (tauriOk() ? 'App bureau' : 'Navigateur web'),
+      '- Version: ' + (document.title.match(/v[\d.]+/) || ['inconnue'])[0],
+      '- Navigateur: ' + navigator.userAgent,
+      '- Fenêtre: ' + window.innerWidth + '×' + window.innerHeight + ' (écran ' + screen.width + '×' + screen.height + ')',
+      '- Connexion: ' + (navigator.onLine ? 'en ligne' : 'hors ligne'),
+      '',
       '**Trail d\'actions**',
       '```json', JSON.stringify(entry.actionTrail || [], null, 2), '```',
       '',


### PR DESCRIPTION
## Summary
- Feedback #115: "Voir comment on peut attribué un nom dynamique aux différents utilisateurs qui irait sur le site pour les feedback si ils rentrent pas leurs noms. Et d'avoir des infos non intrusive pour le debugguage et des rapports de connexion simple"
- **Dynamic name**: `initUserProfile()` (app.js) used to default every fresh install to the literal, identical string `'Animateur'`. On the public web build, every anonymous tester who never opens Settings > Profil shows up as the exact same name in every GitHub issue. Now derives a short uppercase suffix from the same id already generated on that line ("Animateur X7K2") — distinct per browser/session, still stable across that browser's future visits (existing localStorage load path unchanged), still freely overwritten by a real name in Settings.
- **Technical context**: new "Infos techniques" block in the feedback issue body (`publishToGitHubIssue`, feedback-bridge.js) — platform (desktop/web), app version (read from `document.title`, the same single-source-of-truth `updater-bridge.js` keeps in sync per CLAUDE.md §7), user agent, window/screen size, online status. Deliberately non-intrusive: only values already sitting in the page (`navigator`/`screen`/`document.title`), no IP, no geolocation, no analytics SDK — same privacy profile the existing click/action trail already has.

## Test plan
- [x] Fresh browser origin (empty localStorage): confirmed generated profile is `{name: "Animateur OX5Y", ...}` — distinct, not the old generic "Animateur"
- [x] Reloaded: confirmed the SAME name persists (loaded from localStorage, not regenerated)
- [x] Verified the technical-context block renders correctly (platform/version/UA/window+screen size/online status all correct values)
- [x] Zero console errors from the change itself (one unrelated `beforeunload` browser warning from my own programmatic test reload, not from this code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)