### PR TITLE
Media panel: the drop zone is the empty state, not a permanent row

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2132,8 +2132,13 @@ body.mode-motion .layer-inout-bar .layer-inout-handle{width:4px;border-radius:2p
 #canvas-area.drop-hover,#timeline-area.drop-hover{outline:2px dashed var(--accent);outline-offset:-2px;}
 
 /* Media Library (media-library.js, v1 2026-07) */
-.media-drop{margin:0 8px 6px;padding:10px 8px;border:1px dashed var(--border2);border-radius:6px;font-size:9.5px;color:var(--text-dim);text-align:center;cursor:default;}
+.media-drop{margin:2px 0;padding:14px 8px;border:1px dashed var(--border2);border-radius:6px;font-size:9.5px;color:var(--text-dim);text-align:center;cursor:default;}
 .media-drop.drop-hover{border-color:var(--accent);color:var(--text);background:var(--accent-dim);}
+/* The listener lives on #media-grid now, so the hover state lands there.
+   With media present there is no dashed box to light up, so the container
+   itself shows the target. */
+#media-grid.drop-hover{outline:1px dashed var(--accent);outline-offset:-2px;border-radius:6px;}
+#media-grid.drop-hover .media-drop{border-color:var(--accent);color:var(--text);background:var(--accent-dim);}
 /* Rebuilt 2026-07 as a row-based list (project-list-table reference:
    thumbnail+name, a colored type pill, an owner-like avatar+name) instead
    of the original thumbnail grid — see media-library.js render(). */

--- a/src/index.html
+++ b/src/index.html
@@ -1166,7 +1166,14 @@
                linked-media.js and media-library.js wire entirely by id, and
                #156 (these controls belong in the Média tab, not the Document
                panel) still holds — they are in this tab, just folded away. -->
-          <div id="media-drop" class="media-drop" data-i18n="mediaDropHint">Glisser des images/vidéos ici, ou cliquer Importer…</div>
+          <!-- The drop zone used to sit here as a permanent dashed box. It now
+               only exists as the EMPTY STATE inside #media-grid (built by
+               render()), so it teaches the gesture while there is nothing to
+               show and then gets out of the way — the hierarchy takes the
+               space back once you have media, and by then you know you can
+               drag onto it. The file-drop listeners moved to #media-grid
+               itself, which is stable across renders and means a drop still
+               works over a POPULATED list, not only over the hint. -->
           <div class="media-search-line">
             <div class="media-search-row">
               <svg class="media-search-icon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>

--- a/src/js/media-library.js
+++ b/src/js/media-library.js
@@ -662,9 +662,16 @@
       var empty = document.createElement('div'); empty.className = 'asset-folder-empty-hint';
       var hasAnyContent = !!((state.mediaLibrary || []).length || Object.keys(state.symbols || {}).length
         || (window.SMProject && SMProject.getOpenTabs && SMProject.getOpenTabs().length));
-      empty.textContent = hasAnyContent
-        ? t('mediaNoMatch', 'Aucun média ne correspond à ce filtre.')
-        : t('mediaEmptyLibrary', 'Aucun média importé.');
+      // Genuinely empty -> this IS the drop zone (its dashed styling and the
+      // gesture it names). Empty only because a filter/search excludes
+      // everything -> a plain message: media exists, the dashed "drop here"
+      // box would be telling you the wrong thing.
+      if (hasAnyContent) {
+        empty.textContent = t('mediaNoMatch', 'Aucun média ne correspond à ce filtre.');
+      } else {
+        empty.className += ' media-drop';
+        empty.textContent = t('mediaDropHint', 'Glisser des images/vidéos ici, ou cliquer Importer…');
+      }
       grid.appendChild(empty);
     }
     // Bulk cleanup (2026-07-31) — catalog-only (never touches the
@@ -701,15 +708,20 @@
     if (window.showToast) showToast(removed + SM.t('toastOrphanEntriesRemovedSuffix'));
   }
 
-  // OS drag-and-drop onto the panel's own drop zone (#media-drop) — routes
+  // OS drag-and-drop onto the panel's own list (#media-grid) — routes
   // through images.js's real import pipeline (images.js:importImageFiles/
   // importVideoFile), same as the toolbar buttons, so entries land as
   // normal layers AND register a library entry. drop-import.js's canvas/
   // timeline drop target now routes image/video files through this exact
   // same pipeline too (2026-08 fix) — only genuinely unrecognized file
   // types still fall back to the rotoscopy reference importer there.
+  // Bound to #media-grid, not to the dashed hint: the hint is rebuilt by
+  // every render() (it IS the empty state now), so listeners on it would die
+  // the first time the list changed. Listening on the stable container also
+  // means dropping files onto a list that already has media works — which is
+  // what anyone would try once the hint is gone.
   function initDropZone() {
-    var zone = document.getElementById('media-drop'); if (!zone) return;
+    var zone = document.getElementById('media-grid'); if (!zone) return;
     zone.addEventListener('dragover', function (e) { if (e.dataTransfer && e.dataTransfer.types.indexOf('Files') >= 0) { e.preventDefault(); zone.classList.add('drop-hover'); } });
     zone.addEventListener('dragleave', function () { zone.classList.remove('drop-hover'); });
     zone.addEventListener('drop', function (e) {


### PR DESCRIPTION
Asked for directly: *"le drag images/vidéo pourrait être ici tant qu'il n'y a pas de fichiers importés et disparaître laissant place à la hiérarchie, on sait par la suite que l'on peut drag."*

The dashed box sat above the list forever, teaching a gesture you already knew, in a panel just cut down to make room. It is the empty state now — it holds the space while there is nothing to show, and the hierarchy takes it back as soon as you have media.

**The listeners moved from `#media-drop` to `#media-grid`.** That is mechanically required (the hint is rebuilt by every `render()`, so listeners on it would die on the first change) and it is better behaviour: dropping files onto an *already populated* list now works, which is what anyone would try once the dashed box is gone. `#media-grid.drop-hover` shows the target there, since there is no box left to light up.

**Two empty states, deliberately different:**

| state | looks like |
|---|---|
| nothing imported | dashed drop zone, "Drag images/videos here…" |
| filter excludes everything | plain "No media matches this filter." |

Showing "drop files here" to someone whose media is merely filtered out would be telling them the wrong thing.

Verified live across all three, plus a real `File` drop firing `importImageFiles` over a populated list. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)