### PR TITLE
Media panel: video entry stays visible through the slow import fallback (feedback #153)

### DIFF
--- a/src/js/images.js
+++ b/src/js/images.js
@@ -395,7 +395,12 @@
     }
     return frames;
   }
-  async function importVideoFrames(frames,prefix){
+  // adoptMediaId (2026-08-30, feedback #153): when the instant WebCodecs
+  // importer bailed, it hands its "decoding…" media-library row over rather
+  // than deleting it — fill THAT row in at the end instead of adding a
+  // second one, so the panel shows one continuous entry across the whole
+  // (slow) bake instead of a row that vanishes and comes back.
+  async function importVideoFrames(frames,prefix,adoptMediaId){
     saveAllLayerFrames();pushUndoLayers(true);
     if(frames.length>state.totalFrames)window.SM.setTotalFrames(frames.length);
     var idx=createUserLayer(prefix);
@@ -443,7 +448,11 @@
     var firstFrameThumb=(frames.filter(function(f){return f.strokes.length;})[0]||{}).strokes;
     firstFrameThumb=firstFrameThumb&&firstFrameThumb[0]&&firstFrameThumb[0].src;
     convertLayerToComponent(idx);
-    if(window.SMMediaLibrary&&firstFrameThumb)SMMediaLibrary.addEntry(state.layers[idx].name,'video',firstFrameThumb,state.layers[idx].name,{layerUid:state.layers[idx].layerUid});
+    if(window.SMMediaLibrary&&firstFrameThumb){
+      var patch={layerUid:state.layers[idx].layerUid,status:'ready',thumb:firstFrameThumb,name:state.layers[idx].name,layerName:state.layers[idx].name};
+      if(adoptMediaId)SMMediaLibrary.updateEntry(adoptMediaId,patch);
+      else SMMediaLibrary.addEntry(state.layers[idx].name,'video',firstFrameThumb,state.layers[idx].name,{layerUid:state.layers[idx].layerUid});
+    }
     showToast(SM.t('toastVideoImportedSuffix')+frames.filter(function(f){return f.strokes.length;}).length+' images sur le calque "'+prefix+'"');
   }
   async function importVideoFile(file){
@@ -454,15 +463,24 @@
     // ffmpeg subprocess. Falls through to the old bake-every-frame-as-JPEG
     // importer below for anything it can't handle (unsupported container/
     // codec, or a browser without WebCodecs — e.g. older Firefox).
+    var adoptId=null;
     if(window.SMNativeVideo){
       try{await SMNativeVideo.importAsLayer(file);return;}
-      catch(e){showToast(SM.t('toastWebCodecsUnavailable')+(e&&e.message||e)+') — import classique…');}
+      catch(e){
+        adoptId=e&&e.pendingMediaId||null; // see importVideoFrames' own comment (feedback #153)
+        showToast(SM.t('toastWebCodecsUnavailable')+(e&&e.message||e)+') — import classique…');
+      }
     }
     showToast(SM.t('toastDecodingVideo'));
     var blobUrl=URL.createObjectURL(file);
     try{
       var frames=await decodeVideoFrames(blobUrl);
-      await importVideoFrames(frames,file.name.replace(/\.[^.]+$/,''));
+      await importVideoFrames(frames,file.name.replace(/\.[^.]+$/,''),adoptId);
+    }catch(e2){
+      // The fallback failed too — now the placeholder really is dead, so
+      // clear it rather than leaving a permanent "decoding…" row behind.
+      if(adoptId&&window.SMMediaLibrary)SMMediaLibrary.removeEntry(adoptId);
+      throw e2;
     }finally{URL.revokeObjectURL(blobUrl);}
   }
   async function importVideo(){

--- a/src/js/native-video-bridge.js
+++ b/src/js/native-video-bridge.js
@@ -920,8 +920,18 @@
     try {
       info = await open(source);
     } catch (e) {
-      if (pendingMediaId && window.SMMediaLibrary) SMMediaLibrary.removeEntry(pendingMediaId);
-      throw e; // unchanged: images.js's own caller catches this and falls through to the slower bake-every-frame path
+      // Hand the placeholder OVER to the fallback importer instead of
+      // deleting it (2026-08-30, feedback #153: "l'icon apparait avec
+      // decoding mais au bout d'un moment celle ci disparait pendant
+      // l'encoding et réapparait par la suite, du coup on a l'impression
+      // d'un bug"). images.js catches this and falls through to the slow
+      // bake-every-frame path, which only added its own entry at the very
+      // END of decoding — so the row vanished for the entire decode and
+      // came back as a different entry, reading exactly like a crash.
+      // The id rides on the error so the caller can adopt the SAME row and
+      // just fill it in; it removes the row itself if the fallback fails too.
+      e.pendingMediaId = pendingMediaId;
+      throw e;
     }
     if (window.saveAllLayerFrames) saveAllLayerFrames();
     if (window.pushUndoLayers) pushUndoLayers();


### PR DESCRIPTION
## Summary
The instant WebCodecs importer adds a `status:'loading'` placeholder row immediately, and on failure **removed** it before rethrowing. `images.js` catches that and falls through to the slow bake-every-frame importer, which only added its own, different entry at the very END of decoding — so the row was gone for the whole decode and came back as a different entry. Reads as a crash; is just bookkeeping.

The placeholder is now handed over rather than deleted: its id rides on the thrown error, `images.js` adopts it, and `importVideoFrames` fills that same row in. If the fallback fails too, the caller removes it, so a dead import doesn't leave a permanent "decoding…" row either.

## Test plan
- [x] `node --check` both files
- [x] Live: an invalid video Blob makes `importAsLayer` reject as expected; entry count goes 0 → 1 and **stays 1** across the failure, row still present, still `status:'loading'`, id carried on the error
- [x] Adopting that id flips the **same** row (id unchanged) to `status:'ready'` with thumbnail and name — one continuous entry, one rendered row
- [x] Zero console errors

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>