### PR TITLE
Keyframe lock reaches the keyframe menu, and works through Parent in Time

### DIFF
--- a/src/js/layer-inout.js
+++ b/src/js/layer-inout.js
@@ -596,6 +596,7 @@
       // a plain (no-modifier, no-move) click can narrow the selection down
       // to just this one layer at mouseup — see that check's own comment.
       _drag = { group: true, type: type, startX: e.clientX, members: members, alt: !!e.altKey, keySel: keySelNow(), pressLi: li, hotEl: handleEl };
+      _drag.linkedOrig = captureLinkedOrig(members.map(function (m) { return m.li; }));
       return;
     }
     // Folder body-drag carries its children along (2026-08-29, feedback
@@ -645,10 +646,12 @@
           fMembers.push({ li: ci, row: crow || null, origIn: cIn, origOut: cOut, part: 'both', lastIn: cIn, lastOut: cOut });
         });
         _drag = { group: true, type: 'both', startX: e.clientX, members: fMembers, alt: !!e.altKey, keySel: keySelNow(), pressLi: li, hotEl: handleEl };
+        _drag.linkedOrig = captureLinkedOrig(fMembers.map(function (m) { return m.li; }));
         return;
       }
     }
     _drag = { li: li, row: row, type: type, startX: e.clientX, origIn: inPointOf(ld), origOut: outPointOf(ld), alt: !!e.altKey, keySel: keySelNow(), hotEl: handleEl };
+    _drag.linkedOrig = captureLinkedOrig([li]);
   }
   // Parent in Time (2026-07-30 on-timeline connector) — a dragged bar's OWN
   // position is kept live via updateBar (cheap, see its neighboring comment
@@ -661,20 +664,54 @@
   // children, same small guard bound resolveLinkedTime itself uses for
   // cycle-safety — still just a handful of cheap updateBar calls, not a
   // full rebuild.
+  // Walks the time-link chain up from l2 looking for srcUid. Factored out of
+  // updateLinkedChildrenBars (it was the only caller) because the keyframe
+  // lock pass in mouseup needs the exact same "is this layer downstream of
+  // what I'm dragging" test — two copies of a transitive walk with its own
+  // cycle guard is precisely the duplicated-pair trap of CLAUDE.md §3.
+  function isTimeLinkDescendant(l2, srcUid) {
+    if (!l2 || !l2.timeLink || !l2.timeLink.uid || !srcUid) return false;
+    var cur = l2, guard = 0;
+    while (cur && cur.timeLink && cur.timeLink.uid && guard++ < 16) {
+      if (cur.timeLink.uid === srcUid) return true;
+      var next = null;
+      state.layers.forEach(function (o) { if (o.layerUid === cur.timeLink.uid) next = o; });
+      cur = next;
+    }
+    return false;
+  }
+  function timeLinkUidOf(li) {
+    var ld = state.layers[li];
+    return (ld && window.SMMotion && window.SMMotion.ensureLayerUid) ? SMMotion.ensureLayerUid(ld) : null;
+  }
+  // Snapshot of every layer downstream of the bars about to be dragged, with
+  // its RESOLVED in/out — deliberately layerInPoint/layerOutPoint and not
+  // inPointOf/outPointOf (see their comment above): a linked edge's raw
+  // ld.inPoint is inert, the value that actually moves is the resolved one.
+  // Taken at drag START because the lock pass in mouseup needs a "before" to
+  // measure against, and a linked child is never in _drag.members.
+  function captureLinkedOrig(liList) {
+    var out = [], seenLi = {};
+    var uids = liList.map(timeLinkUidOf).filter(Boolean);
+    if (!uids.length) return out;
+    liList.forEach(function (li) { seenLi[li] = true; });
+    state.layers.forEach(function (l2, li2) {
+      if (seenLi[li2]) return; // dragged directly — already a member
+      var hit = uids.some(function (u) { return isTimeLinkDescendant(l2, u); });
+      if (!hit) return;
+      out.push({
+        li: li2,
+        origIn: window.layerInPoint ? layerInPoint(l2) : 0,
+        origOut: window.layerOutPoint ? layerOutPoint(l2) : state.totalFrames - 1
+      });
+    });
+    return out;
+  }
   function updateLinkedChildrenBars(sourceLi) {
-    var srcLd = state.layers[sourceLi];
-    var srcUid = (srcLd && window.SMMotion && window.SMMotion.ensureLayerUid) ? SMMotion.ensureLayerUid(srcLd) : null;
+    var srcUid = timeLinkUidOf(sourceLi);
     if (!srcUid) return;
     state.layers.forEach(function (l2, li2) {
-      if (!l2.timeLink || !l2.timeLink.uid) return;
-      var cur = l2, guard = 0, found = false;
-      while (cur && cur.timeLink && cur.timeLink.uid && guard++ < 16) {
-        if (cur.timeLink.uid === srcUid) { found = true; break; }
-        var next = null;
-        state.layers.forEach(function (o) { if (o.layerUid === cur.timeLink.uid) next = o; });
-        cur = next;
-      }
-      if (!found) return;
+      if (!isTimeLinkDescendant(l2, srcUid)) return;
       var row = _liToRow[li2];
       if (row) updateBar(row, li2);
     });
@@ -1044,6 +1081,26 @@
       };
       if (d.group) d.members.forEach(function (m) { lockOne(m.li, m.origIn, m.origOut); });
       else lockOne(d.li, d.origIn, d.origOut);
