### PR TITLE
Fix Animation 2D layer multi-select silently collapsing (feedback #147)

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -5653,7 +5653,24 @@ function renderLayerList(frameOnly){
         _layerSel=[];
         for(var l=Math.min(anchor,idx);l<=Math.max(anchor,idx);l++)_layerSel.push(l);
       }else{_layerSel=[idx];_layerSelAnchor=idx;}
-      window.SM.setActiveLayer(idx);
+      // preserveLayerSel (2026-08-29 fix, feedback #147: "impossible de
+      // faire du multi select de calque dans animation 2D"). The three
+      // branches above already build a correct multi-item _layerSel — but
+      // setActiveLayer's OWN default behavior (added by 16f606b, "Fix
+      // Motion row highlight not syncing for non-row-click selections",
+      // for Motion's identical Cmd/Shift row handler in motion.js) is to
+      // immediately collapse _layerSel back down to [idx] unless told not
+      // to, since every OTHER caller (canvas hit, camera/media-library/
+      // nemo-script/shapes-panel) wants exactly that single-row reset.
+      // 16f606b updated motion.js's own Cmd/Shift branches to pass `true`
+      // (see setLayerParent... setActiveLayer(li,true) there) but never
+      // touched this Animation 2D handler — so a Cmd- or Shift-click here
+      // built the right _layerSel for one tick and then immediately wiped
+      // it via this same trailing call, silently down to a single row.
+      // Confirmed live: a Cmd-click on a second row ended with
+      // _layerSel===[thatRow] instead of both. Only the plain-click branch
+      // (no modifier) actually WANTS the collapse-to-one-row default.
+      window.SM.setActiveLayer(idx,e.metaKey||e.ctrlKey||e.shiftKey);
     });
     row.addEventListener('dblclick',function(){var idx3=parseInt(this.dataset.layer);var l2=state.layers[idx3];if(l2.symbolId){window.SM.enterSymbol(l2.symbolId);return;}if(l2.lfsGroup){window.SM.enterSymbol(l2.lfsIds.full);return;}startLayerRename(idx3);});
     function beginLayerReorder(e){


### PR DESCRIPTION
## Summary
- Animation 2D's layer-row click handler (`renderLayerList`, `src/js/timeline.js`) already had complete Cmd/Ctrl-toggle and Shift-range logic for `_layerSel` — the actual bug was one line down: its trailing `window.SM.setActiveLayer(idx)` call was missing the `preserveLayerSel` flag, so it immediately collapsed the just-built multi-selection back down to a single row.
- Root cause traced via `git log -L` on `setActiveLayer`: commit `16f606b` ("Fix Motion row highlight not syncing for non-row-click selections") added the `preserveLayerSel` parameter and updated **Motion's own** Cmd/Shift row handler (`motion.js`) to pass `setActiveLayer(li, true)`, but never touched this Animation 2D call site — so Animation 2D has been silently broken for multi-select since that commit, even though the pre-existing `.lrow.sel` CSS was always there waiting to be used.
- Fix mirrors Motion's own pattern exactly: `window.SM.setActiveLayer(idx, e.metaKey||e.ctrlKey||e.shiftKey)`.
- `_layerSel`/`_layerSelAnchor` are kept as the existing shared globals (see commit message for the reasoning) rather than split into a separate Animation-2D-only array — they already were the same module-level state read/written by both modes.

Fixes mysteropodes/nemo#597.

## Test plan
- [x] `node --check src/js/timeline.js`
- [x] Live-verified in the browser with **real dispatched `click` DOM events** carrying `metaKey`/`shiftKey`/`ctrlKey` on the actual `.lrow` elements (not state manipulation):
  - Plain click narrows the selection to one row.
  - Shift-click ranges from a frozen anchor.
  - Cmd-click toggles rows in and back out of a multi-selection — including folder CHILD rows (`.lrow.in-folder`), matching the original report's own click trail.
  - Every selected row gets the pre-existing `.lrow.sel` visual (indigo background + inset ring) — no new CSS needed.
  - Selection survives a full `renderLayerList()` re-render (not wiped by re-render, same guarantee Motion's `_layerSel` already has).
  - Motion mode's own independent multi-select (untouched code path) still works — regression check.
  - `read_console_messages({onlyErrors:true})` — zero errors throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)