### PR TITLE
Layer Properties shows the targeted shape's own transform

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -6492,6 +6492,23 @@
     renderFollowPathRow(body, ld, state.activeLayerIdx);
     renderTimeLinkRow(body, ld, state.activeLayerIdx);
     renderMatteRow(body, ld, state.activeLayerIdx);
+    // A targeted SHAPE shows its own Transform, not the layer's (2026-08-30,
+    // feedback #173: "si on select une shape dans elements alors dans layer
+    // properties on voit les propriétés de la shape, pareil si on select une
+    // box de shape via double clic"). Both routes already converge on the
+    // same state — the Elements row click and the canvas double-click both
+    // set _motionExpandedElement — so one branch here serves both, which is
+    // exactly why the feedback names them together.
+    // The layer's own Parent/Path/Time/Matte rows stay above: they belong to
+    // the layer whatever is targeted inside it, and dropping them would make
+    // the panel lose the parent pill the moment you inspect a shape.
+    var elSel = (window._motionExpandedElement != null && window._motionExpandedLayer === state.activeLayerIdx)
+      ? window._motionExpandedElement : null;
+    if (elSel) {
+      var elHolder = ensureElementHolder(ld, elSel);
+      renderTransformGroup(body, elHolder, SM.t('hdrTransformElement'));
+      return;
+    }
     renderTransformGroup(body, ld, 'Transform');
   }
   // Track matte, IN Layer Properties (2026-08-30, "un bouton matte qui


### PR DESCRIPTION
Feedback #173 : *« si on select une shape dans elements alors dans layer properties on voit les propriétés de la shape, pareil si on select une box de shape via double clic »*.

Les deux routes qu'il nomme **convergent déjà sur le même état** — `_motionExpandedElement` est ce que pose le clic sur la ligne Elements **et** ce que pose le double-clic canvas. Une seule branche sert donc les deux, ce qui est précisément pourquoi le retour les cite ensemble.

Layer Properties rend désormais le groupe Transform de l'**élément** (intitulé « Transform (element) », le libellé existant) dès qu'une forme du calque actif est ciblée, et celui du calque sinon.

Les lignes **Parent / Path / Time / Matte** du calque restent délibérément au-dessus : elles appartiennent au calque quoi qu'on cible à l'intérieur, et les retirer ferait perdre au panneau sa pastille de parent au moment même où on inspecte une forme.

## Vérifié en pilotant, avec des valeurs volontairement différentes sur chaque niveau

Position du calque `[11,22]`, position de l'élément `shA` `[333,444]` :

| Geste | En-tête | Valeurs |
|---|---|---|
| cibler la forme (double-clic canvas) | « Transform (element) » | **333 / 444** |
| cibler la forme (clic ligne Elements) | même état | mêmes lignes |
| clic dans le vide + re-sélection du calque | « Transform » | **11 / 22** |

Zéro exception. `npm test` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)