### PR TITLE
Image mesh: keyframe the vertices through Motion's own vtxN tracks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -702,7 +702,7 @@ post-traitement dans `buildSceneJson` : il réutilise les items déjà construit
 et leur applique la matrice DELTA — ne jamais dupliquer la boucle de
 construction (CLAUDE.md §3).
 
-## 12. Image mesh — déformer une image importée (2026-08-30, PR1+PR2)
+## 12. Image mesh — déformer une image importée (2026-08-30, PR1+PR2+PR3)
 
 `image-mesh.js` (+ `draw_image_mesh` dans engine.rs). Demande de Cyril :
 déformer/animer une image importée via un maillage éditable, AVEC un système de
@@ -806,9 +806,57 @@ monde (960,270) et (960,350) passent au fond ; cycle marche/arrêt/marche →
 chaque glissé dans l'ordre ; l'export (`render_to_pixels`) ne contient AUCUNE
 poignée alors que l'écran en montre 137.
 
-**Pas encore fait** : les clés Motion par sommet (PR3, via le patron
-`vtx*`/`applyPathVertexOffsets` de motion.js), l'ajout/suppression de sommets,
-et le tracé d'un contour à main levée (aujourd'hui on part du rectangle et on
-déplace ses sommets, ou on appelle `SMImageMesh.setOutline` par script). Une
-entrée orpheline reste possible si l'IMAGE est supprimée sans passer par le
-bouton Mesh — `releaseIfUnused` ne couvre que le chemin de détachement.
+**Pas encore fait** : l'ajout/suppression de sommets et le tracé d'un contour à
+main levée (aujourd'hui on part du rectangle et on déplace ses sommets, ou on
+appelle `SMImageMesh.setOutline` par script). Une entrée orpheline reste
+possible si l'IMAGE est supprimée sans passer par le bouton Mesh —
+`releaseIfUnused` ne couvre que le chemin de détachement.
+
+### 12ter. Animation des sommets (PR3)
+
+Les sommets d'un maillage passent par la **même machinerie `vtxN`** que ceux
+d'un Path (`hasPathVertexMotion`/`valueAtFrame`) — donc clés, courbes d'ease,
+éditeur de courbes, expressions et contrôles d'expression sont hérités sans une
+ligne de code de plus. Deux différences volontaires, imposées par ce qu'est une
+image :
+
+1. **Le holder est clé par `meshId`, pas par `strokeId`.** Un raster n'a PAS de
+   strokeId stable d'une frame à l'autre : `layerElements` en tamponne un
+   paresseusement sur le dict de LA frame, et le dict d'une image fixe est un
+   objet littéral SÉPARÉ par frame — la frame 5 en recevrait donc un différent
+   de la frame 0 et l'animation disparaîtrait au scrub. `meshId` est écrit sur
+   toutes les frames par `propagate`, c'est le seul id qu'une image fixe porte
+   réellement de bout en bout.
+2. **La valeur est en POURCENT de la taille de l'image**, pas en pixels — le
+   maillage est stocké normalisé (§12), et le pourcent c'est cette même unité
+   rendue lisible dans l'éditeur de courbes (« 20 » plutôt que « 0,2 »). La
+   division par 100 se fait une seule fois, dans `meshVertexOffsetAt`.
+
+L'offset animé s'AJOUTE à `mesh.offsets` (le sculpt de repos) : le chronomètre
+décide auquel des deux un glissé sur le canevas écrit, exactement comme
+n'importe quelle autre propriété Motion.
+
+⚠️ Trois pièges de plus, tous trouvés en pilotant :
+1. **Écouter sur `document` en capture, PAS sur `#canvas-area`.** motion.js a
+   lui aussi un `pointerdown` en capture sur `#canvas-area`, et entre écouteurs
+   du MÊME élément l'ordre de capture est l'ordre d'enregistrement — motion.js
+   charge en premier, donc il gagnait : glisser un sommet en mode Motion
+   déplaçait silencieusement tout le calque (`ld.motionStatic.position` = le
+   delta exact du glissé). Un écouteur en capture sur un ANCÊTRE passe toujours
+   avant, quel que soit l'ordre d'enregistrement — même astuce que
+   l'interception de clic de tweens.js.
+2. **Ne pas éteindre le mode Édition sur une sélection transitoirement nulle.**
+   `renderImageMeshPanel` tourne depuis `updateUI`, donc à chaque changement de
+   frame, et `loadFrame` reconstruit les items : le mode s'éteignait dès que la
+   tête de lecture bougeait, ce qui rend l'animation d'un maillage impossible
+   (clé, scrub, clé). `editing` est une préférence collante.
+3. **Un fantôme d'onion est un instantané d'une AUTRE frame.** `osTagFrame`
+   (tweens.js) tamponne `__osLayer`/`__osFrame` sur chaque raster fantôme pour
+   qu'`onionLayerItems` le pose à SA frame — sinon le fantôme affichait le
+   sculpt de repos et contredisait le dessin vivant. Vérifié : 12 frames
+   fantômes, 12 poses distinctes.
+
+**Le compte de lignes de la timeline passe par `meshVertexRowCount`**, partagé
+par le panneau ET la grille (§11) — un maillage 32×32 fait 1093 sommets, donc
+il y a un plafond (200) qui DOIT être le même des deux côtés. Vérifié :
+44/44 lignes à 4×4, 219/219 à 32×32.

