### PR TITLE
Fix drawing tools ignoring the active layer's Motion transform (feedback #135)

### DIFF
--- a/src/js/draw-bridge.js
+++ b/src/js/draw-bridge.js
@@ -31,7 +31,49 @@
   // every mainstream drawing app. viewtools-bridge.js's global
   // Alt-drag-to-rotate explicitly cedes Alt to the brushes for this.
   var sizing = false, sizeStartX = 0, sizeStartVal = 0, sizeAnchorW = null;
-  var samples = []; // [x,y,width]
+  var samples = []; // [x,y,width] — RENDERED/world space while dragging (see commitStroke)
+
+  // Motion transform (2026-08-29, feedback #135: "si je dessine dans le
+  // layer dont la position a été changé dans motion... le dessin se
+  // recale"). `samples` is captured via screenToWorld — RENDERED/world
+  // space, correct for the live overlay preview (which must track the
+  // cursor at its true on-screen position, matching whatever else is
+  // already drawn on a Motion-transformed layer). But a layer's Motion
+  // Position/Rotation/Scale is, by design, applied ONLY at render time
+  // (buildSceneJson's pathTransform — see motion.js's computeMotionMat
+  // header) and is NEVER baked into the Paper.js document's own segments —
+  // same contract every other interaction file in this codebase already
+  // honors (subselect-bridge.js's/rig-bridge.js's own toLocalPoint,
+  // select-bridge.js's hitPt, timeline.js's openInPlaceTextEditor fix for
+  // #131). This file committed the raw world-space samples straight into
+  // the real Path, so a Motion-transformed layer applied its offset a
+  // SECOND time on top at the next render — the freshly-drawn shape
+  // visibly snapped away from where it was actually drawn, while existing
+  // content (already living correctly in local space) stayed put — exactly
+  // the reported "ceux qui sont déjà dedans reste avec la transformation".
+  // Mapped once, right before commitStroke does anything else with
+  // `samples`, so every downstream consumer (angledSamples, centerline/
+  // outline building, trim-stroke-ends — which compares against OTHER
+  // layer content already in local space) sees consistent coordinates.
+  function toLocalPoint(pt, layerIdx) {
+    if (!window.SMMotion) return pt;
+    var map = SMMotion.layerMotionPointMap ? SMMotion.layerMotionPointMap(layerIdx) : null;
+    // 3D layers — layerMotionPointMap only recognizes the base 2D
+    // properties and returns null for a 3D-toggled layer even with real
+    // rotationX/rotationY set; layerMotion3DPointMap is the dedicated
+    // (perspective-correct, not affine) counterpart — see its own header
+    // comment in motion.js for the ray-plane-intersection math.
+    if (!map && SMMotion.layerMotion3DPointMap) map = SMMotion.layerMotion3DPointMap(layerIdx);
+    if (!map) return pt;
+    var lp = map.inv(pt.x, pt.y);
+    return new Point(lp[0], lp[1]);
+  }
+  function mapSamplesToLocal(smp, layerIdx) {
+    return smp.map(function (s) {
+      var lp = toLocalPoint(new Point(s[0], s[1]), layerIdx);
+      return [lp.x, lp.y, s[2]];
+    });
+  }
   // Live brush-preset dab cache (2026-08-27): buildBrushDabs is a full
   // rebuild "not cheap per mousemove" (see its other caller,
   // regenerateBrushTexture, tools.js) — a stylus fires 120-240 events/s
