### PR TITLE
Media panel: the whole row is the drag handle, not its 30px thumbnail

### DIFF
--- a/src/js/media-library.js
+++ b/src/js/media-library.js
@@ -394,10 +394,16 @@
       // otherwise — a linked entry whose preview failed is still perfectly
       // insertable (the linked branch of insertImageOnCanvas never reads
       // m.thumb), so losing drag there would be a real regression.
+      // The drag handle is the WHOLE tile/row, not just the preview image
+      // (2026-08-30). It used to be the <img>, which on a list row is a 30x30
+      // thumbnail — 9% of the row's area, measured on the deployed build — so
+      // grabbing the name, the badges, or anywhere else did nothing at all,
+      // and "drag an item from the media panel onto the canvas" read as simply
+      // broken. Dragging does not conflict with clicking: a click still jumps
+      // to the source layer, and the context menu is untouched.
       if (reinsertKind(m)) {
-        var dragEl = img || thumb;
-        dragEl.draggable = true;
-        dragEl.addEventListener('dragstart', function (e) {
+        tile.draggable = true;
+        tile.addEventListener('dragstart', function (e) {
           e.dataTransfer.setData('application/x-nemo-media-id', m.id);
           e.dataTransfer.effectAllowed = 'copy';
         });
@@ -561,10 +567,10 @@
       });
       // Same fallback as the tile view: drag from the thumb box when there's
       // no preview img to hang the listener on.
+      // Whole row is the handle — see buildTile's own note.
       if (reinsertKind(m)) {
-        var dragEl = img || thumb;
-        dragEl.draggable = true;
-        dragEl.addEventListener('dragstart', function (e) {
+        row.draggable = true;
+        row.addEventListener('dragstart', function (e) {
           e.dataTransfer.setData('application/x-nemo-media-id', m.id);
           e.dataTransfer.effectAllowed = 'copy';
         });


### PR DESCRIPTION
Reported as *"j'ai pas le drag d'élément depuis le panel media et preset vers le canvas"*.

**The mechanism was fine.** Driving a drop programmatically on the *deployed* build inserted the image correctly. What was wrong is **where you were allowed to grab**.

Only the preview `<img>` carried `draggable`. On a list row that image is **30×30 inside a 195×51 row — 9% of its area**, measured on the live site. Grab the name, a badge, or anywhere else — which is what anyone actually does — and the browser started no drag at all. The feature read as missing rather than fussy.

The row and the tile are the handle now. Dragging doesn't conflict with clicking: a click still jumps to the source layer, and the context menu is untouched.

**Verified live in both densities:** a `dragstart` fired on the **name** and on a **badge** both carry the media id, and dropping that on the canvas inserts the image (0 → 1 stroke). The tile is draggable as a whole in grid view. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)