--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -1460,7 +1460,17 @@
           // (CLAUDE.md §3). Returns null — costing one property read — for
           // every ordinary image.
           if (window.SMImageMesh) {
-            var meshPayload = SMImageMesh.scenePayload(c, rb);
+            // Animated pose (2026-08-30) — per-vertex Motion tracks, keyed
+            // by meshId on this layer's element holders (see motion.js's
+            // meshHolder comment). The guard is the cheap one: a mesh with
+            // no vertex tracks at all (the common case) passes no poseAt
+            // and scenePayload takes its zero-cost path.
+            var cMeshId = c.data && c.data.meshId;
+            var meshPose = null;
+            if (cMeshId && window.SMMotion && SMMotion.hasMeshVertexMotionFor && SMMotion.hasMeshVertexMotionFor(i, cMeshId)) {
+              meshPose = function (vi) { return SMMotion.meshVertexOffsetAt(i, cMeshId, vi, renderFrame); };
+            }
+            var meshPayload = SMImageMesh.scenePayload(c, rb, meshPose);
             if (meshPayload) imgItem.mesh = meshPayload;
           }
           items.push({ image: imgItem });
@@ -2364,7 +2374,17 @@
           // deformed silhouette, otherwise the ghost and the live drawing
           // disagree about where the artwork is, which is worse than no ghost.
           if (window.SMImageMesh) {
-            var oMesh = SMImageMesh.scenePayload(c, rb);
+            // An onion ghost is a snapshot of ANOTHER frame, so an animated
+            // mesh has to be posed at THAT frame, not the current one —
+            // renderOS stamps the source (layer, frame) on the ghost item
+            // for exactly this (tweens.js's osTagFrame).
+            var oMeshId = c.data && c.data.meshId;
+            var oPose = null;
+            if (oMeshId && c.data.__osFrame != null && window.SMMotion && SMMotion.hasMeshVertexMotionFor && SMMotion.hasMeshVertexMotionFor(c.data.__osLayer, oMeshId)) {
+              var oLi = c.data.__osLayer, oFr = c.data.__osFrame;
+              oPose = function (vi) { return SMMotion.meshVertexOffsetAt(oLi, oMeshId, vi, oFr); };
+            }
+            var oMesh = SMImageMesh.scenePayload(c, rb, oPose);
             if (oMesh) oItem.mesh = oMesh;
           }
           items.push({ image: oItem });

--- a/src/js/image-mesh-bridge.js
+++ b/src/js/image-mesh-bridge.js
@@ -83,10 +83,21 @@
     if (!m && SMMotion.layerMotion3DPointMap) m = SMMotion.layerMotion3DPointMap(state.activeLayerIdx);
     return m;
   }
