### PR TITLE
No selection gizmo over text being typed in place

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2746,6 +2746,17 @@
   }
   function buildTransformBoxItems() {
     if (state.tool !== 'select') return [];
+    // Stand down while text is being typed in place (2026-08-30, feedback
+    // #175: "la bounding box perturbe quand j'utilise l'outil de texte avant
+    // de select le text comme un élément comme un autre"). The in-place
+    // editor already draws its OWN orange box and resize grip; the select
+    // gizmo drawn on top of it is a second, competing frame for the same
+    // object — and on a brand-new EMPTY text its near-zero bounds collapse
+    // all 8 handles into a knot right where the caret sits, which is what
+    // the screenshot shows. The text becomes an ordinary selectable element
+    // the moment the editor closes, which is exactly what he asked for
+    // ("avant de select le text comme un élément comme un autre").
+    if (window.isInPlaceTextEditing && window.isInPlaceTextEditing()) return [];
     // Motion mode (2026-08-21 fix, "2 points d'ancrage et 2 rotation qui
     // s'affiche" on a Component with several elements): this function is
     // the Animation 2D transform box — corners/ring/anchor computed from

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -7055,6 +7055,9 @@ function closeTextPopover(){var pop=document.getElementById('text-popover');if(p
 // vector-text-bridge.js parses for glyph outlines, so the overlay LOOKS
 // like the vector result it's about to become, not a generic stand-in.
 var _inplaceTa=null,_inplaceRoot=null,_inplaceHidden=null,_inplaceIsNew=false,_inplaceHandle=null;
+// Readable from the render side (engine-bridge) so overlays can stand
+// down while text is being typed in place — see buildTransformBoxItems.
+window.isInPlaceTextEditing=function(){return !!_inplaceTa;};
 // Area-text creation (2026-08-17, same ask as openInPlaceTextEditor above:
 // "comme AI ou Figma" also means the INITIAL drag-a-box placement, not just
 // re-editing) — builds a throwaway single-glyph vector-text root (needed


### PR DESCRIPTION
Feedback #175, **première moitié** : *« la bounding box perturbe quand j'utilise l'outil de texte avant de select le text comme un élément comme un autre »*.

## Le problème

L'éditeur de texte in-place dessine **déjà** sa propre boîte orange et sa poignée de redimensionnement. Le gizmo de sélection était dessiné **par-dessus** — un second cadre concurrent autour du même objet.

Sur un texte **neuf et vide**, ses bornes quasi nulles tassent les 8 poignées en un nœud pile là où se trouve le curseur : exactement l'enchevêtrement de sa capture.

## Le correctif

`buildTransformBoxItems` se retire pendant que l'éditeur est ouvert. Rien dans le chemin de rendu ne pouvait le savoir avant : `_inplaceTa` était privé au module `timeline.js` et lu nulle part ailleurs. Un petit accesseur `window.isInPlaceTextEditing()` expose **ce seul fait**, pas les internes de l'éditeur.

Le texte redevient un élément sélectionnable ordinaire dès que l'éditeur se ferme — précisément la distinction qu'il pose (*« avant de select le text comme un élément comme un autre »*).

**Vérifié** : construction de scène **3569** octets avec le gizmo, **506** pendant l'édition, et exactement **3569** de nouveau après — supprimé puis restauré, pas fuité.

## ⚠️ PAS corrigé ici, et je le dis franchement

La seconde moitié de #175 : *« le petit carré orange… ne marche que en width »*.

**Ce n'est pas une poignée cassée.** Le texte vectoriel n'a **aucune notion de hauteur fixe** : la hauteur de la boîte est toujours dérivée du contenu (`ta.scrollHeight`), et la poignée n'écrit que `d.fixedWidth` parce qu'il n'existe pas de `d.fixedHeight` à écrire.

Rendre la hauteur redimensionnable veut dire ajouter du **vrai texte de zone** avec son comportement de débordement — une fonctionnalité, pas un correctif, qui mérite sa propre PR.

`npm test` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)