### PR TITLE
duplicateLayer: give the copy its own mesh instead of sharing the original's

### DIFF
--- a/src/js/image-mesh.js
+++ b/src/js/image-mesh.js
@@ -517,6 +517,19 @@
     state.imageMeshes = s;
   }
 
+  // Deep-copies a mesh under a FRESH id (2026-08-30). The store is
+  // project-level and keyed by meshId, so anything that copies a raster while
+  // preserving its meshId — duplicateLayer does exactly that, deliberately,
+  // because every OTHER id it preserves is per-layer data — ends up with two
+  // rasters pointing at one shared mesh: deforming either moved both.
+  // Returns the new id, or null if the source is gone.
+  NS.duplicate = function (meshId) {
+    var src = get(meshId);
+    if (!src) return null;
+    var id = newId();
+    store()[id] = JSON.parse(JSON.stringify(src));
+    return id;
+  };
   NS.get = get;
   NS.attach = attach;
   NS.detach = detach;

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1212,6 +1212,33 @@ window.SM={
     // as elementMotion just above), so relinkRigBinds matches correctly
     // on the duplicate without any extra remapping.
     if(src.rig)state.layers[ni].rig=JSON.parse(JSON.stringify(src.rig));
+    // Image meshes are the ONE id here that must NOT be preserved (2026-08-30).
+    // Every other id above is per-layer data that the frame clone copied too,
+    // so keeping it keeps the copy matched. A meshId instead points into
+    // state.imageMeshes, a PROJECT-level store — preserving it left both
+    // layers driving one shared mesh, and deforming either moved both.
+    // Confirmed live: pushing a vertex on the original moved the same vertex
+    // on the copy. The mesh is deep-copied under a fresh id, and that id is
+    // rewritten in all three places that reference it: the frame dicts, the
+    // per-vertex elementMotion holder (keyed by meshId, not strokeId — see
+    // motion.js's own note on why), and any rig bind targeting it.
+    (function remapMeshes(){
+      if(!window.SMImageMesh||!SMImageMesh.duplicate)return;
+      var map={};
+      (state.layers[ni].frames||[]).forEach(function(fr){
+        (fr.strokes||[]).forEach(function(st){
+          if(!st||!st.meshId)return;
+          if(!map[st.meshId]){var nid=SMImageMesh.duplicate(st.meshId);if(!nid)return;map[st.meshId]=nid;}
+          st.meshId=map[st.meshId];
+        });
+      });
+      var em=state.layers[ni].elementMotion;
+      if(em)Object.keys(map).forEach(function(oldId){
+        if(em[oldId]){em[map[oldId]]=em[oldId];delete em[oldId];}
+      });
+      var rg=state.layers[ni].rig;
+      if(rg&&rg.binds)rg.binds.forEach(function(b){if(b.meshId&&map[b.meshId])b.meshId=map[b.meshId];});
+    })();
     // Combine groups (2026-07-29): the frame clone above already preserves
     // each stroke's data.groupId unchanged, so the duplicate's strokes carry
     // the SAME groupId strings as the original — harmless for duplicateLayer


### PR DESCRIPTION
Found by the cross-tool sweep, confirmed by measurement: **duplicate a layer holding a meshed image, push a vertex on the original, and the same vertex moves on the copy.** Two layers, one mesh.

The cause is a real asymmetry, not a plain oversight. `duplicateLayer` deliberately **preserves** every id it copies — `strokeId`, `groupId`, and the rest — because each keys *per-layer* data that the frame clone copied alongside it, so keeping the id keeps the copy matched. Its own comments say exactly that. `meshId` is the one id that doesn't work that way: it points into `state.imageMeshes`, a **project-level** store, so preserving it hands both layers the same object.

The mesh is now deep-copied under a fresh id (`SMImageMesh.duplicate`, kept in the module that owns id generation), and that id is rewritten in **all three** places that reference it:

- the frame dicts,
- the per-vertex `elementMotion` holder (keyed by `meshId`, not `strokeId`),
- any rig bind targeting it.

**Verified live:** duplicating produces `im_1` and `im_2`, two entries in the store; the copy's holder is re-keyed to `im_2`; deforming vertex 10 of `im_1` to `[0.33, 0.22]` leaves `im_2`'s vertex 10 at `[0, 0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)