### PR TITLE
Fix Subselect node handles misaligned on Component instances

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -3271,7 +3271,23 @@
     // 3D-toggled layer even with real rotationX/rotationY set; layerMotion3DPointMap
     // is the dedicated perspective-correct counterpart (motion.js).
     if (!motionMap && window.SMMotion && SMMotion.layerMotion3DPointMap) motionMap = SMMotion.layerMotion3DPointMap(state.activeLayerIdx);
-    function toRendered(x, y) { return motionMap ? motionMap.fwd(x, y) : [x, y]; }
+    // 2026-08-29 fix (feedback #125) — see subselect-bridge.js's toLocalPoint
+    // comment for the full story: a Component's own instance placement
+    // (`ld.symMatrix`, set by dragging/resizing the instance with the Select
+    // tool) is a second render-time-only transform, applied in
+    // getEffectiveStrokes (app.js) BEFORE Motion, that this overlay never
+    // composed in either — same symptom as the Motion gap above (handles
+    // drawn at the shape's raw position while the ribbon itself renders
+    // wherever symMatrix placed it). symMatrix is a plain Paper Matrix
+    // (already-baked translation, no pivot decomposition needed), applied
+    // FIRST so the result feeds into the SAME Motion mapping above, mirroring
+    // the forward order in app.js (raw -> symMatrix -> Motion -> world).
+    var symLd = state.layers[state.activeLayerIdx];
+    var symMat = (symLd && symLd.symMatrix && typeof symMatrixOf === 'function') ? symMatrixOf(symLd) : null;
+    function toRendered(x, y) {
+      if (symMat) { var sp = symMat.transform(new Point(x, y)); x = sp.x; y = sp.y; }
+      return motionMap ? motionMap.fwd(x, y) : [x, y];
+    }
     segs.forEach(function (s, i) {
       var pt = toRendered(s.point[0], s.point[1]);
       var hi = s.handleIn, ho = s.handleOut;

--- a/src/js/subselect-bridge.js
+++ b/src/js/subselect-bridge.js
@@ -57,18 +57,46 @@
   // marquee's containment test, drag delta math) consistently in the SAME
   // space path.segments/nodeEditSegmentsData already use — no other line
   // needs to change.
+  //
+  // 2026-08-29 fix (feedback #125, "pourquoi les points de tracé ne
+  // correspondent pas à la forme dessinée ?"): the Motion mapping above
+  // covers Motion Position/Rotation/Scale, but a Component's OWN instance
+  // placement (`ld.symMatrix` — set by dragging/resizing the instance on
+  // stage with the Select tool, symGestureAccumulate in app.js) is a
+  // SEPARATE render-time-only transform, applied in getEffectiveStrokes
+  // (app.js) BEFORE Motion, and was never accounted for here at all. Same
+  // failure mode as the Motion bug above: click straight through to
+  // layer.hitTest/nodeHandles[].pos in raw document space while the shape
+  // actually renders wherever symMatrix placed it — confirmed live
+  // (reproduced the reported screenshot exactly: node handles clustered at
+  // the shape's raw position, the visible ribbon rendered elsewhere via
+  // symMatrix). symMatrix is a plain Paper Matrix (no pivot decomposition
+  // needed, unlike Motion), applied to the ALREADY Motion-inverted point —
+  // mirrors the forward order in app.js (raw -> symMatrix -> Motion ->
+  // world), so undoing it here means peeling Motion off first, then
+  // symMatrix. buildNodeHandleItems (engine-bridge.js) needs the same fix
+  // for the overlay's forward direction — see its own comment.
   function toLocalPoint(pt, layerIdx) {
-    if (!window.SMMotion) return pt;
-    var map = SMMotion.layerMotionPointMap ? SMMotion.layerMotionPointMap(layerIdx) : null;
-    // 3D layers (2026-07-29 fix) — layerMotionPointMap returns null for a
-    // 3D-toggled layer even with real rotationX/rotationY set (it only
-    // recognizes the base 2D properties); layerMotion3DPointMap is the
-    // dedicated perspective-correct counterpart — see its own header
-    // comment in motion.js for the ray-plane-intersection math.
-    if (!map && SMMotion.layerMotion3DPointMap) map = SMMotion.layerMotion3DPointMap(layerIdx);
-    if (!map) return pt;
-    var lp = map.inv(pt.x, pt.y);
-    return new Point(lp[0], lp[1]);
+    var p = pt;
+    if (window.SMMotion) {
+      var map = SMMotion.layerMotionPointMap ? SMMotion.layerMotionPointMap(layerIdx) : null;
+      // 3D layers (2026-07-29 fix) — layerMotionPointMap returns null for a
+      // 3D-toggled layer even with real rotationX/rotationY set (it only
+      // recognizes the base 2D properties); layerMotion3DPointMap is the
+      // dedicated perspective-correct counterpart — see its own header
+      // comment in motion.js for the ray-plane-intersection math.
+      if (!map && SMMotion.layerMotion3DPointMap) map = SMMotion.layerMotion3DPointMap(layerIdx);
+      if (map) {
+        var lp = map.inv(p.x, p.y);
+        p = new Point(lp[0], lp[1]);
+      }
+    }
+    var ld = state.layers[layerIdx];
+    if (ld && ld.symMatrix && typeof symMatrixOf === 'function') {
+      var inv = symMatrixOf(ld).inverted();
+      if (inv) p = inv.transform(p);
+    }
+    return p;
   }
 
   // Illustrator/Figma "Convert Anchor Point" convention, ported to a plain


### PR DESCRIPTION
## Summary
- Fixes GitHub feedback issue #125 (`mysteropodes/strokemotion-feedback`): "pourquoi les points de tracé ne correspondent pas à la forme dessiné ?" — node/handle overlay in the Subselect tool floats away from the visible stroke.
- Root cause: `subselect-bridge.js`'s `toLocalPoint` (pointer hit-test/drag mapping) and `engine-bridge.js`'s `buildNodeHandleItems` (Rust-engine overlay renderer) already mapped points through a layer's **Motion** transform (Position/Rotation/Scale, 2026-07-29 fix), but never through `ld.symMatrix` — the separate, render-time-only transform that places a **Component instance** on stage (set when you drag/resize a component instance with the Select tool). Editing a stroke that lives in a Component layer with a non-identity `symMatrix` hit-tested and drew the node overlay at the shape's raw/untransformed position, while the visible ribbon rendered wherever `symMatrix` actually placed it.
- Both call sites now also compose `symMatrix`, applied **before** Motion — mirroring the real render order in `app.js`'s `getEffectiveStrokes` (`raw -> symMatrix -> Motion -> world`).

## Root cause confirmation
Live-reproduced in a browser preview: drew a tapered vector-brush stroke, converted its layer to a Component, set a non-identity `symMatrix` (scale + rotation + translation, simulating a resized/moved instance), then selected it with Subselect — node handles rendered clustered at the shape's raw position while the visible stroke rendered elsewhere, matching the reported screenshot exactly. A Motion-only transform (no symMatrix) was confirmed to already work correctly, ruling that out as the cause.

## Test plan
All verified live via synthetic pointer events + direct point-transform comparison in a browser preview (`python3 -m http.server`, fresh port):
- [x] Plain path (no Motion, no symMatrix) — node handles track correctly (baseline, no regression).
- [x] Motion-only transform (rotation + non-uniform scale + position) — node handles track correctly (no regression from the 2026-07-29 fix).
- [x] `symMatrix`-only (Component instance placement, scale + rotation + translation) — previously broken, now tracks correctly.
- [x] `symMatrix` + Motion combined — composition order (`symMatrix` then Motion) verified correct.
- [x] `node --check` on both modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)