### PR TITLE
Motion: double-click on canvas targets one element and boxes the others

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -4571,7 +4571,45 @@
     });
   }
   function buildOverlayItems() {
-    return buildOverlayItemsInner().concat(hoverOverlayItems());
+    return buildOverlayItemsInner().concat(hoverOverlayItems()).concat(perObjectBoxItems());
+  }
+  // Sibling element boxes in MOTION (2026-08-30, feedback #170 "dans motion
+  // le double clic dans le canvas... ne révèle toujours pas les box
+  // individuelle"). Animation 2D draws these from buildTransformBoxItems
+  // (engine-bridge), which returns [] outright in Motion — Motion has its
+  // own complete overlay, and the two were deliberately kept from firing
+  // together. So the same idea needs its own small builder here.
+  // The DOUBLE-CLICKED element keeps Motion's real gizmo (drawn above via
+  // activeMotionTarget/_motionExpandedElement); every other shape on the
+  // layer gets a dim outline, so each one reads as individually targetable
+  // — clicking its row, or double-clicking it on canvas, makes it active.
+  function perObjectBoxItems() {
+    if (window._perObjBoxes !== state.activeLayerIdx) return [];
+    var lyr = userLayers[state.activeLayerIdx];
+    if (!lyr) return [];
+    var items = [];
+    var zs = 1 / Math.max(0.0001, view.zoom);
+    // Same layer-level Motion map the gizmo itself uses, so a moved/rotated
+    // layer carries its sibling boxes with it instead of leaving them at the
+    // untransformed geometry.
+    // Reached through the export rather than a bare call: layerMotionPointMap
+    // is defined on the SMMotion object literal at the bottom of this file,
+    // not as a local function in this closure.
+    var map = (window.SMMotion && SMMotion.layerMotionPointMap) ? SMMotion.layerMotionPointMap(state.activeLayerIdx) : null;
+    lyr.children.forEach(function (ch) {
+      if (!ch.data || !ch.data.strokeId || ch.data.groupId) return;
+      if (ch.data.isBrushTextureCopy || ch.data.isLinkedFillCompanion || ch.data.isDuplicatorCopy) return;
+      if (ch.data.strokeId === window._motionExpandedElement) return; // has the real gizmo
+      var b = ch.strokeBounds;
+      if (!b || !b.width || !b.height) return;
+      function P(x, y) { if (!map) return [x, y]; return map.fwd(x, y); }
+      var c1 = P(b.left, b.top), c2 = P(b.right, b.top), c3 = P(b.right, b.bottom), c4 = P(b.left, b.bottom);
+      items.push({ segments: [{ point: c1 }, { point: c2 }], closed: false, fillColor: null, strokeColor: [63, 107, 245, 120], strokeWidth: 1 * zs });
+      items.push({ segments: [{ point: c2 }, { point: c3 }], closed: false, fillColor: null, strokeColor: [63, 107, 245, 120], strokeWidth: 1 * zs });
+      items.push({ segments: [{ point: c3 }, { point: c4 }], closed: false, fillColor: null, strokeColor: [63, 107, 245, 120], strokeWidth: 1 * zs });
+      items.push({ segments: [{ point: c4 }, { point: c1 }], closed: false, fillColor: null, strokeColor: [63, 107, 245, 120], strokeWidth: 1 * zs });
+    });
+    return items;
   }
   function buildOverlayItemsInner() {
     var ml = multiLayerBox();

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -7594,6 +7594,38 @@ function onViewDoubleClick(event){
       return;
     }
   }
