### PR TITLE
Motion gizmo hugs the targeted element instead of the whole layer

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -5007,7 +5007,20 @@
       var nb = t.boundsCenter;
       lb = { left: nb.x - hs, top: nb.y - hs, right: nb.x + hs, bottom: nb.y + hs, width: hs * 2, height: hs * 2, center: { x: nb.x, y: nb.y } };
     } else {
-      lb = (ld && ld.symbolId) ? symbolUnionBounds(t.li) : (userLayers[t.li] && userLayers[t.li].bounds);
+      // Per-ELEMENT target hugs its own shape (2026-08-30, feedback #170
+      // re-opened: "ça m'ouvre pas ça comme un groupe avec les 2 bounding
+      // box différencié"). activeMotionTarget has computed t.bounds for the
+      // expanded element since the per-element branch was added — this
+      // function simply never read it and always took the whole LAYER's
+      // union, so on a layer with two shapes the gizmo drew ONE box around
+      // both while its anchor correctly sat on the element. Seen on screen,
+      // not deduced: the box spanned a square at (700,420) and a circle at
+      // (1030,780) together.
+      // Only when a strokeId is actually targeted; the whole-layer case
+      // (t.strokeId null) keeps the union it always used, and a Component
+      // keeps symbolUnionBounds' duration-stable box.
+      lb = (t.strokeId && t.bounds) ? t.bounds
+        : ((ld && ld.symbolId) ? symbolUnionBounds(t.li) : (userLayers[t.li] && userLayers[t.li].bounds));
     }
     if (!lb) return null;
     var anc = valueAtFrame(t.holder, 'anchor', state.currentFrame);


### PR DESCRIPTION
Feedback #170, **rouvert** : *« ça m'ouvre pas ça comme un groupe avec les 2 bounding box différencié »*.

Il avait raison, et j'avais marqué l'issue résolue **sans jamais regarder l'écran** — la PR précédente était vérifiée par des compteurs d'octets de JSON de scène, ce qui prouvait que les contours voisins étaient *émis* mais ne disait rien du gizmo lui-même.

## Ce qu'on voit réellement

Sur un calque à deux formes, double-cliquer l'une dessinait l'ancre correctement **sur cette forme** mais **une seule boîte autour des deux**.

`motionBoxGeom` (ligne ~5010) prenait toujours l'union du calque entier — `userLayers[t.li].bounds` — et ne lisait **jamais** `t.bounds`, que `activeMotionTarget` calcule pourtant pour l'élément étendu depuis que la branche par-élément existe.

L'ancre suivait donc l'élément et la boîte non : exactement l'état à moitié fonctionnel de la capture, un carré en (700,420) et un cercle en (1030,780) partageant une boîte.

## Le correctif

Une cible **par élément** utilise désormais ses propres bornes. Uniquement quand un `strokeId` est réellement ciblé : le cas calque entier garde l'union qu'il a toujours eue, et un Composant garde la boîte stable sur la durée de `symbolUnionBounds` (dont c'est toute la raison d'être — le pivot ne doit pas sauter entre les keyframes).

## Vérifié **à l'écran**, les deux sens et la non-régression

| Geste | Résultat |
|---|---|
| double-clic sur le carré | gizmo serré sur `700,420,220×220`, cercle en contour |
| double-clic sur le cercle | le gizmo migre sur `1030,780,240×240` |
| aucun élément étendu | boîte union de retour, `700,420,570×600` |

Deux boîtes différenciées, ce qui était la demande.

## Leçon que je note pour moi

Un delta d'octets prouve que quelque chose est **émis**, pas que ça **rend juste**. Tout ce qui concerne ce que l'utilisateur *voit* doit être vu.

`npm test` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)