### PR TITLE
Area text: fixed height, clipped overflow, InDesign-style marker

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2742,6 +2742,30 @@
       var tb = window._inplaceTextBoxBounds;
       items.push(boundsRectItem(tb.left, tb.top, tb.right, tb.bottom, null, col, sw));
     }
+    // Overflow marker for area text (2026-08-30, feedback #175 "à la
+    // indesign"): a red square with a + at the box's bottom-right when the
+    // text no longer fits the fixed height. InDesign's own convention, and
+    // the reason it exists — the held-back text isn't lost, it just has
+    // nowhere to go, and a silently short block gives you no way to know.
+    // Red, not the box's orange: it's a condition to resolve, not part of
+    // the frame. Drawn here so it sits under the same includeEditorOverlays
+    // gate as everything else in this function and can never reach a render.
+    var ovLayer = userLayers[state.activeLayerIdx];
+    if (ovLayer) {
+      var ovSeen = {};
+      ovLayer.children.forEach(function (c) {
+        if (!c.data || !c.data.isTextRoot || !c.data.textOverflow || !c.data.fixedHeight) return;
+        if (!c.data.anchorTopLeft || ovSeen[c.data.groupId]) return;
+        ovSeen[c.data.groupId] = true;
+        var w = c.data.fixedWidth || c.bounds.width;
+        var x = c.data.anchorTopLeft.x + w, y = c.data.anchorTopLeft.y + c.data.fixedHeight;
+        var hs = 6 / view.zoom, red = [230, 70, 70, 255];
+        items.push(boundsRectItem(x - hs, y - hs, x + hs, y + hs, red, [255, 255, 255, 255], 1 / view.zoom));
+        var p = 3.2 / view.zoom;
+        items.push(lineItem([x - p, y], [x + p, y], [255, 255, 255, 255], 1.4 / view.zoom));
+        items.push(lineItem([x, y - p], [x, y + p], [255, 255, 255, 255], 1.4 / view.zoom));
+      });
+    }
     return items;
   }
   function buildTransformBoxItems() {

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -7157,14 +7157,15 @@ function openInPlaceTextEditor(root,isNew){
   handle.id='tp-inplace-resize-handle';
   document.body.appendChild(handle);
   _inplaceHandle=handle;
-  var resizing=false,resizeStartX=0,resizeStartWidth=0;
+  var resizing=false,resizeStartX=0,resizeStartWidth=0,resizeStartY=0,resizeStartHeight=0;
   handle.addEventListener('pointerdown',function(e){
     e.preventDefault();e.stopPropagation();
-    resizing=true;resizeStartX=e.clientX;
-    // First drag on a not-yet-fixed-width (auto-grow) box starts from its
-    // CURRENT rendered width, not an arbitrary default — so the box doesn't
-    // visibly jump the instant you grab the handle.
+    resizing=true;resizeStartX=e.clientX;resizeStartY=e.clientY;
+    // First drag on a not-yet-fixed box starts from its CURRENT rendered
+    // size, not an arbitrary default — so the box doesn't visibly jump the
+    // instant you grab the handle. Same reasoning for height as width.
     resizeStartWidth=d.fixedWidth||(parseFloat(ta.style.width)/view.zoom);
+    resizeStartHeight=d.fixedHeight||(parseFloat(ta.style.height)/view.zoom);
     handle.setPointerCapture(e.pointerId);
   });
   handle.addEventListener('pointermove',function(e){
@@ -7172,6 +7173,15 @@ function openInPlaceTextEditor(root,isNew){
     e.preventDefault();e.stopPropagation();
     var deltaWorld=(e.clientX-resizeStartX)/view.zoom;
     d.fixedWidth=Math.max(20,resizeStartWidth+deltaWorld);
+    // Height too (2026-08-30, feedback #175: "ne marche que en width", and
+    // "à la indesign" for what should happen once it can). Before this
+    // there was no d.fixedHeight to write at all — the box height was
+    // always derived from content, which is exactly why the grip only ever
+    // moved one axis. Now it's a real area-text box: text that no longer
+    // fits is held back rather than shrunk or spilled, and the overflow
+    // marker (drawn in reposition) says so.
+    var deltaYWorld=(e.clientY-resizeStartY)/view.zoom;
+    d.fixedHeight=Math.max(size||20,resizeStartHeight+deltaYWorld);
     reposition();
   });
   function endResize(e){if(!resizing)return;resizing=false;try{handle.releasePointerCapture(e.pointerId);}catch(err){}}
@@ -7215,7 +7225,12 @@ function openInPlaceTextEditor(root,isNew){
     ta.style.textAlign=d.align||'left';
     if(d.fixedWidth){ta.style.whiteSpace='pre-wrap';ta.style.width=(d.fixedWidth*view.zoom)+'px';}
     else{ta.style.whiteSpace='pre';ta.style.width=Math.max(20,ta.scrollWidth)+'px';}
-    ta.style.height=ta.scrollHeight+'px';
+    // A fixed height wins over content height — that's what makes the box an
+    // AREA rather than an auto-grow label. Without it the editor would keep
+    // growing while the rendered text is being clipped, so the two would
+    // disagree about where the box ends.
+    if(d.fixedHeight)ta.style.height=(d.fixedHeight*view.zoom)+'px';
+    else ta.style.height=ta.scrollHeight+'px';
     // Live bounding box (2026-08, "un bounding box comme dans tout éditeur
     // de texte") — screen px back to world units (÷view.zoom, mirroring
     // fontPx's own ×view.zoom a few lines up) so buildTextDragBoxItems
@@ -7269,6 +7284,7 @@ function closeInPlaceTextEditor(cancel){
   var topLeft=groupBounds.topLeft.clone();
   pushUndo();
   window.SMVectorText.vectorTextGroupMembers(root).forEach(function(p){p.remove();});
+  opts.fixedHeight=d.fixedHeight||null;
   window.SMVectorText.buildVectorTextGroup(newText,d.vectorFont,d.size,d.color,d.align,d.fixedWidth,topLeft,layer,opts).then(function(res){
     if(res.paths.length)selectedPaths=res.paths.slice();
     saveActiveLayerFrame();updateUI();

--- a/src/js/vector-text-bridge.js
+++ b/src/js/vector-text-bridge.js
@@ -240,6 +240,21 @@ function buildVectorTextGroup(text, fontKey, size, color, align, fixedWidthWorld
       return Math.max(0, w - letterSpacing); // no trailing tracking after the last glyph
     }
     var wrapped = wrapVectorLines(displayText, fixedWidthWorld, runWidth);
+    // Area text (2026-08-30, feedback #175: "à la indesign"). With a fixed
+    // HEIGHT declared, only the lines that fit inside the box are drawn and
+    // the rest is held back — InDesign's behaviour, and the reason its
+    // overflow marker exists at all: the text isn't lost, it just has
+    // nowhere to go, and the box tells you so.
+    // Chosen over shrinking the type or letting it spill: both silently
+    // change what you laid out, whereas a visible marker asks you to decide.
+    // Line spacing is uniform (baselineY below steps by lineHeight), so
+    // "does line li fit" is exact arithmetic, not a measurement.
+    var fixedHeightWorld = opts.fixedHeight || null;
+    var overflowed = false;
+    if (fixedHeightWorld && wrapped.length) {
+      var fits = Math.max(1, Math.floor(fixedHeightWorld / lineHeight));
+      if (wrapped.length > fits) { overflowed = true; wrapped = wrapped.slice(0, fits); }
+    }
     var maxW = 0;
     wrapped.forEach(function (l) { maxW = Math.max(maxW, runWidth(l)); });
     var groupId = 'vtxt' + Date.now().toString(36) + '_' + Math.floor(Math.random() * 1e6);
@@ -304,6 +319,10 @@ function buildVectorTextGroup(text, fontKey, size, color, align, fixedWidthWorld
       root.data.isText = true; root.data.isTextRoot = true;
       root.data.text = text; root.data.vectorFont = resolvedFontKey; root.data.size = size;
       root.data.color = color; root.data.align = align; root.data.fixedWidth = fixedWidthWorld || null;
+      // Both persisted on the root beside fixedWidth, so a reload rebuilds
+      // the same box AND knows it still overflows without re-measuring.
+      root.data.fixedHeight = fixedHeightWorld || null;
+      root.data.textOverflow = overflowed || false;
       root.data.bold = !!opts.bold; root.data.italic = !!opts.italic;
       root.data.underline = !!opts.underline; root.data.strike = !!opts.strike;
       root.data.letterSpacing = letterSpacing; root.data.wordSpacing = wordSpacing;


### PR DESCRIPTION
Feedback #175, seconde moitié — *« le petit carré orange… ne marche que en width »*, avec **« à la indesign »** comme réponse à « que doit-il se passer quand le texte ne rentre plus ».

La poignée ne bougeait qu'un axe parce qu'il n'y avait **rien d'autre à bouger** : la hauteur de boîte était toujours dérivée du contenu et aucun `d.fixedHeight` n'existait à écrire. Ce n'est donc pas un correctif de poignée, c'est le **concept de texte de zone** que la poignée attendait.

## Trois morceaux

- **`d.fixedHeight`** est stocké à côté de `d.fixedWidth`, et la poignée drague désormais **les deux axes**, chacun partant de la taille **actuellement rendue** pour que la boîte ne saute pas quand on l'attrape — le raisonnement que la largeur appliquait déjà.
- Les lignes qui ne rentrent pas sont **retenues**, ni rétrécies ni débordantes. Les deux alternatives changent silencieusement ce que tu as mis en page ; un marqueur visible te demande de trancher. L'interligne est uniforme, donc « la ligne N rentre-t-elle » est de l'arithmétique exacte, pas une mesure.
- Un **carré rouge avec un +** au coin bas-droit quand du texte est retenu — la convention d'InDesign, et sa raison d'être : le texte n'est pas perdu, il n'a nulle part où aller, et un bloc silencieusement raccourci ne te le dirait pas. **Rouge** et non l'orange de la boîte : c'est une condition à résoudre, pas un élément du cadre.

La zone de saisie de l'éditeur adopte aussi la hauteur fixe : sinon elle continuerait de grandir pendant que le texte **rendu** est coupé, et les deux seraient en désaccord sur où finit la boîte.

## Vérifié en pilotant — six lignes en corps 40 (interligne 50)

| Cas | Rendu | Débordement |
|---|---|---|
| sans hauteur fixe | 287px | `false` |
| `fixedHeight` 150 | **137px** (3 lignes) | **`true`** |

Le marqueur ajoute 549 octets d'overlay, reproductible en on/off. Relecture d'export : **0 pixel rouge** sur 310 992 opaques — il est sous le même gate `includeEditorOverlays` que tout autre overlay d'éditeur.

`fixedHeight` et `textOverflow` persistent sur la racine du texte à côté de `fixedWidth`, donc un rechargement reconstruit la même boîte et sait qu'elle déborde encore sans re-mesurer.

`npm test` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)