### PR TITLE
Fix layer in-point handle unreachable near frame 0 + grid grip swallowed entirely (feedback #137)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -8535,7 +8535,28 @@
       // dispatchEvent trace: stopPropagation/preventDefault both firing from
       // THIS function on every attempt, zero trace of the rect's own
       // listener ever running.
-      if (e.target.closest('.fc.motion-fc, .layer-inout-handle, .layer-inout-key, .layer-inout-bar, .motion-key-connect, #frame-hdr, #playhead-flag, #bars-row, #motion-graph-resize')) return;
+      //
+      // .layer-reorder-grip (feedback #137, found live while investigating
+      // "difficile d'attraper le in point... interfère avec le déplacement
+      // de layer en index"): the grip (timeline.js, installLayerReorderGrip)
+      // was added 2026-08-24 with its OWN mousedown/pointerdown listener but
+      // was never added to THIS exemption list — same missing-exemption bug
+      // as every entry above, just in a different file, so it was easy to
+      // miss. The practical effect was worse than "hard to grab": since this
+      // CAPTURE-phase listener always runs first and this class wasn't
+      // exempted, EVERY mousedown on the grip was swallowed into a marquee-
+      // select before the grip's own handler ever ran — verified live via
+      // dispatchEvent trace (grip's own listener never fired, not even
+      // once) and by dragging the grip a full 65px vertically, which is
+      // normally more than enough to reorder, and nothing moved. So
+      // dragging the grip to reorder a layer directly in the frame-grid
+      // didn't actually work AT ALL, frame 0 or not — only the layer-list
+      // panel's own row-drag (a separate, unaffected code path) did. The
+      // SAME-DAY fix for the frame-0 handle-vs-grip overlap (dd7a202) was
+      // therefore built and shipped on top of a handler that could never
+      // run in the first place. Exempting the grip here is what actually
+      // makes both that fix and normal grid-side reordering reachable.
+      if (e.target.closest('.fc.motion-fc, .layer-inout-handle, .layer-inout-key, .layer-inout-bar, .motion-key-connect, .layer-reorder-grip, #frame-hdr, #playhead-flag, #bars-row, #motion-graph-resize')) return;
       // Scrollbar clicks land on the wrap itself but outside its client
       // area — intercepting them would break scrollbar dragging.
       var r = wrap.getBoundingClientRect();

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -5602,17 +5602,38 @@ function installLayerReorderGrip(row,li){
     // physically under this grip: every native click there resolves to
     // the grip first, making the handle unclickable (feedback 2026-08:
     // "quand les calques sont calé au tout début c'est compliqué
-    // d'attraper le in point"). Hit-test for a handle FIRST — same ±6px
-    // tolerance as the handle's own CSS ::before hitbox — and hand off to
-    // its real onDown instead of reordering when the click is really on
-    // one; native reordering is unaffected everywhere else, including the
+    // d'attraper le in point"). Hit-test for a handle FIRST and hand off
+    // to its real onDown instead of reordering when one is really there;
+    // native reordering is unaffected everywhere else, including the
     // long-bar-scrolled-under-the-grip case this grip exists for (a
     // handle is never physically there in that case).
+    //
+    // feedback #137 ("des difficultés à attraper le in point... et va
+    // interférer avec le déplacement de layer en index"): the original
+    // version of this hand-off distance-tested the CLICK POINT against
+    // each handle's rect with a fixed ±6px tolerance — reachable in
+    // theory, but fragile in practice. A click that misses that radius by
+    // a hair (real mouse/trackpad imprecision, HiDPI rounding) falls
+    // through to armLayerReorder below; armLayerReorder itself stays
+    // inert for a purely-horizontal drag (moveLayerReorder requires
+    // dy>=4 AND dy>=dx*.55 before it actually reorders anything), but a
+    // real hand's natural vertical wobble while dragging "horizontally"
+    // is often enough to cross that threshold — turning a missed trim
+    // grab into a genuinely unwanted reorder, exactly the interference
+    // reported. Testing rect OVERLAP instead of click-point distance
+    // removes the magic-number fragility: whenever a handle is visually
+    // co-located with the grip at all (the only time this ambiguity can
+    // exist in the first place), every click anywhere on the grip
+    // unconditionally favors that handle — there is no legitimate "I
+    // meant reorder" click in that overlapping region anyway, and the
+    // layer-list panel's own row-drag (a separate, non-overlapping
+    // affordance) still reorders layers normally in the meantime.
     if(window.SMLayerInOut&&window.SMLayerInOut.onDown){
+      var gripRect=grip.getBoundingClientRect();
       var handles=row.querySelectorAll('.layer-inout-handle');
       for(var hi=0;hi<handles.length;hi++){
         var h=handles[hi],r=h.getBoundingClientRect();
-        if(e.clientX>=r.left-6&&e.clientX<=r.right+6&&e.clientY>=r.top-6&&e.clientY<=r.bottom+6){
+        if(r.left<=gripRect.right&&r.right>=gripRect.left&&r.top<=gripRect.bottom&&r.bottom>=gripRect.top){
           e.preventDefault();e.stopPropagation();
           window.SMLayerInOut.onDown(li,row,h.classList.contains('left')?'in':'out',e,h);
           return;


### PR DESCRIPTION
## Summary
- Root cause was deeper than the reported "hard to grab the in-point near frame 0": `.layer-reorder-grip` (timeline.js, added 2026-08-24) was never added to motion.js's capture-phase marquee-starter exemption list on `#fg-wrap`. That capture-phase listener always runs before any of the grip's own bubble-phase listeners, so **every** mousedown on the grip was being swallowed into a marquee-select before the grip's own handler (or the same-day fix in `dd7a202` for the frame-0 handle-vs-grip overlap) ever got a chance to run.
- Verified live: a `dispatchEvent` trace showed the grip's own handler was called **zero** times, and dragging the grip 65px vertically (a large, unambiguous reorder gesture) did nothing. So reordering a layer by dragging the frame-grid's own grip didn't work **at all**, frame 0 or not — only the separate layer-list panel's row-drag did.
- Fixed by adding `.layer-reorder-grip` to the exemption list, so the grip's own click handler is reachable again.
- With that handler reachable, also hardened the existing frame-0 disambiguation (`dd7a202`) in `installLayerReorderGrip` (timeline.js): it previously distance-tested the click point against each handle's rect with a fixed ±6px tolerance — geometrically sufficient for the exact case measured, but fragile by construction (HiDPI/sub-pixel rounding could tip a boundary-exact case). Replaced with a rect-overlap test between the handle and the grip itself: whenever a handle is visually co-located with the grip at all (the only time this ambiguity can exist), every click on the grip unconditionally favors the handle.

## Test plan
- [x] `node --check` on `src/js/motion.js` and `src/js/timeline.js`
- [x] Live in a browser preview, via faithful `dispatchEvent` sequences (mousedown + incremental mousemoves + mouseup) matched against live `getBoundingClientRect()` geometry:
  - [x] Confirmed the pre-fix bug: grip's own listener never fires (0 calls traced), and a 65px vertical drag on the grip does not reorder layers
  - [x] Post-fix: a layer whose in-point sits at frame 0 — dragging its grip horizontally trims the in-point (0 → 3/4), layer order stays untouched
  - [x] Post-fix: a layer whose in-point is far from frame 0 (40) — dragging its grip vertically reorders it normally (moved past a neighboring layer)
  - [x] Post-fix, 3-layer scenario matching the reporter's screenshot (all three layers at frame 0, middle one selected): trimming the middle layer's in-point works and leaves the other two layers' in-points and the array order untouched
- [x] Re-verified after rebasing onto latest `main` (5 unrelated commits landed meanwhile) — fix survived the rebase intact