### PR TITLE
i18n: the 4 strings the sweep missed (Folder layer, brush capture)

### DIFF
--- a/src/js/brush-editor.js
+++ b/src/js/brush-editor.js
@@ -176,7 +176,7 @@
       params.customStamp = res.stamp;
       refreshCaptureStatus();
       renderPreview();
-      showToast(SM.t('toastShapeCapturedSuffix') + res.stamp.pointCount + ' points)');
+      showToast(SM.t('toastShapeCapturedSuffix') + res.stamp.pointCount + SM.t('brushCapturePointsSuffix'));
     });
     syncCaptureRowVisibility();
     syncMarkerTipVisibility();

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -5958,7 +5958,7 @@
           // resolves to a Folder specifically (an ordinary Null parent
           // leaves this disabled, same guard the drag-out gesture uses —
           // see folderLayerParentIdx, timeline.js).
-          { label: 'Retirer du dossier', disabled: (typeof folderLayerParentIdx !== 'function' || folderLayerParentIdx(li) < 0), action: function () { window.SM.removeLayerFromFolder(li); } },
+          { label: SM.t('ctxRemoveFromFolder'), disabled: (typeof folderLayerParentIdx !== 'function' || folderLayerParentIdx(li) < 0), action: function () { window.SM.removeLayerFromFolder(li); } },
           // Component / camera / audio (2026-08-30, Cyril: "la possibilité de
           // créer un composant dans motion... et pareil pour layer sound et
           // camera"). The three header buttons are visible in Motion again

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -5816,7 +5816,7 @@ function renderLayerList(frameOnly){
       window.showContextMenu(e.clientX,e.clientY,[
         {label:SM.t('ctxInsertLayer'),action:function(){window.SM.addLayer();}},
         {label:SM.t('ctxInsertLayerNull'),action:function(){window.SM.addNullLayer();}},
-        {label:'Insérer un dossier',action:function(){window.SM.addFolderLayer();}},
+        {label:SM.t('ctxInsertLayerFolder'),action:function(){window.SM.addFolderLayer();}},
         {label:SM.t('ctxInsertLayerEffect'),action:function(){window.SM.addEffectLayer();}},
         {label:SM.t('ctxInsertLayerGuide'),action:function(){window.SM.addGuideLayer();}},
         {label:SM.t('ctxDuplicateLayer'),action:function(){window.SM.duplicateLayer();}},
@@ -5834,7 +5834,7 @@ function renderLayerList(frameOnly){
         {label:l4.shy?SM.t('ctxRemoveShyMark'):SM.t('ctxMarkAsShy'),action:function(){window.SM.toggleLayerShy(idx4);}},
         {label:SM.t('ctxMergeSelectedLayers'),disabled:_layerSel.length<2,action:function(){window.SM.mergeLayersIntoOne(_layerSel.slice());}},
         {label:SM.t('ctxRemoveFromFolder'),disabled:!l4.folderId,action:function(){delete l4.folderId;renderLayerList();renderTimeline();}},
-        {label:'Retirer du dossier (parent)',disabled:folderLayerParentIdx(idx4)<0,action:function(){window.SM.removeLayerFromFolder(idx4);}},
+        {label:SM.t('ctxRemoveFromFolderParent'),disabled:folderLayerParentIdx(idx4)<0,action:function(){window.SM.removeLayerFromFolder(idx4);}},
         {label:SM.t('ctxConvertToComponent'),disabled:!!l4.symbolId||!!l4.lfsGroup,action:function(){window.SM.convertActiveLayerToComponent();}},
         {label:SM.t('ctxBreakApartComponent'),disabled:!l4.symbolId,action:function(){window.SM.convertComponentToLayer();}},
         {sep:true},


### PR DESCRIPTION
**Supersedes #335**, which can no longer be merged: its branch carries an `i18n.js` built *before* the expression-engine rewrite, so merging it would revert `titleExprCodeHint` to the old vocabulary — a real regression hidden inside a one-line-per-locale diff.

The conversions themselves were still needed. All four verified still hardcoded on `main` before redoing them:

| file | was | now |
|---|---|---|
| `timeline.js` | `'Insérer un dossier'` | `ctxInsertLayerFolder` |
| `timeline.js` | `'Retirer du dossier (parent)'` | `ctxRemoveFromFolderParent` |
| `motion.js` | `'Retirer du dossier'` | `ctxRemoveFromFolder` |
| `brush-editor.js` | `' points)'` | `brushCapturePointsSuffix` |

The two new keys landed with `c622cdf`; the other two already existed. Verified live in en/fr/ja/es.

🤖 Generated with [Claude Code](https://claude.com/claude-code)