### PR TITLE
An expression returning NaN can no longer take the Rust engine down

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -2262,14 +2262,33 @@
     var dim = PROP_DIM[prop];
     if (dim === undefined && prop.indexOf('vtx') === 0) dim = 2;
     function fill(n) { var o = []; for (var i = 0; i < dim; i++) o.push(n); return o; }
+    // Every component must be FINITE (2026-08-30). The bare-number branch
+    // below already rejected NaN; the array branch did not, and that gap was
+    // load-bearing: `[0/0, 100]` is valid JavaScript with no syntax error and
+    // no reported expression error, so a NaN went straight through, reached
+    // the scene JSON — where JSON.stringify turns NaN and Infinity into
+    // `null` — and the Rust engine rejected the payload with "invalid type:
+    // null, expected f64". Measured: a position expression of exactly that
+    // form threw on every render.
+    //
+    // Returning null here routes it into the path that already exists for a
+    // bad result: the located "must return a number" error on that one
+    // property row, that property falling back to its raw value, and the rest
+    // of the scene still rendering. This is the same family as the
+    // Option<String> incident in CLAUDE.md — one malformed value must not be
+    // able to take the whole engine down for the session.
+    function allFinite(a) {
+      for (var i = 0; i < a.length; i++) if (typeof a[i] !== 'number' || !isFinite(a[i])) return false;
+      return true;
+    }
     if (Array.isArray(result)) {
-      if (result.length >= dim) return result.slice(0, dim);
+      if (result.length >= dim) { var cut = result.slice(0, dim); return allFinite(cut) ? cut : null; }
       // A single number in an array applies to every dimension, same
       // forgiving reading as a bare number below.
-      if (result.length === 1 && dim >= 2) return fill(result[0]);
+      if (result.length === 1 && dim >= 2 && typeof result[0] === 'number' && isFinite(result[0])) return fill(result[0]);
       return null;
     }
-    if (typeof result === 'number' && !isNaN(result)) return fill(result);
+    if (typeof result === 'number' && isFinite(result)) return fill(result);
     return null;
   }
   function evalExpressionFor(holder, prop, frame, rawValue) {


### PR DESCRIPTION
`normalizeExprResult` checked NaN on the **bare-number** branch and not on the **array** branch. That gap was load-bearing: `[0/0, 100]` is valid JavaScript with no syntax error and no reported expression error, so the NaN went straight through, reached the scene JSON — where `JSON.stringify` turns NaN and Infinity into `null` — and the Rust engine rejected the whole payload with *"invalid type: null, expected f64"*, **on every render**.

Every component must be finite now, on both branches, with Infinity rejected alongside NaN. Returning null routes it into the path that already exists for a bad result: the located error on that one property row, the property falling back to its raw value, and the rest of the scene still rendering. Same family as the `Option<String>` incident in CLAUDE.md — one malformed value must not take the engine down for a session.

**Verified live on five cases.** Before, a position expression of `[0/0, 100]` threw on every render. After:

| expression | reported | null in scene JSON |
|---|---|---|
| `[0/0, 100]` | "must return a number" | no |
| `[1/0, 100]` | "must return a number" | no |
| `0/0` | "must return a number" | no |
| `[0/0]` | "must return a number" | no |
| `[123, 456]` | — | no |

Console clean.

---

**Correcting my own earlier claim.** I first hit this error during a sweep and reported it as pre-existing and unrelated, filing a task for it. **That was wrong.** It came from my own broken Sculpt code writing NaN mesh offsets (fixed in `d56cdb7`), whose values survived into the autosave — so my "isolation test" on a fresh reload was reading contaminated restored state, not a clean app. A genuinely fresh project shows no such error.

What *is* real, and is what this fixes, is that a user expression reaches the same failure with one line of ordinary JavaScript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)