### PR TITLE
Fill/Stroke keyframe rows open the real colour picker

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -8503,8 +8503,15 @@
     swatch.title = swatchTitle;
     swatch.addEventListener('click', function (e) {
       e.stopPropagation();
-      if (!window.openLayerColorSwatches) return;
-      openLayerColorSwatches(swatch, rgba255ToHex(currentRgba()), function (hex) {
+      // The REAL colour picker, not the layer-label palette (2026-08-31,
+      // feedback #180: "je n'ai pas le bon panneau de couleurs (celui des
+      // labels de couleurs)"). openLayerColorSwatches offers 8 fixed label
+      // colours with the full picker hidden behind a "+" — right for
+      // tagging a layer, wrong for a shape's fill, where you want the whole
+      // spectrum and an alpha slider straight away. ColorPicker.open takes
+      // the same (anchor, hex, callback) shape, so only the call changes.
+      if (!window.ColorPicker || !ColorPicker.open) return;
+      ColorPicker.open(swatch, rgba255ToHex(currentRgba()), function (hex) {
         pushUndo();
         var v = hexToRgba255(hex);
         if (!setSelectedKeyVector(holder, prop, v)) setValue(holder, prop, v);


### PR DESCRIPTION
Feedback #180 : *« je n'ai pas le bon panneau de couleurs (celui des labels de couleurs) »*. **Le mien**, hérité du travail de ce matin sur les keyframes de couleur.

Les swatches des lignes Fill et Stroke appelaient `openLayerColorSwatches` — la palette d'**étiquettes de calque** : 8 couleurs fixes de marquage, avec le vrai sélecteur caché derrière un « + ». C'est juste pour étiqueter un calque, faux pour le fond d'une forme, où on veut le spectre et un curseur d'alpha tout de suite.

`ColorPicker.open` prend la même forme `(ancre, hex, callback)`, donc seul le site d'appel change ; le chemin de commit en dessous (`setSelectedKeyVector` puis `setValue`) est intact.

## Vérifié en pilotant

Cliquer le swatch Fill ouvre maintenant `.color-picker-pop` et non plus `.lcs-pop`. Chrono armé, saisir `00CC44` en frame 12 pose une clé `[0,204,68,255]`, et la frame 6 interpole au **milieu exact** `[37,181,161.5,255]` face à la clé `[74,158,255]` en 0.

## ⚠️ Pas traité ici

L'autre moitié de #180 : *« select couleurs ne prend pas en compte la selection de la propriété »* — sélectionner la **ligne** de propriété Fill puis utiliser le panneau de couleurs principal.

Ce panneau écrit via `SM.setFillColor`, qui agit sur la sélection **canvas**, pas sur une ligne de propriété Motion sélectionnée. Câbler la sélection de ligne dedans est un changement à part, que je préfère faire délibérément plutôt que de le greffer ici.

`npm test` 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)