### PR TITLE
Motion: default column preset to 3D/Mograph

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -313,11 +313,16 @@
   // untouched, while the column/filter preferences follow the workstation.
   var _motionSearch = '';
   var _motionFilterMode = 'all';
-  var _motionColumnPreset = 'animation';
+  // Default column preset (2026-08-29, Cyril: "3D/mograph par default") — the
+  // 3D Layer/Duplicator toggle icons only show under this preset (see
+  // style.css's `[data-motion-columns]` rules); 'animation' (the prior
+  // default) hid them, which read as "these icons disappeared" until you
+  // knew to open the column picker and switch presets.
+  var _motionColumnPreset = '3d';
   var _motionSnapEnabled = true;
   try {
     _motionFilterMode = localStorage.getItem('nemo-motion-filter') || 'all';
-    _motionColumnPreset = localStorage.getItem('nemo-motion-columns') || 'animation';
+    _motionColumnPreset = localStorage.getItem('nemo-motion-columns') || '3d';
     _motionSnapEnabled = localStorage.getItem('nemo-motion-snap') !== '0';
   } catch (e) {}
   function propHasContent(holder, prop) { return isAnimated(holder, prop) || !!(holder.motionStatic && holder.motionStatic[prop]); }


### PR DESCRIPTION
## Summary
- The 3D Layer and Duplicator toggle icons on Motion layer rows only show under the "3D / Mograph" column preset — the other three presets (Compact/Animation/Compositing) hide them by design (pre-existing feature, `c1699af`). "Animation" was the default a fresh session started on, so these icons read as "missing" until you knew to open the column picker.
- Default preset moves to `3d`. The picker itself is untouched — a saved preference still wins.

## Test plan
- [x] `node --check src/js/motion.js`
- [x] Live, fresh origin (empty localStorage): `data-motion-columns` starts on `"3d"`, both icons render `display:flex` on a plain layer row
- [x] Zero console errors

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>