### PR TITLE
Persistence audit: fix vector-text formatting loss + Figma image blob: URL

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -694,6 +694,26 @@ function serP(p){var isVB=!!(p.data&&p.data.isVectorBrush);var center=isVB&&p.da
   textAlign:(p.data&&p.data.isTextRoot)?p.data.align:undefined,
   textFixedWidth:(p.data&&p.data.isTextRoot&&p.data.fixedWidth)?p.data.fixedWidth:undefined,
   anchorTopLeft:(p.data&&p.data.isTextRoot&&p.data.anchorTopLeft)?{x:p.data.anchorTopLeft.x,y:p.data.anchorTopLeft.y}:undefined,
+  // Typography panel formatting (2026-08-16, vector-text-bridge.js's own
+  // header comment: "opts... bold/italic/underline/strike/letterSpacing/
+  // wordSpacing/lineHeightMult/textCase") — added to buildVectorTextGroup's
+  // opts and to updateTextPropsPanel's read-back (which drives these
+  // straight off root.data.*) at the time, but never added HERE. A save/
+  // reload silently dropped all 8: the ALREADY-BUILT glyph geometry still
+  // looked right immediately after reopening (segments are baked, real
+  // geometry), but the Typography panel showed Bold/Italic/etc. unchecked,
+  // and the very next edit through that panel (applyTextPropsEdit rebuilds
+  // from the panel's — now wrong — state) visibly reverted the text to
+  // unformatted. Found by cross-checking every writer of p.data on a vector
+  // text root against this whitelist (CLAUDE.md §1), not reported live.
+  bold:(p.data&&p.data.isTextRoot&&p.data.bold)?true:undefined,
+  italic:(p.data&&p.data.isTextRoot&&p.data.italic)?true:undefined,
+  underline:(p.data&&p.data.isTextRoot&&p.data.underline)?true:undefined,
+  strike:(p.data&&p.data.isTextRoot&&p.data.strike)?true:undefined,
+  letterSpacing:(p.data&&p.data.isTextRoot&&p.data.letterSpacing)?p.data.letterSpacing:undefined,
+  wordSpacing:(p.data&&p.data.isTextRoot&&p.data.wordSpacing)?p.data.wordSpacing:undefined,
+  lineHeightMult:(p.data&&p.data.isTextRoot&&p.data.lineHeightMult&&p.data.lineHeightMult!==1.25)?p.data.lineHeightMult:undefined,
+  textCase:(p.data&&p.data.isTextRoot&&p.data.textCase&&p.data.textCase!=='none')?p.data.textCase:undefined,
   // Vector mask (2026-08, AE-style "Mask") — see engine-bridge.js's
   // buildSceneJson mask-extraction comment for how these three drive the
   // engine's clip. §1 consumer check: buildSceneJson reads them (done),
@@ -747,7 +767,12 @@ function desP(d,layer,op){var prev=project.activeLayer;layer.activate();var p=ne
   // live object here for its per-clone 3D projector cache — the one real,
   // current consumer.
   if(d.dupCloneId)p.data.dupCloneId=d.dupCloneId;if(d.dup3D)p.data.dup3D=d.dup3D;
-  if(d.isTextRoot){p.data.isTextRoot=true;p.data.text=d.text||'';p.data.vectorFont=d.vectorFont||'Roboto-Regular';p.data.size=d.textSize||48;p.data.color=d.textColor||'#000000';p.data.align=d.textAlign||'left';if(d.textFixedWidth)p.data.fixedWidth=d.textFixedWidth;if(d.anchorTopLeft)p.data.anchorTopLeft={x:d.anchorTopLeft.x,y:d.anchorTopLeft.y};}
+  if(d.isTextRoot){p.data.isTextRoot=true;p.data.text=d.text||'';p.data.vectorFont=d.vectorFont||'Roboto-Regular';p.data.size=d.textSize||48;p.data.color=d.textColor||'#000000';p.data.align=d.textAlign||'left';if(d.textFixedWidth)p.data.fixedWidth=d.textFixedWidth;if(d.anchorTopLeft)p.data.anchorTopLeft={x:d.anchorTopLeft.x,y:d.anchorTopLeft.y};
+    // Typography panel formatting — see serP's own comment on this same
+    // field set for the full story of why this was missing.
+    if(d.bold)p.data.bold=true;if(d.italic)p.data.italic=true;if(d.underline)p.data.underline=true;if(d.strike)p.data.strike=true;
+    if(d.letterSpacing)p.data.letterSpacing=d.letterSpacing;if(d.wordSpacing)p.data.wordSpacing=d.wordSpacing;
+    p.data.lineHeightMult=d.lineHeightMult||1.25;if(d.textCase&&d.textCase!=='none')p.data.textCase=d.textCase;}
   if(d.isMask){p.data.isMask=true;p.data.maskMode=d.maskMode||'add';if(d.maskFeather)p.data.maskFeather=d.maskFeather;}
   if(d.strokeGradientAlongPath)p.data.strokeGradientAlongPath=d.strokeGradientAlongPath;
   // Retained-path stamp (engine-bridge.js, 2026-07-28): the stored stroke

--- a/src/js/figma-import.js
+++ b/src/js/figma-import.js
@@ -56,9 +56,14 @@
 //     otherwise decompose, not fetching a fill's source bitmap). Fetched
 //     as a blob (not linked directly — the Tauri build's `img-src` CSP is
 //     `'self' data: blob:`, no external host, and S3's signed-URL host
-//     isn't a fixed domain worth allowlisting) and inserted as a plain
-//     Raster, same shape as psd-import-bridge.js's layer.canvas -> Raster
-//     step.
+//     isn't a fixed domain worth allowlisting), then converted to a base64
+//     data: URI (FileReader, 2026-08-29 persistence-audit fix — a blob: URL
+//     doesn't survive past the current page's lifetime, but this value gets
+//     written verbatim into the Raster's persisted data.src on save; the
+//     first version of this file used URL.createObjectURL and any project
+//     saved with a Figma-imported image would show it broken on the next
+//     real reload) and inserted as a plain Raster, same self-contained
+//     shape as psd-import-bridge.js's layer.canvas -> Raster step.
 //
 // Scope of THIS pass, stated honestly (mirrors svg-import.js's own
 // "scope, stated honestly" section):
@@ -265,15 +270,34 @@
     if (node.type !== 'GROUP') out.skipped.push(node.type + ' (' + (node.name || '?') + ')');
   }
 
-  // Fetches one image fill's bytes and returns an object URL — kept as a
-  // blob: URL (already allowed by the Tauri build's img-src CSP) rather
-  // than pointing a Raster straight at the returned S3 URL, whose host
-  // isn't a fixed domain worth (or even reliably possible) allowlisting.
-  function fetchImageAsObjectUrl(url) {
+  // Fetches one image fill's bytes and returns a self-contained base64
+  // data: URI — NOT a blob: URL (kept fixed 2026-08-29, persistence audit):
+  // a blob: URL is only valid for the lifetime of the page/tab that created
+  // it, but this value gets written verbatim into a Raster's persisted
+  // data.src (serR, app.js) the moment the project is saved. A project
+  // saved with a Figma-imported image, then reopened in any later session,
+  // would try to load that stale blob: reference and show a broken image —
+  // the exact "no data loss on reload" contract serR's own header comment
+  // promises ("fully self-contained in the project JSON, no external file
+  // dependency after import"), silently violated for this one import path.
+  // psd-import-bridge.js's equivalent step (layer.canvas.toDataURL) already
+  // produces a real data: URI; this mirrors that via FileReader since the
+  // source here is an already-fetched Blob, not a canvas. Still avoids
+  // pointing a Raster straight at the returned S3 URL (Tauri's img-src CSP
+  // doesn't allowlist that host, and it's a signed URL that expires anyway)
+  // — the fetch-as-blob step is unchanged, only what happens to the blob is.
+  function fetchImageAsDataUrl(url) {
     return fetch(url).then(function (r) {
       if (!r.ok) throw new Error('HTTP ' + r.status);
       return r.blob();
-    }).then(function (blob) { return URL.createObjectURL(blob); });
+    }).then(function (blob) {
+      return new Promise(function (resolve, reject) {
+        var reader = new FileReader();
+        reader.onload = function () { resolve(reader.result); };
+        reader.onerror = function () { reject(reader.error || new Error('FileReader failed')); };
+        reader.readAsDataURL(blob);
+      });
+    });
   }
 
   // Converts an already-fetched Figma file JSON (GET /v1/files/:key?geometry=paths
