### PR TITLE
Coalesce Motion Graph Editor drag renders to one per frame

### DIFF
--- a/src/js/motion-graph.js
+++ b/src/js/motion-graph.js
@@ -287,6 +287,32 @@
       e.preventDefault(); e.stopPropagation();
     }
   }
+  // Feedback #128 ("dur à contrôler parfois... saccadé"): onMove used to call
+  // render() (a full rebuild: re-samples EVERY frame of EVERY plotted curve
+  // via M().valueAtFrame, rebuilds the whole SVG as a string, replaces
+  // el.innerHTML) PLUS renderLayerList() PLUS SMEngineBridge.renderNow() —
+  // all synchronously on every single raw mousemove tick, no coalescing at
+  // all. On a graph with more than a couple of animated properties or a
+  // longer timeline this is exactly the "drag lags behind the cursor, feels
+  // saccadé" symptom — same class of bug CLAUDE.md §5bis already documents
+  // for other raw-drag paths in this app (timeline zoom handle, in/out bars),
+  // fixed the same way here: the DATA write (k.v/k.frame/cps[wi].x/y) stays
+  // synchronous on every move so no motion is ever dropped, but the actual
+  // re-render is coalesced to one rAF tick — a mouse fires far more move
+  // events per frame than the screen can show anyway. onUp still forces one
+  // final synchronous render so the very last position is never left
+  // waiting on a queued frame that never fires (drag ended, no more moves).
+  var _renderQueued = false;
+  function scheduleRender() {
+    if (_renderQueued) return;
+    _renderQueued = true;
+    requestAnimationFrame(function () {
+      _renderQueued = false;
+      render();
+      if (window.renderLayerList) renderLayerList();
+      if (window.SMEngineBridge) SMEngineBridge.renderNow();
+    });
+  }
   function onMove(e) {
     if (!_drag) return;
     var p = localPt(e), rg = _el._rg, innerH = _el._innerH;
@@ -322,15 +348,15 @@
       cps[_drag.wi].y = Math.max(-1, Math.min(2, ny));
       delete cps[_drag.wi].tx; delete cps[_drag.wi].ty;
     }
-    render();
-    if (window.renderLayerList) renderLayerList();
-    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+    scheduleRender();
   }
   function onUp() {
     if (!_drag) return;
     _drag = null;
     if (window.renderTimeline) renderTimeline();
     render();
+    if (window.renderLayerList) renderLayerList();
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
   }
 
   function toggle(on) {


### PR DESCRIPTION
## Summary
- Addresses [#128](https://github.com/mysteropodes/nemo/issues/578) — user confirmed via follow-up questions that "hard to control" specifically means the drag itself feels imprecise/jerky (not a tangent-clarity issue).
- `motion-graph.js`'s `onMove` ran a full `render()` (re-samples every frame of every plotted curve, rebuilds the whole SVG as a string, replaces `innerHTML`) plus `renderLayerList()` plus `SMEngineBridge.renderNow()` synchronously on every raw `mousemove` — no coalescing at all. Same class of perf bug CLAUDE.md §5bis already documents (and fixes) elsewhere in this app for other raw-drag paths (timeline zoom handle, in/out bars): on a graph with more than a couple of animated properties, the visual update visibly lags behind the cursor — reads exactly as "saccadé."
- Fix: the data write (key value/frame, ease-waypoint x/y) stays synchronous on every move, so no motion input is ever dropped — only the expensive re-render is coalesced to one `requestAnimationFrame` tick via a `scheduleRender()` guard. `onUp` forces one final synchronous render so the drag's last position is never left waiting on a queued frame that never fires.

## Test plan
- [x] Live in-browser: 40 synthetic `mousemove` events fired synchronously during one drag scheduled exactly 1 `requestAnimationFrame` call (previously would have run the full render chain 40 times).
- [x] Confirmed the dragged key's final value/position is correct after the coalesced drag.
- [x] No console errors during the gesture.
- [x] `node --check src/js/motion-graph.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)