### PR TITLE
Key colours carry onto the line that joins the keyframes

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1143,6 +1143,17 @@ body:not(.mode-motion) #motion-props-sec{display:none;}
 .motion-key-connect{fill:#2E6B60;pointer-events:auto;cursor:ew-resize;transition:fill .1s linear;}
 .motion-key-connect:hover{fill:#3E8C7E;}
 .motion-key-connect.sel{fill:#6FD9C4;}
+/* Key colour carried onto the span between two same-coloured keys, so a
+   coloured group (a walk cycle, say) reads as one block rather than a few
+   tinted diamonds. Declared AFTER the plain rules on purpose: .tinted and
+   :hover have equal specificity, so source order is what lets a user colour
+   win over the default teal. The two states below outrank both by adding a
+   second class/pseudo, and keep hover/selection legible on ANY user colour
+   by brightening it rather than replacing it — replacing would throw away
+   the very information the colour was set to carry. */
+.motion-key-connect.tinted{fill:var(--key-color,#2E6B60);}
+.motion-key-connect.tinted:hover{fill:var(--key-color,#3E8C7E);filter:brightness(1.25);}
+.motion-key-connect.tinted.sel{fill:var(--key-color,#6FD9C4);filter:brightness(1.45);}
 /* Alt = retime (first key planted, second one slides). Driven by the SAME
    #frame-grid.timelink-alt class layer-inout.js already toggles for the
    Parent-in-Time dot reveal, mirroring the spec's own .kstage.alt container

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -8142,7 +8142,24 @@
         // .sel mirrors the diamonds' own convention: on when BOTH endpoint
         // keys are selected, which is exactly the state a connector click
         // (below) produces — never toggled independently of them.
-        rect.setAttribute('class', 'motion-key-connect' + (isKeySelected(ld, prop, a) && isKeySelected(ld, prop, b) ? ' sel' : ''));
+        // Key colours carry onto the connector (2026-08-30, "quand je parle
+        // de group c'est le trait qui joint les keyframes"): colouring a
+        // walk cycle's keys should paint the whole SPAN, so the group reads
+        // as one coloured block at a glance instead of a few tinted diamonds
+        // lost in a row of identical ones.
+        // Only when both endpoints carry the SAME colour — that is what
+        // "inside the group" means. A span between two differently coloured
+        // keys is a BOUNDARY between groups, and one between a coloured and
+        // an uncoloured key is half outside, so both keep the default fill
+        // rather than guessing which side owns them.
+        // Same .tinted + --key-color mechanism the diamonds already use
+        // (see the dia.classList.add('tinted') line above), so a colour is
+        // set in exactly one place and CSS owns every state.
+        var tint = (a.color && b.color && a.color === b.color) ? a.color : null;
+        rect.setAttribute('class', 'motion-key-connect'
+          + (isKeySelected(ld, prop, a) && isKeySelected(ld, prop, b) ? ' sel' : '')
+          + (tint ? ' tinted' : ''));
+        if (tint) rect.style.setProperty('--key-color', tint);
         rect.setAttribute('data-i', i);
         // The connector is a draggable TARGET, not decoration
         // (nemo-timeline-inout-spec.html, 2026-08-16): "le trait est une


### PR DESCRIPTION
Les clés pouvaient déjà être colorées, mais seuls les **losanges** prenaient la couleur — et quelques losanges teintés dans une rangée de losanges identiques ne se lisent guère mieux que pas de couleur du tout. Ce qui rend un groupe lisible, c'est la **travée** : *« quand je parle de group c'est le trait qui joint les keyframes »*.

Le connecteur entre deux clés prend maintenant leur couleur, donc colorer les clés d'un cycle de marche peint tout le cycle comme un bloc.

## La règle

Uniquement quand **les deux extrémités portent la MÊME couleur**. Une travée entre deux clés de couleurs différentes est une **frontière entre groupes**, et une travée entre une clé colorée et une clé non colorée est à moitié dehors — les deux gardent le remplissage par défaut plutôt que de deviner quel côté les possède.

Réutilise le mécanisme `.tinted` + `--key-color` déjà employé par les losanges, donc une couleur est posée à un seul endroit et le CSS possède tous les états. Les deux états teintés **éclaircissent** la couleur de l'utilisateur au lieu de la remplacer : la sélection doit rester non ambiguë, mais substituer le turquoise de sélection jetterait précisément l'information que la couleur servait à porter.

## Vérifié en pilotant

Cinq clés : trois ambre, puis verte, puis non colorée.

| Travée | Résultat |
|---|---|
| ambre → ambre | `#e8b64c` teinté |
| ambre → ambre | `#e8b64c` teinté |
| ambre → verte | turquoise par défaut (frontière) |
| verte → aucune | turquoise par défaut (à moitié dehors) |

Sélectionné + teinté garde `#e8b64c` en `brightness(1.45)` ; retirer les couleurs ramène chaque connecteur au turquoise, y compris le sélectionné.

🤖 Generated with [Claude Code](https://claude.com/claude-code)