### PR TITLE
Keep a harmonized correction as a soft tween edit, not a hard keyframe

### DIFF
--- a/src/js/tweens.js
+++ b/src/js/tweens.js
@@ -4077,6 +4077,23 @@ function harmonizeAfterEdit(fi){
   if(prevKey>=0)restrictTo[prevKey]=true;
   if(nextKey>=0)restrictTo[fi]=true;
   generateTweens(restrictTo);
+  // #126 ("plutôt 2"): a harmonized correction stays a SOFT tween-frame
+  // fix, not a hard new keyframe — the whole point of Harmonize is to
+  // blend the edit into the existing tween on both sides, not fork the
+  // span in two permanently. Without this, the promotion
+  // _maybePromoteInterpolated already performed (app.js, on the save that
+  // ran right before this function was called) would stick, and the next
+  // full "Tween (T)" regen would treat this frame as a hard boundary
+  // forever. generateTweens() above never writes to fA/fB themselves —
+  // only the frames strictly between — so this frame's corrected strokes
+  // survive the regen call untouched; only its classification flips back
+  // down here. isManualEdit is what makes it show green (tw-manual, see
+  // style.css) and what "Skip manually-edited frames" (state.tweenSkipManual,
+  // read in generateTweens' own per-frame loop below) now has something
+  // real to actually skip on a future whole-layer regen.
+  if(prevKey>=0&&nextKey>=0){
+    f.isKeyframe=false;f.isInterpolated=true;f.isManualEdit=true;
+  }
 }
 
 // ---- ARCS ----


### PR DESCRIPTION
## Summary
- Follow-up to [#122](https://github.com/mysteropodes/nemo/issues/572) per user feedback on [#126](https://github.com/mysteropodes/nemo/issues/576): editing an in-between frame already promotes it to a real keyframe on save (pre-existing `_maybePromoteInterpolated` behavior, confirmed correct for the *default*, non-Harmonize case) — but with Harmonize on, this permanently forked the tween span in two, which isn't what "harmonize" was meant to mean. Asked the user to pick between keeping the hard-keyframe promotion or making the correction stay a soft tween edit — they picked the latter ("option 2").
- `harmonizeAfterEdit` (tweens.js) now flips the edited frame back down to `isInterpolated:true, isManualEdit:true` after regenerating the two neighboring sub-spans. `generateTweens()` never writes to the span boundaries themselves (only the frames strictly between), so the correction's own geometry is untouched by the regen call — only its classification changes.
- Side effect (a genuine bonus, not scope creep — it's the exact mechanism this needed): `isManualEdit` was read in several places (the green `tw-manual` timeline marker, the "Skip manually-edited frames" checkbox's regen-skip logic) but never actually *set* anywhere in the codebase — dead code from an earlier iteration. This is the first code path that ever sets it, so both of those pre-existing UI affordances become functional for the first time.

## Test plan
- [x] Live in-browser: dragged a Subselect node on a tween in-between frame with Harmonize on — the frame stays `isInterpolated:true` with `isManualEdit:true` (not promoted to a keyframe), its own corrected geometry is preserved exactly, both neighboring spans regenerate around it, and the two real keyframes stay untouched.
- [x] Timeline cell for the edited frame renders with the `tw-manual` (green) class.
- [x] "Skip manually-edited frames" checked → a full "Tween (T)" regen preserves the corrected frame's content exactly. Unchecked → the same regen correctly overwrites it back to plain interpolation. Confirms the toggle is now a real, functional switch, not dead code.
- [x] `node --check src/js/tweens.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)