### PR TITLE
Double-click an ungrouped shape: its own transform box first, Subselect second

### DIFF
--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -1311,6 +1311,15 @@
         // click, then immediately double-click again" fast path into
         // Subselect is untouched — see tools.js's onViewDoubleClick.
         if (window._groupEnteredGid && (!p.data || p.data.groupId !== window._groupEnteredGid)) window._groupEnteredGid = null;
+        // Same reset for the ungrouped-shape flag (2026-08-30, feedback #165).
+        // Deliberately written the same way rather than folded in with the
+        // line above: the two track different things and a shape can carry
+        // both a strokeId and a groupId. Clicking away from the entered shape
+        // ends its continuity, so coming back to it is a fresh first
+        // double-click — which is exactly the "je clic ailleurs, je reviens
+        // sur la bounding box globale" half of the request. Without it this
+        // would reproduce the July bug quoted just above, one level down.
+        if (window._shapeEnteredId && (!p.data || p.data.strokeId !== window._shapeEnteredId)) window._shapeEnteredId = null;
       } else {
         // p is ALREADY selected (idx2>=0) — but its own group siblings might
         // not be (2026-07-29 fix, QA-confirmed): right after a Subselect

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -7536,6 +7536,13 @@ function onMouseMoveTool(event){
 // this way counts as "the second one" — naturally invalidated the moment
 // the user selects anything else (dblWholeGroupSelected below goes false).
 var _groupEnteredGid=null;
+// Same signal, for an UNGROUPED shape (2026-08-30, feedback #165). The layer
+// plays the role the group plays above: first double-click isolates the one
+// shape you clicked and STAYS on Select, so it can be transformed with its own
+// box; a second double-click on that same shape enters Subselect. Cleared by
+// select-bridge.js alongside _groupEnteredGid the moment the selection moves
+// somewhere else, which is what makes "click elsewhere, come back out" work.
+var _shapeEnteredId=null;
 // Double-click a filled shape to also select the stroke(s) that bound it —
 // matches Animate's "double-click a fill selects its surrounding stroke"
 // convention. There's no stored link between a fill (built by the Fill
@@ -7603,6 +7610,38 @@ function onViewDoubleClick(event){
       if(window.SMEngineBridge)SMEngineBridge.renderNow();
       return;
     }
+  }
+  // Ungrouped shape, FIRST double-click (2026-08-30, feedback #165: "quand
+  // j'ai deux éléments sur un même calque et que je double clic avec select
+  // j'aimerais plutôt avoir accès à la bounding box de transformation de
+  // l'élément... et pouvoir le transformer, le subselect apparaîtrait plutôt
+  // avec un autre double clic"). This is the SAME rule the group branch above
+  // already implements, with the layer standing in for the group: isolate the
+  // one shape, keep Select, so it can be moved/scaled/rotated with its own
+  // box. Only a second double-click on that same shape goes on to Subselect.
+  //
+  // The guard mirrors _groupEnteredGid's exactly, and for the same reason:
+  // "this shape is the current selection" is true after any ordinary single
+  // click too, so it cannot distinguish a first double-click from a second.
+  // Only a shape this mechanism itself most recently entered counts.
+  // Restricted to UNGROUPED shapes on purpose. A grouped one already spends
+  // its first double-click entering the group (branch above), and the July
+  // 2026 spec for that case is explicit that the SECOND one reaches Subselect
+  // — "l'outil subselect n'apparait qu'après si on double clic sur un des
+  // éléments du group". Applying this step to members too would silently make
+  // groups need three double-clicks instead of two. Caught by re-testing the
+  // group path after writing this: it did exactly that.
+  var dblSid=fillPath.data&&fillPath.data.strokeId;
+  var alreadyIsolated=!dblSid||_shapeEnteredId===dblSid;
+  if(!dblGid&&!alreadyIsolated){
+    clearSel();fsClearSel();
+    _fsIsolation={groupId:fillPath.data&&fillPath.data.groupId,path:fillPath};
+    selectedPaths=[fillPath];
+    state.selectedStrokeIndices=selectedPaths.map(getSI).filter(function(i2){return i2>=0;});
+    _shapeEnteredId=dblSid||null;
+    renderArcs();updateUI();
+    if(window.SMEngineBridge)SMEngineBridge.renderNow();
+    return;
   }
   clearSel();
   fsClearSel();


### PR DESCRIPTION
Feedback #165 — *"…j'aimerais plutôt avoir accès à la bounding box de transformation de l'élément que je double clic et pouvoir le transformer, le subselect apparaîtrait plutôt avec un autre double clic."*

This is the **same rule the group branch of `onViewDoubleClick` already implements**, with the layer standing in for the group. A grouped shape's first double-click enters the group and stays on Select; an ungrouped one jumped straight to Subselect, so there was no way to reach one shape's own transform box without leaving the shape level entirely.

Now: first double-click isolates the clicked shape and **keeps Select** — move, scale, rotate with its own box — and only a second double-click on that same shape goes on to Subselect.

The first/second guard mirrors `_groupEnteredGid` exactly, and for the same reason it exists: *"this shape is the current selection"* is also true after any ordinary single click. `select-bridge.js` resets the new flag beside the group one, which is what makes clicking away and coming back a **fresh** first double-click — the *"je clic ailleurs, je reviens sur la bounding box globale"* half. Without that reset this would have reproduced, one level down, the July bug quoted in that very function.

**Restricted to ungrouped shapes on purpose — and this is worth flagging.** My first version applied to group members too, which silently made a group need **three** double-clicks to reach Subselect instead of two, directly against the July 2026 spec (*"l'outil subselect n'apparait qu'après si on double clic sur un des éléments du group"*). Caught by re-testing the group path after writing it, not by reading it.

**Verified live**, three double-clicks each:

| | 1st | 2nd | 3rd |
|---|---|---|---|
| ungrouped | `select [A]` | `subselect [A]` | `subselect [A]` |
| grouped *(unchanged)* | `select [A,B]` | `subselect [A]` | `subselect [A]` |

Plus the reset path: click B → double-click B → double-click A, each one a fresh first double-click. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)