### PR TITLE
Re-stamp brush texture dabs after a Vector Sculpt gesture

### DIFF
--- a/src/js/labs/vector-sculpt.js
+++ b/src/js/labs/vector-sculpt.js
@@ -297,6 +297,16 @@
     var layer = userLayers[state.activeLayerIdx];
     // Fills whose walls were sculpted re-trace against the new geometry.
     touched.forEach(function (p) { if (typeof fillRegenerateLinked === 'function') fillRegenerateLinked(layer, p); });
+    // Feedback #129 ("le sculpt brush marche pas sur des stroke texturé"): a
+    // brush-texture anchor's dabs are disposable stamps computed once at
+    // apply-time — they never re-follow an edited anchor on their own (see
+    // regenerateBrushTexture's own header comment, tools.js). subselect-
+    // bridge.js's node-drag already re-stamps on drag-end; this tool's own
+    // push/smooth drag moves the anchor's segments exactly the same way but
+    // never called the same re-stamp, so sculpting a textured stroke visibly
+    // did nothing — the anchor itself moved (invisible, camouflaged), the
+    // dabs stayed put.
+    touched.forEach(function (p) { if (typeof regenerateBrushTexture === 'function') regenerateBrushTexture(p, layer); });
     touched = [];
     saveActiveLayerFrame();
     if (wasInterpolated && typeof harmonizeAfterEdit === 'function') harmonizeAfterEdit(state.currentFrame);


### PR DESCRIPTION
## Summary
- Fixes [#129](https://github.com/mysteropodes/nemo/issues/579): "le sculpt brush marche pas sur des stroke texturé" (sculpt brush doesn't work on textured strokes).
- `regenerateBrushTexture`'s own header comment already documents this exact failure class for node edits: a brush-texture anchor's dabs are disposable stamps computed once, and never re-follow an edited anchor unless something explicitly re-stamps them. `subselect-bridge.js` already calls it on node-drag-end; `vector-sculpt.js`'s push/smooth drag mutates the anchor's segments the same way but never called it — so sculpting a textured stroke moved the (camouflaged, invisible) anchor while the visible dabs stayed exactly where they were, reading as "nothing happened."
- Fix: `onUp` now calls `regenerateBrushTexture(p, layer)` for every touched path, alongside the existing `fillRegenerateLinked` call — same call, same place subselect-bridge.js already uses it.

## Test plan
- [x] Live in-browser: drew a plain stroke, applied a "chalk-round" texture preset (96 dabs), enabled Vector Sculpt, pushed the stroke — the invisible anchor's segments shifted and the dab nearest the pushed region followed to the new position exactly (verified by direct position comparison, not just visually — texture dabs at low zoom are subtle).
- [x] Confirmed `regenerateBrushTexture` correctly no-ops on a plain (non-textured) path — no regression to ordinary sculpting.
- [x] `node --check src/js/labs/vector-sculpt.js`.
- [x] No console errors during the gesture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)