### PR TITLE
Motion per-element isolation: live drag, a way out, and a reachable target

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -5561,6 +5561,16 @@
         _motionDrag.basePos[0] + (event.point.x - _motionDrag.start.x),
         _motionDrag.basePos[1] + (event.point.y - _motionDrag.start.y)
       ]);
+      // The DOCUMENT changed, so say so (2026-08-30, "n'est pas en temps
+      // reel, il bouge pas sur le canvas pendant le drag que au
+      // relachement"). engine-bridge caches the serialized scene base
+      // during a drag keyed on _sceneVersion (CLAUDE.md §5.3) — the whole
+      // point being that an intercepted drag leaves the document untouched.
+      // This one does NOT: it moves an element. Without the bump the cached
+      // base was replayed every tick and the shape only jumped when the
+      // drop invalidated it. Same hazard §5.3 already flags for the eraser
+      // ("la gomme mutte SANS bump de version").
+      window._sceneVersion = (window._sceneVersion || 0) + 1;
     } else if (_motionDrag.mode === 'multiLayerMove') {
       var mdx=event.point.x-_motionDrag.start.x,mdy=event.point.y-_motionDrag.start.y;
       _motionDrag.records.forEach(function(r){setValue(r.t.holder,'position',[r.pos[0]+mdx,r.pos[1]+mdy]);});

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -734,6 +734,44 @@
         e.stopImmediatePropagation(); e.preventDefault();
         return;
       }
