### PR TITLE
Coalesce Vector Sculpt texture re-stamp to one per frame (feedback #139)

### DIFF
--- a/src/js/labs/vector-sculpt.js
+++ b/src/js/labs/vector-sculpt.js
@@ -34,6 +34,43 @@
   var wasInterpolated = false;
   var resizeStartX = 0, resizeStartRadius = 60;
   var cursor = null;
+  // Feedback #139 ("le sculpt deform n'est pas en temps réel sur une brush
+  // avec un preset"): #129 fixed regenerateBrushTexture() never being called
+  // at all, but only wired it into onUp (drag-END) — regenerateBrushTexture's
+  // own header comment in tools.js is explicit: "buildBrushDabs is a full
+  // rebuild, not cheap per mousemove" (remove every old dab Path + walk the
+  // anchor's current geometry stamping up to BRUSH_MAX_DABS=900 fresh Path
+  // objects — measured ~14.8ms worst case per full rebuild, see tools.js's
+  // BRUSH_MAX_DABS comment). So onMove moved the anchor but the visible dabs
+  // stayed put until release — exactly the "not real-time" complaint. Same
+  // fix shape as feedback #128 (motion-graph.js, CLAUDE.md §5bis): the DATA
+  // write (segment positions, in applyPush/applySmooth) stays synchronous on
+  // every move, but the expensive re-stamp is coalesced to one rAF tick —
+  // a mouse/stylet fires far more move events per frame than the screen can
+  // show anyway, so re-stamping once per SCREEN REFRESH instead of once per
+  // input event loses nothing visible. onUp already forces one final
+  // synchronous regenerateBrushTexture call (added by #129) so the very last
+  // position is never left showing a stale/queued texture.
+  var texRafQueued = false, texLayer = null;
+  function scheduleTextureUpdate(layer) {
+    texLayer = layer;
+    if (texRafQueued) return;
+    texRafQueued = true;
+    requestAnimationFrame(function () {
+      texRafQueued = false;
+      flushTextureUpdate();
+    });
+  }
+  function flushTextureUpdate() {
+    var layer = texLayer;
+    if (!layer || !touched.length) return;
+    // regenerateBrushTexture no-ops instantly on a path with no
+    // brushTexturePreset (its own guard, tools.js) — safe/cheap to call for
+    // every touched path regardless of whether it's textured, so a
+    // non-textured stroke's sculpt behavior is unaffected by this at all.
+    touched.forEach(function (p) { if (typeof regenerateBrushTexture === 'function') regenerateBrushTexture(p, layer); });
+    SMEngineBridge.renderNow();
+  }
 
   function isActive() {
     return !!(window.SMLabs && window.SMLabs.isOn('vector-sculpt') &&
@@ -282,7 +319,14 @@
     if (!undoPushed) { pushUndo(); ensureKeyframe(); undoPushed = true; }
     var moved = e.shiftKey ? applySmooth(layer, cur, R) : applyPush(layer, cur, cur.subtract(lastW), R);
     lastW = cur;
-    if (moved) { saveActiveLayerFrame(); SMEngineBridge.renderNow(); }
+    if (moved) {
+      saveActiveLayerFrame();
+      SMEngineBridge.renderNow();
+      // #139: re-stamp textured strokes' visible dabs during the drag too,
+      // not just at release — coalesced to one rAF tick (see
+      // scheduleTextureUpdate's header comment above).
+      scheduleTextureUpdate(layer);
+    }
   }
   function onUp(e) {
     if (resizing) {


### PR DESCRIPTION
## Summary

- Feedback #139 (`mysteropodes/strokemotion-feedback`): "le sculpt deform n'est pas en temps réel sur une brush avec un preset" — Vector Sculpt's push/smooth deform on a textured stroke only updated the visible dabs on drag-release, not during the drag.
- #129 (merged earlier today, PR #301) fixed `onUp` never calling `regenerateBrushTexture` at all. That left the *live* case still broken: `regenerateBrushTexture`'s own header comment in `tools.js` warns "buildBrushDabs is a full rebuild, not cheap per mousemove" — exactly what this issue is asking for.
- Applied the same fix shape as feedback #128 (`motion-graph.js`, documented in CLAUDE.md §5bis): the anchor's segment-position **data write** stays synchronous on every `onMove` (no motion ever dropped), but the expensive **re-stamp** (`regenerateBrushTexture` — remove every old dab Path, walk the anchor's current geometry, create up to `BRUSH_MAX_DABS`=900 fresh Path objects) is now coalesced to one `requestAnimationFrame` tick via `scheduleTextureUpdate()`/`flushTextureUpdate()`, instead of running on every raw pointer event. `onUp` still forces one final synchronous call (already added by #129) so the last position is never left showing a stale/queued texture.

## Approach chosen and why

Went with **rAF-coalesced full rebuild**, matching #128 exactly, rather than the cheaper "translate existing dabs, exact rebuild only at onUp" fallback the task description flagged as a fallback option. Measured live before committing to this:

- Single dense textured stroke (~2200px, `chalk-scribble` preset, 358-368 dabs — not a toy path): **~3-6.5ms** per full `regenerateBrushTexture` call + **~3ms** render, comfortably inside a 60fps (16.6ms) frame budget.
- Deliberately adversarial stress case: 3 overlapping textured strokes under one brush radius at once (796 combined dabs, `charcoal-rough` + `chalk-scribble`, two of the library's densest presets): **~9-15ms** typical, one **~20.6ms** outlier. Borderline in that rare worst case, but self-corrects every single frame (coalescing means it never accumulates a backlog) rather than causing sustained stutter — and it's a genuinely uncommon scenario (3 different textured strokes all within one ~100px-world brush radius simultaneously).

Given the common case is clearly smooth and the adversarial case only degrades gracefully (occasional single dropped frame, not persistent lag), the simpler rAF-coalesced full rebuild was kept rather than adding a second, more complex "cheap approximation during drag, exact on release" code path.

## Test plan

- [x] `node --check src/js/labs/vector-sculpt.js`
- [x] Live in-browser verification (fresh `python3 -m http.server` on an unused port): synthesized a long wavy stroke, applied `chalk-scribble` texture (368 dabs), enabled Labs `vector-sculpt`, dispatched real `PointerEvent`s through the actual document-capture listeners (not calling internals directly).
  - Fired 8-10 synthetic `pointermove` events **synchronously within one JS turn** → confirmed **0** `regenerateBrushTexture` calls until yielding to the next animation frame, then exactly **1** — proves per-frame coalescing, not per-event.
  - Took screenshots **mid-drag, mouse still held down** — the dab texture visibly follows the pushed geometry in real time (screenshots show the crest deforming into a sharp push shape with dabs tracking the new curve, not the old one), confirming the actual visual/live-feedback requirement, not just a data-level check.
  - Released the drag: exactly 1 more synchronous call (`onUp`'s existing final call) — final dab count (358) matches `data.brushCompanions.length` exactly, only one `brushGroupId` present in the layer (no leftover/duplicate dabs from intermediate coalesced calls).
  - Regression check: repeated the same drag on a plain non-textured stroke — `regenerateBrushTexture` is still called (coalesced) but no-ops instantly via its own guard (`data.brushTexturePreset` unset), zero dabs created, layer child count unchanged, no errors — sculpt behavior on non-textured strokes is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)