### PR TITLE
A stale transform gizmo silently killed canvas selection

### DIFF
--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -6755,8 +6755,27 @@ function onMouseDown(event){
       var xd=event.point.getDistance(xh.pos);if(xd<bestXd){bestXd=xd;bestXh=xh;}
     }
     if(bestXh){
-      pushUndo();
       var xb=xformSelBounds();
+      // Stale gizmo guard (2026-08-30, feedback #167 "impossible de le
+      // reselect dans le canvas"). xformSelBounds() returns null the moment
+      // every selectedPaths entry is dead — and after loadFrame rebuilds the
+      // layer's items (any frame change; a duplicator layer re-materializes
+      // ALL of its children on every scrub) those entries name objects that
+      // no longer exist, while xformHandles still holds the handle positions
+      // computed before. A click near an old handle then entered this branch
+      // and threw on xb.center, which killed the REST of onMouseDown — the
+      // ordinary hit-test-and-select code below never ran, so nothing could
+      // be selected again until something else happened to refresh the
+      // handles. Reproduced exactly: select a copy, scrub, deselect, click —
+      // "Cannot read properties of null (reading 'center')" at this line,
+      // then zero selection on every subsequent click.
+      // Falling through (rather than returning) is what makes the click do
+      // the useful thing: the stale gizmo is dropped and the click is
+      // treated as the plain selection click the user meant.
+      if(!xb){ xformHandles=[]; bestXh=null; }
+    }
+    if(bestXh){
+      pushUndo();
       if(bestXh.type==='rotate'){
         _xform.active=true;_xform.type='rotate';_xform.center=xb.center.clone();
         _xform.startAngle=Math.atan2(event.point.y-_xform.center.y,event.point.x-_xform.center.x)*180/Math.PI;_xform.lastAngle=0;


### PR DESCRIPTION
Feedback #167 (*« si je deselect un objet dupliqué avec duplicator alors impossible de le reselect dans le canvas »*).

**Ce n'est finalement pas un bug du duplicateur** — c'en est un général, que le duplicateur rend simplement facile à déclencher.

## La cause

`xformSelBounds()` renvoie `null` dès que **toutes** les entrées de `selectedPaths` sont mortes, et `onMouseDown` lisait `xb.center` **sans garde**.

Après que `loadFrame` reconstruit les items d'un calque (n'importe quel changement de frame — et un calque duplicateur re-matérialise **tous** ses enfants à chaque scrub), ces entrées désignent des objets qui n'existent plus, tandis que `xformHandles` contient encore les positions de poignées calculées **avant** la reconstruction. Un clic tombant près d'une ancienne poignée entrait alors dans la branche gizmo et levait :

```
TypeError: Cannot read properties of null (reading 'center')
  at onMouseDown (tools.js:6761)
```

Et comme ça levait **au milieu du handler**, tout le code ordinaire de hit-test-et-sélection plus bas **ne tournait jamais**. Le clic ne faisait donc rien, et continuait à ne rien faire, jusqu'à ce qu'autre chose rafraîchisse les poignées — *« impossible de le reselect »* au mot près.

Reproduit avant correctif : sélectionner une copie, scrub vers une autre frame et retour, déselectionner, cliquer → l'exception, puis **0 sélectionné à chaque clic suivant**.

## Le correctif

La garde **abandonne le gizmo périmé** (vide `xformHandles`, oublie la poignée) et **retombe dans le flux normal** au lieu de sortir — le clic fait donc la chose utile : il devient le clic de sélection que l'utilisateur voulait.

## Vérifié

| | |
|---|---|
| même séquence après fix | **1** sélectionné au re-clic, **1** sur la copie suivante, zéro exception |
| scale légitime, calque ordinaire | intact — glisser la poignée SE redimensionne toujours (120×100 → 154×146) |

Même famille que l'avertissement du §12bis : une entrée de `selectedPaths` survit à l'objet qu'elle nomme, et tout ce qui en dérive doit attendre `null` plutôt que supposer la sélection encore réelle.

`npm test` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)