### PR TITLE
Add Scale X/Y aspect-ratio lock in Motion (feedback #120)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -998,6 +998,9 @@ body.mode-motion #btn-tween-curves{display:none;}
 .motion-anchor-grid-btn{color:var(--text-dark);cursor:pointer;}
 .motion-anchor-grid-btn:hover{background:var(--panel3);color:var(--text);}
 .motion-anchor-grid-btn.on{color:var(--accent);}
+.motion-scale-lock{color:var(--text-dark);cursor:pointer;flex:none;}
+.motion-scale-lock:hover{background:var(--panel3);color:var(--text);}
+.motion-scale-lock.on{color:var(--accent);}
 .motion-anchor-grid-row{height:auto;justify-content:center;padding:6px 8px;cursor:default;background:rgba(255,255,255,.02);}
 .motion-anchor-grid{display:grid;grid-template-columns:repeat(3,18px);grid-template-rows:repeat(3,18px);gap:3px;}
 .motion-anchor-cell{width:18px;height:18px;padding:0;border:1px solid var(--border2);border-radius:3px;background:var(--panel2);cursor:pointer;position:relative;}

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -301,6 +301,14 @@
   // untouched default-value property gets hidden). Global toggle (not
   // per-layer/per-group) — one button affects everything.
   var _hideUnanimated = false;
+  // Scale X/Y aspect-ratio lock (feedback #120, "il manque le cadenas pour
+  // que le x et y scale soit lié") — per-holder, not persisted with the
+  // project (exportJSON's layer serialization, timeline.js, is an explicit
+  // field whitelist — this is an editing convenience like _hideUnanimated
+  // above, not project data, so a WeakSet avoids needing to add a field
+  // there+on import for a purely-UI toggle). Cleared automatically when a
+  // holder is garbage-collected, no explicit cleanup needed.
+  var _scaleLockedHolders = new WeakSet();
   // Motion timeline workspace filters. They are UI-only: project data stays
   // untouched, while the column/filter preferences follow the workstation.
   var _motionSearch = '';
@@ -5308,6 +5316,29 @@
               nvals[dim] = nv;
               setValue(holder, prop, nvals);
             }
+            // Aspect-ratio lock (feedback #120) — carries THIS dimension's
+            // multiplicative change onto the other one, same convention
+            // After Effects' own Scale chain-link uses (a ratio, not an
+            // identical additive delta — 100%→110% on X takes a 50% Y to
+            // 55%, not to 60%). Reads the OTHER dimension's PRE-edit value
+            // from `vals` (this row's own render-time snapshot, same
+            // fallback `display.value` already uses) rather than
+            // re-deriving it, so a mixed multi-selection locks onto the
+            // same reference every dimension's display used.
+            if (prop === 'scale' && PROP_DIM[prop] === 2 && _scaleLockedHolders.has(holder)) {
+              var otherDim = dim === 0 ? 1 : 0;
+              var beforeThis = Number(vals[dim]) || 0;
+              var beforeOther = Number(vals[otherDim]) || 0;
+              if (beforeThis !== 0) {
+                var afterOther = beforeOther * (nv / beforeThis);
+                var otherChanged = setSelectedKeyDimension(holder, prop, otherDim, afterOther);
+                if (!otherChanged) {
+                  var onvals = isAnimated(holder, prop) ? valueAtFrame(holder, prop, state.currentFrame) : staticValue(holder, prop);
+                  onvals[otherDim] = afterOther;
+                  setValue(holder, prop, onvals);
+                }
+              }
+            }
             // renderLayerList too (not just the timeline, the original
             // single-panel behavior): these same rows now render in TWO
             // places (bottom Transform group + right-panel mirror,
@@ -5320,6 +5351,24 @@
           }, display.mixed);
           fieldWrap.appendChild(f);
         })(d);
+      }
+      // Aspect-ratio lock toggle (feedback #120) — Scale only, right after
+      // its X/Y fields so it reads as "these two are chained" rather than
+      // a generic row control.
+      if (prop === 'scale' && PROP_DIM[prop] === 2) {
+        var lockBtn = document.createElement('div');
+        lockBtn.className = 'lico motion-scale-lock' + (_scaleLockedHolders.has(holder) ? ' on' : '');
+        lockBtn.title = 'Lier Scale X et Y (garder le ratio)';
+        lockBtn.innerHTML = _scaleLockedHolders.has(holder)
+          ? '<svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg>'
+          : '<svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 7.5-2"/></svg>';
+        lockBtn.addEventListener('click', function (e) {
+          e.stopPropagation();
+          if (_scaleLockedHolders.has(holder)) _scaleLockedHolders.delete(holder);
+          else _scaleLockedHolders.add(holder);
+          renderLayerList(); renderTimeline();
+        });
+        fieldWrap.appendChild(lockBtn);
       }
       var unit = document.createElement('span'); unit.className = 'motion-unit'; unit.textContent = PROP_UNIT[prop];
       fieldWrap.appendChild(unit);


### PR DESCRIPTION
## Summary
- Feedback #120: "dans motion> timeline> propertie scale il manque le cadenas pour que le x et y scale soit lié"
- New lock toggle next to Scale's X/Y fields in the Motion Transform group (renders in both places it shows — bottom panel + right-panel mirror, `renderTransformProps` is the single shared function per CLAUDE.md §11's alignment invariant). When locked, editing one dimension carries the same multiplicative ratio onto the other — the After Effects chain-link convention (100%→150% on X takes 50%→75% on Y, not to 100%).

## Scope decision
Per-holder, session-only state (`WeakSet`), not persisted with the project. `exportJSON`'s layer serialization (timeline.js) is an explicit field whitelist, not a full-object dump — adding a persisted field would need changes on both the export and import side for what's really an editing convenience, same category as the existing `_hideUnanimated` filter toggle (also not persisted).

## Test plan
- [x] Locked, changed Scale X 100→150 → confirmed Y followed to 150
- [x] Unlocked, set Y independently to 50 (now X=150/Y=50, an asymmetric ratio — not a coincidental 1:1 case)
- [x] Re-locked, changed X 150→75 (×0.5) → confirmed Y went 50→25 exactly (proves the ratio math, not just "both moved")
- [x] Unlocked again, changed X → confirmed Y did NOT move (no regression on the existing unlocked path)
- [x] Zero console errors throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)