### PR TITLE
Export: route folder-layer projects through the engine renderer

### DIFF
--- a/src/js/export.js
+++ b/src/js/export.js
@@ -453,8 +453,19 @@ function exportHasActiveEffects(){
 // (CLAUDE.md §3's whole point). Blend ALSO gets a native Paper fallback in
 // exportBuildFrame for the paths this routing can't cover (SVG, scale>1).
 function exportHasLayerCompositing(){
+  // isFolderLayer (audit 2026-08-29, prouvé au pixel près) : un Dossier
+  // (#319) est une feature de COMPOSITING moteur — composite_scene rend
+  // ses enfants dans une passe isolée À LA POSITION Z DU DOSSIER, alors
+  // que le fallback Paper.js ci-dessous peint tout dans l'ordre brut de
+  // state.layers. Dès qu'un calque étranger s'intercale entre un enfant
+  // et son dossier dans l'ordre brut, l'export fallback inverse la
+  // superposition visible à l'écran (mesuré : pixel de chevauchement
+  // rouge à l'écran/moteur, bleu dans exportFrameDataURL — même scène).
+  // Même logique de routage que blend/matte/3D/motionBlur/order : toute
+  // feature que le chemin Paper ne sait pas reproduire route l'export par
+  // le moteur.
   return state.layers.some(function(ld){
-    return (ld.blendMode&&ld.blendMode!=='normal')||(ld.matteMode&&ld.matteMode!=='none');
+    return (ld.blendMode&&ld.blendMode!=='normal')||(ld.matteMode&&ld.matteMode!=='none')||!!ld.isFolderLayer;
   });
 }
 // 3D layers and Motion Blur (2026-08-17 audit, "vérifie les export de


### PR DESCRIPTION
## Audit sénior 2026-08-29 — divergence écran/export prouvée au pixel près

Un Dossier (#319) rend ses enfants dans une passe isolée **à la position z du dossier** (`composite_scene`, engine.rs), alors que le fallback Paper.js d'export (`exportFrameDataURL` — utilisé quand le projet n'a ni effet, ni blend, ni matte, ni 3D…) peint tout dans l'**ordre brut** de `state.layers`. Dès qu'un calque étranger s'intercale entre un enfant et son dossier dans l'ordre brut, l'export inverse la superposition visible à l'écran.

**Mesuré sur la même scène** (enfant rouge idx 0, calque bleu chevauchant idx 1, dossier idx 2) : pixel de chevauchement **rouge** à l'écran et via `renderFrameToPixelsPNG`, **bleu** dans `exportFrameDataURL`.

## Fix
Une ligne dans `exportHasLayerCompositing` : `isFolderLayer` route l'export par le moteur — exactement la logique de routage que blend/matte y suivent déjà, et que les rattrapages 3D/motionBlur/order documentent dans `exportHasEngineOnlyMotion` juste en dessous (« toute feature que le chemin Paper ne sait pas reproduire route l'export par le moteur »).

## Vérification en direct (port frais)
- `exportNeedsEngine()` = true dès qu'un dossier existe ; chemin moteur → pixel rouge, identique à l'écran
- projet sans dossier → gate false, fallback inchangé
- zéro erreur console

🤖 Generated with [Claude Code](https://claude.com/claude-code)