+  // The animated pose for this mesh at the current frame, or null when it
+  // has no vertex tracks at all. Identical to what buildSceneJson feeds the
+  // renderer (engine-bridge.js) — the handles have to sit on the picture,
+  // so both sides read the same thing rather than the overlay quietly
+  // showing the rest sculpt while the image renders its animated pose.
+  function poseAtFor(t) {
+    if (!window.SMMotion || !SMMotion.hasMeshVertexMotionFor) return null;
+    var li = state.activeLayerIdx;
+    if (!SMMotion.hasMeshVertexMotionFor(li, t.meshId)) return null;
+    return function (vi) { return SMMotion.meshVertexOffsetAt(li, t.meshId, vi, state.currentFrame); };
+  }
   function renderedVerts(t) {
     if (!window.SMEngineBridge || !SMEngineBridge.rasterImageRect) return null;
     var rect = SMEngineBridge.rasterImageRect(t.raster);
-    var pts = SMImageMesh.worldVerts(t.mesh, rect);
+    var pts = SMImageMesh.worldVerts(t.mesh, rect, poseAtFor(t));
     if (!pts) return null;
     var mm = motionMap();
     if (mm) pts = pts.map(function (p) { return mm.fwd(p[0], p[1]); });
@@ -186,13 +197,32 @@
     if (mm && mm.inv) { var iv = mm.inv(w[0], w[1]); w = [iv[0], iv[1]]; }
     var uv = SMImageMesh.normalizedOf(rect, w[0], w[1]);
     var rest = t.mesh.verts[dragIdx];
-    SMImageMesh.setOffset(t.meshId, dragIdx, uv[0] - rest[0], uv[1] - rest[1]);
+    // Where the drag lands depends on the stopwatch, exactly like every
+    // other Motion property: an ANIMATED vertex records a key (or a static
+    // override) on its vtxN track, an un-animated one edits the mesh's own
+    // rest sculpt. The track value is a deviation ON TOP of the sculpt, so
+    // it is measured from rest+sculpt rather than from rest.
+    var li = state.activeLayerIdx;
+    if (window.SMMotion && SMMotion.isMeshVertexAnimated && SMMotion.isMeshVertexAnimated(li, t.meshId, dragIdx)) {
+      var sculpt = (t.mesh.offsets && t.mesh.offsets[dragIdx]) || [0, 0];
+      SMMotion.setMeshVertexOffset(li, t.meshId, dragIdx, uv[0] - rest[0] - sculpt[0], uv[1] - rest[1] - sculpt[1]);
+    } else {
+      SMImageMesh.setOffset(t.meshId, dragIdx, uv[0] - rest[0], uv[1] - rest[1]);
+    }
     dragMoved = true;
     SMEngineBridge.renderNow();
   }
   function onUp(e) {
     if (dragIdx < 0) return;
     e.stopImmediatePropagation(); e.preventDefault();
+    // A drag that landed on a vtxN track may have created a keyframe, which
+    // only shows up once the timeline re-renders — the panel/grid pair is
+    // rebuilt wholesale (motion.js), never incrementally, so nothing else
+    // would repaint it until the next unrelated UI event.
+    var tUp = targetMesh();
+    if (dragMoved && tUp && window.SMMotion && SMMotion.isMeshVertexAnimated
+        && SMMotion.isMeshVertexAnimated(state.activeLayerIdx, tUp.meshId, dragIdx)
+        && typeof updateUI === 'function') updateUI();
     dragIdx = -1;
     SMEngineBridge.resume();
     // The mesh lives in state.imageMeshes, not in the frame's strokes, so
@@ -211,7 +241,16 @@
     var sec = el('p-imagemesh-sec');
     if (!sec) return;
     var r = singleRaster();
-    if (!r) { sec.style.display = 'none'; editing = false; return; }
+    // NOT `editing = false` here. This runs from updateUI, which fires on
+    // every frame change — and loadFrame rebuilds the Paper items, so
+    // singleRaster() is transiently null in the middle of an ordinary
+    // scrub. Clearing the mode there turned edit mode off the instant the
+    // playhead moved, which makes animating a mesh (key a vertex, scrub,
+    // key it again) impossible. Found live doing exactly that. `editing`
+    // is a sticky preference; with no valid target the overlay returns []
+    // and the pointer handlers bail on their own, so leaving it on costs
+    // nothing. It is cleared only when the mesh is genuinely gone (below).
+    if (!r) { sec.style.display = 'none'; return; }
     sec.style.display = '';
     var has = !!(r.data && r.data.meshId && SMImageMesh.get(r.data.meshId));
     if (!has) editing = false;
@@ -281,15 +320,33 @@
     if (rows) rows.addEventListener('change', setDensity);
     var rst = el('btn-imagemesh-reset');
     if (rst) rst.addEventListener('click', resetPose);
-    // Capture phase on #canvas-area, before the Select tool's own drag —
-    // identical wiring to gradient-bridge/perspective-bridge/symmetry-bridge.
-    var tgt = document.getElementById('canvas-area') || document.getElementById('drawing-canvas');
-    if (tgt) {
-      tgt.addEventListener('pointerdown', onDown, { capture: true });
-      tgt.addEventListener('pointermove', onMove, { capture: true });
-      tgt.addEventListener('pointerup', onUp, { capture: true });
-      tgt.addEventListener('pointercancel', onUp, { capture: true });
+    // Capture phase on DOCUMENT, not on #canvas-area.
+    //
+    // gradient-bridge/perspective-bridge/symmetry-bridge all listen on
+    // #canvas-area, and that is enough for them because nothing else
+    // competes for the same gesture. It is NOT enough here: motion.js also
+    // has a capture-phase pointerdown on #canvas-area (its own canvas drag
+    // that moves a layer), and among listeners on the SAME element capture
+    // order is registration order — motion.js loads first, so it won.
+    // Found live in Motion mode: dragging a mesh vertex silently moved the
+    // whole layer instead, leaving ld.motionStatic.position at exactly the
+    // drag delta and no key on the vertex.
+    //
+    // A capture listener on an ANCESTOR always runs before one on a
+    // descendant, whatever the registration order — the same trick tweens.js
+    // documents for its reassign-click intercept ("registered on document,
+    // to steal a click before any per-tool bridge on #canvas-area sees it").
+    // The target check keeps this scoped to the canvas exactly as before,
+    // and every handler bails without stopping propagation unless it is
+    // really taking the gesture.
+    function inCanvas(e) {
+      var area = document.getElementById('canvas-area');
+      return !!(area && e.target && area.contains(e.target));
     }
+    document.addEventListener('pointerdown', function (e) { if (inCanvas(e)) onDown(e); }, { capture: true });
+    document.addEventListener('pointermove', function (e) { if (dragIdx >= 0) onMove(e); }, { capture: true });
+    document.addEventListener('pointerup', function (e) { if (dragIdx >= 0) onUp(e); }, { capture: true });
+    document.addEventListener('pointercancel', function (e) { if (dragIdx >= 0) onUp(e); }, { capture: true });
   }
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
   else init();

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -3703,6 +3703,80 @@
     if (!ld || !ld.elementMotion || !strokeId) return segments;
     return applyPathVertexOffsets(segments, ld.elementMotion[strokeId], frameIdx);
   }
