### PR TITLE
Keep the canvas selection alive while scrubbing frames (feedback #155)

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4314,11 +4314,46 @@ function goToFrame(idx){
   // real, on-screen frame. clearSel(true) drops the shape selection (not the
   // layer selection — the `true` preserves _layerActiveExplicit, unlike a
   // canvas deselect, so layer-sec doesn't flicker shut on every scrub).
+  // ...but DROPPING the selection is not the same as needing to rebuild it
+  // (2026-08-30, feedback #155: "drag le curseur de temps dans motion
+  // deselect le calque et donc les objets sur le canvas, il faudrait que la
+  // selection persiste"). The ghost-pointer hazard above is real, yet the
+  // strokes themselves have stable identities (data.strokeId, the same id
+  // relinkBrushCompanions/rig binds already rely on across a rebuild) — so
+  // remember WHICH strokes were selected and re-point the selection at
+  // their freshly-rebuilt counterparts after loadFrame, instead of leaving
+  // the user to re-select on every scrub tick. A stroke that genuinely
+  // isn't on the new frame (a different drawing) simply isn't restored,
+  // which is the correct outcome rather than a special case.
+  // Skipped during playback: goToFrame runs per displayed frame there, and
+  // nothing can act on a selection mid-play anyway.
+  var _selIdsToRestore=null;
+  if(selectedPaths.length&&!state.playing){
+    _selIdsToRestore=selectedPaths.map(function(p){return p&&p.data&&p.data.strokeId;}).filter(Boolean);
+    if(!_selIdsToRestore.length)_selIdsToRestore=null;
+  }
   if(selectedPaths.length||_nodeSel.length)clearSel(true);
   saveAllLayerFrames();state.currentFrame=idx;window._curFrame=idx;
   if(window.SMAudio&&!state.playing)SMAudio.scrubAt(idx); // scrub audio au deplacement du playhead (v19)
   // frameOnly: goToFrame changes the frame and nothing else — see updateUI.
-  loadFrame(idx);if(!state.playing){renderOS();renderArcs();updateUI(true);}else{updatePlayhead();}
+  loadFrame(idx);
+  // Re-point the selection at the rebuilt objects (feedback #155 — see the
+  // capture above). Scoped to the ACTIVE layer, matching getSI's own
+  // assumption that a selection lives in one layer; done BEFORE the render
+  // calls below so the transform box is drawn in the same pass rather than
+  // popping in a frame later.
+  if(_selIdsToRestore&&userLayers[state.activeLayerIdx]){
+    var _kids=userLayers[state.activeLayerIdx].children,_restored=[];
+    for(var _si=0;_si<_kids.length;_si++){
+      var _k=_kids[_si];
+      if(_k&&_k.data&&_k.data.strokeId&&_selIdsToRestore.indexOf(_k.data.strokeId)>=0)_restored.push(_k);
+    }
+    if(_restored.length){
+      selectedPaths=_restored;
+      state.selectedStrokeIndices=selectedPaths.map(getSI).filter(function(i){return i>=0;});
+    }
+  }
+  if(!state.playing){renderOS();renderArcs();updateUI(true);}else{updatePlayhead();}
 }
 
 // F5/insertFrame — Animate's actual convention (corrected: an earlier pass

--- a/src/js/images.js
+++ b/src/js/images.js
@@ -395,7 +395,12 @@
     }
     return frames;
   }