@@ -375,16 +399,16 @@
           var srcUrl = opts.imageMap[img.imageRef];
           if (!srcUrl) { out.skipped.push('IMAGE fill (' + img.name + '): no imageMap entry for ' + img.imageRef); continue; }
           try {
-            var objUrl = await fetchImageAsObjectUrl(srcUrl);
+            var dataUrl = await fetchImageAsDataUrl(srcUrl);
             var prevActive = project.activeLayer; layer.activate();
             /* eslint-disable no-loop-func */
             await new Promise(function (resolve) {
-              var r = new Raster(objUrl);
+              var r = new Raster(dataUrl);
               r.onLoad = function () {
                 r.size = new Size(Math.max(1, img.w), Math.max(1, img.h));
                 r.position = new Point(img.mat.e + img.w / 2, img.mat.f + img.h / 2);
                 r.opacity = img.opacity;
-                r.data.src = objUrl;
+                r.data.src = dataUrl;
                 resolve();
               };
               r.onError = function () { resolve(); };


### PR DESCRIPTION
## Summary
Requested audit: verify project save/reload loses nothing, and look at file weight.

**Audited and found complete (no fix needed):** \`exportJSON\`/\`importJSON\` (every top-level and per-layer field cross-checked, both directions), \`serP\`/\`desP\` (every \`p.data.*\` field a Path can carry). Weight: JSON already minified, coordinates already rounded to 3 decimals, default fields already omitted extensively via \`undefined\` — no changes needed there.

**Two real gaps found and fixed**, by cross-referencing every writer of \`p.data\` against \`serP\`'s whitelist:

1. **Vector text Typography formatting** (bold/italic/underline/strike/letterSpacing/wordSpacing/lineHeightMult/textCase) was set by \`buildVectorTextGroup\` but never added to \`serP\`/\`desP\`. Silently dropped on save/reload — the baked geometry still looked right immediately, but the Typography panel showed everything unchecked, and the next edit through that panel visibly reverted the formatting.
2. **Figma-imported images** used \`URL.createObjectURL\` (a \`blob:\` URL, valid only for the current page's lifetime) as the Raster's persisted \`data.src\`. Any project with a Figma-imported image would show it broken on a real reload. Fixed to produce a proper base64 \`data:\` URI via \`FileReader\`, matching \`psd-import-bridge.js\`'s already-correct pattern.

## Test plan
- [x] \`node --check\` both files
- [x] Live: vector text with all 8 formatting fields, full \`exportJSON()\`→\`importJSON()\` round-trip, all 8 restored correctly; plain text round-trips with zero of these keys present (no regression/bloat)
- [x] Live: Raster built from a real \`data:\` URI survives a full round-trip identically; confirmed the FileReader conversion itself produces a genuine \`data:image/png;base64,...\` string
- [x] Zero console errors

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>