+      // Parent in Time (2026-08-30, "j'aimerais ça pour le parent in time"):
+      // a layer whose in/out is DRIVEN by the dragged one moves too, but it
+      // is never in d.members, so its standing keyLock never fired — its bar
+      // slid out from under its own keyframes. Measured before the fix:
+      // source in 0 -> 20, linked child's in 0 -> 20 (the link itself works),
+      // keys [10,20] unchanged where an unlinked layer with the same lock
+      // correctly gave [30,40].
+      // Reads RESOLVED points on both sides (captureLinkedOrig's comment says
+      // why raw is wrong here) via a lockOne variant rather than reusing the
+      // one above, which is hard-wired to inPointOf/outPointOf.
+      (d.linkedOrig || []).forEach(function (m) {
+        var l2 = state.layers[m.li]; if (!l2 || !l2.keyLock) return;
+        if (l2.keyLock === 'layer' && d.type !== 'both') return;
+        var nowIn = window.layerInPoint ? layerInPoint(l2) : m.origIn;
+        var nowOut = window.layerOutPoint ? layerOutPoint(l2) : m.origOut;
+        var moved = l2.keyLock === 'out' ? nowOut - m.origOut : nowIn - m.origIn;
+        if (!moved) return;
+        SMMotion.shiftLayerMotionKeys(m.li, moved);
+        lockDx = moved;
+      });
     }
     var selDx = 0;
     if (hasKeySel && !altHeld) {

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -6162,10 +6162,7 @@
           { sep: true },
           // showContextMenu has no submenus — a disabled row is the honest
           // way to title a group rather than a button that does nothing.
-          { label: SM.t('ctxLockKeyframesOnColon'), disabled: true, action: function () {} },
-          { label: SM.t('ctxKeyLockInPoint') + (ld.keyLock === 'in' ? '  ✓' : ''), action: function () { window.SM.setLayerKeyLock(li, ld.keyLock === 'in' ? null : 'in'); } },
-          { label: SM.t('ctxKeyLockOutPoint') + (ld.keyLock === 'out' ? '  ✓' : ''), action: function () { window.SM.setLayerKeyLock(li, ld.keyLock === 'out' ? null : 'out'); } },
-          { label: SM.t('ctxKeyLockWholeLayer') + (ld.keyLock === 'layer' ? '  ✓' : ''), action: function () { window.SM.setLayerKeyLock(li, ld.keyLock === 'layer' ? null : 'layer'); } },
+          ...buildKeyLockMenuItems(li, ld),
           { label: SM.t('ctxAddMarkerOnLayer'), action: function () { if (window.SMMarkers) SMMarkers.addLayerMarker(li, state.currentFrame, ''); } },
           // UI/UX audit (2026-07-30): used to grey this out via `disabled`
           // when the layer isn't a Component — showContextMenu has no
@@ -6585,6 +6582,31 @@
   // EXISTING call site (the side-panel Temps row, the menu-based creation
   // from buildTimeLinkMenuItems, a pickwhip drop that didn't land on a
   // specific target anchor) is 100% unaffected.
+  // The standing keyframe lock (ld.keyLock, van Dijk's "Lock Keyframes to In
+  // and Out Points"), as menu rows. Shared verbatim by the Motion layer row
+  // and the keyframe cell (2026-08-30, "sur le clic droit des keyframes dans
+  // motion j'aimerais ça pour le parent in time") so the two surfaces can
+  // never drift in labels, order or check state — the same reason
+  // buildTimeLinkMenuItems is one function feeding three menus.
+  // Order stays In / Out / Layer, matching the surface that already shipped.
+  // Every row toggles: picking the active mode again clears the lock, so the
+  // group behaves like radio buttons that can also be switched fully off.
+  function buildKeyLockMenuItems(li, ld) {
+    function row(mode, key) {
+      return {
+        label: SM.t(key) + (ld.keyLock === mode ? '  ✓' : ''),
+        action: function () { window.SM.setLayerKeyLock(li, ld.keyLock === mode ? null : mode); }
+      };
+    }
+    return [
+      // showContextMenu has no submenus — a disabled row is the honest way
+      // to title a group rather than a button that does nothing.
+      { label: SM.t('ctxLockKeyframesOnColon'), disabled: true, action: function () {} },
+      row('in', 'ctxKeyLockInPoint'),
+      row('out', 'ctxKeyLockOutPoint'),
+      row('layer', 'ctxKeyLockWholeLayer')
+    ];
+  }
   function setLayerTimeLink(li, targetIdx, mode, srcAnchor) {
     var ld = state.layers[li], src = state.layers[targetIdx];
     if (!ld || !src || targetIdx === li) return false;
@@ -8397,6 +8419,12 @@
             menu.push({ label: SM.t('ctxParentInTimeLinkTimeEllipsis'), action: function () {
               window.showContextMenu(e.clientX + 8, e.clientY + 8, window.buildTimeLinkMenuItems(state.activeLayerIdx, state.layers[state.activeLayerIdx], function () { renderLayerList(); renderTimeline(); }));
             } });
+            // The standing keyframe lock belongs next to it, on the same
+            // target and by the same rule (the active layer — a keyframe row
+            // always belongs to the expanded active layer's tracks). Asked
+            // for directly: this is the surface you're on when you care
+            // whether your keys follow a retimed in/out point.
+            buildKeyLockMenuItems(state.activeLayerIdx, state.layers[state.activeLayerIdx]).forEach(function (it) { menu.push(it); });
           }
           window.showContextMenu(e.clientX, e.clientY, menu);
         });


