### PR TITLE
Fix easing-curve drag point sometimes stopping mid-gesture

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -3658,7 +3658,18 @@ function buildTweenCurveSVG(li,fA,fB,svgW,svgH){
       c.style.cursor='grab';
       c.addEventListener('pointerdown',function(e){
         e.stopPropagation();e.preventDefault();
-        c.setPointerCapture(e.pointerId);
+        // Feedback #124 ("parfois le point s'arète alors que je drag
+        // encore"): capture used to be set on `c`, the individual <circle>
+        // — but redraw() (called on every move below) tears down and
+        // rebuilds EVERY circle from scratch, including the one currently
+        // captured. Per the Pointer Events spec, capture is released the
+        // instant its target leaves the document, and re-establishing it on
+        // a freshly created element mid-drag is unreliable across browsers
+        // (observed intermittently, matching "parfois"/sometimes) — capture
+        // could silently drop and stop delivering move/up to this drag
+        // entirely. `svg` itself is never destroyed by redraw() (only its
+        // children are), so capturing there instead survives every redraw.
+        svg.setPointerCapture(e.pointerId);
         function move(ev){
           var r=svg.getBoundingClientRect();
           var nx=fromSX(ev.clientX-r.left),ny=fromSY(ev.clientY-r.top);
@@ -3668,7 +3679,7 @@ function buildTweenCurveSVG(li,fA,fB,svgW,svgH){
           redraw();
           scheduleRegen();
         }
-        function up(ev){c.releasePointerCapture(ev.pointerId);svg.removeEventListener('pointermove',move);svg.removeEventListener('pointerup',up);regenNow();}
+        function up(ev){svg.releasePointerCapture(ev.pointerId);svg.removeEventListener('pointermove',move);svg.removeEventListener('pointerup',up);regenNow();}
         svg.addEventListener('pointermove',move);svg.addEventListener('pointerup',up);
       });
       c.addEventListener('dblclick',function(e){


### PR DESCRIPTION
## Summary
- Fixes [#124](https://github.com/mysteropodes/nemo/issues/574): dragging a control point on the tween easing-curve editor (either the persistent inline strip or the floating inset) could intermittently stop responding mid-drag while the mouse button was still held.
- Root cause: `buildTweenCurveSVG` (timeline.js) set pointer capture on the individual `<circle>` being dragged, but the drag's own `move` handler calls `redraw()` on every tick — which tears down and rebuilds *every* circle from scratch, including the one currently captured. Per the Pointer Events spec, capture is released the instant its target leaves the document; re-establishing it on a freshly recreated element mid-drag is unreliable across browsers, matching the reported "parfois" (sometimes).
- Fix: capture now lives on the `<svg>` element itself, which `redraw()` never destroys (only its children are torn down/rebuilt).

## Test plan
- [x] `node --check src/js/timeline.js`
- [x] Live in-browser: opened the floating curve inset for a real tween span, dispatched 15 rapid synthetic `pointermove` events (each one triggering `redraw()`) after `pointerdown`+capture — confirmed the control point's final position reflected the *last* move event, i.e. capture survived every redraw instead of dropping after the first one.
- [x] No console errors during the drag sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)