### PR TITLE
Corner radius no longer un-rotates the shape

### DIFF
--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -6299,12 +6299,30 @@ function paramShapeBoxOf(path,ps){
 window.stampParamShapeBox=stampParamShapeBox;
 window.syncParamShapeBoxOnTranslate=syncParamShapeBoxOnTranslate;
 window.syncParamShapeBoxOnScale=syncParamShapeBoxOnScale;
+// ps.box is stored AXIS-ALIGNED and un-rotated, on purpose: it is the shape's
+// declared size, and syncParamShapeBoxOnTranslate/OnScale keep it that way
+// through those two gestures. Rotation is deliberately NOT folded into it —
+// it lives on the stroke as data.boxAngle (see tools.js:1129 and serP), which
+// both rotate gestures and the Rotation field already maintain.
+//
+// So a rebuild has to put the rotation back (2026-08-30, feedback #163: "if I
+// want to change the radius of one corner now, it rotates back first"). It
+// was the ONE reader of boxAngle that ignored it: rotate a rounded rect, then
+// touch any corner radius, and the shape snapped back to axis-aligned —
+// measured, corners went from (670,512) to (740,400). Same for a star's own
+// parameters.
+function reapplyParamShapeAngle(path,b){
+  var ang=(path.data&&path.data.boxAngle)||0;
+  if(!ang)return;
+  path.rotate(ang,new Point((b.x1+b.x2)/2,(b.y1+b.y2)/2));
+}
 function applyParamShapeStar(path){
   var ps=path.data&&path.data.paramShape;if(!ps||ps.kind!=='star')return;
   var b=paramShapeBoxOf(path,ps),cx=(b.x1+b.x2)/2,cy=(b.y1+b.y2)/2,outerR=Math.min(b.x2-b.x1,b.y2-b.y1)/2;
   var built=buildStarPolygonPath(cx,cy,outerR,ps.pointCount,ps.innerRatio,ps.cornerRadius);
   path.segments=built.segments;path.closed=true;
   built.remove();
+  reapplyParamShapeAngle(path,b);
 }
 window.buildStarPolygonPath=buildStarPolygonPath;
 window.applyParamShapeStar=applyParamShapeStar;
@@ -6314,6 +6332,7 @@ function applyParamShapeRect(path){
   var built=buildRoundRectPath(b.x1,b.y1,b.x2,b.y2,ps.tl||0,ps.tr||0,ps.br||0,ps.bl||0);
   path.segments=built.segments;path.closed=true;
   built.remove();
+  reapplyParamShapeAngle(path,b);
 }
 window.applyParamShapeRect=applyParamShapeRect;
 function insertBooleanResult(layer,insertAt,result,fillColor,opacity,strokeInfo,srcData,preserveGeometry){


### PR DESCRIPTION
Feedback #163 — *"If I want to change the radius of one corner now, it rotates back first…"*

**Reproduced exactly.** Rotate a parametric rect 30°, then touch any corner radius: the corners jumped from `(670,512)` back to `(740,400)` — axis-aligned again, rotation gone.

**The data was never lost.** `ps.box` is stored axis-aligned and un-rotated *on purpose* — it is the shape's declared size, and `syncParamShapeBoxOnTranslate`/`OnScale` keep it that way. Rotation deliberately lives elsewhere, on the stroke as `data.boxAngle`, which both rotate gestures (`select-bridge.js:1537`, `:1964`) and the Rotation field (`timeline.js:3411`) already maintain, and which `serP`/`desP` already persist.

`applyParamShapeRect` and `applyParamShapeStar` were simply **the one reader of `boxAngle` that ignored it** — they rebuilt from the box and stopped, discarding the orientation every other reader respects. They put it back now, rotating the rebuilt path about the box centre.

**Verified live**, and the star needed a better measurement than the rect. Two independent bad metrics — an edge angle that legitimately moves when `innerRatio` changes, and a "farthest tip" that ties between five tips 72° apart — gave misleading numbers before I found one that tests the contract:

| case | result |
|---|---|
| rect, rotated 30°, radius changed | first side sits at **30°** (was 0° before) |
| star, built rotated vs built straight then rotated | **max deviation 0.000 px** across all 10 vertices |
| unrotated shape | unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)