### PR TITLE
Un-freeze the Rig tool, with its own button and the S shortcut

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -96,7 +96,10 @@ html,body{width:100%;height:100%;overflow:hidden;background:var(--gutter);color:
   font-size:8px;font-weight:700;letter-spacing:.02em;text-transform:uppercase;
   background:rgba(255,180,60,.18);color:#ffb43c;vertical-align:1px;}
 .tool-btn.in-dev-locked{opacity:.45;cursor:default;}
-.tool-btn.in-dev-locked::after{content:'dev';position:absolute;bottom:-1px;right:-1px;
+/* .in-dev (2026-08-30): the badge WITHOUT the lock — a tool that works and is
+   honest about being young. Full opacity and a normal cursor, since it is
+   genuinely usable; only the corner marker is shared with the locked state. */
+.tool-btn.in-dev-locked::after,.tool-btn.in-dev::after{content:'dev';position:absolute;bottom:-1px;right:-1px;
   padding:0 3px;border-radius:4px;font-size:6px;font-weight:700;line-height:1.3;
   background:rgba(255,180,60,.85);color:#1a1206;pointer-events:none;}
 #app-topbar-spacer{flex:1;min-width:8px;}

--- a/src/index.html
+++ b/src/index.html
@@ -175,14 +175,11 @@
          click-drag=curve handle, chainable), rendered live while the tool
          is active; dragging an existing bone anchor poses it instead
          (rig-bridge.js unifies both gestures behind one onDown). -->
-    <!-- Freeze (2026-08, PR #209: "mettre en freeze (in Dev)" — see the
-         SM_FROZEN_IN_DEV registry above and SM.setTool's gate, timeline.js).
-         Points at the freeze-specific rigFrozenTitle key (not toolRig,
-         that's the real tool description for once un-frozen) so this
-         title still switches language like everything else instead of
-         staying stuck in one language — restore data-i18n-title="toolRig"
-         when un-freezing. -->
-    <button class="tool-btn in-dev-locked" data-tool="rig" disabled data-i18n-title="rigFrozenTitle" title="Rig — en développement, pas encore disponible dans cette build"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="19" r="2.2" fill="currentColor" stroke="none"/><circle cx="12" cy="10" r="2.2" fill="currentColor" stroke="none"/><circle cx="19" cy="5" r="2.2" fill="currentColor" stroke="none"/><path d="M6.6 17.4 10.4 11.6M13.6 8.4 17.4 6.6"/></svg></button>
+    <!-- Un-frozen 2026-08-30 (see the SM_FROZEN_IN_DEV registry below), and
+         restored to data-i18n-title="toolRig" exactly as the freeze comment
+         asked. Keeps its own dedicated button and the S shortcut; the "dev"
+         badge stays, since the tool is reachable but still young. -->
+    <button class="tool-btn in-dev" data-tool="rig" data-i18n-title="toolRig" title="Rig — bones drawn with the Pen, posed, and bound to strokes or to an image's mesh points (S)"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="19" r="2.2" fill="currentColor" stroke="none"/><circle cx="12" cy="10" r="2.2" fill="currentColor" stroke="none"/><circle cx="19" cy="5" r="2.2" fill="currentColor" stroke="none"/><path d="M6.6 17.4 10.4 11.6M13.6 8.4 17.4 6.6"/></svg><span class="sk">S</span></button>
     <!-- Missing separator (feedback 2026-07) — freehand painting tools
          (Draw/Pen/Fill brush) and geometric shape tools (Line/Rect/
          Ellipse) read as one undifferentiated group without this; Text
@@ -2107,7 +2104,12 @@
      files: every gate (SM.setTool for Rig, timeline.js; setAppMode for
      StoryBoard, motion.js; the ctx-import-3d menu row, timeline.js) reads
      the SAME source, so un-freezing a feature later is one line here. -->
-<script>window.SM_FROZEN_IN_DEV={rig:true,storyboard:true,import3d:true};</script>
+<!-- Rig un-frozen 2026-08-30: it has moved a long way since the freeze —
+     three modes, a weight brush, IK, and bones that now drive image meshes
+     as well as strokes with a per-target choice. It keeps its "en dev"
+     badge: reachable and honest about being young, rather than hidden.
+     StoryBoard and import3d stay frozen, untouched. -->
+<script>window.SM_FROZEN_IN_DEV={rig:false,storyboard:true,import3d:true};</script>
 <script src="js/ui.js"></script>
 <script src="js/color-picker.js"></script>
 <script src="js/app.js"></script>


### PR DESCRIPTION
Rig was frozen as *in Dev* (`a8ab08f`, PR #209) so the public web beta wouldn't ship a half-finished feature. It has moved a long way since: three modes, a weight brush, IK, and — as of today — bones that drive an **image's mesh points** as well as strokes, with a per-target choice.

So everything merged today was deployed but **unreachable**: the tool that opens it couldn't be selected at all. Confirmed on the live site — the button was `disabled`, and even `SM.setTool('rig')` was refused by the gate.

**One line** in the `SM_FROZEN_IN_DEV` registry, exactly as its own comment promised. **StoryBoard and import3d stay frozen** and are untouched.

The button keeps its **dev badge** — reachable and honest about being young, rather than hidden. That needed a new `.in-dev` class: the existing `.in-dev-locked` couples the badge to `opacity:.45` and a default cursor, which is right for something you *can't* use and wrong for something you can. Only the corner marker is shared.

`data-i18n-title` goes back to `toolRig`, precisely as the freeze comment asked, so the real description returns in all four locales. The `S` hint is on the button now, like every other tool.

**Verified live:** enabled at full opacity with its badge; a click **and** the `S` key both leave `state.tool === 'rig'`; drawing on the canvas creates a bone; and with a meshed image on the layer, the panel's own **Auto-assign** produces a 25-point mesh bind. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)