### PR TITLE
Fix keyframe connector bar frozen during in/out drag (feedback #149)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -7947,12 +7947,32 @@
         if (!track || !track.keys.length) return;
         rects.forEach(function (r) {
           var sel;
-          if (r.getAttribute('class') === 'motion-key-connect') {
-            var i = +r.getAttribute('data-i');
-            sel = track.keys[i] && track.keys[i + 1] && isKeySelected(rowEl._smHolder, rowEl._smProp, track.keys[i]) && isKeySelected(rowEl._smHolder, rowEl._smProp, track.keys[i + 1]);
-          } else {
+          // classList.contains, NOT getAttribute('class')===… (2026-08-29
+          // fix, feedback #149: "si je select une keyframe plus un in/out
+          // point... la barre verte de suit pas pendant le drag"). A
+          // connector whose BOTH endpoints are already selected renders
+          // with class "motion-key-connect sel" (see its own build-time
+          // `.sel` suffix a few hundred lines up) — the strict `===` check
+          // here only ever matched the UNselected/single-line-class case,
+          // so a fully-selected connector (the exact state a click on the
+          // connector itself, or a marquee over both diamonds, produces)
+          // fell into the durblock `else` branch instead. There it read a
+          // nonexistent `data-ki` (connectors only ever carry `data-i`),
+          // `+null` coerced to 0, and by sheer coincidence checked
+          // track.keys[0]'s selection instead of its own two endpoints —
+          // reproduced live: a 3-key track with only keys[1]/keys[2]
+          // selected (their connector IS `.sel`) dragged an in-point handle
+          // with that selection active; both diamonds translated live but
+          // the connector between them stayed at transform:'' the whole
+          // drag, visibly detaching from the diamonds it connects, though
+          // the data committed correctly at drop either way (this was a
+          // live-preview-only bug, not a data bug).
+          if (r.classList.contains('motion-key-durblock')) {
             var ki = +r.getAttribute('data-ki');
             sel = track.keys[ki] && isKeySelected(rowEl._smHolder, rowEl._smProp, track.keys[ki]);
+          } else {
+            var i = +r.getAttribute('data-i');
+            sel = track.keys[i] && track.keys[i + 1] && isKeySelected(rowEl._smHolder, rowEl._smProp, track.keys[i]) && isKeySelected(rowEl._smHolder, rowEl._smProp, track.keys[i + 1]);
           }
           if (sel) r.style.transform = 'translateX(' + px + 'px)';
         });


### PR DESCRIPTION
## Summary
- The green/teal `.motion-key-connect` SVG connector bar between two selected keyframe diamonds visibly detached from them while dragging an in/out handle — both diamonds tracked the drag live, but the connector between them stayed frozen at its pre-drag position.
- Root cause: `previewKeyframeShift`'s `'selected'` mode (`src/js/motion.js`) distinguished a connector rect from a duration-block rect via `r.getAttribute('class') === 'motion-key-connect'` — a **strict string match**. A connector whose both endpoints are already selected renders with class `"motion-key-connect sel"` (its own build-time `.sel` suffix) — exactly the state a click on the connector itself, or a marquee over both diamonds, produces — so the match always failed for it. It fell into the duration-block branch instead, read a non-existent `data-ki` attribute (connectors only ever carry `data-i`), `+null` silently coerced to `0`, so it ended up checking `keys[0]`'s selection state instead of its own two real endpoints.
- Fix: `r.classList.contains('motion-key-durblock')` instead of the strict equality check — robust regardless of any other class (like `.sel`) also present.

Fixes mysteropodes/nemo#599.

## Test plan
- [x] `node --check src/js/motion.js`
- [x] Reproduced and fixed live via **real dispatched `mousedown`/`mousemove`/`mouseup` DOM events** (not state manipulation, per CLAUDE.md §4 — this class of live-preview-only bug doesn't show up any other way):
  - Built a 3-key Position track (frames 0/20/40), selected keys at 20 and 40 by a real click on their connector (exactly the "select a keyframe" step from the report), then dragged the layer's in-point handle with a real drag.
  - **Before the fix**: the connector between the two selected keys stayed at `transform:''` through the whole drag while both its diamonds translated live — reproduced the exact reported desync.
  - **After the fix**: the connector's `translateX` matches the diamonds' at every intermediate `mousemove` (checked mid-drag, not just at drop).
  - The correctly-unselected connector (frame 0→20, only one endpoint selected) stays static in both cases — that "no stretch on a partial selection" behavior is pre-existing and intentional, unchanged by this fix.
  - Duration blocks (`.motion-key-durblock`, the other branch touched by this same disambiguation) still track correctly for both a selected and an unselected key — regression check.
  - Final committed keyframe/in-point data was already correct before this fix (it was a live-preview-only visual bug, not a data bug) and remains correct after.
  - `read_console_messages({onlyErrors:true})` — zero errors throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)