### PR DESCRIPTION
Deux moitiés d'une même demande : *« sur le clic droit des keyframes dans motion j'aimerais ça pour le parent in time »*.

## 1. Le menu

Le verrou permanent (`ld.keyLock`, le « Lock Keyframes to In and Out Points » de van Dijk) n'existait que sur le menu de la **ligne de calque**. Il est maintenant aussi sur le **clic droit d'une clé**, juste à côté de l'entrée Parent in Time qui s'y trouvait déjà — même cible et même règle (le calque actif). Les deux menus sont construits par une seule fonction, donc ils ne peuvent plus diverger en libellés, ordre ou coche.

## 2. Ça ne marchait pas pour Parent in Time

C'est le cas qui a motivé la demande. Un calque dont l'in/out est **piloté** par un autre bouge quand on drague la source — `updateLinkedChildrenBars` redessine bien sa barre — mais il n'est jamais dans `_drag.members`, donc `lockOne` ne le visitait pas : **ses clés restaient sur place pendant que la barre glissait dessous**.

Mesuré avant le correctif : in de la source 0 → 20, in de l'enfant lié 0 → 20 (le lien lui-même marchait), clés `[10,20]` inchangées — là où un calque **non lié** portant le même verrou donnait correctement `[30,40]`.

Le début de drag capture désormais chaque descendant transitif avec ses in/out **résolus** (`layerInPoint`/`layerOutPoint`, pas `inPointOf` : sur une arête liée le `ld.inPoint` brut est inerte), et la passe de verrou du `mouseup` les parcourt aussi. La marche transitive est **extraite** de `updateLinkedChildrenBars` plutôt que recopiée — deux marches à garde de cycle censées rester d'accord, c'est exactement le piège du §3.

## Vérifié en pilotant — 6 calques dans une même scène

Source, trois liés avec verrous in/out/layer, un lié sans verrou, un non lié avec verrou.

**Drag du IN de la source, +20**

| Calque | Avant | Après | |
|---|---|---|---|
| lié `keyLock=in` | [10,20] | **[30,40]** | suit |
| lié sans verrou | [10,20] | [10,20] | intact |
| lié `keyLock=out` | [10,20] | [10,20] | intact (l'out de la source n'a pas bougé) |
| lié `keyLock=layer` | [10,20] | [10,20] | intact (drag d'arête, pas du corps) |
| non lié `keyLock=in` | [10,20] | [10,20] | intact |

**Drag du CORPS de la source (+8 après clamp de l'out)**

| Calque | Avant | Après | |
|---|---|---|---|
| lié `keyLock=in` | [30,40] | **[38,48]** | |
| lié `keyLock=layer` | [10,20] | **[18,28]** | le mouvement du corps le réveille |
| les trois autres | | inchangés | |

Tous les verrous qui se déclenchent utilisent le **même +8**, donc ils sont d'accord entre eux et avec le clamp.

Menu vérifié sur les deux surfaces : choisir « the out point » depuis le menu des clés pose le verrou, et le menu de la ligne de calque montre la coche déplacée avec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)