### PR TITLE
Show text-animator glyphs as individually keyframe-editable Motion elements

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -5833,7 +5833,22 @@
     var flat = layerElements(li, ld);
     var out = [], emittedGroups = {};
     flat.forEach(function (entry) {
-      var gid = entry.sd.groupId;
+      // Feedback #143 ("toujours pas de keyframes de properties par rapport
+      // au animation de texte dans la timeline motion"): vector-text glyphs
+      // (vector-text-bridge.js) share their run's data.groupId — the SAME
+      // field a normal Cmd+G/Combine group uses to opaquely collapse its
+      // members into one summary row below. That collapse is right for an
+      // ordinary group (you usually want to animate the whole thing
+      // together), but wrong for text: text-animator.js's whole point is a
+      // per-letter/word/line STAGGER, each unit with its OWN keyframes, and
+      // collapsing them left nothing to see or edit here even though the
+      // keys are real and the animation renders correctly. Raster-split
+      // characters never had this problem — splitTextIntoCharacters tags
+      // them with data.textGroupId, a DIFFERENT field this collapse never
+      // checked, so they already listed individually. Vector text now gets
+      // the same treatment: skip the group-collapse, list each glyph as its
+      // own expandable element row, exactly like every other ungrouped shape.
+      var gid = entry.sd.isVectorText ? null : entry.sd.groupId;
       if (gid) {
         if (!emittedGroups[gid]) {
           emittedGroups[gid] = true;


### PR DESCRIPTION
## Summary
- Fixes [#143](https://github.com/mysteropodes/nemo/issues/593), a genuine follow-up gap on top of mysteropodes/nemo#582 (not a duplicate/stale-cache report — verified live before writing any code).
- Vector-text glyphs share their run's `data.groupId`, the same field an ordinary Cmd+G/Combine group uses to opaquely collapse its members into one "Group" summary row in Motion's Elements tree. Right for a normal group, wrong for text — text-animator's whole point is a per-unit stagger with individual keyframes, and the collapse left the real, correctly-rendering keys with nowhere to be seen or edited. Raster-split characters never had this problem (different field, `data.textGroupId`, never caught by this collapse).
- `buildShapeTree` (motion.js) now skips the group-collapse specifically for `data.isVectorText` entries — same individual-row treatment raster-split text already gets.

## Test plan
- [x] Live in-browser: built a 3-glyph vector-text run, applied a text-animator fadeIn preset, switched to Motion — Elements tree now shows 3 individually-expandable "Shape N" rows instead of one inert "Group" row; expanding one reveals real Opacity keyframe diamonds on the timeline (2 keys, matching the preset's start/end frames), not just an empty property row.
- [x] Regression check: an unrelated plain Cmd+G group (2 ordinary rectangles) still correctly collapses into one opaque "Group" row — the fix is scoped to vector text only.
- [x] `node --check src/js/motion.js`, no console errors during the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)