### PR TITLE
Add tracked-role attach for hand-drawn Animation 2D objects (feedback #151)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -66,6 +66,12 @@
       "runtimeExecutable": "python3",
       "runtimeArgs": ["-m", "http.server", "61437", "-d", "src"],
       "port": 61437
+    },
+    {
+      "name": "nemo-fb151-role-attach-qa",
+      "runtimeExecutable": "python3",
+      "runtimeArgs": ["-m", "http.server", "65193", "-d", "src"],
+      "port": 65193
     }
   ]
 }

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -229,6 +229,20 @@ var state={
   refMedia:null, // rotoscopy reference {type:'video'|'imageseq'|'image',...} — reference-bridge.js
   mediaLibrary:[], // {id,name,kind:'image'|'video',thumb,layerName} — browsable catalog of imports, media-library.js
   symbols:{},activeSymbolId:null,openSymbolTabs:[],
+  // Tracked roles (2026-08-29, feedback #151, "attacher un objet à un autre
+  // même sans identité stable entre frames" — hand-drawn Animation 2D
+  // "attach to a redrawn-every-frame object" workflow, distinct from
+  // Motion's own continuous parentLayerUid). A role is a stable NAME (e.g.
+  // "Balle") a shape can carry PER FRAME via data.trackRoleId — the tagged
+  // shape itself has a fresh strokeId every frame (redrawn, not tweened),
+  // the ROLE is what's stable, not any one stroke. Project-level registry,
+  // same category/persistence as symbols/palettes above — {roleId:{name}}.
+  // roleId IS the trimmed name itself (collision-free by construction: two
+  // roles with the same name ARE the same role, see tagSelectionAsRole/
+  // attachSelectionToRole in select-bridge.js) rather than a separately
+  // generated id — deliberately the simplest backing store that works, no
+  // dedicated management panel for v1 per the confirmed scope.
+  trackRoles:{},
   activeMontageViewId:null, // StoryBoard montage currently entered (enterMontageView) — see app.js
   // Layer folders: purely organizational metadata, not a real tree — each
   // layer optionally carries ld.folderId pointing into this map. Keeping
@@ -655,6 +669,28 @@ function serP(p){var isVB=!!(p.data&&p.data.isVectorBrush);var center=isVB&&p.da
   // Group membership (2026-07, group-bridge.js's Cmd+G) — a stable id
   // shared by every member, same pattern as strokeId/brushGroupId above.
   groupId:(p.data&&p.data.groupId)?p.data.groupId:undefined,
+  // Tracked-role attach (2026-08-29, feedback #151 — see state.trackRoles'
+  // own comment, app.js, for the full "hand-drawn, redrawn-every-frame
+  // object" design). trackRoleId: this stroke IS the named role's occupant
+  // THIS frame (tagSelectionAsRole, select-bridge.js). attachedToRoleId +
+  // attachOffset: this stroke rides along with that role — offset frozen
+  // at attach-time (attachSelectionToRole), re-applied ONCE every time the
+  // role gets re-tagged in a frame (tagSelectionAsRole's reposition pass),
+  // never a live/continuous link. Plain data, round-trips through JSON as-
+  // is like paramShape/fillGradient above.
+  // §1 consumer check: buildSceneJson/onionLayerItems/export.js/selectedPaths
+  // treat a tagged/attached stroke as an ordinary Path (no exclusion —
+  // this is meant to select/tween/undo exactly like any other shape, the
+  // reposition is a one-time geometry bake at tag-time, not a render-time
+  // concern). Tween matching (tweens.js splitTweenables/autoMatch): NOT
+  // excluded, same reasoning. Duplication (_materializeClones, tools.js):
+  // trackRoleId is explicitly stripped on clone (a copy must not silently
+  // claim to be the role's occupant) — attachedToRoleId/attachOffset are
+  // NOT stripped (a duplicated attached object staying attached is the
+  // expected behavior).
+  trackRoleId:(p.data&&p.data.trackRoleId)?p.data.trackRoleId:undefined,
+  attachedToRoleId:(p.data&&p.data.attachedToRoleId)?p.data.attachedToRoleId:undefined,
+  attachOffset:(p.data&&p.data.attachOffset)?{x:p.data.attachOffset.x,y:p.data.attachOffset.y}:undefined,
   // Dynamic shape (2026-08-18, "shape dynamique round corner sur rect...")
   // — plain data like fillGradient just above, round-trips through JSON
   // as-is. The item's REAL segments already encode the CURRENT radii
@@ -754,6 +790,11 @@ function desP(d,layer,op){var prev=project.activeLayer;layer.activate();var p=ne
   // ctrl+Z"). Legacy data predating the field (undefined) keeps the old
   // fallback chain untouched.
   p.strokeColor=d.hasRealStroke===false?null:(d.strokeColor||((d.isVectorBrush||d.brushTexturePreset||d.bitmapBrushSpec||d.isBrushTextureCopy||dNoStrokeChannel||dIsShadowChannel)?null:'#fff'));p.strokeWidth=d.strokeWidth||3;p.strokeCap=typeof d.strokeCap==='string'?d.strokeCap:'round';p.strokeJoin=typeof d.strokeJoin==='string'?d.strokeJoin:'round';if(d.miterLimit!==undefined)p.miterLimit=d.miterLimit;if(d.fillColor)p.fillColor=d.fillColor;else p.fillColor=null;p.opacity=op!==undefined?op:(d.opacity!==undefined?d.opacity:1);if(d.dashArray&&d.dashArray.length)p.dashArray=d.dashArray;if(d.dashOffset!==undefined)p.dashOffset=d.dashOffset;if(d.paintOrder){p.data.paintOrder=d.paintOrder;}if(d.isVectorBrush){p.data.isVectorBrush=true;if(d.centerSegments)p.data.centerSegments=d.centerSegments;if(d.widthProfile)p.data.widthProfile=d.widthProfile;if(d.strokeProfile)p.data.strokeProfile=d.strokeProfile;if(d.profileBase)p.data.profileBase=d.profileBase;if(d.isFillShape)p.data.isFillShape=true;applyBrushKeyline(p);}if(d.isFillCloseLine)p.data.isFillCloseLine=true;if(d.fillSeed)p.data.fillSeed=d.fillSeed;if(d.fillSeeds&&d.fillSeeds.length)p.data.fillSeeds=d.fillSeeds;if((d.fillSeed||(d.fillSeeds&&d.fillSeeds.length))&&d.fillGapPx!==undefined)p.data.fillGapPx=d.fillGapPx;if(d.fillWalls)p.data.fillWalls=d.fillWalls;if(d.strokeId)p.data.strokeId=d.strokeId;if(d.brushGroupId)p.data.brushGroupId=d.brushGroupId;if(d.isLinkedFillCompanion)p.data.isLinkedFillCompanion=true;if(d.linkedFillId)p.data.linkedFillId=d.linkedFillId;if(d.tweenOn)p.data.tweenOn=true;if(d.boxAngle)p.data.boxAngle=d.boxAngle;if(d.xformAnchorKey)p.data.xformAnchorKey=d.xformAnchorKey;if(d.xformAnchorCustom)p.data.xformAnchorCustom=d.xformAnchorCustom;if(d.isBrushTextureCopy)p.data.isBrushTextureCopy=true;if(d.brushTexturePreset)p.data.brushTexturePreset=d.brushTexturePreset;if(d.bitmapBrushSpec)p.data.bitmapBrushSpec=d.bitmapBrushSpec;if(d.bitmapPressureProfile)p.data.bitmapPressureProfile=d.bitmapPressureProfile;if(d.preTextureOpacity!==undefined)p.data.preTextureOpacity=d.preTextureOpacity;if(d.preTextureStroke!==undefined)p.data.preTextureStroke=d.preTextureStroke;if(d.channelTag)p.data.channelTag=d.channelTag;if(d.shadowSwatchId)p.data.shadowSwatchId=d.shadowSwatchId;if(d.ownerId)p.data.ownerId=d.ownerId;if(d.ownerName)p.data.ownerName=d.ownerName;if(d.ownerColor)p.data.ownerColor=d.ownerColor;if(d.revisionParentId)p.data.revisionParentId=d.revisionParentId;if(d.isRevisionGhost)p.data.isRevisionGhost=true;if(d.revisionAction)p.data.revisionAction=d.revisionAction;if(d.preRevisionOpacity!==undefined)p.data.preRevisionOpacity=d.preRevisionOpacity;if(d.fillGradient)p.data.fillGradient=d.fillGradient;if(d.groupId)p.data.groupId=d.groupId;if(d.paramShape)p.data.paramShape=d.paramShape;if(d.effects&&d.effects.length)p.data.effects=d.effects;
+  // Tracked-role attach (2026-08-29, feedback #151) — see serP's own
+  // comment on these three fields for the full round-trip contract.
+  if(d.trackRoleId)p.data.trackRoleId=d.trackRoleId;
+  if(d.attachedToRoleId)p.data.attachedToRoleId=d.attachedToRoleId;
+  if(d.attachOffset)p.data.attachOffset={x:d.attachOffset.x,y:d.attachOffset.y};
   if(d.isVectorText)p.data.isVectorText=true;if(d.vectorChar)p.data.vectorChar=d.vectorChar;if(d.isText)p.data.isText=true;
   if(d.charIndex!=null)p.data.charIndex=d.charIndex;if(d.wordIndex!=null)p.data.wordIndex=d.wordIndex;if(d.lineIndex!=null)p.data.lineIndex=d.lineIndex;
   // Mograph duplicator copy tags (applyLayerDuplicator) — belt-and-suspenders

--- a/src/js/project.js
+++ b/src/js/project.js
@@ -61,6 +61,7 @@
     while(userLayers.length>0)userLayers.pop().remove();state.layers=[];
     Object.keys(_symbolPaperLayers).forEach(function(k){_symbolPaperLayers[k].forEach(function(l){l.remove();});});_symbolPaperLayers={};
     state.symbols={};state.openSymbolTabs=[];state.activeSymbolId=null;
+    state.trackRoles={}; // feedback #151 — see state.trackRoles' own comment, app.js
     state.canvasW=cfg.w;state.canvasH=cfg.h;state.canvasBg='#ffffff';state.fps=cfg.fps;
     // v12: default timeline length is 5 SECONDS of frames at the project's
     // own fps (was a flat 24 frames — only 1s at 24fps, or under a second

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -2384,11 +2384,32 @@
       // copier/couper/coller existe pour tous les éléments") — only shown
       // when there's actually something in the canvas clipboard, otherwise
       // fall through to the native menu exactly as before.
-      if (!(_canvasClip && _canvasClip.snaps && _canvasClip.snaps.length)) return;
+      var emptyItems = [];
+      if (_canvasClip && _canvasClip.snaps && _canvasClip.snaps.length) {
+        emptyItems.push({ label: 'Coller', shortcut: '⌘V', action: function () { pasteSelection(); } });
+      }
+      // Tracked-role proximity suggestion (2026-08-29, feedback #151, design
+      // point 4 — the secondary assist on top of the core tag/attach
+      // mechanic above). Offered from the empty-canvas menu specifically
+      // BECAUSE nothing needs to be pre-selected here: it exists to help
+      // the user FIND which shape on this frame is the role's occupant
+      // when it isn't obvious, not to act on an already-chosen shape.
+      // Advisory only — selects the candidate (visible via the normal
+      // selection highlight) and asks for a confirming action; never tags
+      // anything on its own.
+      var roleSuggestions = collectRoleSuggestions();
+      if (roleSuggestions.length) {
+        if (emptyItems.length) emptyItems.push({ sep: true });
+        roleSuggestions.forEach(function (s) {
+          emptyItems.push({
+            label: 'Suggérer la forme pour « ' + s.name + ' »…',
+            action: function () { applyRoleSuggestion(s); }
+          });
+        });
+      }
+      if (!emptyItems.length) return;
       e.preventDefault(); e.stopImmediatePropagation();
-      window.showContextMenu(e.clientX, e.clientY, [
-        { label: 'Coller', shortcut: '⌘V', action: function () { pasteSelection(); } },
-      ]);
+      window.showContextMenu(e.clientX, e.clientY, emptyItems);
       return;
     }
     e.preventDefault(); e.stopImmediatePropagation();
@@ -2495,6 +2516,26 @@
         action: function () { toggleTweenOnForSelection(); }
       },
     ]);
