### PR TITLE
Statusbar shortcut bar: translate the key names, not just the descriptions

### DIFF
--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -15,7 +15,7 @@
 (function(){
   var I18N={
     en:{
-      settingsTitle:'Settings',
+      scAltClick:'Alt+click',scAltClickTip:'Alt+click near a tip',scAltDrag:'Alt+drag',scAltDragPivot:'Alt+drag (pivot)',scAltDragEmpty:'Alt+drag (empty area)',scAltDragChain:'Alt+drag the end of a 2-bone chain',scAltDragHandle:'Alt+drag a handle',scClick:'Click',scClickTip:'Click near a tip',scRightClick:'Right-click',scCtrlDragCorner:'Ctrl+drag a corner',scDoubleClick:'Double-click',scSpace:'Space',scDragExisting:'Drag an existing anchor or handle',scShiftClick:'Shift+click',scDelete:'Del',scEscape:'Esc',settingsTitle:'Settings',
       settingsTabGeneral:'General',settingsTabUpdates:'Updates',settingsTabCollab:'Collaboration',settingsTabFeedback:'Feedback',settingsTabFigma:'Figma',settingsTabShortcuts:'Shortcuts',
       settingsLanguage:'Language',
       roleAnimator:'Animator',roleSupervisor:'Supervisor',roleProducer:'Producer',
@@ -721,7 +721,7 @@
       mgraphModeValue:'value',mgraphModeSpeed:'speed',mgraphFrozen:'frozen',mgraphExprLegend:'solid = expression, dashed = keyframes',
     },
     fr:{
-      settingsTitle:'Réglages',
+      scAltClick:'Alt+clic',scAltClickTip:'Alt+clic près d’une pointe',scAltDrag:'Alt+glisser',scAltDragPivot:'Alt+glisser (pivot)',scAltDragEmpty:'Alt+glisser (zone vide)',scAltDragChain:'Alt+glisser le bout d’une chaîne de 2 os',scAltDragHandle:'Alt+glisser une poignée',scClick:'Clic',scClickTip:'Clic près d’une pointe',scRightClick:'Clic-droit',scCtrlDragCorner:'Ctrl+glisser un coin',scDoubleClick:'Double-clic',scSpace:'Espace',scDragExisting:'Glisser une ancre ou une poignée existante',scShiftClick:'Shift+clic',scDelete:'Suppr',scEscape:'Échap',settingsTitle:'Réglages',
       settingsTabGeneral:'Général',settingsTabUpdates:'Mises à jour',settingsTabCollab:'Collaboration',settingsTabFeedback:'Feedback',settingsTabFigma:'Figma',settingsTabShortcuts:'Raccourcis',
       settingsLanguage:'Langue',
       roleAnimator:'Animateur',roleSupervisor:'Superviseur',roleProducer:'Producteur',
@@ -1427,7 +1427,7 @@
       mgraphModeValue:'valeur',mgraphModeSpeed:'vitesse',mgraphFrozen:'figé',mgraphExprLegend:'plein = expression, pointillés = clés',
     },
     ja:{
-      settingsTitle:'設定',
+      scAltClick:'Alt+クリック',scAltClickTip:'先端付近をAlt+クリック',scAltDrag:'Alt+ドラッグ',scAltDragPivot:'Alt+ドラッグ（基準点）',scAltDragEmpty:'Alt+ドラッグ（空白部分）',scAltDragChain:'2ボーン チェーンの端をAlt+ドラッグ',scAltDragHandle:'ハンドルをAlt+ドラッグ',scClick:'クリック',scClickTip:'先端付近をクリック',scRightClick:'右クリック',scCtrlDragCorner:'角をCtrl+ドラッグ',scDoubleClick:'ダブルクリック',scSpace:'スペース',scDragExisting:'既存のアンカーまたはハンドルをドラッグ',scShiftClick:'Shift+クリック',scDelete:'Delete',scEscape:'Esc',settingsTitle:'設定',
       settingsTabGeneral:'一般',settingsTabUpdates:'アップデート',settingsTabCollab:'コラボレーション',settingsTabFeedback:'フィードバック',settingsTabFigma:'Figma',settingsTabShortcuts:'ショートカット',
       settingsLanguage:'言語',
       roleAnimator:'アニメーター',roleSupervisor:'スーパーバイザー',roleProducer:'プロデューサー',
@@ -2100,7 +2100,7 @@
       mgraphModeValue:'値',mgraphModeSpeed:'速度',mgraphFrozen:'固定',mgraphExprLegend:'実線 = 式、破線 = キーフレーム',
     },
     es:{
-      settingsTitle:'Ajustes',
+      scAltClick:'Alt+clic',scAltClickTip:'Alt+clic cerca de una punta',scAltDrag:'Alt+arrastrar',scAltDragPivot:'Alt+arrastrar (pivote)',scAltDragEmpty:'Alt+arrastrar (zona vacía)',scAltDragChain:'Alt+arrastrar el extremo de una cadena de 2 huesos',scAltDragHandle:'Alt+arrastrar un manejador',scClick:'Clic',scClickTip:'Clic cerca de una punta',scRightClick:'Clic derecho',scCtrlDragCorner:'Ctrl+arrastrar una esquina',scDoubleClick:'Doble clic',scSpace:'Espacio',scDragExisting:'Arrastrar un ancla o manejador existente',scShiftClick:'Shift+clic',scDelete:'Supr',scEscape:'Esc',settingsTitle:'Ajustes',
       settingsTabGeneral:'General',settingsTabUpdates:'Actualizaciones',settingsTabCollab:'Colaboración',settingsTabFeedback:'Feedback',settingsTabFigma:'Figma',settingsTabShortcuts:'Atajos',
       settingsLanguage:'Idioma',
       roleAnimator:'Animador',roleSupervisor:'Supervisor',roleProducer:'Productor',

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -2617,35 +2617,35 @@ function getToolHelp(tool){
     // Ctrl was already held. Alt+glisser also had two DIFFERENT meanings
     // depending on where the drag starts (pivot vs empty canvas) collapsed
     // into one label that only documented the first — split into two rows.
-    select:{desc:tt('thSelectDesc'),sc:[['V',tt('thTool')],['Shift+clic',tt('thAdd')],['Alt+glisser (pivot)',tt('thMoveAnchor')],['Alt+glisser (zone vide)',tt('thLassoEmpty')],['Ctrl+glisser un coin',tt('thDistort')],['Suppr',tt('thErase')],['Shift+X',tt('thFlipH')],['Shift+Alt+X',tt('thFlipV')]]},
-    subselect:{desc:tt('thSubselectDesc'),sc:[['A',tt('thTool')],['Alt+clic',tt('thBreakTangent')]]},
-    fsselect:{desc:tt('thFsselectDesc'),sc:[['Shift+clic',tt('thAdd')]]},
-    draw:{desc:tt('thDrawDesc'),sc:[['B',tt('thTool')],['Alt+glisser',tt('thSize')],['[ ]',tt('thSizePlusMinus')]]},
+    select:{desc:tt('thSelectDesc'),sc:[['V',tt('thTool')],[tt('scShiftClick'),tt('thAdd')],[tt('scAltDragPivot'),tt('thMoveAnchor')],[tt('scAltDragEmpty'),tt('thLassoEmpty')],[tt('scCtrlDragCorner'),tt('thDistort')],[tt('scDelete'),tt('thErase')],['Shift+X',tt('thFlipH')],['Shift+Alt+X',tt('thFlipV')]]},
+    subselect:{desc:tt('thSubselectDesc'),sc:[['A',tt('thTool')],[tt('scAltClick'),tt('thBreakTangent')]]},
+    fsselect:{desc:tt('thFsselectDesc'),sc:[[tt('scShiftClick'),tt('thAdd')]]},
+    draw:{desc:tt('thDrawDesc'),sc:[['B',tt('thTool')],[tt('scAltDrag'),tt('thSize')],['[ ]',tt('thSizePlusMinus')]]},
     // Shift (angle 45°) and Alt (break the handle being dragged into a
     // corner) were undocumented for Pen — the ONLY place a user would
     // learn them was Subselect's own Alt+clic row above, a different tool.
-    pen:{desc:tt('thPenDesc'),sc:[['P',tt('thTool')],['Clic',tt('thAnchor')],['Shift',tt('thAngle45')],['Alt+glisser une poignée',tt('thBreakTangent')],['Échap',tt('thFinish')]]},
+    pen:{desc:tt('thPenDesc'),sc:[['P',tt('thTool')],[tt('scClick'),tt('thAnchor')],['Shift',tt('thAngle45')],[tt('scAltDragHandle'),tt('thBreakTangent')],[tt('scEscape'),tt('thFinish')]]},
     line:{desc:tt('thLineDesc'),sc:[['Shift',tt('thAngle45')]]},
     rect:{desc:tt('thRectDesc'),sc:[['Shift',tt('thSquare')]]},
     ellipse:{desc:tt('thEllipseDesc'),sc:[['Shift',tt('thCircle')]]},
-    fill:{desc:tt('thFillDesc'),sc:[['Alt+glisser',tt('thClosingStroke')],['Shift+clic',tt('thRemoveFill')],['Échap',tt('thCancelStroke')]]},
+    fill:{desc:tt('thFillDesc'),sc:[[tt('scAltDrag'),tt('thClosingStroke')],[tt('scShiftClick'),tt('thRemoveFill')],[tt('scEscape'),tt('thCancelStroke')]]},
     fillbrush:{desc:tt('thFillbrushDesc'),sc:[]},
     // Alt+glisser live-resizes the brush here exactly like it does on Draw
     // (above) — was undocumented on this sibling tool specifically, even
     // though the gesture and the code path are the same.
-    eraser:{desc:tt('thEraserDesc'),sc:[['E',tt('thTool')],['Alt+glisser',tt('thSize')],['[ ]',tt('thSizePlusMinus')]]},
+    eraser:{desc:tt('thEraserDesc'),sc:[['E',tt('thTool')],[tt('scAltDrag'),tt('thSize')],['[ ]',tt('thSizePlusMinus')]]},
     eyedropper:{desc:tt('thEyedropperDesc'),sc:[['I',tt('thTool')]]},
-    hand:{desc:tt('thHandDesc'),sc:[['Espace',tt('thHoldTemp')],['Espace',tt('thTapPlay')]]},
+    hand:{desc:tt('thHandDesc'),sc:[[tt('scSpace'),tt('thHoldTemp')],[tt('scSpace'),tt('thTapPlay')]]},
     zoom:{desc:tt('thZoomDesc'),sc:[['Z',tt('thTool')]]},
-    rotate:{desc:tt('thRotateDesc'),sc:[['Alt+glisser',tt('thOnOtherTool')]]},
-    camera:{desc:tt('thCameraDesc'),sc:[['Clic-droit',tt('thEasingCurve')]]},
+    rotate:{desc:tt('thRotateDesc'),sc:[[tt('scAltDrag'),tt('thOnOtherTool')]]},
+    camera:{desc:tt('thCameraDesc'),sc:[[tt('scRightClick'),tt('thEasingCurve')]]},
     comment:{desc:tt('thCommentDesc'),sc:[]},
     text:{desc:tt('thTextDesc'),sc:[]},
     perspective:{desc:tt('thPerspectiveDesc'),sc:[]},
     // Rig's Tracer step is Pen-style bone drawing (rig-bridge.js) — same
     // Shift/Alt semantics as Pen, undocumented here (only Pen's own row
     // had them, a different tool).
-    rig:{desc:tt('thRigDesc'),sc:[['S',tt('thTool')],['Clic',tt('thAnchor')],['Shift',tt('thAngle45')],['Clic près d’une pointe',tt('thRigBranch')],['Alt+clic près d’une pointe',tt('thRigExtend')],['Alt+glisser une poignée',tt('thBreakTangent')],['Glisser une ancre ou une poignée existante',tt('thRigPose')],['Alt+glisser le bout d’une chaîne de 2 os',tt('thRigIK')],['Double-clic',tt('thFinish')]]},
+    rig:{desc:tt('thRigDesc'),sc:[['S',tt('thTool')],[tt('scClick'),tt('thAnchor')],['Shift',tt('thAngle45')],[tt('scClickTip'),tt('thRigBranch')],[tt('scAltClickTip'),tt('thRigExtend')],[tt('scAltDragHandle'),tt('thBreakTangent')],[tt('scDragExisting'),tt('thRigPose')],[tt('scAltDragChain'),tt('thRigIK')],[tt('scDoubleClick'),tt('thFinish')]]},
   };
   return TOOL_HELP[tool];
 }
@@ -2665,20 +2665,20 @@ function updateStatusBarHelp(){
   // 1. A canvas element is selected (select/subselect) — most specific.
   if((state.tool==='select'||state.tool==='subselect')&&typeof selectedPaths!=='undefined'&&selectedPaths.length>0){
     var n=selectedPaths.length;
-    statusbarHelpRender(n+' '+tt(n>1?'thElementsSelected':'thElementSelected')+' —',[['Suppr',tt('thErase')],['⌘/Ctrl+D',tt('thDuplicate')],['↑↓←→',tt('thMove')],['Échap',tt('thDeselect')]]);
+    statusbarHelpRender(n+' '+tt(n>1?'thElementsSelected':'thElementSelected')+' —',[[tt('scDelete'),tt('thErase')],['⌘/Ctrl+D',tt('thDuplicate')],['↑↓←→',tt('thMove')],[tt('scEscape'),tt('thDeselect')]]);
     return;
   }
   // 2. fsselect has an active fill/stroke pick.
   if(state.tool==='fsselect'&&typeof _fsSel!=='undefined'&&_fsSel.length){
     var fsPrimSB=fsPrimarySel();
     var fsCountSB=_fsSel.length>1?' ('+_fsSel.length+')':'';
-    statusbarHelpRender(tt(fsPrimSB.kind==='stroke'?'hdrStroke':'hdrFill')+fsCountSB+' '+tt('thSelected')+' —',[['Suppr',tt('thErase')],['Échap',tt('thDeselect')]]);
+    statusbarHelpRender(tt(fsPrimSB.kind==='stroke'?'hdrStroke':'hdrFill')+fsCountSB+' '+tt('thSelected')+' —',[[tt('scDelete'),tt('thErase')],[tt('scEscape'),tt('thDeselect')]]);
     return;
   }
   // 3. A timeline keyframe cell (or span) is selected.
   if(typeof _sel!=='undefined'&&_sel.frames&&_sel.frames.length>0){
     var kn=_sel.frames.length;
-    statusbarHelpRender(kn+' '+tt(kn>1?'thKeyframesSelected':'thKeyframeSelected')+' —',[['F6',tt('scKey')],['F7',tt('scBlank')],['T',tt('scTween')],['D',tt('scDupli')],['F',tt('scFlip')],['X',tt('scMirror')],['Suppr',tt('thErase')]]);
+    statusbarHelpRender(kn+' '+tt(kn>1?'thKeyframesSelected':'thKeyframeSelected')+' —',[['F6',tt('scKey')],['F7',tt('scBlank')],['T',tt('scTween')],['D',tt('scDupli')],['F',tt('scFlip')],['X',tt('scMirror')],[tt('scDelete'),tt('thErase')]]);
     return;
   }
   // 4. The active tool's own help.


### PR DESCRIPTION
The status-bar cheat-sheet built each hint as `[key, description]`. Descriptions went through `tt()`, but the key labels were French literals, so a non-French user saw `Alt+glisser (pivot)` and `Suppr` inside an otherwise translated UI.

17 new i18n keys across en/fr/ja/es; 31 hardcoded labels now resolve through `tt()`. Language-neutral labels (`V`, `F5`, `[ ]`, `↑↓←→`, `Shift+X`) stay literal by design.

Verified live in all four locales — English `select` now reads `V | Shift+click | Alt+drag (pivot) | Alt+drag (empty area) | Ctrl+drag a corner | Del`, and French is unchanged.

Closes feedback #157 (partial — the embedded/linked tooltip half was already fixed by #350).

🤖 Generated with [Claude Code](https://claude.com/claude-code)