### PR TITLE
Double-click shows every object's box, not just the clicked one

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2949,6 +2949,32 @@
         });
       }
     }
+    // Per-object boxes (2026-08-30, the full #165 spec: "2 shape > double
+    // clic > 2 bounding box de shape"): while the double-click isolation
+    // mode is on for THIS layer, every sibling shape also shows its own
+    // dim outline box, so each object on the layer reads as individually
+    // grabbable — the isolated one keeps the full gizmo drawn above, the
+    // others get outline-only (their box becomes the active one the moment
+    // they're clicked, via select-bridge's _shapeEnteredId handoff).
+    // Skips synthetic/companion children (§1: dabs, brush copies, duplicator
+    // copies carry no strokeId or carry their own tags) by requiring a
+    // strokeId and no groupId — the mode is defined for ungrouped shapes.
+    if (window._perObjBoxes === state.activeLayerIdx && userLayers[state.activeLayerIdx]) {
+      var poMap = (window.SMMotion && SMMotion.layerMotionPointMap) ? SMMotion.layerMotionPointMap(state.activeLayerIdx) : null;
+      userLayers[state.activeLayerIdx].children.forEach(function (ch) {
+        if (!ch.data || !ch.data.strokeId || ch.data.groupId) return;
+        if (ch.data.isBrushTextureCopy || ch.data.isLinkedFillCompanion || ch.data.isDuplicatorCopy) return;
+        if (selectedPaths.indexOf(ch) >= 0) return; // the active one has the real gizmo
+        var sb = ch.strokeBounds;
+        if (!sb || !sb.width || !sb.height) return;
+        function PW(x, y) { if (!poMap) return [x, y]; return poMap.fwd(x, y); }
+        var q1 = PW(sb.left, sb.top), q2 = PW(sb.right, sb.top), q3 = PW(sb.right, sb.bottom), q4 = PW(sb.left, sb.bottom);
+        items.push(lineItem(q1, q2, [74, 158, 255, 130], 1 * zs));
+        items.push(lineItem(q2, q3, [74, 158, 255, 130], 1 * zs));
+        items.push(lineItem(q3, q4, [74, 158, 255, 130], 1 * zs));
+        items.push(lineItem(q4, q1, [74, 158, 255, 130], 1 * zs));
+      });
+    }
     return items;
   }
   function buildMarqueeItems() {

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -1319,7 +1319,22 @@
         // double-click — which is exactly the "je clic ailleurs, je reviens
         // sur la bounding box globale" half of the request. Without it this
         // would reproduce the July bug quoted just above, one level down.
-        if (window._shapeEnteredId && (!p.data || p.data.strokeId !== window._shapeEnteredId)) window._shapeEnteredId = null;
+        if (window._shapeEnteredId && (!p.data || p.data.strokeId !== window._shapeEnteredId)) {
+          // Per-object boxes (2026-08-30): while that mode is on, clicking a
+          // SIBLING shape on the same layer hands the isolation over to it
+          // instead of ending it — that is the mode's whole point ("je peux
+          // transformer tranquillement mes shapes avec leur propre bounding
+          // box"), and it keeps the next double-click on the newly clicked
+          // shape reaching Subselect, since alreadyIsolated (tools.js) then
+          // sees ITS id. Clicking a grouped shape or one on another layer
+          // still ends the continuity exactly as before.
+          if (window._perObjBoxes === state.activeLayerIdx && p.data && p.data.strokeId && !p.data.groupId) {
+            window._shapeEnteredId = p.data.strokeId;
+          } else {
+            window._shapeEnteredId = null;
+            window._perObjBoxes = null;
+          }
+        }
       } else {
         // p is ALREADY selected (idx2>=0) — but its own group siblings might
         // not be (2026-07-29 fix, QA-confirmed): right after a Subselect

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -7639,6 +7639,16 @@ function onViewDoubleClick(event){
     selectedPaths=[fillPath];
     state.selectedStrokeIndices=selectedPaths.map(getSI).filter(function(i2){return i2>=0;});
     _shapeEnteredId=dblSid||null;
+    // Per-object boxes (2026-08-30, the full #165 spec re-read after "le
+    // double clic n'affiche pas les box de chaque objet"): the request was
+    // never just isolating the CLICKED shape — it was "2 shapes > double
+    // clic > 2 bounding box de shape", every object on the layer showing
+    // its own box at once, each grabbable. This flag makes
+    // buildTransformBoxItems (engine-bridge) draw a dim outline box around
+    // every OTHER shape on this layer while the clicked one keeps the full
+    // gizmo; clicking a sibling migrates the isolation to it
+    // (select-bridge's _shapeEnteredId handoff) instead of ending it.
+    window._perObjBoxes=state.activeLayerIdx;
     renderArcs();updateUI();
     if(window.SMEngineBridge)SMEngineBridge.renderNow();
     return;


### PR DESCRIPTION
Suite en direct du feedback #165 : *« le double clic n'affiche pas les box de chaque objet avec l'outil select comme j'avais dit »*.

En relisant la demande d'origine face à ce que la PR #374 a livré : la demande n'a jamais été d'isoler seulement **la forme cliquée** — c'était *« 2 shape > double clic > 2 bounding box de shape »*, chaque objet du calque montrant sa boîte **en même temps**, chacune saisissable. #374 avait livré la moitié isolation, avec une seule boîte.

## Maintenant, au premier double-clic sur une forme non groupée

- la forme cliquée garde le **gizmo complet** (poignées, anneau, ancre), et chaque **autre** forme du calque reçoit une boîte de contour discrète — chaque objet se lit comme individuellement saisissable ;
- cliquer une voisine **transmet l'isolation** (le `_shapeEnteredId` de select-bridge migre au lieu de s'effacer) : sa boîte devient l'active et le mode continue — cette continuité est tout l'intérêt du mode, et elle permet au double-clic suivant sur la forme fraîchement cliquée d'atteindre **Subselect** ;
- cliquer une forme groupée ou un autre calque met fin au mode exactement comme l'ancien reset, et désélectionner masque les boîtes avec la sélection.

Les boîtes des voisines sautent les enfants synthétiques (§1 : dabs, copies de brush, copies du duplicateur) et les formes groupées — le mode est défini pour les non groupées. Dessinées dans `buildTransformBoxItems`, déjà sous le gate `includeEditorOverlays` : **elles ne peuvent jamais atteindre un export**, par la même construction que tout autre overlay d'éditeur (§13).

## Vérifié en pilotant

| Geste | Résultat |
|---|---|
| double-clic A | gizmo sur A + mode actif |
| clic simple B | l'isolation **migre** (sélection `shB`, mode toujours actif) |
| double-clic B | **Subselect** |

La construction de scène avec le flag émet exactement les 4 lignes de contour de la voisine (5221 contre 4685 octets, reproductible dans les deux sens).

Une fausse alerte pendant le test était mon propre double-clic synthétique qui manquait sa cible (divergence de mapping écran paper/moteur) — l'appel direct a prouvé la logique saine.

`npm test` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)