### PR TITLE
QA sweep: dead matteOn track resurrected, and a zombie expression panel

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -6509,6 +6509,17 @@
         // first is gone. Leaving them behind would keep invisible state
         // that silently reappears the next time a matte is set.
         delete ld.mattesMore;
+        // The matteOn track goes too — found by driving (2026-08-30 sweep):
+        // with the track left behind, setting a NEW matte later resurrected
+        // the old on/off keys, and the fresh matte was mysteriously OFF
+        // from wherever the dead track said so, with nothing visible to
+        // explain it (the row only renders while a matte exists). Same
+        // invisible-state class as mattesMore right above; the expression
+        // slot follows for the same reason. Undo restores all of it in one
+        // step — pushUndoLayers ran first.
+        if (ld.motion) delete ld.motion.matteOn;
+        if (ld.motionStatic) delete ld.motionStatic.matteOn;
+        if (ld.expressions) delete ld.expressions.matteOn;
         matteChanged();
       } });
     }

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -5616,6 +5616,15 @@ function paintFillSwatches(v){
 // caller.
 function renderLayerList(frameOnly){
   if(frameOnly&&state.appMode!=='motion')return;
+  // Split code editor sync (2026-08-30, found by driving: deleting the
+  // layer whose expression the panel was showing left the panel open on a
+  // dead expression — a zombie that silently swallowed edits). refresh()
+  // re-reads its expression from the model and CLOSES ITSELF when the
+  // holder no longer resolves; hooked here because every path that changes
+  // what the panel could be stale against (layer deletion, undo/redo,
+  // project load) already funnels through renderLayerList, and the call is
+  // one snapshot read when open, nothing when closed.
+  if(window.SMExprPanel&&SMExprPanel.isOpen())SMExprPanel.refresh();
   var _scroll=_tlScrollSnapshot(); // see _tlScrollSnapshot — same wipe, same jump
   var list=document.getElementById('layer-list');list.innerHTML='';
   // Motion mode: expandable Transform property rows instead of the plain


### PR DESCRIPTION
Deux bugs trouvés **en pilotant** les features du jour contre la suppression, l'undo et la re-pose — tous deux dans la même famille « état invisible ».

## 1. La piste `matteOn` morte ressuscitait

Retirer un matte laissait sa piste `matteOn` (et une éventuelle expression) derrière. La ligne ne se rend que tant qu'un matte existe, donc les restes étaient invisibles — jusqu'à ce qu'un **nouveau** matte soit posé plus tard : les vieilles clés ressuscitaient et le matte frais était mystérieusement **éteint** à partir de là où la piste morte le disait, sans rien à l'écran pour l'expliquer.

Piloté avant correctif : retirer, re-poser, `matteOnAt(15)` **faux** sans raison visible.

Le retrait supprime maintenant `ld.motion.matteOn`, `ld.motionStatic.matteOn` et `ld.expressions.matteOn` avec le mode — le même balayage que les extras `mattesMore` avaient déjà, pour la même raison. `pushUndoLayers` tourne d'abord, donc **un seul undo ramène tout le matte**, piste et expression comprises (vérifié).

## 2. Le panneau d'expression zombie

Supprimer le calque dont l'expression était ouverte dans l'éditeur split laissait le panneau ouvert sur une expression morte — un zombie qui **avalait silencieusement les éditions** (`applyExprCode` renvoie `false` sur un ref irrésoluble).

`renderLayerList` ping maintenant `SMExprPanel.refresh()` quand le panneau est ouvert : refresh relit son expression depuis le modèle et **se ferme tout seul** quand le holder ne résout plus. Accroché là parce que tout chemin qui peut rendre le panneau périmé (suppression de calque, undo/redo, chargement de projet) passe déjà par `renderLayerList` — et l'appel coûte une lecture de snapshot ouvert, rien fermé.

Piloté : suppression par le vrai bouton poubelle → panneau fermé, wrapper démonté, canvas revenu pleine largeur, zéro exception.

## Aussi balayé, propre

- `duplicateLayer` copie en profondeur matteMode/mattesMore/matteOn — muter la copie ne touche pas l'original
- supprimer un calque **source** de matte dégrade le rendu sans erreur
- l'undo du keyframe de couleur (sélecteur) rétablit clé + couleur d'item en un cran
- « + parent » / « + matte » s'annulent chacun en un cran
- scrub de 24 frames avec matte + parents actifs : aucune exception

`npm test` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)