### PR TITLE
Add manual per-vertex weight override to the Rig tool (feedback #112)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -165,6 +165,20 @@ body.mac-overlay-titlebar #app{padding-top:28px;}
 #history-btn{flex:none;width:24px;height:24px;border-radius:6px;background:transparent;border:none;color:rgba(236,234,231,.45);cursor:pointer;display:flex;align-items:center;justify-content:center;}
 #history-btn:hover{background:var(--panel3);color:var(--accent-hover);}
 #history-pop{display:none;position:fixed;width:280px;max-height:420px;overflow-y:auto;background:var(--panel2);border:1px solid var(--border);border-radius:8px;box-shadow:0 8px 24px rgba(0,0,0,.4);z-index:600;padding:6px;}
+/* Rig manual weight-override popover (feedback #112) — rig-bridge.js's
+   openRigWeightPopover, same fixed/panel2/shadow convention as #history-pop
+   above, built dynamically rather than static markup (one advanced tool's
+   one interaction, see that function's own comment). */
+.rig-weight-popover{position:fixed;width:200px;background:var(--panel2);border:1px solid var(--border);border-radius:8px;box-shadow:0 8px 24px rgba(0,0,0,.4);z-index:600;padding:8px;display:flex;flex-direction:column;gap:6px;}
+.rig-weight-title{font-size:10px;font-weight:600;color:var(--text-dim);margin-bottom:2px;}
+.rig-weight-row{display:flex;align-items:center;gap:5px;}
+.rig-weight-lbl{flex:1;font-size:10px;color:var(--text);}
+.rig-weight-input{flex:0 0 48px;}
+.rig-weight-pct{font-size:9px;color:var(--text-dim);}
+.rig-weight-del{flex:none;width:16px;height:16px;border-radius:50%;background:transparent;border:none;color:var(--text-dim);cursor:pointer;font-size:11px;line-height:1;}
+.rig-weight-del:hover{background:var(--red);color:#fff;}
+.rig-weight-add select{flex:1;font-size:10px;}
+.rig-weight-add .pbtn,.rig-weight-row>.pbtn{font-size:10px;padding:4px 8px;}
 #history-pop.open{display:block;}
 #history-pop .hist-item{display:flex;gap:8px;align-items:center;padding:7px 8px;border-radius:6px;font-size:11px;cursor:pointer;color:var(--text);}
 #history-pop .hist-item:hover{background:var(--panel3);}

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1560,6 +1560,27 @@ function relinkRigBinds(ld,layer){
 // re-sampled at pose time via getLocationAt — same offset, current bone
 // geometry — so both position AND local tangent stay correctly anchored
 // to the SAME point on the bone as it's posed.
+// Weight of ONE point against a set of candidate bones — same distance-
+// falloff formula rigBindStroke's own weighForPoints uses per-vertex during
+// a full bind pass, factored out so a single vertex can be recomputed later
+// (the manual weight-override popover's "Réinitialiser (auto)" button,
+// rig-bridge.js, feedback #112) without a second copy of this math.
+function rigWeighOnePoint(rig,boneIds,p,radius,softness){
+  var w=[];
+  boneIds.forEach(function(bid){
+    var bone=rig.bones[bid];if(!bone)return;
+    var bp=_boneSegsToPath(bone.restSegments,bone.closed);
+    var loc=bp.getNearestLocation(p);
+    bp.remove();
+    if(!loc)return;
+    var dist=loc.point.getDistance(p);
+    var boneRadius=bone.radius||radius;
+    var t=Math.max(0,1-dist/boneRadius);
+    var infl=softness?t+(t*t*(3-2*t)-t)*softness:t;
+    if(infl>0)w.push({boneId:bid,offset:loc.offset,w:infl});
+  });
+  return w;
+}
 function rigBindStroke(ld,path,boneIds,radius,rotate,softness){
   var rig=ensureLayerRig(ld);
   // CompoundPath BEFORE the segments/length guard, deliberately: a
@@ -1607,28 +1628,15 @@ function rigBindStroke(ld,path,boneIds,radius,rotate,softness){
   softness=Math.max(0,Math.min(1,softness||0));
   // Shared by the ribbon's own boundary AND (below) its centerSegments —
   // same per-point "nearest offset on each bone's rest curve, falloff by
-  // distance" weighting, just fed a different point list.
+  // distance" weighting, just fed a different point list. The actual
+  // per-point formula is rigWeighOnePoint (below this function), factored
+  // out so the manual weight-override popover's "Réinitialiser (auto)"
+  // button (rig-bridge.js, feedback #112) can recompute ONE vertex the
+  // exact same way a full bind pass would, instead of a second,
+  // independently-maintained copy of this formula (CLAUDE.md §3).
   function weighForPoints(pts){
     return pts.map(function(pt){
-      var w=[],p=new Point(pt[0],pt[1]);
-      boneIds.forEach(function(bid){
-        var bone=rig.bones[bid];if(!bone)return;
-        var bp=_boneSegsToPath(bone.restSegments,bone.closed);
-        var loc=bp.getNearestLocation(p);
-        bp.remove();
-        if(!loc)return;
-        var dist=loc.point.getDistance(p);
-        // Per-bone radius override (2026-07-29, Shapper-style influence
-        // circles, rig-bridge.js Assign mode) — bone.radius is set by dragging
-        // that bone's own on-canvas circle; falls back to the passed-in
-        // default (the panel's Rayon de poids field) for a bone that's never
-        // been adjusted, so existing single-radius projects are unaffected.
-        var boneRadius=bone.radius||radius;
-        var t=Math.max(0,1-dist/boneRadius);
-        var infl=softness?t+(t*t*(3-2*t)-t)*softness:t;
-        if(infl>0)w.push({boneId:bid,offset:loc.offset,w:infl});
-      });
-      return w;
+      return rigWeighOnePoint(rig,boneIds,new Point(pt[0],pt[1]),radius,softness);
     });
   }
   var rest=path.segments.map(function(s){return[s.point.x,s.point.y];});

--- a/src/js/rig-bridge.js
+++ b/src/js/rig-bridge.js
@@ -211,6 +211,32 @@ var _rigDraw = { path: null, boneId: null, ld: null, draggingHandle: false, last
     return best;
   }
 
+  // Per-vertex weight hit-test (feedback #112, "l'autoweight" — Shapper's
+  // own strength per its actual source isn't a smarter auto-weight
+  // algorithm (it doesn't have one — pure manual weight table, confirmed
+  // reading its shipped code), it's that a bad auto/default weight is
+  // always hand-correctable afterward. Nemo already had rigAutoAssignLayer
+  // (app.js) but nothing to touch up ONE vertex's result — this is that
+  // missing manual step, additive to the existing radius-handle drag, not
+  // a replacement for it (radius = coarse per-bone reach, this = fine
+  // per-vertex override). Hits the LIVE (posed) position, `bind._live`,
+  // not `bind.rest` — the user is clicking what they SEE on canvas, which
+  // is wherever the shape currently sits, posed or not.
+  function hitBoundVertex(pt) {
+    var ld = state.layers[state.activeLayerIdx];
+    if (!ld || !ld.rig) return null;
+    var tol = 10 / view.zoom, best = null, bestD = tol;
+    ld.rig.binds.forEach(function (b) {
+      if (!b._live || !b._live.segments) return;
+      var segs = b._live.segments;
+      for (var i = 0; i < segs.length; i++) {
+        var d = pt.getDistance(segs[i].point);
+        if (d < bestD) { bestD = d; best = { bind: b, vi: i }; }
+      }
+    });
+    return best;
+  }
+
   function onDown(e) {
     if (!shouldIntercept()) return;
     e.stopImmediatePropagation();
@@ -230,7 +256,16 @@ var _rigDraw = { path: null, boneId: null, ld: null, draggingHandle: false, last
         pushUndo();
         _radiusDrag = { ld: ld, boneId: rh.boneId, center: rh.center };
         window.SMEngineBridge.suspend();
+        return;
       }
+      // Missed every radius handle — try a bound vertex instead (manual
+      // per-vertex weight override, see hitBoundVertex's own comment).
+      // Opening the popover doesn't mutate anything by itself, so no
+      // pushUndo here; openRigWeightPopover pushes one on the FIRST actual
+      // edit inside it, same "checkpoint at the first real mutation, not
+      // at UI-open time" convention _radiusDrag/_posing already follow.
+      var bv = hitBoundVertex(pt);
+      if (bv) openRigWeightPopover(bv.bind, bv.vi, e);
       return;
     }
 
@@ -499,6 +534,152 @@ var _rigDraw = { path: null, boneId: null, ld: null, draggingHandle: false, last
     _rigDraw.path = null; _rigDraw.boneId = null; _rigDraw.ld = null; _rigDraw.draggingHandle = false;
     if (window.renderLayerList) renderLayerList();
     if (window.renderRigModeUI) renderRigModeUI();
+  }
+
+  // ---- Manual per-vertex weight override popover (feedback #112) -------
+  // Dynamic DOM popover, same idiom as color-picker.js/brush-preset-picker.js
+  // (built once on first use, positioned+clamped near the click, closed on
+  // outside-click/Escape) rather than static markup in index.html — this is
+  // one advanced tool's one interaction, not a panel other code needs to
+  // reference by a stable id.
+  var _weightPop = null, _weightPopClose = null;
+  function closeRigWeightPopover() {
+    if (!_weightPop) return;
+    _weightPop.remove();
+    _weightPop = null;
+    if (_weightPopClose) { _weightPopClose(); _weightPopClose = null; }
+  }
+  function boneLabel(ld, boneId) {
+    var idx = Object.keys(ld.rig.bones).indexOf(boneId);
+    return 'Os ' + (idx >= 0 ? idx + 1 : '?');
+  }
+  // First real edit inside the popover gets ONE undo checkpoint — same
+  // "checkpoint at first mutation, not at UI-open time" convention every
+  // other Rig interaction in this file follows (_radiusDrag, _posing).
+  function openRigWeightPopover(bind, vi, e) {
+    closeRigWeightPopover();
+    var ld = state.layers[state.activeLayerIdx];
+    if (!ld || !ld.rig) return;
+    var undoPushed = false;
+    function ensureUndo() { if (!undoPushed) { pushUndo(); undoPushed = true; } }
+    function liveUpdate() {
+      applyRigDeform(ld);
+      if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+    }
+
+    var el = document.createElement('div');
+    el.className = 'rig-weight-popover';
+    document.body.appendChild(el);
+
+    function render() {
+      el.innerHTML = '';
+      var title = document.createElement('div');
+      title.className = 'rig-weight-title';
+      title.textContent = 'Poids du vertex #' + (vi + 1);
+      el.appendChild(title);
+
+      var entries = bind.weights[vi] || (bind.weights[vi] = []);
+      var boundIds = {};
+      entries.forEach(function (we) { boundIds[we.boneId] = true; });
+
+      entries.slice().forEach(function (we) {
+        var row = document.createElement('div');
+        row.className = 'rig-weight-row';
+        var lbl = document.createElement('span');
+        lbl.className = 'rig-weight-lbl';
+        lbl.textContent = boneLabel(ld, we.boneId);
+        row.appendChild(lbl);
+        var inp = document.createElement('input');
+        inp.type = 'number'; inp.className = 'pi scrub rig-weight-input';
+        inp.min = '0'; inp.max = '100'; inp.step = '1';
+        inp.value = Math.round(we.w * 100);
+        inp.addEventListener('input', function () {
+          ensureUndo();
+          we.w = Math.max(0, Math.min(100, parseFloat(inp.value) || 0)) / 100;
+          liveUpdate();
+        });
+        row.appendChild(inp);
+        var pct = document.createElement('span');
+        pct.className = 'rig-weight-pct'; pct.textContent = '%';
+        row.appendChild(pct);
+        var del = document.createElement('button');
+        del.className = 'rig-weight-del'; del.textContent = '×';
+        del.title = 'Retirer cet os de ce vertex';
+        del.addEventListener('click', function () {
+          ensureUndo();
+          var idx = entries.indexOf(we);
+          if (idx >= 0) entries.splice(idx, 1);
+          liveUpdate();
+          render();
+        });
+        row.appendChild(del);
+        el.appendChild(row);
+      });
+
+      // "+ ajouter" — every bone NOT already influencing this vertex
+      // (usually because auto-weight's radius never reached it).
+      var addable = Object.keys(ld.rig.bones).filter(function (bid) { return !boundIds[bid]; });
+      if (addable.length) {
+        var addRow = document.createElement('div');
+        addRow.className = 'rig-weight-row rig-weight-add';
+        var sel = document.createElement('select');
+        sel.className = 'pi';
+        addable.forEach(function (bid) {
+          var opt = document.createElement('option');
+          opt.value = bid; opt.textContent = boneLabel(ld, bid);
+          sel.appendChild(opt);
+        });
+        addRow.appendChild(sel);
+        var addBtn = document.createElement('button');
+        addBtn.className = 'pbtn'; addBtn.textContent = '+ Ajouter';
+        addBtn.addEventListener('click', function () {
+          ensureUndo();
+          var bone = ld.rig.bones[sel.value];
+          var bp = _boneSegsToPath(bone.restSegments, bone.closed);
+          var restPt = bind.rest[vi];
+          var loc = bp.getNearestLocation(new Point(restPt[0], restPt[1]));
+          bp.remove();
+          entries.push({ boneId: sel.value, offset: loc ? loc.offset : 0, w: 0.5 });
+          liveUpdate();
+          render();
+        });
+        addRow.appendChild(addBtn);
+        el.appendChild(addRow);
+      }
+
+      var resetRow = document.createElement('div');
+      resetRow.className = 'rig-weight-row';
+      var resetBtn = document.createElement('button');
+      resetBtn.className = 'pbtn';
+      resetBtn.textContent = 'Réinitialiser (auto)';
+      resetBtn.title = 'Recalcule ce vertex avec la formule de poids automatique (distance aux os, rayon + adoucissement du panneau)';
+      resetBtn.addEventListener('click', function () {
+        ensureUndo();
+        var boneIds = Object.keys(ld.rig.bones);
+        var restPt = bind.rest[vi];
+        bind.weights[vi] = rigWeighOnePoint(ld.rig, boneIds, new Point(restPt[0], restPt[1]), panelDefaultRadius(), panelSoftness());
+        liveUpdate();
+        render();
+      });
+      resetRow.appendChild(resetBtn);
+      el.appendChild(resetRow);
+    }
+    render();
+
+    var left = Math.min(e.clientX + 12, window.innerWidth - 220);
+    var top = Math.min(e.clientY - 8, window.innerHeight - 260);
+    el.style.left = Math.max(4, left) + 'px';
+    el.style.top = Math.max(4, top) + 'px';
+
+    function onOutside(ev) { if (!el.contains(ev.target)) closeRigWeightPopover(); }
+    function onKey(ev) { if (ev.key === 'Escape') closeRigWeightPopover(); }
+    document.addEventListener('mousedown', onOutside, true);
+    document.addEventListener('keydown', onKey);
+    _weightPopClose = function () {
+      document.removeEventListener('mousedown', onOutside, true);
+      document.removeEventListener('keydown', onKey);
+    };
+    _weightPop = el;
   }
 
   function init() {


### PR DESCRIPTION
## Summary
- Feedback #112: "j'aimerais que tu t'attaques à l'outil de rig... Ni l'autoweight", and a follow-up request to actually study Shapper before implementing.
- Studied Shapper's real shipped code (a CEP extension found on this machine) rather than assuming. Key finding, worth restating here since it flips the original assumption: **Shapper has no auto-weight algorithm at all** — grepped its source, nothing named `autoWeight`/`computeWeights`/`bindWeights` exists. Its entire rigging workflow is built around manual per-vertex weight editing (two distinct hand-editing modes in its own code). Nemo already has auto-weight (`rigAutoAssignLayer`) that Shapper doesn't — what Nemo was missing is the ability to correct one vertex's result by hand afterward, which is almost certainly the real "autoweight" gap in the feedback.

## What this adds
In Assign mode, clicking a bound shape's vertex (when it doesn't hit an existing radius handle) opens a small popover:
- Every bone currently influencing that vertex, with a scrub-adjustable weight (0-100%)
- "×" to drop a bone's influence entirely
- "+ Ajouter" for a bone the auto-weight radius never reached
- "Réinitialiser (auto)" — recomputes the vertex with the normal distance-falloff formula

Additive to the existing per-bone radius-handle drag (coarse, whole-bone reach) — this is the fine, per-vertex override for when auto-weight gets one point wrong.

## Implementation notes
- `rigWeighOnePoint` (app.js) factored out of `rigBindStroke`'s `weighForPoints` so the popover's reset button reuses the exact bind-pass formula (CLAUDE.md §3), not a second copy.
- Popover built dynamically (`rig-bridge.js`), same idiom as `color-picker.js`/`brush-preset-picker.js` — not static markup in `index.html`.
- Hit-tests the LIVE (posed) vertex position (`bind._live`), not the rest pose — matches what the user actually sees on canvas.
- One undo checkpoint per popover session (first edit inside it), same convention every other Rig interaction in this file follows.

## Test plan
- [x] Drew 2 bones, built a target shape, ran Auto-assign
- [x] Real click on a bound vertex → popover opens showing its actual computed weights (94%/3%)
- [x] Edited a weight via the scrub input → confirmed the stored value updated and the live-posed deformation amount changed accordingly (measured: reducing one bone's weight from 94%→50% visibly reduced how far that vertex followed the posed bone)
- [x] "Réinitialiser (auto)" → recomputed correctly with the panel's current radius/softness
- [x] "+ Ajouter" → added the other bone at a sane default weight
- [x] "×" → removed a bone's influence
- [x] Undo → reverted a whole popover session's edits in one step
- [x] Zero console errors throughout
- [x] Existing radius-handle drag path unchanged (structurally isolated by an early `return`, not touched)

Note: the Rig tool is currently gated behind an "in development" freeze flag (`SM_FROZEN_IN_DEV.rig`) — tested by bypassing that flag for this session only (`window.SM_FROZEN_IN_DEV.rig = false`), the freeze itself is untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)