### PR TITLE
Timeline toolbar: inactive buttons take the recessed grey too

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -924,7 +924,7 @@ body.mode-motion #btn-tween-curves{display:none;}
 .toolbar-custom-row .toolbar-custom-ico svg{width:14px;height:14px;}
 .toolbar-custom-row .toolbar-custom-name{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}
 .toolbar-custom-row input[type=checkbox]{flex:none;margin:0;}
-.tb{background:transparent;border:none;color:rgba(236,234,231,.55);cursor:pointer;padding:2px;border-radius:7px;display:flex;align-items:center;justify-content:center;width:28px;height:28px;transition:background .15s,color .15s;}
+.tb{background:transparent;border:none;color:var(--text-recessed);cursor:pointer;padding:2px;border-radius:7px;display:flex;align-items:center;justify-content:center;width:28px;height:28px;transition:background .15s,color .15s;}
 .tb:hover{background:rgba(255,255,255,.06);color:var(--text);}
 .tb.active{color:var(--accent-hover);}
 .tb.playing{color:var(--green);}


### PR DESCRIPTION
Follow-up to #355 — the `.tb` timeline toolbar (onion skin, ghosts, loop, graph, audio…) was the last icon family still on its own `rgba(236,234,231,.55)`, so its unlit buttons sat visibly brighter than the tool column and the collapsed panel headers beside them.

Now on `--text-recessed` like the rest. `:hover`, `.active`, `.playing` and `.pingpong` are untouched, so an engaged toggle still reads as engaged.

Measured live: all 12 visible inactive buttons `rgb(93,98,103)`, active still `rgb(126,160,250)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)