-  async function importVideoFrames(frames,prefix){
+  // adoptMediaId (2026-08-30, feedback #153): when the instant WebCodecs
+  // importer bailed, it hands its "decoding…" media-library row over rather
+  // than deleting it — fill THAT row in at the end instead of adding a
+  // second one, so the panel shows one continuous entry across the whole
+  // (slow) bake instead of a row that vanishes and comes back.
+  async function importVideoFrames(frames,prefix,adoptMediaId){
     saveAllLayerFrames();pushUndoLayers(true);
     if(frames.length>state.totalFrames)window.SM.setTotalFrames(frames.length);
     var idx=createUserLayer(prefix);
@@ -443,7 +448,11 @@
     var firstFrameThumb=(frames.filter(function(f){return f.strokes.length;})[0]||{}).strokes;
     firstFrameThumb=firstFrameThumb&&firstFrameThumb[0]&&firstFrameThumb[0].src;
     convertLayerToComponent(idx);
-    if(window.SMMediaLibrary&&firstFrameThumb)SMMediaLibrary.addEntry(state.layers[idx].name,'video',firstFrameThumb,state.layers[idx].name,{layerUid:state.layers[idx].layerUid});
+    if(window.SMMediaLibrary&&firstFrameThumb){
+      var patch={layerUid:state.layers[idx].layerUid,status:'ready',thumb:firstFrameThumb,name:state.layers[idx].name,layerName:state.layers[idx].name};
+      if(adoptMediaId)SMMediaLibrary.updateEntry(adoptMediaId,patch);
+      else SMMediaLibrary.addEntry(state.layers[idx].name,'video',firstFrameThumb,state.layers[idx].name,{layerUid:state.layers[idx].layerUid});
+    }
     showToast(SM.t('toastVideoImportedSuffix')+frames.filter(function(f){return f.strokes.length;}).length+' images sur le calque "'+prefix+'"');
   }
   async function importVideoFile(file){
@@ -454,15 +463,24 @@
     // ffmpeg subprocess. Falls through to the old bake-every-frame-as-JPEG
     // importer below for anything it can't handle (unsupported container/
     // codec, or a browser without WebCodecs — e.g. older Firefox).
+    var adoptId=null;
     if(window.SMNativeVideo){
       try{await SMNativeVideo.importAsLayer(file);return;}
-      catch(e){showToast(SM.t('toastWebCodecsUnavailable')+(e&&e.message||e)+') — import classique…');}
+      catch(e){
+        adoptId=e&&e.pendingMediaId||null; // see importVideoFrames' own comment (feedback #153)
+        showToast(SM.t('toastWebCodecsUnavailable')+(e&&e.message||e)+') — import classique…');
+      }
     }
     showToast(SM.t('toastDecodingVideo'));
     var blobUrl=URL.createObjectURL(file);
     try{
       var frames=await decodeVideoFrames(blobUrl);
-      await importVideoFrames(frames,file.name.replace(/\.[^.]+$/,''));
+      await importVideoFrames(frames,file.name.replace(/\.[^.]+$/,''),adoptId);
+    }catch(e2){
+      // The fallback failed too — now the placeholder really is dead, so
+      // clear it rather than leaving a permanent "decoding…" row behind.
+      if(adoptId&&window.SMMediaLibrary)SMMediaLibrary.removeEntry(adoptId);
+      throw e2;
     }finally{URL.revokeObjectURL(blobUrl);}
   }
   async function importVideo(){

--- a/src/js/native-video-bridge.js
+++ b/src/js/native-video-bridge.js
@@ -920,8 +920,18 @@
     try {
       info = await open(source);
     } catch (e) {
-      if (pendingMediaId && window.SMMediaLibrary) SMMediaLibrary.removeEntry(pendingMediaId);
-      throw e; // unchanged: images.js's own caller catches this and falls through to the slower bake-every-frame path
+      // Hand the placeholder OVER to the fallback importer instead of
+      // deleting it (2026-08-30, feedback #153: "l'icon apparait avec
+      // decoding mais au bout d'un moment celle ci disparait pendant
+      // l'encoding et réapparait par la suite, du coup on a l'impression
+      // d'un bug"). images.js catches this and falls through to the slow
+      // bake-every-frame path, which only added its own entry at the very
+      // END of decoding — so the row vanished for the entire decode and
+      // came back as a different entry, reading exactly like a crash.
+      // The id rides on the error so the caller can adopt the SAME row and
+      // just fill it in; it removes the row itself if the fallback fails too.
+      e.pendingMediaId = pendingMediaId;
+      throw e;
     }
     if (window.saveAllLayerFrames) saveAllLayerFrames();
     if (window.pushUndoLayers) pushUndoLayers();


### PR DESCRIPTION
## Summary
The layer is never actually deselected — reproduced live: `_layerSel` stays `[0]` and the row keeps `act`. What goes is the **canvas** selection: `goToFrame` drops `selectedPaths` (1 → 0) on every scrub, so the transform box vanishes and you must re-click the artwork after each playhead move.

The `clearSel(true)` doing it is defensible (loadFrame rebuilds Paper children with fresh identities, so old `selectedPaths` would be detached ghosts — documented hazard from a prior QA sweep). But *dropping* and *rebuilding* aren't the same thing, and strokes carry stable `data.strokeId` — the identity `relinkBrushCompanions` and rig binds already use to survive a rebuild.

Now: capture the selected strokeIds, re-point the selection at the rebuilt counterparts after `loadFrame`, before the render pass. A stroke genuinely absent from the destination frame isn't restored — correct, not a special case. Skipped during playback.

## Test plan
- [x] `node --check`
- [x] Live in Motion: 2-stroke selection survives scrubs to frame 12, 3, back to 0 — same strokeIds, objects genuinely attached (0 detached parents), `selectedStrokeIndices` consistent `[0,1]`
- [x] On a deliberately empty keyframe: selection drops to 0, no ghosts, doesn't resurrect on return
- [x] Zero console errors

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>