+
+  // ---- Image mesh vertices (2026-08-30, image-mesh.js) ----
+  //
+  // An image mesh's vertices key through the SAME vtxN machinery a Path's
+  // vertices already use — same holder shape, same tracks, so mesh
+  // animation inherits keyframes, ease curves, the graph editor,
+  // expressions and the expression controls for free. Two deliberate
+  // differences, both forced by what an image is:
+  //
+  // 1. The holder is keyed by **meshId**, not strokeId. A raster has no
+  //    stable strokeId across frames: layerElements stamps one lazily onto
+  //    the frame's own dict, and a still image's dict is a SEPARATE object
+  //    literal per frame (images.js's import loop), so frame 5 would get a
+  //    different id from frame 0 and the animation would vanish on scrub.
+  //    meshId is written to every frame by SMImageMesh.propagate, which
+  //    makes it the only id an imported still actually carries throughout.
+  //
+  // 2. The value is in PERCENT of the image's own size, not pixels. The
+  //    mesh itself is stored normalized over the raster's display rect
+  //    (image-mesh.js's header) so it survives moving/scaling the image;
+  //    percent is that same unit made readable in the graph editor, where
+  //    "20" beats "0.2". meshVertexOffsetAt does the /100 once, here, so
+  //    no caller has to remember it.
+  //
+  // This offset is ADDED to the mesh's own static pose (mesh.offsets),
+  // which stays the rest sculpt — the stopwatch is what decides which of
+  // the two an on-canvas drag writes to, exactly like every other Motion
+  // property.
+  function meshHolder(li, meshId) {
+    var ld = state.layers[li];
+    if (!ld || !ld.elementMotion || !meshId) return null;
+    return ld.elementMotion[meshId] || null;
+  }
+  function hasMeshVertexMotionFor(li, meshId) {
+    return hasPathVertexMotion(meshHolder(li, meshId));
+  }
+  // [du, dv] in NORMALIZED units for one vertex at one frame, or null when
+  // this mesh has no vertex tracks at all (the common case — one cheap
+  // lookup and out, so an un-animated mesh costs nothing per frame).
+  function meshVertexOffsetAt(li, meshId, vi, frameIdx) {
+    var h = meshHolder(li, meshId);
+    if (!h || !hasPathVertexMotion(h)) return null;
+    var v = valueAtFrame(h, 'vtx' + vi, frameIdx);
+    if (!v || (!v[0] && !v[1])) return null;
+    return [v[0] / 100, v[1] / 100];
+  }
+  // Writes a vertex's ANIMATED offset (normalized in, percent out) through
+  // the ordinary setValue path: a key at the playhead when the stopwatch is
+  // on, a static override when it isn't.
+  function setMeshVertexOffset(li, meshId, vi, du, dv) {
+    var ld = state.layers[li];
+    if (!ld || !meshId) return false;
+    setValue(ensureElementHolder(ld, meshId), 'vtx' + vi, [du * 100, dv * 100]);
+    return true;
+  }
+  function isMeshVertexAnimated(li, meshId, vi) {
+    var h = meshHolder(li, meshId);
+    return !!h && isAnimated(h, 'vtx' + vi);
+  }
+  // How many vertex rows the timeline will list for a mesh. Shared by the
+  // panel and the grid so the two can NEVER disagree about the row count —
+  // CLAUDE.md §11's alignment invariant is the constraint that matters most
+  // in this file, and a dense mesh (32x32 = 1089 vertices) is exactly the
+  // case where an ad-hoc cap on one side only would drift. Capped because
+  // rendering four figures' worth of rows on both sides would lock the UI;
+  // the vertices past the cap are still animatable by dragging them on
+  // canvas, they just have no row.
+  var MESH_ROW_CAP = 200;
+  function meshVertexRowCount(meshId) {
+    if (!window.SMImageMesh) return 0;
+    var m = SMImageMesh.get(meshId);
+    if (!m || !m.verts) return 0;
+    return Math.min(m.verts.length, MESH_ROW_CAP);
+  }
   // ---- Trim Paths (2026-08, "animer les stroke en in et out") ----
   // AE's own feature: Start/End (0-100%, position along the path's arc
   // length) plus Offset (shifts the whole window). Opt-in — untouched
