### PR TITLE
Figma import: live Google Fonts for text, not just 4 bundled TTFs

### DIFF
--- a/src/js/figma-import.js
+++ b/src/js/figma-import.js
@@ -167,17 +167,40 @@
   }
 
   var ALIGN_MAP = { LEFT: 'left', CENTER: 'center', RIGHT: 'right', JUSTIFIED: 'left' };
-  // Best-effort match against the bundled/live-fetchable vector fonts —
-  // NOT a live Google Fonts lookup (that needs a Tauri command on desktop,
-  // untestable here — see file header). An unmatched family falls back to
-  // Roboto rather than failing the whole node.
-  function resolveFontKey(figmaFamily) {
-    var fam = (figmaFamily || '').toLowerCase();
+  // Font matching, in order (2026-08-29, v2 follow-up — Cyril's stated top
+  // priority once the token/import loop itself was working): an exact match
+  // against a bundled family needs no network; otherwise fetch the family
+  // live from Google Fonts via SMVectorText.addGoogleFont (vector-text-
+  // bridge.js) — the SAME catalog lookup the Typography panel's "+" field
+  // already uses, so a Figma text node keeps its actual family (Poppins,
+  // Manrope, Space Grotesk, ...) instead of silently landing on Roboto just
+  // because it wasn't one of the 4 bundled TTFs. Works on both desktop
+  // (Tauri's fetch_google_font) and the web build (worker/index.js's
+  // /api/google-font proxy) — addGoogleFont itself picks the right path.
+  // A family Google Fonts doesn't have (typo, or a paid/self-hosted font
+  // Figma reports by its real name) degrades to the old loose bundled-name
+  // match, then Roboto — reported in `report.skipped`, never a hard failure
+  // for the whole import.
+  async function resolveFontKey(figmaFamily, report) {
+    var fam = (figmaFamily || '').trim();
+    if (!fam) return 'Roboto-Regular';
+    var famLc = fam.toLowerCase();
     var VF = window.SMVectorText ? window.SMVectorText.VECTOR_FONTS : {};
     var keys = Object.keys(VF);
     for (var i = 0; i < keys.length; i++) {
-      var label = (VF[keys[i]].label || '').toLowerCase();
-      if (label.indexOf(fam) === 0 || fam.indexOf(label) === 0) return keys[i].replace(/-Bold$/, '-Regular');
+      var label = (VF[keys[i]].label || '').toLowerCase().replace(/ bold$/, '');
+      if (label === famLc) return keys[i].replace(/-Bold$/, '-Regular');
+    }
+    if (window.SMVectorText && window.SMVectorText.addGoogleFont) {
+      try {
+        return await window.SMVectorText.addGoogleFont(fam);
+      } catch (e) {
+        if (report) report.skipped.push('Police "' + fam + '" introuvable sur Google Fonts — police de repli utilisée');
+      }
+    }
+    for (var j = 0; j < keys.length; j++) {
+      var label2 = (VF[keys[j]].label || '').toLowerCase();
+      if (label2.indexOf(famLc) === 0 || famLc.indexOf(label2) === 0) return keys[j].replace(/-Bold$/, '-Regular');
     }
     return 'Roboto-Regular';
   }
@@ -301,7 +324,7 @@
       for (var ti = 0; ti < out.texts.length; ti++) {
         var t = out.texts[ti];
         if (!t.text) continue;
-        var fontKey = resolveFontKey(t.style.fontFamily);
+        var fontKey = await resolveFontKey(t.style.fontFamily, report);
         var size = t.style.fontSize || 24;
         var align = ALIGN_MAP[t.style.textAlignHorizontal] || 'left';
         try {

--- a/src/js/vector-text-bridge.js
+++ b/src/js/vector-text-bridge.js
@@ -346,10 +346,12 @@ function vectorTextGroupMembers(root) {
 // UA trick sidesteps needing that API/key entirely, just a way to send an
 // unusual header, which the Tauri command provides.
 //
-// Desktop-only for now — the web build (nemo-web-public-beta) has no Rust
-// backend at runtime to send that header from, and would need its own
-// small Cloudflare Worker doing the same UA-spoofed relay (mirrors
-// worker-feedback/'s own trust-boundary role) — not yet built.
+// Works on both builds: desktop sends the spoofed UA itself via Tauri
+// (fetch_google_font, reqwest); the web build (nemo-editor) has no Rust
+// backend to do that from, so it instead proxies through a small Cloudflare
+// Worker route doing the same UA-spoofed relay (worker/index.js's
+// /api/google-font, added 2026-08-28 — mirrors worker-feedback/'s own
+// trust-boundary role).
 function tauriOk() { return typeof window.__TAURI__ !== 'undefined'; }
 function base64ToArrayBuffer(b64) {
   var bin = atob(b64);


### PR DESCRIPTION
## Summary
- The Figma importer's text-font resolution now falls through to a live Google Fonts lookup (`SMVectorText.addGoogleFont`, same catalog the Typography panel's "+" field uses) before giving up and defaulting to Roboto — a Figma frame using Poppins/Space Grotesk/etc. now keeps its actual family instead of silently landing on Roboto.
- Works on both desktop (Tauri `fetch_google_font`) and the web build (`worker/index.js`'s `/api/google-font` proxy) — confirmed live via curl against the deployed `nemomotion.org` worker, which returns a real Poppins TTF.
- A family Google Fonts doesn't have degrades gracefully (loose bundled match, then Roboto), recorded in the import report's `skipped` list — never a hard failure for the whole import.
- Fixed a stale comment in `vector-text-bridge.js` claiming the web build has no Google Fonts proxy (it was added same-day in a later commit that didn't circle back to this file's header).

This is Cyril's stated v2 priority for the Figma importer.

## Test plan
- [x] `node --check` on both touched files
- [x] Live in-browser fixture test: real network call with no local `/api/google-font` route falls back gracefully — text still imports (Roboto), skip reason recorded, zero unhandled errors
- [x] Live in-browser fixture test (mocked `addGoogleFont` success): text imports with the live-resolved key on `data.vectorFont` (`Google:<family>-Regular`), confirming the full `resolveFontKey` → `buildVectorTextGroup` contract
- [x] `curl` against the deployed worker's `/api/google-font` route confirms it serves real font bytes for an arbitrary family (Poppins)
- [x] Zero console errors beyond the expected/intentional 404 from the fallback-path test

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>