### PR TITLE
Curve editor: Cmd/Ctrl+click deletes a point, fix undo (feedback #152)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -1354,8 +1354,24 @@
   // itself (layer target) or `ld.elementMotion[strokeId]` (element target).
   // Null when there's no motion at all this frame (the overwhelmingly common
   // case) — callers skip the per-item transform pass entirely then.
+  //
+  // 2026-08-29 fix (feedback #150, "les expressions ont l'air d'agir juste
+  // sur la bounding box pas les objets"): the early-return only checked
+  // holder.motion/motionStatic — a layer that's NEVER been keyframed or
+  // given a static override (both genuinely undefined, the common state for
+  // a just-drawn layer) bailed out here even with an expression enabled on
+  // one of its properties, so the actual render never picked it up. The
+  // selection-box overlay (motionBoxGeom, above) has no such guard — it
+  // calls valueAtFrame unconditionally, which DOES evaluate expressions
+  // regardless of motion/motionStatic — so the box moved with the
+  // expression while the object itself stayed put. Now also proceeds when
+  // any of the 5 properties this function actually reads has an enabled
+  // expression (hasExpr), matching what the box already does.
   function computeMotionMat(holder, frameIdx) {
-    if (!holder || (!holder.motion && !holder.motionStatic)) return null;
+    var hasAnyExpr = holder && holder.expressions &&
+      (hasExpr(holder, 'position') || hasExpr(holder, 'anchor') || hasExpr(holder, 'rotation') ||
+       hasExpr(holder, 'scale') || hasExpr(holder, 'opacity'));
+    if (!holder || (!holder.motion && !holder.motionStatic && !hasAnyExpr)) return null;
     var pos = valueAtFrame(holder, 'position', frameIdx);
     var anc = valueAtFrame(holder, 'anchor', frameIdx);
     var rot = valueAtFrame(holder, 'rotation', frameIdx)[0];

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -414,6 +414,31 @@
       }
     }
     var hit=hitT(mx,my);
+    // Cmd/Ctrl+click on a point deletes it (2026-08-29, feedback #152:
+    // "impossible de supprimer un point de tangents... avec alt" — Alt was
+    // already spoken for at this same click site, one line below: it reveals
+    // the point's tangent handles, an existing feature, not available to
+    // repurpose for delete). Delete/Backspace-while-hovering-a-selected-point
+    // (see the keydown handler below) already did this, just wasn't
+    // discoverable — this is an additional, more standard-feeling gesture,
+    // not a replacement. Same endpoint guard, same pushUndo-before-mutate
+    // convention as every other gesture in this widget — and the SAME
+    // _scrubLiveActive bracket the drag gestures use: pushUndo/pushUndoLayers
+    // are literally the same function (see tweens.js), so without this,
+    // pushCurve()'s own generateTweens()→pushUndoLayers() call (tween mode)
+    // would push a SECOND, redundant entry right after mine, and Ctrl+Z
+    // would need pressing twice to undo one delete.
+    if(hit>=0&&(e.metaKey||e.ctrlKey)){
+      var delPts=activePoints();
+      if(hit!==0&&hit!==delPts.length-1){
+        if(window.pushUndo)window.pushUndo();
+        delPts.splice(hit,1);
+        selected=null;dragging=null;
+        draw();
+        window._scrubLiveActive=true;pushCurve();window._scrubLiveActive=false;
+      }
+      return;
+    }
     // 2026-07-30 fix: unlike the camera-handle and tangent-handle drags just
     // above (both already call pushUndo once per gesture), plain point-drag
     // had NEITHER a pre-gesture snapshot NOR the _scrubLiveActive guard —
@@ -499,7 +524,17 @@
       // to the derived (auto) Catmull-Rom — the escape hatch matching
       // the drag that set it (green handles turn orange again).
       var dpts=activePoints(),dp=dpts[dblHit];
-      if(typeof dp.tx==='number'){delete dp.tx;delete dp.ty;selected=dblHit;draw();pushCurve();}
+      if(typeof dp.tx==='number'){
+        // pushUndo added 2026-08-29 (feedback #152, "ctrl + z ne marche pas
+        // pour ça") — this and the add-point/delete-point gestures below
+        // were the only point-editing actions in this widget with no
+        // pre-mutate snapshot at all, unlike every drag gesture above.
+        // _scrubLiveActive bracket: see the Cmd/Ctrl-click delete handler's
+        // comment a few lines up for why it's needed here too.
+        if(window.pushUndo)window.pushUndo();
+        delete dp.tx;delete dp.ty;selected=dblHit;draw();
+        window._scrubLiveActive=true;pushCurve();window._scrubLiveActive=false;
+      }
       return;
     }
     var yr=yRange();
@@ -507,9 +542,11 @@
     var pts=activePoints();
     var idx=pts.length;
     for(var i=1;i<pts.length;i++){if(pts[i].x>nx){idx=i;break;}}
+    if(window.pushUndo)window.pushUndo(); // see comment above
     pts.splice(idx,0,{x:nx,y:ny});
     selected=idx;
-    draw();pushCurve();
+    draw();
+    window._scrubLiveActive=true;pushCurve();window._scrubLiveActive=false;
   });
   cvs.addEventListener('mouseenter',function(){hovering=true;});
   cvs.addEventListener('mouseleave',function(){hovering=false;});
@@ -519,9 +556,11 @@
     var pts=activePoints();
     if(selected===0||selected===pts.length-1)return; // endpoints are permanent
     e.preventDefault();
+    if(window.pushUndo)window.pushUndo(); // feedback #152, see dblclick handler's comment above
     pts.splice(selected,1);
     selected=null;
-    draw();pushCurve();
+    draw();
+    window._scrubLiveActive=true;pushCurve();window._scrubLiveActive=false;
   });
 
   function isMatch(p){


### PR DESCRIPTION
## Summary
- Alt+click doesn't delete a curve point — Alt is already used at the same click site to reveal tangent handles (existing feature). Added Cmd/Ctrl+click as an additional delete gesture (endpoints still protected). The existing Delete/Backspace-while-selected path stays as-is, just wasn't discoverable.
- None of the point-editing gestures (add, delete, tangent-reset) called \`pushUndo\` — every drag gesture in this widget already does. Fixed, with the same \`_scrubLiveActive\` bracket the drags use (needed because \`pushUndo\`/\`pushUndoLayers\` are the same function, and \`pushCurve()\`'s own internal call would otherwise double-push).

## Test plan
- [x] \`node --check\`
- [x] Live, real dispatched DOM events (not console shortcuts): add via double-click (5→6 points), Cmd/Ctrl+click delete (6→5, exactly one new undo entry), single \`undo()\` restores all 6
- [x] Delete-key path re-verified identically on a fresh reload (11→10 delete, one undo entry, single undo restores to 11)
- [x] Zero console errors

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>