@@ -727,6 +769,12 @@
   function commitStroke() {
     if (window.SMBitmapBrush) window.SMBitmapBrush.endLivePreview(); // clear the screen-space preview — the real baked Raster (if any) takes over below
     if (samples.length < 2) return;
+    // Map from rendered/world space into the active layer's raw document
+    // space BEFORE anything else touches `samples` — see the header comment
+    // above (feedback #135). A no-op (returns points unchanged) whenever
+    // the layer has no effective Motion transform, which is the
+    // overwhelmingly common case.
+    samples = mapSamplesToLocal(samples, state.activeLayerIdx);
     // Bake the calligraphic nib once, here, so every consumer below (centerline
     // + width profile, brush-preset dabs, bitmap brush, symmetry/Labs hooks)
     // sees the same widths the live preview showed.

--- a/src/js/pen-bridge.js
+++ b/src/js/pen-bridge.js
@@ -21,6 +21,30 @@
   var reshapingSeg = null;
   var canvasEl = null; // set in init(), read by the cursor-affordance hover check in onMove
 
+  // Motion transform (2026-08-29, feedback #135: "si je dessine dans le
+  // layer dont la position a été changé dans motion... le dessin se
+  // recale") — same fix/reasoning as draw-bridge.js's toLocalPoint (see its
+  // header comment for the full story). Unlike Draw/Shape, the Pen tool
+  // mutates a real Paper.js Path (_pen.path, shared with tools.js)
+  // continuously across the whole multi-click gesture rather than
+  // deferring to one commit at the end — every anchor placement and
+  // proximity/tangent check against _pen.path's existing (raw, local-
+  // space) segments below must map the pointer's rendered/world position
+  // through this FIRST, or a Motion-transformed layer places each new
+  // anchor at its raw click position instead of the equivalent local one
+  // (same failure mode subselect-bridge.js/rig-bridge.js already document
+  // for hit-testing). setPenPreview's rubber-band line is deliberately fed
+  // the UNMAPPED world point (w) instead — it's a live overlay, must track
+  // the cursor at its true on-screen position.
+  function toLocalPoint(pt, layerIdx) {
+    if (!window.SMMotion) return pt;
+    var map = SMMotion.layerMotionPointMap ? SMMotion.layerMotionPointMap(layerIdx) : null;
+    if (!map && SMMotion.layerMotion3DPointMap) map = SMMotion.layerMotion3DPointMap(layerIdx);
+    if (!map) return pt;
+    var lp = map.inv(pt.x, pt.y);
+    return new Point(lp[0], lp[1]);
+  }
+
   function shouldIntercept() {
     return (
       window.SMEngineBridge && window.SMEngineBridge.isEnabled() &&
@@ -33,7 +57,10 @@
     e.stopImmediatePropagation();
     e.preventDefault();
     var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
-    var pt = new Point(w[0], w[1]);
+    // Motion transform fix (feedback #135, see toLocalPoint's header
+    // comment above) — every anchor placed/hit-tested below must live in
+    // the same raw document space as _pen.path's existing segments.
+    var pt = toLocalPoint(new Point(w[0], w[1]), state.activeLayerIdx);
     var layer = userLayers[state.activeLayerIdx];
 
     // Alt+drag directly on an ALREADY-PLACED anchor of the in-progress path
@@ -148,7 +175,10 @@
     window.SMEngineBridge.setPenPreview(w);
     if (draggingHandle && _pen.path) {
       var seg = reshapingSeg || _pen.path.lastSegment;
-      var pt = new Point(w[0], w[1]);
+      // Motion transform fix (feedback #135) — seg.point lives in raw
+      // document space; the pointer must be mapped the same way before the
+      // handle delta is computed against it.
+      var pt = toLocalPoint(new Point(w[0], w[1]), state.activeLayerIdx);
       var delta = pt.subtract(seg.point);
       seg.handleOut = delta;
       // Alt/Option held: break the handle's symmetry (only the OUT side
@@ -172,7 +202,10 @@
       // Both are dynamic overrides of the tool's normal static cursor
       // (SM.setTool's cc['pen']='crosshair'), so anything that doesn't
       // match falls back to that same default rather than getting stuck.
-      var pt = new Point(w[0], w[1]);
+      // Motion transform fix (feedback #135) — _pen.path.segments live in
+      // raw document space; map the pointer the same way for these
+      // proximity checks.
+      var pt = toLocalPoint(new Point(w[0], w[1]), state.activeLayerIdx);
       var tol = 10 / view.zoom;
       var nearAnchor = false;
       if (e.altKey) {

--- a/src/js/shape-bridge.js
+++ b/src/js/shape-bridge.js
@@ -13,6 +13,24 @@
   var shapeStart = null; // world [x,y]
   var shapeTool = null;
 
+  // Motion transform (2026-08-29, feedback #135: "si je dessine dans le
+  // layer dont la position a été changé dans motion... le dessin se
+  // recale") — same fix/reasoning as draw-bridge.js's toLocalPoint (see its
+  // header comment for the full story). shapeStart/the live drag endpoint
+  // are rendered/world-space (screenToWorld), correct for the live overlay
+  // preview built by overlayItem() below; only commitShape needs to map
+  // them into the active layer's raw document space before building the
+  // real Path, so a Motion-transformed layer doesn't apply its offset a
+  // second time on top at the next render.
+  function toLocalPoint(pt, layerIdx) {
+    if (!window.SMMotion) return pt;
+    var map = SMMotion.layerMotionPointMap ? SMMotion.layerMotionPointMap(layerIdx) : null;
+    if (!map && SMMotion.layerMotion3DPointMap) map = SMMotion.layerMotion3DPointMap(layerIdx);
+    if (!map) return pt;
+    var lp = map.inv(pt.x, pt.y);
+    return new Point(lp[0], lp[1]);
+  }
+
   function shouldIntercept() {
     return (
       window.SMEngineBridge && window.SMEngineBridge.isEnabled() &&
@@ -197,10 +215,18 @@
   }
 
   function commitShape(ex, ey) {
-    var start = new Point(shapeStart[0], shapeStart[1]);
-    var end = new Point(ex, ey);
+    // World-space endpoints — the <2px drag-discard check below stays
+    // against THESE (a screen-space "did you actually drag" threshold,
+    // unaffected by the layer's Motion transform).
+    var worldStart = new Point(shapeStart[0], shapeStart[1]);
+    var worldEnd = new Point(ex, ey);
     var layer = userLayers[state.activeLayerIdx];
     layer.activate();
+    // Motion transform fix (feedback #135, see toLocalPoint's header
+    // comment above) — map into the layer's raw document space before
+    // building the actual shape geometry.
+    var start = toLocalPoint(worldStart, state.activeLayerIdx);
+    var end = toLocalPoint(worldEnd, state.activeLayerIdx);
     var geom = shapeGeom(shapeTool, start.x, start.y, end.x, end.y);
     var path = new Path();
     geom.segments.forEach(function (sd) {
@@ -219,7 +245,7 @@
     } else {
       path.fillColor = state.fillEnabled ? state.fillColor : null;
     }
-    if (start.getDistance(end) < 2) {
+    if (worldStart.getDistance(worldEnd) < 2) {
       path.remove();
       if (state.undoStack.length) state.undoStack.pop();
     } else {


### PR DESCRIPTION
## Summary

Fixes feedback #135 (repo `mysteropodes/strokemotion-feedback`): *"si je dessine dans le layer dont la position a été changé dans motion alors le dessin ou la forme se recale alors que celui-ci devrait être à sa même place où il a été dessiné peu importe la transformation du layer. ceux qui sont déjà dedans reste avec la transformation"* — drawing into a layer whose Position/Rotation/Scale was keyed in Motion snapped the freshly-drawn shape away from where it was actually drawn, while existing content on the same layer correctly stayed in place.

**Root cause was narrower than the original hypothesis.** The task initially suspected `tools.js`'s `onMouseDown`/`onMouseDrag`/`onMouseUp` (Paper.js-native tool handlers). Investigation showed these are dead-code fallbacks only reachable when the Rust engine is *disabled* — and in that state Paper's own canvas renders the raw, untransformed document directly (Motion is applied exclusively inside `buildSceneJson`, confirmed via grep: no Paper-native equivalent exists anywhere). So `event.point` there already matches what's on screen; mapping it would have introduced a *new* bug in that fallback state. `tools.js` was left untouched.

The real, live code path — `draw-bridge.js`, `shape-bridge.js`, `pen-bridge.js` — intercepts pointer events via capture-phase listeners whenever the Rust engine is enabled (the default, "almost always" per every bridge file's own header comment) and had **zero** Motion-transform mapping of its own. A layer's Motion Position/Rotation/Scale is, by design, applied only at render time (`buildSceneJson`'s `pathTransform`) and never baked into the Paper.js document — every other interaction file in this codebase already accounts for this (`subselect-bridge.js`/`rig-bridge.js`'s own `toLocalPoint`, `select-bridge.js`'s hit-testing, `timeline.js`'s `openInPlaceTextEditor` fix for #131/#305) — these three files were the gap.

## Fix

Added the same established `toLocalPoint`/`layerMotionPointMap(...).inv()` pattern (with `layerMotion3DPointMap` fallback for 3D-toggled layers) to each bridge, applied right before real Paper.js geometry is committed:

- **`draw-bridge.js`** — `commitStroke()` maps the whole `samples` array once, before `angledSamples`/centerline-building. Covers Draw, vector brush, and Fill Brush (all funnel through here). The live drag preview (`overlayItem`/`renderWithOverlayItem`) is deliberately left in world space so the stroke tracks the cursor correctly while drawing.
- **`shape-bridge.js`** — `commitShape()` maps the two drag corners before building geometry (Line/Rect/Ellipse/Star/Speech Bubble). The `<2px` drag-discard threshold stays against the *original* world-space points (a screen-space gesture check, not geometry).
- **`pen-bridge.js`** — `onDown`/`onMove` map every anchor placement and proximity/tangent check against `_pen.path`'s existing (local-space) segments — this tool mutates a real `Path` continuously across a multi-click gesture rather than deferring to one commit at the end. `setPenPreview`'s rubber-band line is deliberately fed the unmapped world point.

A no-op (identity passthrough) whenever the active layer has no effective Motion transform — verified live.

## Test plan

All verification done live in a fresh browser preview (`python3 -m http.server` on an unused port, per CLAUDE.md §4), with a Layer 1 given `Position X = -400` in Motion mode (a large, unambiguous offset).

- **Rectangle tool**: dragged a rectangle from screen (150,360) to (250,420). It rendered exactly at the drag position (no jump on mouseup). Verified via console: raw stored bounds differ from the forward-Motion-mapped (rendered) bounds by exactly `+400` in X, and the rendered bounds convert back to the exact screen drag coordinates through the view's zoom/pan.
- **Draw/Brush tool**: dragged a stroke from (300,380) to (360,440). Same verification — raw storage offset by exactly `+400`, rendered position matches the drag exactly.
- **Pen tool**: placed 3 anchors by click (150,460)/(200,480)/(250,460), double-click to finalize. All three anchors' forward-mapped (rendered) positions convert back to the exact click coordinates; raw storage offset by `+400` as expected.
- **Zero-regression check**: created a second layer (`Layer 2`, no Motion transform) and drew a stroke on it. Verified via console: `SMMotion.layerMotionPointMap(1) === null` for that layer, so `toLocalPoint` returns points unchanged (identity) — the fix has no effect at all on a plain layer.
- **Select tool / Motion gizmo**: on the Motion-transformed layer, in Motion mode (where `select-bridge.js`'s own Motion-hit-test compensation is scoped — confirmed this scoping is pre-existing and unrelated to this change), clicking the visibly-offset rectangle selected it correctly and the position gizmo rendered exactly on the shape's rendered position.
- **Subselect / Eraser**: not touched by this diff (zero overlap — `git diff --stat` shows only `draw-bridge.js`, `shape-bridge.js`, `pen-bridge.js` changed). Read `subselect-bridge.js` and confirmed its own `toLocalPoint` Motion-mapping is entirely self-contained and unconditional (not gated to Motion mode, unlike `select-bridge.js`), so it's unaffected either way. `eraser-bridge.js` has no `SMMotion` usage at all currently (a separate, pre-existing gap out of scope for this fix — not introduced or worsened here). Live click-driven testing of Eraser was cut short by the shared preview browser being actively used by other concurrent sessions in this environment (tabs kept getting re-navigated out from under this session); the zero-code-overlap argument stands regardless.
- `node --check` passes on all three modified files, both before and after rebasing onto latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)