+  // Motion mode (2026-08-30, feedback #170 "dans motion le double clic dans
+  // le canvas sur plusieurs éléments ne révèle toujours pas les box
+  // individuelle"): Motion's active tool is 'draw', not 'select', so this
+  // whole function used to early-return below and the double-click did
+  // NOTHING there — the Animation 2D isolation shipped earlier today never
+  // reached it. Motion already HAS a per-element target of its own
+  // (_motionExpandedElement, which motionBoxGeom aims the gizmo at); the
+  // gesture just had no way in from the canvas, only from the timeline's
+  // element rows. So this hands the double-click to that existing machinery
+  // rather than running Animation 2D's selectedPaths isolation, which
+  // Motion's own overlay would ignore anyway.
+  if(state.appMode==='motion'){
+    var mLayer=userLayers[state.activeLayerIdx];
+    if(!mLayer)return;
+    var mHit=mLayer.hitTest(event.point,{fill:true,stroke:true,tolerance:4/view.zoom});
+    if(!mHit||!mHit.item)return;
+    var mItem=mHit.item;
+    while(mItem.parent&&mItem.parent!==mLayer)mItem=mItem.parent;
+    var mSid=mItem.data&&mItem.data.strokeId;
+    if(!mSid)return;
+    if(mItem.data.isBrushTextureCopy||mItem.data.isLinkedFillCompanion||mItem.data.isDuplicatorCopy)return;
+    var M=window.SMMotion;
+    if(!M)return;
+    window._motionExpandedLayer=state.activeLayerIdx;
+    window._motionExpandedElement=mSid;
+    window._perObjBoxes=state.activeLayerIdx;
+    if(M.selectShapesByStrokeIds)M.selectShapesByStrokeIds(state.activeLayerIdx,[mSid]);
+    if(window.renderLayerList)renderLayerList();
+    if(window.renderTimeline)renderTimeline();
+    if(window.SMEngineBridge)SMEngineBridge.renderNow();
+    return;
+  }
   if(state.tool!=='select')return;
   var layer=userLayers[state.activeLayerIdx];
   // fill AND stroke (2026-08-30, feedback #166 "au double clic toujours box
@@ -7716,7 +7748,11 @@ function onViewDoubleClick(event){
 }
 view.onMouseDown=onMouseDown;view.onMouseDrag=onMouseDrag;view.onMouseUp=onMouseUp;view.onMouseMove=onMouseMoveTool;view.onDoubleClick=onViewDoubleClick;
 canvasEl.addEventListener('dblclick',function(e){
-  if(!(window.SMEngineBridge&&SMEngineBridge.isEnabled())||state.tool!=='select')return;
+  // state.tool is 'draw' in Motion mode, so the select-only gate kept this
+  // bridge from ever firing there (feedback #170) — onViewDoubleClick has
+  // its own Motion branch now and decides for itself.
+  if(!(window.SMEngineBridge&&SMEngineBridge.isEnabled()))return;
+  if(state.tool!=='select'&&state.appMode!=='motion')return;
   var w=SMEngineBridge.screenToWorld(e.clientX,e.clientY);
   onViewDoubleClick({point:new Point(w[0],w[1])});
   e.preventDefault();e.stopImmediatePropagation();


### PR DESCRIPTION
Feedback #170 (*« dans motion le double clic dans le canvas sur plusieurs éléments ne révèle toujours pas les box individuelle »*).

**Mon propre trou** : le travail livré plus tôt aujourd'hui (#390/#392) ne concernait que l'Animation 2D, et je ne l'avais dit nulle part.

## Deux raisons pour lesquelles ça ne pouvait pas marcher en Motion

Les deux trouvées en pilotant :

1. **`state.tool` vaut `'draw'` en Motion**, pas `'select'`. `onViewDoubleClick` et le pont `dblclick` du canvas étaient tous deux gardés sur `'select'` — le double-clic n'y faisait donc **rien du tout**. Pas « la mauvaise chose » : rien.
2. **`buildTransformBoxItems` renvoie `[]` d'emblée en Motion**, par conception — Motion a son overlay complet et les deux sont délibérément empêchés de tirer ensemble (ce garde existe pour éviter le bug des deux anneaux/ancres du 2026-08-21).

## Le correctif

Motion **possédait déjà** sa cible par-élément — `_motionExpandedElement`, que `motionBoxGeom` vise — le geste n'avait simplement aucune entrée depuis le canvas, seulement depuis les lignes d'élément de la timeline.

Le double-clic passe donc la main à cette machinerie existante, plutôt que de lancer l'isolation `selectedPaths` de l'Animation 2D que l'overlay Motion ignorerait de toute façon. Les contours des frères ont un petit builder dans l'overlay **de Motion**, avec le même `layerMotionPointMap` que le gizmo — un calque transformé emporte donc ses boîtes avec lui.

Le hit-test reprend celui corrigé en #392 : fill **et** stroke, remontée d'un hit CompoundPath vers l'item de niveau calque, refus des compagnons synthétiques.

## Vérifié en pilotant — 3 formes (rect plein, cercle plein, trait sans fill) en Motion

| Geste | Résultat |
|---|---|
| double-clic sur le rect | `_motionExpandedElement` = `shA`, boîtes actives |
| double-clic sur le **trait sans fill** | `_motionExpandedElement` = `shC` |
| boîtes des frères | 1200 octets d'overlay, reproductible en on/off |
| relecture de l'export | **0 pixel** de couleur d'overlay — toujours sous `includeEditorOverlays` (§13) |

Zéro exception sur toute la passe. `npm test` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)