@@ -7498,6 +7572,15 @@
       if (!entry.sd.isRaster && entry.sd.segments && entry.sd.segments.length) {
         renderPathVertexGroup(list, ensureElementHolder(ld, entry.strokeId), entry.sd.segments.length);
       }
+      // Image mesh (2026-08-30) — the raster counterpart of the Path group
+      // just above: same accordion, same vertex rows, same stopwatches,
+      // just fed by the mesh's vertices instead of a path's segments. Its
+      // holder is keyed by meshId rather than strokeId (see meshHolder's
+      // own comment). MUST stay mirrored by renderTimelineMotion's grid
+      // half — CLAUDE.md §11.
+      if (entry.sd.isRaster && entry.sd.meshId && meshVertexRowCount(entry.sd.meshId)) {
+        renderMeshVertexGroup(list, ensureElementHolder(ld, entry.sd.meshId), meshVertexRowCount(entry.sd.meshId));
+      }
       // Fill color (2026-07): opt-in extended property, hidden unless the
       // element actually has a fill — same convention as Path above.
       if (entry.sd.fillColor) {
@@ -7715,6 +7798,27 @@
     var grp = document.createElement('div'); grp.className = 'lrow motion-group-row';
     var arrow = document.createElement('span'); arrow.className = 'lico larrow'; arrow.textContent = isPathGroupExpanded(holder) ? '▾' : '▸';
     var label = document.createElement('span'); label.textContent = 'Path';
+    grp.appendChild(arrow); grp.appendChild(label);
+    grp.addEventListener('click', function (e) {
+      e.stopPropagation();
+      window._motionExpandedPathHolder = isPathGroupExpanded(holder) ? null : holder;
+      renderLayerList(); renderTimeline();
+    });
+    list.appendChild(grp);
+    if (!isPathGroupExpanded(holder)) return;
+    for (var vi = 0; vi < vertexCount; vi++) renderVertexRow(list, holder, vi);
+  }
+  // Image mesh accordion (2026-08-30) — identical to renderPathVertexGroup
+  // above apart from its label, and sharing its expand state
+  // (_motionExpandedPathHolder is keyed by HOLDER, and a mesh holder is a
+  // different object from any path holder, so "one group open at a time"
+  // keeps working across both without a second flag). Written as its own
+  // function rather than a `label` parameter on renderPathVertexGroup so
+  // the grid-half mirror has an obviously-paired call to point at.
+  function renderMeshVertexGroup(list, holder, vertexCount) {
+    var grp = document.createElement('div'); grp.className = 'lrow motion-group-row';
+    var arrow = document.createElement('span'); arrow.className = 'lico larrow'; arrow.textContent = isPathGroupExpanded(holder) ? '▾' : '▸';
+    var label = document.createElement('span'); label.textContent = SM.t('hdrImageMesh');
     grp.appendChild(arrow); grp.appendChild(label);
     grp.addEventListener('click', function (e) {
       e.stopPropagation();
@@ -8308,6 +8412,22 @@
             grid.appendChild(pathHdrSpacer);
             if (isPathGroupExpanded(elHolder)) {
               for (var vi = 0; vi < entry.sd.segments.length; vi++) renderTracksFor(grid, elHolder, 'vtx' + vi);
+            }
+          }
+          // Image mesh group — the exact mirror of renderElementsList's own
+          // renderMeshVertexGroup call: same condition, same row count from
+          // the SAME shared helper (meshVertexRowCount), same
+          // spacer-then-rows shape. Note the holder is the MESH holder
+          // (keyed by meshId), not elHolder — the expand state and the
+          // tracks both live on it, so reusing elHolder here would silently
+          // render the wrong side of the accordion.
+          if (entry.sd.isRaster && entry.sd.meshId && meshVertexRowCount(entry.sd.meshId)) {
+            var meshHolderEl = ensureElementHolder(ld, entry.sd.meshId);
+            var meshHdrSpacer = document.createElement('div'); meshHdrSpacer.className = 'frow motion-group-row';
+            grid.appendChild(meshHdrSpacer);
+            if (isPathGroupExpanded(meshHolderEl)) {
+              var mCount = meshVertexRowCount(entry.sd.meshId);
+              for (var mvi = 0; mvi < mCount; mvi++) renderTracksFor(grid, meshHolderEl, 'vtx' + mvi);
             }
           }
           // Fill color (mirrors renderElementsList's renderFillColorRow call
@@ -10306,6 +10426,13 @@
     applyParentChainToSegments: applyParentChainToSegments,
     applyParentChainToImageRect: applyParentChainToImageRect,
     applyPathVertexOffsetsFor: applyPathVertexOffsetsFor,
+    // Image mesh vertex tracks (2026-08-30) — see meshHolder's own comment
+    // for why these are keyed by meshId and expressed in percent.
+    hasMeshVertexMotionFor: hasMeshVertexMotionFor,
+    meshVertexOffsetAt: meshVertexOffsetAt,
+    setMeshVertexOffset: setMeshVertexOffset,
+    isMeshVertexAnimated: isMeshVertexAnimated,
+    meshVertexRowCount: meshVertexRowCount,
     applyTrimFor: applyTrimFor,
     hasParamShapeMotionFor: hasParamShapeMotionFor,
     applyParamShapeFor: applyParamShapeFor,

--- a/src/js/tweens.js
+++ b/src/js/tweens.js
@@ -4275,6 +4275,16 @@ function renderGhostAll(){
 // every one of renderOS()'s many call sites across app.js/timeline.js) so
 // every existing "state changed, recompute the ghost overlays" call site
 // keeps working unmodified and picks up Ghost All for free.
+// Stamps which (layer, frame) an onion ghost came FROM (2026-08-30, image
+// mesh). An onion item is a snapshot of a DIFFERENT frame, and an animated
+// image mesh has a different shape on every frame — without this, a ghost
+// rendered the mesh's rest sculpt instead of that frame's pose, so the
+// ghost and the live drawing disagreed about where the artwork is.
+// Transient by construction: onionPrevLayer/onionNextLayer are never in
+// userLayers, never serialized, and rebuilt wholesale by every renderOS —
+// the `__` prefix marks that, same convention as data.__engineSrcDict.
+// Read by engine-bridge.js's onionLayerItems.
+function osTagFrame(item,li,fi){if(item&&item.data){item.data.__osLayer=li;item.data.__osFrame=fi;}}
 function renderOS(){
   // toggleOnion()/setOnionMode()/setOnionRange()/toggleGhostAll() etc. all
   // just mutate state then call renderOS() — none of them ever bumped
@@ -4366,8 +4376,8 @@ function renderOS(){
   // outline modes still never touch texture-tagged items (canTint excludes
   // them) — that's the original stray-blue-line halo bug this skip was
   // added to prevent, still guarded, just no longer by omitting them outright.
-  for(var fi=cf-1;fi>=state.onionIn&&fi>=0;fi--){var strokes=getEffectiveStrokes(li,fi);if(!strokes.length)continue;if(window.SMGroup&&osLd&&osLd.groups)strokes=SMGroup.applyCombinesToStrokes(strokes,osLd);var dist=cf-fi;var op=(state.onionPrevOpacity/100)*Math.max(.15,1-(dist/prevRangeSpan)*.85);strokes.forEach(function(sd){var isTex=!!(sd.isBrushTextureCopy||sd.brushTexturePreset);if(sd.isRaster){var pr=desR(sd,onionPrevLayer);pr.opacity=op;return;}var effOp=isTex?op*(sd.opacity!==undefined?sd.opacity:1):op;var p=desP(sd,onionPrevLayer,effOp);var canTint=(sd.hasRealStroke||sd.fillColor)&&!isTex;if(state.onionMode==='tinted'&&canTint)p.strokeColor=new Color(1,.3,.3,op);else if(state.onionMode==='outline'&&canTint){p.fillColor=null;p.strokeColor=new Color(1,.3,.3,op*.8);p.strokeWidth=1;}else p.opacity=effOp;});}
-  for(var fi2=cf+1;fi2<=state.onionOut&&fi2<state.totalFrames;fi2++){var strokes2=getEffectiveStrokes(li,fi2);if(!strokes2.length)continue;if(window.SMGroup&&osLd&&osLd.groups)strokes2=SMGroup.applyCombinesToStrokes(strokes2,osLd);var dist2=fi2-cf;var op2=(state.onionNextOpacity/100)*Math.max(.15,1-(dist2/nextRangeSpan)*.85);strokes2.forEach(function(sd){var isTex2=!!(sd.isBrushTextureCopy||sd.brushTexturePreset);if(sd.isRaster){var nr=desR(sd,onionNextLayer);nr.opacity=op2;return;}var effOp2=isTex2?op2*(sd.opacity!==undefined?sd.opacity:1):op2;var p=desP(sd,onionNextLayer,effOp2);var canTint2=(sd.hasRealStroke||sd.fillColor)&&!isTex2;if(state.onionMode==='tinted'&&canTint2)p.strokeColor=new Color(.3,.55,1,op2);else if(state.onionMode==='outline'&&canTint2){p.fillColor=null;p.strokeColor=new Color(.3,.55,1,op2*.8);p.strokeWidth=1;}else p.opacity=effOp2;});}
+  for(var fi=cf-1;fi>=state.onionIn&&fi>=0;fi--){var strokes=getEffectiveStrokes(li,fi);if(!strokes.length)continue;if(window.SMGroup&&osLd&&osLd.groups)strokes=SMGroup.applyCombinesToStrokes(strokes,osLd);var dist=cf-fi;var op=(state.onionPrevOpacity/100)*Math.max(.15,1-(dist/prevRangeSpan)*.85);strokes.forEach(function(sd){var isTex=!!(sd.isBrushTextureCopy||sd.brushTexturePreset);if(sd.isRaster){var pr=desR(sd,onionPrevLayer);pr.opacity=op;osTagFrame(pr,li,fi);return;}var effOp=isTex?op*(sd.opacity!==undefined?sd.opacity:1):op;var p=desP(sd,onionPrevLayer,effOp);var canTint=(sd.hasRealStroke||sd.fillColor)&&!isTex;if(state.onionMode==='tinted'&&canTint)p.strokeColor=new Color(1,.3,.3,op);else if(state.onionMode==='outline'&&canTint){p.fillColor=null;p.strokeColor=new Color(1,.3,.3,op*.8);p.strokeWidth=1;}else p.opacity=effOp;});}
+  for(var fi2=cf+1;fi2<=state.onionOut&&fi2<state.totalFrames;fi2++){var strokes2=getEffectiveStrokes(li,fi2);if(!strokes2.length)continue;if(window.SMGroup&&osLd&&osLd.groups)strokes2=SMGroup.applyCombinesToStrokes(strokes2,osLd);var dist2=fi2-cf;var op2=(state.onionNextOpacity/100)*Math.max(.15,1-(dist2/nextRangeSpan)*.85);strokes2.forEach(function(sd){var isTex2=!!(sd.isBrushTextureCopy||sd.brushTexturePreset);if(sd.isRaster){var nr=desR(sd,onionNextLayer);nr.opacity=op2;osTagFrame(nr,li,fi2);return;}var effOp2=isTex2?op2*(sd.opacity!==undefined?sd.opacity:1):op2;var p=desP(sd,onionNextLayer,effOp2);var canTint2=(sd.hasRealStroke||sd.fillColor)&&!isTex2;if(state.onionMode==='tinted'&&canTint2)p.strokeColor=new Color(.3,.55,1,op2);else if(state.onionMode==='outline'&&canTint2){p.fillColor=null;p.strokeColor=new Color(.3,.55,1,op2*.8);p.strokeWidth=1;}else p.opacity=effOp2;});}
   userLayers[state.activeLayerIdx].activate();
 }
 


### PR DESCRIPTION
**PR 3 of 3**, completing the image mesh (#351 data model + rendering, #352 the on-canvas editor).

Arm a vertex's stopwatch in the timeline, drag it on canvas, scrub, drag again. The deformation animates with keyframes, ease curves, the graph editor, expressions and expression controls — none of which had to be written here, because a mesh vertex is now just another `vtxN` track on an ordinary element holder.

## Two deliberate differences from a Path's vertices

**The holder is keyed by `meshId`, not `strokeId`.** A raster has no stable strokeId across frames: `layerElements` stamps one lazily onto that frame's own dict, and a still image's dict is a *separate object literal per frame* (images.js's import loop) — so frame 5 would get a different id from frame 0 and the animation would vanish on scrub. `meshId` is written to every frame by `SMImageMesh.propagate`, which makes it the only id an imported still actually carries throughout.

**The value is in percent of the image's own size, not pixels.** The mesh is stored normalized over the raster's display rect so it survives moving and scaling the image; percent is that same unit made readable in the graph editor, where `20` beats `0.2`. The `/100` happens once, in `meshVertexOffsetAt`.

The animated offset is *added* to `mesh.offsets`, which stays the rest sculpt — the stopwatch decides which of the two an on-canvas drag writes to, exactly like every other Motion property.

## Three more things found by driving the app

- **Listen on `document` in capture, not on `#canvas-area`.** motion.js also has a capture-phase `pointerdown` there, and among listeners on the *same* element capture order is registration order — motion.js loads first, so it won. Dragging a mesh vertex in Motion mode silently moved the whole layer instead, leaving `ld.motionStatic.position` at exactly the drag delta and no key on the vertex. A capture listener on an *ancestor* always runs first whatever the registration order — the same trick tweens.js documents for its own click intercept.
- **Do not clear edit mode on a transiently null selection.** That check runs from `updateUI`, i.e. on every frame change, and `loadFrame` rebuilds the items — so the mode switched itself off the moment the playhead moved, which makes animating a mesh (key → scrub → key) impossible.
- **An onion ghost is a snapshot of another frame.** `renderOS` now stamps the source layer/frame on each ghost raster (`osTagFrame`) and the onion path poses it at *that* frame — otherwise a ghost showed the rest sculpt and contradicted the live drawing.

## §11

Timeline rows go through one shared `meshVertexRowCount` used by **both** the panel and the grid. A 32×32 mesh is 1093 vertices, so there is a cap (200) — and a cap applied on one side only is exactly how the two lists drift apart.

## Verified live

- **Interpolation:** two keys at frames 0 and 12 (`[20,-20]` and `[-20,20]`) give a pose of `0.2 / 0.1376 / 0 / -0.1376 / -0.2` at frames 0/3/6/9/12 — eased, not linear.
- **Rendered:** frames 0, 6 and 12 differ from each other by 9 612 / 10 561 / 13 609 sampled pixels, with named coordinates changing colour — (1020,480) is yellow at f0 and green at f6 and f12; (900,600) yellow at f0 and f6, green at f12.
- **Alignment:** 44 list rows = 44 grid rows at 4×4; 219 = 219 at 32×32 with the cap applied (200 vertex rows shown out of 1093 vertices).
- **Round trip:** save → import keeps the keys byte-identical and the reloaded frames render the same pixels.
- **Onion:** 12 ghost frames resolve to 12 distinct poses, tagged `[layer, frame, meshId]`.
- `read_console_messages({onlyErrors:true})` clean throughout.

## Not in this PR

Adding/removing individual vertices and drawing a freehand outline — today you start from the rectangle and move its vertices, or call `SMImageMesh.setOutline` from a script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)