### PR TITLE
Figma import: images actually arrive, and text lands where the layout puts it

### DIFF
--- a/src/js/figma-import.js
+++ b/src/js/figma-import.js
@@ -233,10 +233,31 @@
   function walkNode(node, frameInv, out) {
     if (!node || node.visible === false) return;
     var mat = matMultiply(frameInv, nodeAbsMatrix(node));
+    // An image fill wins over fillGeometry (2026-08-30, feedback #144:
+    // "l'import d'image échoue, pas d'image"). This used to require the
+    // ABSENCE of fillGeometry — but every fetch in this file asks for
+    // `geometry=paths`, and Figma then returns fillGeometry for every node
+    // that has a fill AT ALL, image fills included. So the condition was
+    // never true in practice and no image was ever imported.
+    //
+    // Worse, the node did not even land in `skipped`: it fell through to the
+    // geometry branch below, where firstSolidPaint() returns null for an
+    // image paint, so it emitted nothing and reported nothing. Measured on a
+    // synthetic file shaped exactly as geometry=paths returns: 0 images,
+    // 0 shapes, and an EMPTY skipped list — the node vanished in silence.
+    // Without fillGeometry the same file imported the image correctly, which
+    // is what isolates fillGeometry as the cause.
+    //
+    // A stroke on an image-filled node is still emitted, since the image
+    // replaces only the FILL.
     var imagePaint = firstImagePaint(node.fills);
-    if (imagePaint && !(node.fillGeometry && node.fillGeometry.length)) {
+    if (imagePaint) {
       var bb = node.absoluteBoundingBox;
       out.images.push({ imageRef: imagePaint.imageRef, mat: mat, w: bb ? bb.width : 0, h: bb ? bb.height : 0, opacity: node.opacity != null ? node.opacity : 1, name: node.name });
+      if (node.strokeGeometry && node.strokeGeometry.length) {
+        var imgStrokeCss = paintToCss(firstSolidPaint(node.strokes), node.opacity);
+        if (imgStrokeCss) out.svgTags = out.svgTags.concat(geometryToPathTags(node.strokeGeometry, imgStrokeCss, mat));
+      }
       return;
     }
     var hasFillGeo = node.fillGeometry && node.fillGeometry.length;
@@ -382,10 +403,34 @@
         var size = t.style.fontSize || 24;
         var align = ALIGN_MAP[t.style.textAlignHorizontal] || 'left';
         try {
+          // The text box's WIDTH, its line height and its letter spacing all
+          // reached this point and were then dropped (2026-08-30, feedback
+          // #144: "mise en page, calage de texte exact par rapport au
+          // layout"). t.w was captured by walkNode and never passed; the
+          // style's lineHeightPx and letterSpacing were never read at all, so
+          // every imported block fell back to the 1.25 default line height and
+          // zero tracking regardless of what the Figma file said.
+          //
+          // Passing the width also makes alignment mean what it means in
+          // Figma — see buildVectorTextGroup's own note: without it, centring
+          // happened inside the widest LINE, which for a single line is a
+          // no-op, so a centred Figma label came in flush left.
+          //
+          // lineHeightPx is Figma's resolved value in px whatever unit the
+          // designer picked (AUTO/PIXELS/PERCENT), so dividing by fontSize is
+          // the multiplier this builder wants. Guarded because AUTO can report
+          // 0 on some nodes, and a 0 multiplier would stack every line on one.
+          var lhPx = t.style.lineHeightPx;
+          var lhMult = (lhPx && size) ? (lhPx / size) : undefined;
           await window.SMVectorText.buildVectorTextGroup(
-            t.text, fontKey, size, t.color, align, null,
+            t.text, fontKey, size, t.color, align, t.w || null,
             { x: t.x, y: t.y }, layer,
-            { bold: (t.style.fontWeight || 400) >= 700, italic: !!t.style.italic }
+            {
+              bold: (t.style.fontWeight || 400) >= 700,
+              italic: !!t.style.italic,
+              lineHeightMult: lhMult,
+              letterSpacing: t.style.letterSpacing || 0,
+            }
           );
           report.textsImported++;
         } catch (e) {

--- a/src/js/vector-text-bridge.js
+++ b/src/js/vector-text-bridge.js
@@ -252,9 +252,18 @@ function buildVectorTextGroup(text, fontKey, size, color, align, fixedWidthWorld
     var wordCursor = 0, charCursor = 0;
     wrapped.forEach(function (line, li) {
       var lineWidth = runWidth(line);
+      // Align within the BOX when one was given, not merely within the widest
+      // line (2026-08-30, feedback #144's "calage de texte exact par rapport
+      // au layout"). With no fixed width the two are identical, so behaviour
+      // for ordinary text is unchanged — but for a text block that declares a
+      // width, centring inside maxW is wrong: a single centred line has
+      // maxW === lineWidth, so the offset was always 0 and the line sat flush
+      // left inside its box. That is the mismatch against a Figma layout,
+      // where a centred line sits in the middle of the frame it belongs to.
+      var boxW = Math.max(maxW, fixedWidthWorld || 0);
       var startX = topLeftWorld.x;
-      if (align === 'center') startX = topLeftWorld.x + (maxW - lineWidth) / 2;
-      else if (align === 'right') startX = topLeftWorld.x + (maxW - lineWidth);
+      if (align === 'center') startX = topLeftWorld.x + (boxW - lineWidth) / 2;
+      else if (align === 'right') startX = topLeftWorld.x + (boxW - lineWidth);
       var cursorX = startX;
       // Ascent ≈ size, matching the raster bake's textBaseline='top' anchor
       // closely enough for the two modes to feel consistent when switching.


### PR DESCRIPTION
Feedback #144, both halves, now that they're pinned down: *"l'import d'image échoue, pas d'image"* and *"mise en page, calage de texte exact par rapport au layout"*.

## Images — the node was dropped in silence

The image branch required the **absence** of `fillGeometry`. But every fetch in this file asks for `geometry=paths`, and Figma then returns `fillGeometry` for any node with a fill at all — image fills included. **The condition was never true in practice.** The node fell through to the geometry branch, where `firstSolidPaint()` returns null for an image paint, emitted nothing, and — because `hasFillGeo` was true — never reached the `skipped` line either.

No image, no shape, **no diagnostic**.

| synthetic file | before | after |
|---|---|---|
| with `fillGeometry` (what `geometry=paths` returns) | 0 images, 0 shapes, **empty** skipped | **1 image** |
| without `fillGeometry` | 1 image | 1 image |
| image + stroke | — | 1 image **+ 1 shape** |

The identical file *without* `fillGeometry` importing correctly is what isolates the cause.

## Text — three values arrived and were thrown away

`t.w` (the box width) was captured by `walkNode` and passed as `null`; `style.lineHeightPx` and `style.letterSpacing` were never read at all, so every block fell back to the 1.25 default line height and zero tracking whatever the file said.

Passing the width needed a fix one level down too: `buildVectorTextGroup` aligned inside `maxW`, the **widest line**. For a single line `maxW === lineWidth`, so the offset was always 0 and a centred Figma label came in **flush left**. It aligns inside the box when a width is given; with no width the two are identical, so ordinary app text is unchanged.

**Measured** against a 400px box at x=100:

| align | result | expected |
|---|---|---|
| LEFT | starts at **101** | box left 100 |
| CENTER | 266..333, centre **299.5** | 300 |
| RIGHT | ends at **499** | box right 500 |

All three were previously identical, flush left. Line height: raising `lineHeightPx` from 40 → 80 on a 40px two-line block moves the second line down by exactly **40px**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)