+      // Leaving per-element isolation (2026-08-30: "si je clic ailleurs ça ne
+      // sors pas et reviens pas en box normal"). Animation 2D has always had
+      // this — its own _shapeEnteredId reset a few hundred lines down — but
+      // the Motion equivalent was never written, so once a double-click had
+      // isolated a shape there was NO way back to the layer box short of
+      // switching modes.
+      //
+      // Placed right after SMMotion.onDown declined the gesture: anything it
+      // took (a handle, the ring, the anchor, or the element body itself) is
+      // work INSIDE the isolation and must not cancel it. What's left here is
+      // a click that hit none of that — empty canvas or another shape — which
+      // is exactly the "clic ailleurs" that should drop back out.
+      if (window._motionExpandedElement != null) {
+        var lyrEx = userLayers[state.activeLayerIdx];
+        var hitEx = lyrEx ? lyrEx.hitTest(new Point(w0[0], w0[1]), { fill: true, stroke: true, tolerance: 6 / view.zoom }) : null;
+        var itEx = hitEx && hitEx.item;
+        while (itEx && itEx.parent && itEx.parent !== lyrEx) itEx = itEx.parent;
+        var sidEx = itEx && itEx.data && itEx.data.strokeId;
+        // Clicking a SIBLING hands the isolation over to it rather than
+        // ending it — same continuity Animation 2D's per-object mode has, and
+        // the thing that makes a multi-shape layer workable. Clicking nothing
+        // exits to the whole-layer box.
+        if (sidEx && sidEx !== window._motionExpandedElement) {
+          window._motionExpandedElement = sidEx;
+          if (SMMotion.selectShapesByStrokeIds) SMMotion.selectShapesByStrokeIds(state.activeLayerIdx, [sidEx]);
+        } else if (!sidEx) {
+          window._motionExpandedElement = null;
+          window._perObjBoxes = null;
+        }
+        if (sidEx || window._motionExpandedElement == null) {
+          window._sceneVersion = (window._sceneVersion || 0) + 1;
+          if (window.renderLayerList) renderLayerList();
+          if (window.renderTimeline) renderTimeline();
+          window.SMEngineBridge.renderNow();
+          e.stopImmediatePropagation(); e.preventDefault();
+          return;
+        }
+      }
     }
     if (!shouldIntercept()) return;
     // Every gesture starts from a clean slate (2026-07-26). onDown has a

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -7608,7 +7608,14 @@ function onViewDoubleClick(event){
   if(state.appMode==='motion'){
     var mLayer=userLayers[state.activeLayerIdx];
     if(!mLayer)return;
-    var mHit=mLayer.hitTest(event.point,{fill:true,stroke:true,tolerance:4/view.zoom});
+    // Tolerance in SCREEN pixels, not world (2026-08-30: "j'ai du mal à y
+    // accéder"). 4/view.zoom looks generous but is the wrong way round —
+    // at 19% zoom, a typical fit-to-canvas view, it collapses to well under
+    // a screen pixel of slack, so the double-click had to land dead on the
+    // shape. 8 screen px is the same order of slack every other hit-test in
+    // this file uses, and it stays constant as you zoom.
+    var mTol=8/Math.max(0.0001,view.zoom);
+    var mHit=mLayer.hitTest(event.point,{fill:true,stroke:true,tolerance:mTol});
     if(!mHit||!mHit.item)return;
     var mItem=mHit.item;
     while(mItem.parent&&mItem.parent!==mLayer)mItem=mItem.parent;


### PR DESCRIPTION
> *« la fonction marche assez mal je trouve… il faut bien travailler ça »*

Juste. J'avais corrigé cette fonctionnalité **retour par retour**. Voici les trois problèmes restants, traités ensemble et chacun vérifié **à l'écran**.

## 1. Le drag n'était pas temps réel

*« il bouge pas sur le canvas pendant le drag que au relachement »*

`engine-bridge` met en cache le socle de scène sérialisé **pendant un drag**, clé sur `_sceneVersion` (§5.3) — la prémisse étant qu'un drag intercepté laisse le document intouché. `elementMove` casse cette prémisse : il déplace un élément. Sans bump, le socle en cache était rejoué à chaque tick et la forme ne sautait qu'au relâchement.

C'est exactement le risque que le §5.3 signale déjà pour la gomme (*« la gomme mutte SANS bump de version »*).

Les autres pistes ont été **écartées par la mesure**, pas par intuition : `elementMotionAt` renvoyait bien `dx:500` en plein drag, et `select-bridge` sort immédiatement après `SMMotion.onDrag`, donc rien ne repeint par-dessus.

## 2. Aucune sortie

*« si je clic ailleurs ça ne sors pas et reviens pas en box normal »*

L'Animation 2D a toujours eu sa remise à zéro sur un clic ailleurs ; **l'équivalent Motion n'avait jamais été écrit**. Une fois une forme isolée par double-clic, il n'existait aucun retour vers la boîte de calque à part changer de mode.

Placé **après** que `SMMotion.onDown` ait décliné le geste — donc tout ce qu'il prend (poignée, anneau, ancre, corps de l'élément) est du travail **dans** l'isolation et ne peut pas l'annuler :
- clic sur une **autre forme** → l'isolation lui est transmise
- clic dans le **vide** → sortie vers la boîte du calque entier

## 3. Difficile à atteindre

*« j'ai du mal à y accéder »*

Le hit-test du double-clic utilisait `4/view.zoom` — ce qui **paraît** généreux et est à l'envers : à 19 % de zoom, une vue « ajustée » ordinaire, ça tombe sous le pixel écran de marge, donc le clic devait atterrir pile sur la forme. Désormais **8 px écran**, constants quel que soit le zoom, le même ordre que tous les autres hit-tests de `tools.js`.

## Vérifié en pilotant, et regardé **en plein geste, pointeur encore enfoncé**

(le contrôle que j'avais sauté plus tôt et qui m'a valu de me faire reprendre)

| Contrôle | Résultat |
|---|---|
| pendant le drag | le carré **bouge visiblement** avec son gizmo, le cercle reste — auparavant figé à sa position de départ alors que la donnée était déjà à [500,0] |
| clic sur l'autre forme | l'isolation migre `shA` → `shB` |
| clic dans le vide | `expanded` null, `perObj` null |
| re-sélection du calque | boîte du calque entier de retour, `700,420,570×600` |

`npm test` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)