### PR TITLE
Auto-reveal Motion timeline elements after applying text animation (#132)

### DIFF
--- a/src/js/text-animator.js
+++ b/src/js/text-animator.js
@@ -217,6 +217,29 @@
         });
       });
     });
+    // Reveal this layer's per-element tracks in the Motion timeline
+    // (2026-08-29, feedback #132: "l'animation de texte marche bien mais
+    // pas de keyframes visible... dans la timeline motion") — the keys
+    // above are real elementMotion, written through the exact same
+    // ensureElementHolder/setKeyAtFrame primitives a manual stopwatch click
+    // uses, and they DO render correctly; what was missing is that
+    // motion.js's renderLayerListMotion/renderTimelineMotion only ever
+    // show a layer's per-element row list while
+    // window._motionExpandedLayer === li (see their own comment: gated on
+    // the MANUAL accordion specifically, not the broader multi-layer
+    // window._motionRevealedLayers, so a property-shortcut reveal like U
+    // doesn't cascade into every element's breakdown too). A manual key
+    // only ever happens after the user has ALREADY clicked that layer's
+    // row open, which sets _motionExpandedLayer — apply() skipped that
+    // step entirely, so the keys existed but the row showing them was
+    // still collapsed. Only touched the first time this group reveals the
+    // layer (not on every live-preview tweak) so it doesn't keep
+    // collapsing a per-element row the user drilled into by hand while
+    // adjusting sliders.
+    if(units.length&&window._motionExpandedLayer!==li){
+      window._motionExpandedLayer=li;
+      window._motionExpandedElement=null;
+    }
     if(window.renderLayerList)renderLayerList();
     if(window.renderTimeline)renderTimeline();
     if(window.SMEngineBridge)SMEngineBridge.renderNow();


### PR DESCRIPTION
## Summary
- Fixes GitHub issue #132 (mysteropodes/strokemotion-feedback): "l'animation de texte marche bien mais pas de keyframes visible appliqué dans la timeline motion pour ça"
- `text-animator.js`'s `apply()` writes real `elementMotion` keys via `SMMotion.ensureElementHolder`/`setKeyAtFrame` for each split character/word/line's own `strokeId` — the exact same primitives the Motion panel's own stopwatch uses — and the animation renders/plays correctly. The bug: the Motion timeline's own per-element track list never showed these keys.
- Root cause: `motion.js`'s `renderLayerListMotion`/`renderTimelineMotion` only render a layer's per-element row list (`renderElementsList`/`buildShapeTree`) while `window._motionExpandedLayer === li` — deliberately narrower than the multi-layer `window._motionRevealedLayers` (see the codebase's own comment referencing feedback #42: a property-shortcut reveal like `U` must not cascade into every element's breakdown too). A manual key only ever happens after the user has already clicked that layer's row open in the Motion panel, which is what sets `_motionExpandedLayer` — applying a text-animator preset skipped that step entirely, so the keys existed and rendered correctly, but the row that would show them stayed collapsed.
- Fix: `apply()` now sets `window._motionExpandedLayer` to the animated layer the first time it reveals a group (mirroring exactly what a manual row click already does — see the arrow-click handler in `motion.js`), so switching to Motion mode after applying a text-animator preset immediately shows its keyframes, the same way a manual key would. Only touches state the first time (not on every live-preview slider tweak), so it doesn't keep collapsing a per-element row the user drilled into by hand.

## Test plan
- [x] `node --check` on `src/js/text-animator.js`
- [x] Verified live in a browser preview: created vector text, applied a text-animator preset ("Terminé"/Done), confirmed `window._motionExpandedLayer` was set to the layer index
- [x] Switched to Motion mode and confirmed the layer list immediately shows `Layer 1 ▾ ... ELEMENTS ▤ Group` (previously required a manual arrow-click first) — the real `elementMotion.opacity` keys written by `apply()` are now visible without any extra manual step

**Known residual (separate, pre-existing, out of scope):** for VECTOR text specifically, all glyphs share one `groupId`, so `buildShapeTree` (motion.js) collapses them into a single non-expandable "Group" summary row rather than N individually-expandable rows with their own keyframe diamonds — this collapsing behavior is a general Motion Elements-tree limitation for ANY grouped multi-shape content (Ctrl+G groups, combined shapes, etc.), not something introduced by or specific to text-animator. This PR fixes the confirmed, diagnosed bug (the section not auto-revealing at all); un-collapsing grouped elements into individually-expandable per-glyph tracks would be a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)