### PR TITLE
Double-click works on strokes and compound shapes, not only filled Paths

### DIFF
--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -7577,9 +7577,25 @@ function onViewDoubleClick(event){
   }
   if(state.tool!=='select')return;
   var layer=userLayers[state.activeLayerIdx];
-  var hit=layer.hitTest(event.point,{fill:true,tolerance:4/view.zoom});
-  if(!hit||!(hit.item instanceof Path)||!hit.item.fillColor)return;
+  // fill AND stroke (2026-08-30, feedback #166 "au double clic toujours box
+  // globale et pas individuelle"): the old {fill:true}-only test made a
+  // double-click on any stroke-only path — every plain drawn line — return
+  // silently, leaving whatever box was already up. Reproduced exactly: with
+  // several shapes selected, dblclick on a fill-less stroke did nothing and
+  // the union box just stayed. A drawn stroke is as much "an object" as a
+  // filled shape, so it gets the same doorway.
+  var hit=layer.hitTest(event.point,{fill:true,stroke:true,tolerance:4/view.zoom});
+  if(!hit||!hit.item)return;
   var fillPath=hit.item;
+  // A hit inside a CompoundPath (boolean/fill results with holes) lands on
+  // a CHILD Path — climb to the layer-level item, which is the one carrying
+  // data.strokeId and the one every consumer (§1) expects in selectedPaths.
+  while(fillPath.parent&&fillPath.parent!==layer)fillPath=fillPath.parent;
+  if(!(fillPath instanceof Path)&&!(fillPath instanceof CompoundPath))return;
+  if(!fillPath.fillColor&&!fillPath.strokeColor)return;
+  // Synthetic companions are not objects to isolate (§1) — a dab or a
+  // duplicator copy under the cursor must not swallow the gesture.
+  if(fillPath.data&&(fillPath.data.isBrushTextureCopy||fillPath.data.isLinkedFillCompanion||fillPath.data.isDuplicatorCopy))return;
   // Group double-click (2026-07-29 fix, Cyril: "si c'est un group et que l'on
   // double clic on doit entrer dans le group avec l'outil select pas
   // subselect, l'outil subselect n'apparait qu'après si on double clic sur


### PR DESCRIPTION
Feedback #166 (*« au double clic toujours box globale et pas individuelle »*), quelques minutes après la sortie de #390. Deux explications candidates, et une seule est un bug corrigeable : sa session **précède le déploiement** (une SPA ouverte ne récupère jamais un nouveau bundle), **et** la porte d'entrée du double-clic rejetait réellement la plupart du contenu dessiné.

## Le bug

L'ancienne porte exigeait `{fill:true}` + `instanceof Path` + `fillColor` — trois conditions qu'un **trait dessiné sans fill** rate d'emblée, et qu'un résultat de fill/booléen à trou (**CompoundPath**) rate au milieu.

Reproduit exactement : plusieurs formes sélectionnées, double-clic sur un trait sans fill → **rien**, silencieusement, et la box union reste — *« toujours box globale »* au mot près.

## Le correctif

- le hit-test prend aussi `stroke:true` — un trait dessiné est autant « un objet » qu'une forme pleine ;
- un hit à l'intérieur d'un CompoundPath **remonte à l'item de niveau calque** (celui qui porte `data.strokeId`, celui que chaque consommateur de `selectedPaths` attend, §1) au lieu d'un contour enfant ;
- les compagnons synthétiques (dabs, linked-fill, copies du duplicateur) sont explicitement refusés pour ne pas avaler le geste.

## Piloté, tout sur un calque

| Geste | Avant | Après |
|---|---|---|
| dbl-clic sur trait sans fill | no-op silencieux | isolé + boîtes par-objet |
| dbl-clic sur CompoundPath donut | selon le point : enfant ou no-op | isolé, item de niveau calque |
| 2e dbl-clic | — | Subselect |
| chemin **groupe** (juillet) | | intact : 1er dbl = groupe entier sur Select, 2e = Subselect, mode par-objet à l'écart |

Zéro exception sur toute la passe. `npm test` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)