### PR TITLE
Document fields sit at the top, on the dark ground, like a selection

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2686,3 +2686,19 @@ body.mode-motion .layer-inout-bar .layer-inout-handle{width:4px;border-radius:2p
   font-size:9.5px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;
   padding:3px 7px;border-radius:4px;line-height:1;margin-top:1px;}
 .start-alpha-text{font-size:11.5px;line-height:1.5;color:rgba(236,234,231,.72);}
+
+/* Document fields presented as the panel's identity block (timeline.js's
+   updatePropsContext moves #canvas-sec here for the Document context).
+   Mirrors #sel-props-sec — the block that holds Position/Size/Rotate for a
+   selection — so "nothing selected" and "something selected" read as the
+   same kind of panel rather than two different layouts. */
+.psec-identity{border-bottom:1px solid var(--border);
+  /* Transparent, NOT a colour of its own — measured: #sel-props-sec is
+     rgba(0,0,0,0) and shows #props-panel's darker rgb(23,22,26) through,
+     while every .psec paints a lighter rgb(32,31,37) on top. That contrast
+     is what makes the identity block read as "the panel's own header area"
+     rather than as one more section, so canvas-sec has to drop .psec's
+     background here rather than pick a hardcoded dark value that would
+     drift from the panel the first time --panel2 changes. */
+  background:transparent;}
+.psec-identity>.pbdy{padding:13px 16px 12px;background:transparent;}

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -2844,6 +2844,9 @@ function updateStatusBarHelp(){
     root.addEventListener('mouseout',clearTitle);
   });
 })();
+// Where #canvas-sec normally sits, captured once before it is ever moved
+// to the top for the Document context (see updatePropsContext).
+var _canvasSecHome=null;
 function updatePropsContext(){
   var hasSel=(state.tool==='select'||state.tool==='subselect')&&selectedPaths.length>0;
   var ctx,hdrText;
@@ -2997,15 +3000,37 @@ function updatePropsContext(){
   var canvasSec=document.getElementById('canvas-sec');
   if(canvasSec){
     var canvasHdr=canvasSec.querySelector('.phdr');
-    if(canvasHdr)canvasHdr.style.display=(ctx==='document')?'none':'';
-    // A hidden header can't be clicked to re-open its body, so make sure
-    // the body is open whenever we take the header away — otherwise a
-    // previously-collapsed Document section would look like an empty panel
-    // with no way back.
+    var canvasBody=canvasSec.querySelector('.pbdy');
+    // Remember where canvas-sec normally lives, ONCE, before the first move
+    // — restoring by "put it back after shapes-sec" would break the moment
+    // anything else is inserted there, whereas the original next sibling is
+    // exactly the contract "this is my slot".
+    if(!_canvasSecHome)_canvasSecHome={parent:canvasSec.parentNode,next:canvasSec.nextSibling};
     if(ctx==='document'){
-      var canvasBody=canvasSec.querySelector('.pbdy');
+      // Document fields sit at the TOP, on the dark ground, exactly where a
+      // selection puts Position/Size/Rotate (2026-08-30, feedback #171
+      // follow-up: "le panel de document avec width height est mal placé il
+      // doit toujours être en haut fond foncé comme pour element selected").
+      // Hiding the duplicate header (previous PR) was only half of it — the
+      // fields were still buried BELOW Effects and Elements, so with the
+      // header gone they read as loose controls belonging to whatever was
+      // above them. #props-panel is a plain block, not flex, so CSS `order`
+      // can't do this; the node is moved instead, and put back below.
+      var rail=document.getElementById('props-panel-rail');
+      if(rail&&canvasSec.previousSibling!==rail)rail.parentNode.insertBefore(canvasSec,rail.nextSibling);
+      canvasSec.classList.add('psec-identity');
+      if(canvasHdr)canvasHdr.style.display='none';
+      // A hidden header can't be clicked to re-open its body, so make sure
+      // the body is open whenever we take the header away — otherwise a
+      // previously-collapsed Document section would look like an empty panel
+      // with no way back.
       if(canvasBody)canvasBody.classList.remove('hid');
       if(canvasHdr)canvasHdr.classList.remove('closed');
+    }else{
+      var moved=(canvasSec.parentNode!==_canvasSecHome.parent)||(canvasSec.nextSibling!==_canvasSecHome.next);
+      if(moved)_canvasSecHome.parent.insertBefore(canvasSec,_canvasSecHome.next);
+      canvasSec.classList.remove('psec-identity');
+      if(canvasHdr)canvasHdr.style.display='';
     }
   }
   // Motion mode: none of these 2D-drawing-tool sections apply (no active


### PR DESCRIPTION
Suite de #171 : *« le panel de document avec width height est mal placé il doit toujours être en haut fond foncé comme pour element selected »*.

Masquer le titre « Document » en double (PR précédente) n'était que la moitié. Les champs W/H/FPS/Frames/BG restaient **enterrés sous Effects et Elements** — donc, le titre parti, ils se lisaient comme des contrôles flottants appartenant à ce qui était au-dessus. Sans doute pire qu'avant.

Une sélection place son bloc d'identité (Position/Size/Rotate) **immédiatement sous l'en-tête contextuel, sur le fond sombre** : c'est cette mise en page qui était demandée.

Deux morceaux — et **j'ai raté le second d'abord** : il a fallu qu'il répète *« fond foncé, comme layer selected »* pour que je le **mesure** au lieu de le supposer.

## Position

`canvas-sec` prend ce même emplacement dans le contexte Document. `#props-panel` est un `block`, pas un flex, donc `order` en CSS ne peut rien : le nœud est déplacé, et sa position d'origine capturée **une seule fois** avant le premier déplacement pour être rendue exactement. Restaurer par « insérer après shapes-sec » casserait dès que quoi que ce soit d'autre atterrit là ; le frère suivant d'origine est le vrai contrat.

## Fond

**Mesuré, pas deviné** : `#sel-props-sec` est `rgba(0,0,0,0)` et laisse voir le `rgb(23,22,26)` plus sombre de `#props-panel`, tandis que chaque `.psec` peint un `rgb(32,31,37)` plus clair par-dessus. C'est ce contraste qui fait lire le bloc d'identité comme *la zone d'en-tête du panneau* plutôt que comme une section de plus.

`.psec-identity` passe donc le fond à **transparent** plutôt que de coder en dur une valeur sombre qui dériverait du panneau à la première évolution de `--panel2`.

## Vérifié en pilotant **et** à l'écran

| État | Position | Fond effectif | Titre interne |
|---|---|---|---|
| rien de sélectionné | **1** sur 9 | `rgb(23,22,26)` hérité du panneau | masqué |
| avec sélection | 6 sur 15 | `rgb(32,31,37)` normal | présent |

Trois allers-retours de sélection le laissent identique dans les deux sens : pas de dérive.

`npm test` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)