### PR TITLE
Fix eraser ignoring the active layer's Motion transform (feedback #135)

### DIFF
--- a/src/js/eraser-bridge.js
+++ b/src/js/eraser-bridge.js
@@ -25,6 +25,37 @@
   // the circle you're about to erase with" affordance either way.
   var sizing = false, sizeStartX = 0, sizeStartVal = 0, sizeAnchorW = null;
 
+  // Motion transform (2026-08-29, same bug/fix as draw-bridge.js/shape-
+  // bridge.js/pen-bridge.js's toLocalPoint — feedback #135, "si je dessine
+  // dans le layer dont la position a été changé dans motion... le dessin se
+  // recale"). eraseAt()'s hitTest and eraseAtPoint() both operate on the
+  // layer's real Paper.js children, which — same as every other bridge in
+  // this codebase — live in RAW/local document space; Motion Position/
+  // Rotation/Scale is applied only at render time (buildSceneJson) and is
+  // never baked into the document. This file's onDown/onMove built their
+  // erase point straight from screenToWorld (RENDERED/world space) with no
+  // mapping at all, so on a Motion-transformed layer the eraser's hitTest
+  // missed the content entirely wherever the click didn't coincidentally
+  // land on the untransformed geometry — reproduced live: dragging directly
+  // across a visibly-rendered shape erased nothing, while the layer's raw
+  // Path bounds (confirmed via inspection) sat well away from the click.
+  // Closest analog is pen-bridge.js, not draw-bridge/shape-bridge: like the
+  // Pen tool, the eraser mutates real Paper.js geometry continuously across
+  // the whole drag (eraseAtPoint runs per pointermove, not once at
+  // pointerup), so every sample needs mapping, not just one commit. The
+  // hover cursor circle (setEraserCursor) is deliberately fed the
+  // UNMAPPED/raw world point — same as pen-bridge's setPenPreview — since
+  // it's a live overlay that must track the cursor at its true on-screen
+  // position.
+  function toLocalPoint(pt, layerIdx) {
+    if (!window.SMMotion) return pt;
+    var map = SMMotion.layerMotionPointMap ? SMMotion.layerMotionPointMap(layerIdx) : null;
+    if (!map && SMMotion.layerMotion3DPointMap) map = SMMotion.layerMotion3DPointMap(layerIdx);
+    if (!map) return pt;
+    var lp = map.inv(pt.x, pt.y);
+    return new Point(lp[0], lp[1]);
+  }
+
   // Stabilizer (2026-08-27, feedback #74 — "il faudrait que la gomme
   // puisse se regler comme le pinceau, et se comporter comme le pinceau,
   // comme dans animate"): #tool-opts-sec (Stabilizer/Smooth) was ALREADY
@@ -179,7 +210,11 @@
     // stroke/stop. The guide now tracks the raw, unsmoothed point — only
     // the erase hit-test itself stays stabilized.
     window.SMEngineBridge.setEraserCursor(rawW, radius);
-    eraseAt(new Point(w[0], w[1]), radius);
+    // Motion transform fix (feedback #135, see toLocalPoint's header comment
+    // above) — layer.hitTest/eraseAtPoint below compare against the layer's
+    // raw document geometry, so the (stabilized) world point must be mapped
+    // into that same local space first.
+    eraseAt(toLocalPoint(new Point(w[0], w[1]), state.activeLayerIdx), radius);
     window.SMEngineBridge.renderNow();
   }
   function onMove(e) {
@@ -202,7 +237,9 @@
     var w = stabilizeErasePoint(rawW);
     var radius = eraseRadiusFor(e);
     window.SMEngineBridge.setEraserCursor(rawW, radius); // raw point — see onDown's comment on this
-    if (pointerIsDown) eraseAt(new Point(w[0], w[1]), radius);
+    // Motion transform fix (feedback #135, see toLocalPoint's header comment
+    // in onDown) — same mapping, every erase sample during the drag.
+    if (pointerIsDown) eraseAt(toLocalPoint(new Point(w[0], w[1]), state.activeLayerIdx), radius);
     window.SMEngineBridge.renderNow();
   }
   function onUp(e) {


### PR DESCRIPTION
## Summary
- Same bug as `draw-bridge.js`/`shape-bridge.js`/`pen-bridge.js`, fixed for those three tools in #308 (feedback #135) — a background agent working on #308 flagged via grep that `eraser-bridge.js` had zero `SMMotion` usage, out of scope for that PR. This finishes the sweep.
- `eraseAt()`'s `hitTest`/`eraseAtPoint()` compare against the layer's raw Paper.js document geometry, which lives in untransformed local space (Motion is applied only at render time, in `buildSceneJson`). `eraser-bridge.js`'s `onDown`/`onMove` built the erase point straight from `screenToWorld` (rendered/world space) with no Motion-mapping at all.
- Reproduced live: on a layer with a Motion Position key, dragging the eraser directly across the visibly-rendered shape did nothing at all (small shape — the wrong point missed the raw geometry's bounds entirely). Logging the exact point handed to `layer.hitTest` on a wider shape confirmed the mechanism precisely: unfixed code hit-tested at `(1290.35, 548.47)` (the raw rendered click position, 200 units off — an exact hit missed, only the fat fallback tolerance caught it), while the fix hit-tests at `(1090.35, 548.47)`, exactly the layer's true local center, exact-hit succeeding immediately.
- Fixed the same way as #308: map the point through `SMMotion.layerMotionPointMap(...).inv()` (falling back to `layerMotion3DPointMap` for 3D layers) before every `eraseAt()` call. Closest analog is `pen-bridge.js` rather than `draw-bridge`/`shape-bridge`: the eraser mutates real Paper.js geometry continuously across the whole drag (`eraseAtPoint` runs per pointermove, not once at pointerup), so every sample needs mapping. The hover cursor circle (`setEraserCursor`) stays fed the unmapped/raw world point, matching the other bridges' live-overlay convention.

## Test plan
- [x] `npm test` — 26/27 pass; the 1 pre-existing failure (`motion drag timeline rebuilds are coalesced and flushed on release`) reproduces identically on unmodified `origin/main`, unrelated to this change (confirmed via `git stash`).
- [x] Live repro in browser preview (`python3 -m http.server` from `src/`): drew a shape, added a Motion Position keyframe, confirmed the eraser missed/mislocated erases before the fix and lands precisely at the click position after, via dispatched real `PointerEvent`s + `layer.hitTest` instrumentation (see commit message for exact before/after coordinates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)