+    // Tracked-role attach (2026-08-29, feedback #151) — hand-drawn
+    // Animation 2D "attach an object to another that has no stable identity
+    // across frames" workflow (a ball redrawn fresh every frame, a hat
+    // riding along) — see state.trackRoles' own comment (app.js) for the
+    // full confirmed design. Single-shape only: tagging/attaching targets
+    // exactly one stroke, offered here the same way per-element tween
+    // opt-in is just above. Path only for v1 (not Raster/CompoundPath) —
+    // matches the confirmed scenario (a hand-drawn vector stroke), a
+    // deliberate scope cut, not an oversight.
+    if (!multi && p0 instanceof Path) {
+      items.push({ sep: true });
+      items.push({
+        label: (p0.data && p0.data.trackRoleId) ? ('Rôle suivi : « ' + p0.data.trackRoleId + ' » (renommer…)') : 'Marquer comme rôle suivi…',
+        action: function () { tagSelectionAsRole(p0); }
+      });
+      items.push({
+        label: (p0.data && p0.data.attachedToRoleId) ? ('Attaché à « ' + p0.data.attachedToRoleId + ' » (changer…)') : 'Attacher à un rôle…',
+        action: function () { openAttachRolePicker(p0, e.clientX, e.clientY); }
+      });
+    }
     if (isActiveRevision || isDeleteGhost) {
       // Same actions as the Properties-panel Accept/Reject buttons
       // (timeline.js updateRevisionPanel) — surfacing them here too so a
@@ -2644,6 +2685,224 @@
     propagate(-1); propagate(1);
     if (window.SM && window.SM.generateTweens) window.SM.generateTweens();
     updateUI(); window.SMEngineBridge.renderNow();
+  }
+
+  // ---- TRACKED-ROLE ATTACH (2026-08-29, feedback #151) ----
+  // Hand-drawn Animation 2D "attach an object to another that has no stable
+  // identity across frames" — see state.trackRoles' own comment (app.js)
+  // for the full confirmed design (points 1-4 of the feature brief). Three
+  // pieces: tagSelectionAsRole (point 1+3 — mark a shape as this frame's
+  // role occupant, which ALSO triggers the one-time reposition of every
+  // attached shape), attachSelectionToRole (point 2 — freeze an offset to
+  // an existing role's CURRENT occupant), and the suggestion pair
+  // (collectRoleSuggestions/applyRoleSuggestion, point 4 — advisory only).
+
+  // Tags `p0` as the current-frame occupant of a named role. Un-tags
+  // whatever OTHER stroke (any layer, this frame) currently carries that
+  // role — "a role has one occupant per frame" is enforced this way rather
+  // than blocked outright (confirmed design: "tagging a new stroke with a
+  // role that's already occupied un-tags the previous occupant"). Then
+  // repositions every stroke (any layer) whose data.attachedToRoleId
+  // matches, by its own frozen data.attachOffset relative to p0's NEW
+  // bounds center — a ONE-TIME bake into this frame's geometry, not a
+  // live link (confirmed design point 3): once done, the attached shape is
+  // plain geometry the artist can hand-adjust with nothing re-triggering.
+  // A "held" (non-keyframe, non-tween) frame reads the nearest PRIOR
+  // keyframe's stroke array BY REFERENCE (getEffectiveStrokes, app.js) — a
+  // live edit made while sitting on one has nowhere of its own to persist
+  // into, and saveActiveLayerFrame/saveAllLayerFrames both skip a frame
+  // that's neither isKeyframe nor isInterpolated outright. Promoting it
+  // first (same idea as _maybePromoteInterpolated's tween-in-between
+  // promotion, tweens.js, just applied to a plain hold too) is what makes
+  // the reposition/tag actually stick past the next frame navigation
+  // instead of visually moving for one frame and silently reverting.
+  function _ensureLiveFrameIsKeyframe(li) {
+    var fr = state.layers[li] && state.layers[li].frames && state.layers[li].frames[state.currentFrame];
+    if (fr && !fr.isKeyframe) { fr.isKeyframe = true; fr.isInterpolated = false; }
+  }
+  function tagSelectionAsRole(p0) {
+    if (!(p0 instanceof Path)) return;
+    var current = (p0.data && p0.data.trackRoleId) || '';
+    var name = prompt('Nom du rôle suivi (ex. « Balle ») — réutilise un nom existant pour continuer ce rôle :', current);
+    if (name == null) return; // cancelled
+    name = name.trim();
+    if (!name) return;
+    var roleId = name; // name IS the id — see state.trackRoles' own comment
+    pushUndo(); // flushes every layer's live geometry to stored frame data + snapshots pre-state
+    if (!state.trackRoles) state.trackRoles = {};
+    if (!state.trackRoles[roleId]) state.trackRoles[roleId] = { name: name };
+    var newCenter = p0.bounds.center;
+    var attachedCount = 0;
+    for (var i = 0; i < state.layers.length; i++) {
+      if (!layerIsEffectivelyVisible(i)) continue;
+      var lyr = userLayers[i];
+      if (!lyr) continue;
+      (function (li) {
+        lyr.children.slice().forEach(function (c) {
+          if (c === p0) return;
+          if (c.data && c.data.trackRoleId === roleId) delete c.data.trackRoleId;
+          if (c instanceof Path && c.data && c.data.attachedToRoleId === roleId && c.data.attachOffset) {
+            var target = newCenter.add(new Point(c.data.attachOffset.x, c.data.attachOffset.y));
+            var delta = target.subtract(c.bounds.center);
+            if (Math.abs(delta.x) > 0.01 || Math.abs(delta.y) > 0.01) {
+              _ensureLiveFrameIsKeyframe(li);
+              c.translate(delta);
+            }
+            attachedCount++;
+          }
+        });
+      })(i);
+    }
+    // Safety net for the edge case of tagging a shape that's currently
+    // sitting on a HELD (non-keyframe) frame of its own layer — see
+    // _ensureLiveFrameIsKeyframe's own comment. The confirmed core scenario
+    // (redrawn fresh every frame) already makes p0's frame a real keyframe
+    // by the time it's drawn, so this is a robustness net, not the common
+    // path.
+    _ensureLiveFrameIsKeyframe(userLayers.indexOf(p0.layer));
+    if (!p0.data) p0.data = {};
+    p0.data.trackRoleId = roleId;
+    saveAllLayerFrames();
+    updateUI(); renderArcs();
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+    showToast('Rôle « ' + name + ' » marqué sur cette frame' + (attachedCount ? (' — ' + attachedCount + ' objet(s) repositionné(s)') : '') + '.');
+  }
+
+  // Opens a flat picker (reusing showContextMenu the same way a submenu
+  // would) listing every defined role — clicking one attaches p0 to it.
+  function openAttachRolePicker(p0, x, y) {
+    var roles = state.trackRoles || {};
+    var roleIds = Object.keys(roles);
+    if (!roleIds.length) { showToast('Aucun rôle suivi défini — utilise d\'abord « Marquer comme rôle suivi… ».'); return; }
+    roleIds.sort(function (a, b) { return (roles[a].name || a).localeCompare(roles[b].name || b); });
+    var pickItems = roleIds.map(function (rid) {
+      var isCurrent = !!(p0.data && p0.data.attachedToRoleId === rid);
+      return { label: (isCurrent ? '✓ ' : '') + (roles[rid].name || rid), action: function () { attachSelectionToRole(p0, rid); } };
+    });
+    window.showContextMenu(x, y, pickItems);
+  }
+
+  // Freezes offset = p0.bounds.center - roleShape.bounds.center at THIS
+  // instant (confirmed design point 2). Errors clearly if the role has no
+  // occupant in the CURRENT frame — "you can't attach to a role that isn't
+  // present right now". Cross-layer by design: the role's shape and the
+  // attached shape can be on the same layer or different ones (both
+  // confirmed cases), so this scans every effectively-visible layer's
+  // live children, not just the active layer.
+  function attachSelectionToRole(p0, roleId) {
+    if (!(p0 instanceof Path)) return;
+    var roleShape = null;
+    for (var i = 0; i < state.layers.length && !roleShape; i++) {
+      if (!layerIsEffectivelyVisible(i)) continue;
+      var lyr = userLayers[i];
+      if (!lyr) continue;
+      for (var j = 0; j < lyr.children.length; j++) {
+        var c = lyr.children[j];
+        if (c !== p0 && c.data && c.data.trackRoleId === roleId) { roleShape = c; break; }
+      }
+    }
+    var roleName = (state.trackRoles && state.trackRoles[roleId] && state.trackRoles[roleId].name) || roleId;
+    if (!roleShape) {
+      showToast('Le rôle « ' + roleName + ' » n\'a pas d\'occupant sur cette frame — impossible d\'attacher ici.');
+      return;
+    }
+    pushUndo();
+    // Safety net (see _ensureLiveFrameIsKeyframe's own comment) for
+    // attaching while sitting on a HELD frame of p0's own layer.
+    _ensureLiveFrameIsKeyframe(userLayers.indexOf(p0.layer));
+    var off = p0.bounds.center.subtract(roleShape.bounds.center);
+    if (!p0.data) p0.data = {};
+    p0.data.attachedToRoleId = roleId;
+    p0.data.attachOffset = { x: off.x, y: off.y };
+    saveAllLayerFrames();
+    updateUI(); renderArcs();
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+    showToast('Attaché au rôle « ' + roleName + ' ».');
+  }
+
+  // ---- Proximity-suggestion assist (design point 4, secondary) ----
+  // Approximate center from a STORED stroke dict's on-curve points (no live
+  // Path needed — this only ever looks at PAST frames, which aren't
+  // materialized). Good enough for a "closest candidate" heuristic; the
+  // actual reposition math above always uses real .bounds.center on live
+  // geometry, never this approximation.
+  function _strokeDictCenter(sd) {
+    if (!sd || !sd.segments || !sd.segments.length) return null;
+    var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    sd.segments.forEach(function (s) {
+      var x = s.point[0], y = s.point[1];
+      if (x < minX) minX = x; if (x > maxX) maxX = x;
+      if (y < minY) minY = y; if (y > maxY) maxY = y;
+    });
+    if (minX > maxX) return null;
+    return new Point((minX + maxX) / 2, (minY + maxY) / 2);
+  }
+  // Nearest PRIOR frame (any layer) that had an occupant for this role,
+  // searching backwards from the frame just before the current one.
+  function _findPriorRoleCenter(roleId) {
+    for (var fi = state.currentFrame - 1; fi >= 0; fi--) {
+      for (var li = 0; li < state.layers.length; li++) {
+        var ld = state.layers[li];
+        var fr = ld && ld.frames && ld.frames[fi];
+        if (!fr || !fr.strokes) continue;
+        for (var k = 0; k < fr.strokes.length; k++) {
+          if (fr.strokes[k].trackRoleId === roleId) {
+            var c = _strokeDictCenter(fr.strokes[k]);
+            if (c) return c;
+          }
+        }
+      }
+    }
+    return null;
+  }
+  // Every defined role that has NO occupant on the CURRENT frame yet, but
+  // DOES have one on some earlier frame — i.e. every role worth suggesting
+  // for right now.
+  function collectRoleSuggestions() {
+    var out = [];
+    var roles = state.trackRoles || {};
+    Object.keys(roles).forEach(function (rid) {
+      var hasNow = false;
+      for (var i = 0; i < state.layers.length && !hasNow; i++) {
+        if (!layerIsEffectivelyVisible(i)) continue;
+        var lyr = userLayers[i];
+        if (!lyr) continue;
+        hasNow = lyr.children.some(function (c) { return c.data && c.data.trackRoleId === rid; });
+      }
+      if (hasNow) return;
+      var priorCenter = _findPriorRoleCenter(rid);
+      if (!priorCenter) return;
+      out.push({ roleId: rid, name: roles[rid].name || rid, center: priorCenter });
+    });
+    return out;
+  }
+  // Closest LIVE Path (any effectively-visible layer, current frame) to a
+  // world-space point.
+  function _findClosestPathToPoint(pt) {
+    var best = null, bestD = Infinity;
+    for (var i = 0; i < state.layers.length; i++) {
+      if (!layerIsEffectivelyVisible(i)) continue;
+      var lyr = userLayers[i];
+      if (!lyr) continue;
+      lyr.children.forEach(function (c) {
+        if (!(c instanceof Path) || !c.segments.length) return;
+        var d = c.bounds.center.getDistance(pt);
+        if (d < bestD) { bestD = d; best = c; }
+      });
+    }
+    return best;
+  }
+  // Advisory only — selects the closest candidate (visible via the normal
+  // selection highlight) and prompts the user to confirm via the usual
+  // "Marquer comme rôle suivi…" action. NEVER tags anything by itself.
+  function applyRoleSuggestion(s) {
+    var cand = _findClosestPathToPoint(s.center);
+    if (!cand) { showToast('Aucune forme trouvée sur cette frame.'); return; }
+    clearSel();
+    selectedPaths = [cand];
+    state.selectedStrokeIndices = selectedPaths.map(getSI).filter(function (i2) { return i2 >= 0; });
+    renderArcs(); updateUI(); window.SMEngineBridge.renderNow();
+    showToast('Forme suggérée pour « ' + s.name + ' » sélectionnée — confirme avec « Marquer comme rôle suivi… ».');
   }
 
   // Read-only peek for engine-bridge.js's buildTransformBoxItems (2026-07

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1884,6 +1884,12 @@ window.SM={
       // Comp markers (markers.js) — pure annotation, but losing them on save
       // would make the feature pointless.
       markers:state.markers||[],shyEnabled:!!state.shyEnabled,
+      // Tracked roles (2026-08-29, feedback #151) — project-level registry,
+      // see state.trackRoles' own comment (app.js). Per-stroke trackRoleId/
+      // attachedToRoleId/attachOffset already round-trip via serP/desP as
+      // part of each frame's own strokes — this is only the {roleId:{name}}
+      // name registry itself.
+      trackRoles:state.trackRoles||{},
       bpm:state.bpm,bpmOffset:state.bpmOffset,bpmShow:!!state.bpmShow,
       motionBlurOn:!!state.motionBlurOn,motionBlurSamples:state.motionBlurSamples,motionBlurShutter:state.motionBlurShutter,
       // Rulers/guides (2026-08-27, "mettre en place les repères et rulers
@@ -2165,6 +2171,7 @@ window.SM={
     }
     state.comments=d.comments||[];
     state.markers=d.markers||[];
+    state.trackRoles=d.trackRoles||{}; // feedback #151 — see state.trackRoles' own comment, app.js
     state.shyEnabled=!!d.shyEnabled;
     state.bpm=d.bpm!=null?d.bpm:120;state.bpmOffset=d.bpmOffset||0;state.bpmShow=!!d.bpmShow;
     state.exprGlobals=d.exprGlobals||'';

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -1402,6 +1402,12 @@ function _materializeClones(snaps,layer,offset){
   snaps.forEach(function(snap){
     var d=JSON.parse(JSON.stringify(snap.d));
     d.strokeId=undefined; // fresh identity below — must NOT alias the source's
+    // Tracked-role tag (2026-08-29, feedback #151) — a duplicate/copy must
+    // NOT silently claim to be the role's current occupant (see
+    // state.trackRoles' own comment, app.js). attachedToRoleId/attachOffset
+    // are deliberately NOT stripped: a duplicated ATTACHED object (the
+    // "hat") staying attached to its role is the expected behavior.
+    d.trackRoleId=undefined;
     if(d.brushGroupId)d.brushGroupId=freshGroupId(d.brushGroupId);
     var clone=desP(d,layer,d.opacity);
     if(offset)clone.translate(new Point(offset,offset));


### PR DESCRIPTION
## Summary
- New feature (feedback #151): lets an artist attach a second object (e.g. a hat) to a first one (a ball) that has **no stable identity across frames** — the ball is redrawn as a genuinely new, differently-shaped stroke every frame in hand-drawn Animation 2D, so Motion's existing `parentLayerUid` (continuous keyframed transform, layer-level) doesn't apply, and this is explicitly NOT motion-tracking (ruled out as unreliable for hand-drawn content in the clarification conversation).
- Confirmed design, 4 points: (1) tracked roles — a project-level named registry, a shape carries `data.trackRoleId` per frame; (2) attach — freezes `offset = attachedShape.center - roleShape.center` at attach time; (3) reposition-on-tag — whenever a shape is (re)tagged with a role on some frame, every attached shape is translated ONCE to `[new occupant center] + [its own frozen offset]` — a one-time bake, not a live/continuous link; (4) proximity-suggestion assist (secondary) — advisory nearest-candidate helper when a role has no occupant yet on the current frame.
- CLAUDE.md §1 consumer check done explicitly: `serP`/`desP` (app.js) round-trip the three new fields as named whitelist entries (not pass-through); `exportJSON`/`importJSON` (timeline.js) persist the `state.trackRoles` registry; tween matching needs no exclusion; `_materializeClones` (Cmd+D/copy/paste, tools.js) strips `trackRoleId` on clone but keeps `attachedToRoleId`/`attachOffset`.
- UI: two context-menu actions on a selected shape — "Marquer comme rôle suivi…" and "Attacher à un rôle…" — plus an advisory "Suggérer la forme pour «role»…" entry on the empty-canvas menu for point 4.

## Test plan
- [x] `node --check` on every touched JS file
- [x] Live browser: ball alone on its own layer, tagged across 3 frames with genuinely different hand-drawn shapes (fresh strokeId each time)
- [x] Live browser: ball sharing a layer with a decoy shape — confirmed the decoy's inherited role tag is correctly un-tagged when the new shape is tagged
- [x] Live browser: hat attached cross-layer, reposition math confirmed to sub-pixel precision on every re-tag
- [x] Full `exportJSON()` → `importJSON()` round-trip confirmed on both stored dicts and live re-`desP`'d objects
- [x] Cmd+D duplication: `trackRoleId` stripped on the copy, `attachedToRoleId`/`attachOffset` preserved on a duplicated attached object
- [x] Attaching to a role with no occupant on the current frame shows a clear toast, leaves existing data untouched
- [x] Proximity-suggestion picks the correct near candidate over a far decoy, never auto-tags
- [x] Zero console errors throughout
- [x] Rebased onto origin/main's concurrent persistence-audit commit (#332, touches the same `serP`/`desP`/`exportJSON` functions) — clean auto-merge, re-verified end-to-end after rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)