### PR TITLE
Media panel: icon buttons for import, and a third (compact) list density

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2187,6 +2187,30 @@ body.mode-motion .layer-inout-bar .layer-inout-handle{width:4px;border-radius:2p
 .media-filter-chip{background:var(--panel3);border:1px solid transparent;border-radius:10px;color:var(--text-dim);font-size:9px;font-weight:600;padding:3px 9px;cursor:pointer;white-space:nowrap;}
 .media-filter-chip:hover{color:var(--text);}
 .media-filter-chip.active{color:var(--accent-hover);background:var(--accent-dim);border-color:var(--accent);}
+/* Import icon buttons (feedback #158) — same visual weight as .pbtn but
+   square, since the drop zone right below already carries the words. */
+.media-import-row{gap:4px;}
+.media-icon-btn{flex:none;width:26px;height:22px;display:flex;align-items:center;justify-content:center;padding:0;border:1px solid var(--border);border-radius:5px;background:var(--panel3);color:var(--text-dim);cursor:pointer;}
+.media-icon-btn:hover{color:var(--text);border-color:var(--accent);}
+.media-icon-btn:active{background:var(--panel2);}
+.media-icon-btn svg{display:block;}
+.media-icon-btn:focus-visible{outline:2px solid var(--accent);outline-offset:1px;}
+/* Compact density (feedback #158, "une liste plus petite"): same .media-row
+   DOM as the normal list — only tighter. Name and badges share one line, and
+   the kind badge is dropped because the folder group header above already
+   says the kind; linked/missing badges stay, since those are STATUS and are
+   the whole reason to glance at this list. */
+.media-compact-view .media-row{padding:1px 5px;gap:6px;border-radius:4px;}
+.media-compact-view .media-row-thumb{width:16px;height:16px;border-radius:3px;}
+.media-compact-view .media-row-playicon{font-size:6px;}
+.media-compact-view .media-row-main{flex-direction:row;align-items:center;gap:6px;}
+.media-compact-view .media-row-name{flex:1;min-width:0;font-size:9.5px;}
+.media-compact-view .media-row-meta{flex:none;flex-wrap:nowrap;gap:4px;}
+.media-compact-view .media-row-badge.kind-image,
+.media-compact-view .media-row-badge.kind-video,
+.media-compact-view .media-row-badge.kind-audio,
+.media-compact-view .media-row-size,
+.media-compact-view .media-row-owner{display:none;}
 .media-view-toggle{flex:none;width:16px;height:16px;display:flex;align-items:center;justify-content:center;color:rgba(236,234,231,.4);cursor:pointer;}
 .media-view-toggle:hover{color:var(--text);}
 .media-view-toggle.active{color:var(--accent);}

--- a/src/index.html
+++ b/src/index.html
@@ -1186,9 +1186,19 @@
           <div class="pr" id="media-convert-row" style="margin-top:2px;margin-bottom:4px">
             <button class="pbtn" id="btn-convert-media" type="button" style="width:100%">Convertir les médias…</button>
           </div>
-          <div class="pr" style="gap:4px">
-            <button class="pbtn" id="btn-media-import-img" style="flex:1" data-i18n="mediaImportImg">Image(s)…</button>
-            <button class="pbtn" id="btn-media-import-video" style="flex:1" data-i18n="mediaImportVideo">Vidéo…</button>
+          <!-- Import: icon buttons, not text (feedback #158). The drop zone
+               directly below already spells out "…or click Import", so a full
+               row of two wide text buttons was saying the same thing twice in
+               a panel that is short on vertical space. NOTE: these carry
+               data-i18n-TITLE, never data-i18n — the latter writes textContent
+               and would wipe the inline SVG on the first applyI18n pass. -->
+          <div class="pr media-import-row" style="gap:4px">
+            <button class="media-icon-btn" id="btn-media-import-img" type="button" data-i18n-title="mediaImportImg" title="Image(s)…" aria-label="Image(s)">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+            </button>
+            <button class="media-icon-btn" id="btn-media-import-video" type="button" data-i18n-title="mediaImportVideo" title="Vidéo…" aria-label="Video">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="14" height="16" rx="2"/><path d="M22 7l-6 4 6 4z"/></svg>
+            </button>
           </div>
           <div id="media-drop" class="media-drop" data-i18n="mediaDropHint">Glisser des images/vidéos ici, ou cliquer Importer…</div>
           <div class="media-search-row">
@@ -1199,7 +1209,12 @@
           <div id="media-filter-chips" class="media-filter-chips"></div>
           <div class="pr media-panel-hdr" style="gap:4px">
             <button class="pbtn" id="btn-media-cleanup" style="flex:1;display:none;font-size:9px">Nettoyer (0)</button>
-            <div class="media-view-toggle" id="media-view-toggle" data-i18n-title="mediaViewToggleTitle" title="Vue liste / grille">
+            <!-- Three densities, not two (feedback #158: "il pourrait y avoir
+                 la possibilité d'avoir une liste plus petite"). Cycles
+                 list -> compact -> grid; the icon and title are rewritten by
+                 media-library.js to show which one is active, so this markup
+                 is only the initial ("list") state. -->
+            <div class="media-view-toggle" id="media-view-toggle" title="Vue liste / grille">
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             </div>
             <div class="media-expand-toggle" id="media-expand-toggle" title="Agrandir / réduire la liste">

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -15,7 +15,7 @@
 (function(){
   var I18N={
     en:{
-      scAltClick:'Alt+click',scAltClickTip:'Alt+click near a tip',scAltDrag:'Alt+drag',scAltDragPivot:'Alt+drag (pivot)',scAltDragEmpty:'Alt+drag (empty area)',scAltDragChain:'Alt+drag the end of a 2-bone chain',scAltDragHandle:'Alt+drag a handle',scClick:'Click',scClickTip:'Click near a tip',scRightClick:'Right-click',scCtrlDragCorner:'Ctrl+drag a corner',scDoubleClick:'Double-click',scSpace:'Space',scDragExisting:'Drag an existing anchor or handle',scShiftClick:'Shift+click',scDelete:'Del',scEscape:'Esc',settingsTitle:'Settings',
+      scAltClick:'Alt+click',scAltClickTip:'Alt+click near a tip',scAltDrag:'Alt+drag',scAltDragPivot:'Alt+drag (pivot)',scAltDragEmpty:'Alt+drag (empty area)',scAltDragChain:'Alt+drag the end of a 2-bone chain',scAltDragHandle:'Alt+drag a handle',scClick:'Click',scClickTip:'Click near a tip',scRightClick:'Right-click',scCtrlDragCorner:'Ctrl+drag a corner',scDoubleClick:'Double-click',scSpace:'Space',scDragExisting:'Drag an existing anchor or handle',scShiftClick:'Shift+click',scDelete:'Del',scEscape:'Esc',mediaEmptyLibrary:'No media imported yet.',mediaViewNext:'View',mediaView_list:'list',mediaView_compact:'compact list',mediaView_grid:'grid',mediaKindVideo:'Video',mediaKindImage:'Image',mediaKindAudio:'Audio',settingsTitle:'Settings',
       settingsTabGeneral:'General',settingsTabUpdates:'Updates',settingsTabCollab:'Collaboration',settingsTabFeedback:'Feedback',settingsTabFigma:'Figma',settingsTabShortcuts:'Shortcuts',
       settingsLanguage:'Language',
       roleAnimator:'Animator',roleSupervisor:'Supervisor',roleProducer:'Producer',
@@ -729,7 +729,7 @@
       mgraphModeValue:'value',mgraphModeSpeed:'speed',mgraphFrozen:'frozen',mgraphExprLegend:'solid = expression, dashed = keyframes',
     },
     fr:{
-      scAltClick:'Alt+clic',scAltClickTip:'Alt+clic près d’une pointe',scAltDrag:'Alt+glisser',scAltDragPivot:'Alt+glisser (pivot)',scAltDragEmpty:'Alt+glisser (zone vide)',scAltDragChain:'Alt+glisser le bout d’une chaîne de 2 os',scAltDragHandle:'Alt+glisser une poignée',scClick:'Clic',scClickTip:'Clic près d’une pointe',scRightClick:'Clic-droit',scCtrlDragCorner:'Ctrl+glisser un coin',scDoubleClick:'Double-clic',scSpace:'Espace',scDragExisting:'Glisser une ancre ou une poignée existante',scShiftClick:'Shift+clic',scDelete:'Suppr',scEscape:'Échap',settingsTitle:'Réglages',
+      scAltClick:'Alt+clic',scAltClickTip:'Alt+clic près d’une pointe',scAltDrag:'Alt+glisser',scAltDragPivot:'Alt+glisser (pivot)',scAltDragEmpty:'Alt+glisser (zone vide)',scAltDragChain:'Alt+glisser le bout d’une chaîne de 2 os',scAltDragHandle:'Alt+glisser une poignée',scClick:'Clic',scClickTip:'Clic près d’une pointe',scRightClick:'Clic-droit',scCtrlDragCorner:'Ctrl+glisser un coin',scDoubleClick:'Double-clic',scSpace:'Espace',scDragExisting:'Glisser une ancre ou une poignée existante',scShiftClick:'Shift+clic',scDelete:'Suppr',scEscape:'Échap',mediaEmptyLibrary:'Aucun média importé.',mediaViewNext:'Affichage',mediaView_list:'liste',mediaView_compact:'liste compacte',mediaView_grid:'grille',mediaKindVideo:'Vidéo',mediaKindImage:'Image',mediaKindAudio:'Audio',settingsTitle:'Réglages',
       settingsTabGeneral:'Général',settingsTabUpdates:'Mises à jour',settingsTabCollab:'Collaboration',settingsTabFeedback:'Feedback',settingsTabFigma:'Figma',settingsTabShortcuts:'Raccourcis',
       settingsLanguage:'Langue',
       roleAnimator:'Animateur',roleSupervisor:'Superviseur',roleProducer:'Producteur',
@@ -1443,7 +1443,7 @@
       mgraphModeValue:'valeur',mgraphModeSpeed:'vitesse',mgraphFrozen:'figé',mgraphExprLegend:'plein = expression, pointillés = clés',
     },
     ja:{
-      scAltClick:'Alt+クリック',scAltClickTip:'先端付近をAlt+クリック',scAltDrag:'Alt+ドラッグ',scAltDragPivot:'Alt+ドラッグ（基準点）',scAltDragEmpty:'Alt+ドラッグ（空白部分）',scAltDragChain:'2ボーン チェーンの端をAlt+ドラッグ',scAltDragHandle:'ハンドルをAlt+ドラッグ',scClick:'クリック',scClickTip:'先端付近をクリック',scRightClick:'右クリック',scCtrlDragCorner:'角をCtrl+ドラッグ',scDoubleClick:'ダブルクリック',scSpace:'スペース',scDragExisting:'既存のアンカーまたはハンドルをドラッグ',scShiftClick:'Shift+クリック',scDelete:'Delete',scEscape:'Esc',settingsTitle:'設定',
+      scAltClick:'Alt+クリック',scAltClickTip:'先端付近をAlt+クリック',scAltDrag:'Alt+ドラッグ',scAltDragPivot:'Alt+ドラッグ（基準点）',scAltDragEmpty:'Alt+ドラッグ（空白部分）',scAltDragChain:'2ボーン チェーンの端をAlt+ドラッグ',scAltDragHandle:'ハンドルをAlt+ドラッグ',scClick:'クリック',scClickTip:'先端付近をクリック',scRightClick:'右クリック',scCtrlDragCorner:'角をCtrl+ドラッグ',scDoubleClick:'ダブルクリック',scSpace:'スペース',scDragExisting:'既存のアンカーまたはハンドルをドラッグ',scShiftClick:'Shift+クリック',scDelete:'Delete',scEscape:'Esc',mediaEmptyLibrary:'インポートされたメディアはありません。',mediaViewNext:'表示',mediaView_list:'リスト',mediaView_compact:'コンパクトリスト',mediaView_grid:'グリッド',mediaKindVideo:'動画',mediaKindImage:'画像',mediaKindAudio:'音声',settingsTitle:'設定',
       settingsTabGeneral:'一般',settingsTabUpdates:'アップデート',settingsTabCollab:'コラボレーション',settingsTabFeedback:'フィードバック',settingsTabFigma:'Figma',settingsTabShortcuts:'ショートカット',
       settingsLanguage:'言語',
       roleAnimator:'アニメーター',roleSupervisor:'スーパーバイザー',roleProducer:'プロデューサー',
@@ -2124,7 +2124,7 @@
       mgraphModeValue:'値',mgraphModeSpeed:'速度',mgraphFrozen:'固定',mgraphExprLegend:'実線 = 式、破線 = キーフレーム',
     },
     es:{
-      scAltClick:'Alt+clic',scAltClickTip:'Alt+clic cerca de una punta',scAltDrag:'Alt+arrastrar',scAltDragPivot:'Alt+arrastrar (pivote)',scAltDragEmpty:'Alt+arrastrar (zona vacía)',scAltDragChain:'Alt+arrastrar el extremo de una cadena de 2 huesos',scAltDragHandle:'Alt+arrastrar un manejador',scClick:'Clic',scClickTip:'Clic cerca de una punta',scRightClick:'Clic derecho',scCtrlDragCorner:'Ctrl+arrastrar una esquina',scDoubleClick:'Doble clic',scSpace:'Espacio',scDragExisting:'Arrastrar un ancla o manejador existente',scShiftClick:'Shift+clic',scDelete:'Supr',scEscape:'Esc',settingsTitle:'Ajustes',
+      scAltClick:'Alt+clic',scAltClickTip:'Alt+clic cerca de una punta',scAltDrag:'Alt+arrastrar',scAltDragPivot:'Alt+arrastrar (pivote)',scAltDragEmpty:'Alt+arrastrar (zona vacía)',scAltDragChain:'Alt+arrastrar el extremo de una cadena de 2 huesos',scAltDragHandle:'Alt+arrastrar un manejador',scClick:'Clic',scClickTip:'Clic cerca de una punta',scRightClick:'Clic derecho',scCtrlDragCorner:'Ctrl+arrastrar una esquina',scDoubleClick:'Doble clic',scSpace:'Espacio',scDragExisting:'Arrastrar un ancla o manejador existente',scShiftClick:'Shift+clic',scDelete:'Supr',scEscape:'Esc',mediaEmptyLibrary:'Ningún medio importado.',mediaViewNext:'Vista',mediaView_list:'lista',mediaView_compact:'lista compacta',mediaView_grid:'cuadrícula',mediaKindVideo:'Video',mediaKindImage:'Imagen',mediaKindAudio:'Audio',settingsTitle:'Ajustes',
       settingsTabGeneral:'General',settingsTabUpdates:'Actualizaciones',settingsTabCollab:'Colaboración',settingsTabFeedback:'Feedback',settingsTabFigma:'Figma',settingsTabShortcuts:'Atajos',
       settingsLanguage:'Idioma',
       roleAnimator:'Animador',roleSupervisor:'Supervisor',roleProducer:'Productor',

--- a/src/js/media-library.js
+++ b/src/js/media-library.js
@@ -194,7 +194,15 @@
   // layer's own color as a stand-in for the reference's owner avatar, since
   // there's no per-user concept here — the layer IS the "owner" of an
   // imported asset), and import date.
-  var KIND_LABEL = { video: 'Vidéo', image: 'Image', audio: 'Audio' };
+  // Lazy getters, not a literal — this was a baked-in French object, so the
+  // kind badge read "Vidéo" inside an otherwise English panel (spotted while
+  // fixing feedback #158, same family as #157). Mirrors asset-tree.js's
+  // KIND_GROUP_LABEL, which already resolves through SM.t for this reason.
+  var KIND_LABEL = {
+    get video() { return t('mediaKindVideo', 'Vidéo'); },
+    get image() { return t('mediaKindImage', 'Image'); },
+    get audio() { return t('mediaKindAudio', 'Audio'); },
+  };
   var _orphanCount = 0; // set fresh by buildRow() on every render() pass, read back after
   // ---- Search / type filter / view mode (2026-08-29, gap-analysis pass
   // against the "Stash" AE panel Cyril pointed at as a reference) — plain
@@ -204,7 +212,19 @@
   // preference, not a transient browsing filter).
   var _searchQuery = '';
   var _activeFilter = 'all'; // 'all' | 'image' | 'video' | 'audio' | 'missing'
-  var _viewMode = 'list'; // 'list' | 'grid'
+  // 'list' | 'compact' | 'grid' — three densities since feedback #158 asked for
+  // "une liste plus petite". compact reuses buildRow (same DOM, same context
+  // menu, same drag wiring) and only changes CSS: a smaller thumb and a single
+  // line, so nothing downstream has to know a third mode exists.
+  var VIEW_MODES = ['list', 'compact', 'grid'];
+  var _viewMode = 'list';
+  try { var _vmSaved = localStorage.getItem('nemo-media-view'); if (VIEW_MODES.indexOf(_vmSaved) >= 0) _viewMode = _vmSaved; } catch (e) {}
+  // Applied to #media-grid AND to every per-kind folder body (rows live in the
+  // folder bodies, not in the grid itself — see render()).
+  function applyViewClasses(el) {
+    el.classList.toggle('media-grid-view', _viewMode === 'grid');
+    el.classList.toggle('media-compact-view', _viewMode === 'compact');
+  }
   var FILTER_CHIPS = [
     { id: 'all', get label() { return t('mediaFilterAll', 'Tout'); } },
     { id: 'image', get label() { return t('assetGroupImages', 'Images'); } },
@@ -486,7 +506,7 @@
   function render() {
     var grid = document.getElementById('media-grid'); if (!grid) return;
     grid.innerHTML = '';
-    grid.classList.toggle('media-grid-view', _viewMode === 'grid');
+    applyViewClasses(grid);
     _orphanCount = 0;
     renderFilterChips();
     if (!window.SMAssetTree) return; // asset-tree.js not loaded — nothing to group into
@@ -556,7 +576,7 @@
       if (!entries.length) return;
       anyShown = true;
       var body = SMAssetTree.folderGroup(grid, { label: SMAssetTree.KIND_GROUP_LABEL[kind], color: SMAssetTree.FOLDER_COLORS[kind], count: entries.length });
-      body.classList.toggle('media-grid-view', _viewMode === 'grid');
+      applyViewClasses(body);
       entries.forEach(function (m) { body.appendChild(_viewMode === 'grid' ? buildTile(m) : buildRow(m)); });
     });
     if (!anyShown) {
@@ -565,7 +585,7 @@
         || (window.SMProject && SMProject.getOpenTabs && SMProject.getOpenTabs().length));
       empty.textContent = hasAnyContent
         ? t('mediaNoMatch', 'Aucun média ne correspond à ce filtre.')
-        : (SM && SM.t ? SM.t('mediaDropHint') : 'Aucun média importé.');
+        : t('mediaEmptyLibrary', 'Aucun média importé.');
       grid.appendChild(empty);
     }
     // Bulk cleanup (2026-07-31) — catalog-only (never touches the
@@ -687,6 +707,21 @@
     });
   }
 
+  // The button shows the mode you are IN, not the one you would switch to —
+  // it is a 3-state cycle now, and "click me to get X" only reads
+  // unambiguously on a 2-state toggle. The title names the next mode instead,
+  // which is where that information belongs.
+  var VIEW_ICON = {
+    list:    '<rect x="3" y="4" width="18" height="4" rx="1"/><rect x="3" y="12" width="18" height="4" rx="1"/>',
+    compact: '<line x1="3" y1="5" x2="21" y2="5"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="3" y1="15" x2="21" y2="15"/><line x1="3" y1="20" x2="21" y2="20"/>',
+    grid:    '<rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/>',
+  };
+  function syncViewToggle(btn) {
+    btn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">' + VIEW_ICON[_viewMode] + '</svg>';
+    btn.classList.toggle('active', _viewMode !== 'list');
+    var next = VIEW_MODES[(VIEW_MODES.indexOf(_viewMode) + 1) % VIEW_MODES.length];
+    btn.title = t('mediaViewNext', 'Affichage') + ' \u2192 ' + t('mediaView_' + next, next);
+  }
   function initSearchAndViewToggle() {
     var input = document.getElementById('media-search');
     var clearBtn = document.getElementById('media-search-clear');
@@ -707,15 +742,27 @@
     }
     var viewBtn = document.getElementById('media-view-toggle');
     if (viewBtn) {
+      syncViewToggle(viewBtn);
       viewBtn.addEventListener('click', function () {
-        _viewMode = _viewMode === 'grid' ? 'list' : 'grid';
-        viewBtn.classList.toggle('active', _viewMode === 'grid');
+        _viewMode = VIEW_MODES[(VIEW_MODES.indexOf(_viewMode) + 1) % VIEW_MODES.length];
+        try { localStorage.setItem('nemo-media-view', _viewMode); } catch (x) {}
+        syncViewToggle(viewBtn);
         render();
       });
     }
   }
 
   function init() {
+    // Rows are built once and cached in the DOM, so a language switch left
+    // every badge/label in the previous locale until the next import forced a
+    // render (confirmed live: SM.t already returned the new string while the
+    // panel did not change). Same escape hatch, and same reason, as
+    // linked-media.js's own afterI18n push — see its comment there. Pushed
+    // from init(), i.e. on DOMContentLoaded, so it lands on the final
+    // window.SM rather than one a later script replaces.
+    window.SM = window.SM || {};
+    window.SM.afterI18n = window.SM.afterI18n || [];
+    if (window.SM.afterI18n.indexOf(render) < 0) window.SM.afterI18n.push(render);
     render();
     initDropZone();
     initCanvasDropTarget();


### PR DESCRIPTION
From feedback #158 — *"dans media y a des choses qui pourraient apparaître en bouton icon plus que bouton text. Et list grid view, il pourrait y avoir la possibilité d'avoir une liste plus petite."*

**Import → icon buttons.** `Image(s)…` / `Vidéo…` took a full row to repeat what the drop zone right below already says in words. Now 26×22 icon buttons with the same labels as tooltips. They use `data-i18n-title`, not `data-i18n` — the latter writes `textContent` and would wipe the inline SVG on the first `applyI18n` pass.

**Three densities, not two.** The toggle cycles list → compact → grid. `compact` reuses `buildRow` unchanged (same DOM, context menu, drag wiring) and only changes CSS: **18px per row vs 52px** for the normal list. It drops the kind badge (the folder header above already says the kind) and keeps linked/missing badges, which are status. Remembered in `localStorage` under `nemo-media-view`.

**Two French leaks found while in there** (same family as #157):
- the empty-library message reused `mediaDropHint` verbatim, printing the same sentence twice in an empty panel;
- `KIND_LABEL` was a hardcoded French literal, so the badge read `Vidéo` in an English panel. Now resolves through `SM.t` like `asset-tree.js`'s `KIND_GROUP_LABEL`. That surfaced a second half: cached rows never repainted on a language switch, so the panel now registers `render()` on `SM.afterI18n`.

Verified live: badges across en/fr/ja/es on a hot switch (`Image/Video` → `Image/Vidéo` → `画像/動画` → `Imagen/Video`), density cycle persisted across reload, both import handlers still firing, no console errors.

Closes feedback #158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)