### PR TITLE
Style Text Animator dropdowns to match the app's dark theme

### DIFF
--- a/src/js/text-animator.js
+++ b/src/js/text-animator.js
@@ -341,7 +341,12 @@
     title.style.cssText='font-weight:600;margin-bottom:10px';
     p.appendChild(title);
 
-    var unitSel=document.createElement('select');
+    // Feedback #142 ("y a pas d'autre dropdown en fond blanc"): these 3
+    // <select>s were built with zero styling, so the browser's own default
+    // (white background, system font) rendered instead of matching the
+    // app's dark chrome — every other dropdown in Nemo uses .psel
+    // (style.css) for exactly this reason.
+    var unitSel=document.createElement('select'); unitSel.className='psel';
     ['char','word','line'].forEach(function(v){
       var o=document.createElement('option'); o.value=v;
       o.textContent=v==='char'?SM.t('textAnimUnitChar'):v==='word'?SM.t('textAnimUnitWord'):SM.t('textAnimUnitLine');
@@ -350,7 +355,7 @@
     unitSel.value=_lastSettings.mode;
     var rUnit=row(SM.t('textAnimUnitLabel')); rUnit.appendChild(unitSel); p.appendChild(rUnit);
 
-    var presetSel=document.createElement('select');
+    var presetSel=document.createElement('select'); presetSel.className='psel';
     var grpIn=document.createElement('optgroup'); grpIn.label=SM.t('textAnimGroupIn');
     var grpOut=document.createElement('optgroup'); grpOut.label=SM.t('textAnimGroupOut');
     presetSel.appendChild(grpIn); presetSel.appendChild(grpOut);
@@ -361,7 +366,7 @@
     presetSel.value=_lastSettings.preset;
     var rPreset=row(SM.t('textAnimStyleLabel')); rPreset.appendChild(presetSel); p.appendChild(rPreset);
 
-    var easeSel=document.createElement('select');
+    var easeSel=document.createElement('select'); easeSel.className='psel';
     Object.keys(EASING_CURVES).forEach(function(k){
       var o=document.createElement('option'); o.value=k; o.textContent=SM.t(EASING_I18N_KEY[k])||EASING_LABELS[k];
       easeSel.appendChild(o);


### PR DESCRIPTION
## Summary
Part of [#142](https://github.com/mysteropodes/nemo/issues/592) — the Unit/Style/Easing `<select>` elements in the "Animer le texte…" panel had zero CSS applied, so the browser's own default (white background) rendered instead of matching every other dropdown in the app, all of which already use the `.psel` class. Added it to all 3.

The docking half of mysteropodes/nemo#592 (the panel should live inline in the right-side Text panel instead of floating) is a larger change, tracked separately — see my next comment on the issue.

## Test plan
- [x] Live in-browser: built vector text, opened the panel — all 3 dropdowns now render dark with the app's custom arrow icon, matching every other select in the UI.
- [x] `node --check src/js/text-animator.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)