### PR TITLE
Fix in-place text editor overlay ignoring the layer's Motion transform (#131)

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -6549,7 +6549,28 @@ function openInPlaceTextEditor(root,isNew){
   handle.addEventListener('pointerup',endResize);
   handle.addEventListener('pointercancel',endResize);
   function reposition(){
-    var topLeftView=view.projectToView(bounds.topLeft);
+    // Motion transform (2026-08-29, feedback #131: "petit pblm de box de
+    // selection de text entre animation2D et motion") — this editor used to
+    // project `bounds.topLeft` straight through view.projectToView with no
+    // regard for the layer's own Motion position/anchor/rotation/scale.
+    // Motion transforms apply to rendering in EITHER app mode (CLAUDE.md
+    // §8: "buildSceneJson applique déjà motionMat à N'IMPORTE QUEL calque"),
+    // so the instant this layer had any Motion key, the textarea/orange box/
+    // resize handle stayed pinned to the RAW un-transformed geometry while
+    // the actual glyphs (and the Select tool's own transform box, which
+    // already goes through this same map — see select-bridge.js's
+    // computeHandles) rendered somewhere else entirely — confirmed live via
+    // a simple Position key: the editor opened ~360px away from the visible
+    // text. Same fix pattern this codebase already applies everywhere else
+    // a screen position is derived from raw geometry (select-bridge.js,
+    // subselect-bridge.js, rig-bridge.js): map the point forward through
+    // layerMotionPointMap before projecting to screen. Rotation of the box
+    // itself is a known residual (this stays axis-aligned; only the ANCHOR
+    // point is corrected) — acceptable for a text-edit overlay, and a much
+    // smaller gap than being positioned hundreds of px off entirely.
+    var motionMap=(window.SMMotion&&SMMotion.layerMotionPointMap)?SMMotion.layerMotionPointMap(state.activeLayerIdx):null;
+    var anchorWorld=motionMap?motionMap.fwd(bounds.topLeft.x,bounds.topLeft.y):[bounds.topLeft.x,bounds.topLeft.y];
+    var topLeftView=view.projectToView(new Point(anchorWorld[0],anchorWorld[1]));
     var canvasEl=document.getElementById('drawing-canvas');
     var cr=canvasEl.getBoundingClientRect();
     var fontPx=(d.size||48)*view.zoom;
@@ -6570,11 +6591,16 @@ function openInPlaceTextEditor(root,isNew){
     // de texte") — screen px back to world units (÷view.zoom, mirroring
     // fontPx's own ×view.zoom a few lines up) so buildTextDragBoxItems
     // (engine-bridge.js) can draw it through the Rust-rendered scene, same
-    // as every other canvas overlay in this app.
+    // as every other canvas overlay in this app. buildTextDragBoxItems draws
+    // this rect directly in world space with no Motion mapping of its own
+    // (unlike buildTransformBoxItems), so the anchor here must already be
+    // the MOTION-MAPPED point (anchorWorld, same fix as topLeftView above)
+    // — otherwise this orange box would still land on the raw geometry even
+    // after the textarea itself was corrected.
     window._inplaceTextBoxBounds={
-      left:bounds.left,top:bounds.top,
-      right:bounds.left+parseFloat(ta.style.width)/view.zoom,
-      bottom:bounds.top+parseFloat(ta.style.height)/view.zoom,
+      left:anchorWorld[0],top:anchorWorld[1],
+      right:anchorWorld[0]+parseFloat(ta.style.width)/view.zoom,
+      bottom:anchorWorld[1]+parseFloat(ta.style.height)/view.zoom,
     };
     handle.style.left=(cr.left+topLeftView.x+parseFloat(ta.style.width))+'px';
     handle.style.top=(cr.top+topLeftView.y+parseFloat(ta.style.height))+'px';


### PR DESCRIPTION
## Summary
- Investigates and fixes GitHub issue #131 (mysteropodes/strokemotion-feedback): "petit pblm de box de slection de text entre animation2D et motion"
- Confirmed live: the Select tool's own outer transform box for a text selection already correctly accounts for a layer's Motion position/anchor/rotation/scale (`computeHandles()` in `select-bridge.js` composes through `SMMotion.layerMotionPointMap`, same as every other hit-test/handle computation in this codebase) — so switching between Animation 2D and Motion with a plain Select-tool text selection behaves correctly once the real click-selection path (`syncMotionLayerSelection`) is exercised.
- The actual bug: `openInPlaceTextEditor`'s `reposition()` (`timeline.js`) — the double-click-to-re-edit-text overlay (textarea, orange bounding box, resize handle) — never accounted for the layer's Motion transform at all. It projected the text's raw, untransformed Paper.js bounds straight to screen coordinates. Since Motion transforms apply to rendering in EITHER app mode (per this codebase's own CLAUDE.md §8: `buildSceneJson` applies `motionMat` to any layer regardless of which mode is active), the instant a layer had any Motion key (Position/Rotation/Scale/Anchor), re-entering text-edit mode opened the overlay wherever the RAW geometry sits — potentially hundreds of pixels from where the text actually renders. Confirmed live with a simple Position key: the editor opened ~360px away from the visible text (screenshotted during investigation).
- Fix: map the anchor point through `layerMotionPointMap` before projecting to screen — the same established pattern this codebase already uses in `select-bridge.js`/`subselect-bridge.js`/`rig-bridge.js` for this exact class of bug (documented at length in CLAUDE.md). Also fixed `window._inplaceTextBoxBounds` (the orange box `engine-bridge.js`'s `buildTextDragBoxItems` draws), which renders directly in world space with no transform mapping of its own and would otherwise still show the box on the raw geometry even after the textarea itself was corrected.

## Test plan
- [x] `node --check` on `src/js/timeline.js`
- [x] Verified live in a browser preview: created vector text, gave its layer a Motion Position offset (`SMMotion.setLayerValue`), then re-opened the in-place text editor
  - Before the fix: textarea landed ~360px horizontally / ~185px vertically away from the actual rendered text (screenshotted)
  - After the fix: textarea/orange box land within ~1-4px of the actual rendered text (the residual is the textarea's own border/padding, not a mapping error) — visually confirmed via screenshot, the edit box now sits directly over the visible "TEST" text at its Motion-offset position

**Note on scope:** the fix maps the anchor POINT through the Motion transform (translation + anchor pivot + scale-of-position), matching the dominant, confirmed symptom. A layer with Motion ROTATION would have its anchor point correctly repositioned but the edit box itself would remain axis-aligned rather than rotating to match — a much smaller residual than the original hundreds-of-pixels mismatch, and consistent with how several other design tools keep text-edit overlays axis-aligned even for rotated text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)