### PR TITLE
Enter a layer's elements from anywhere inside its box (#176)

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2838,6 +2838,26 @@
         return nvItems;
       }
     }
+    // Group entered with nothing picked yet (2026-08-31, feedback #176):
+    // every element shows its own box and none is active, so there is no
+    // selection to build a gizmo from — but the boxes must still draw. The
+    // per-object block at the end of this function handles them; returning
+    // early here would take them with it.
+    if (!selectedPaths.length && window._perObjBoxes === state.activeLayerIdx) {
+      var poItems = [];
+      var poZs = 1 / view.zoom;
+      var poMap = (window.SMMotion && SMMotion.layerMotionPointMap) ? SMMotion.layerMotionPointMap(state.activeLayerIdx) : null;
+      (window.perObjectShapesOf ? perObjectShapesOf(userLayers[state.activeLayerIdx]) : []).forEach(function (ch) {
+        var sb = ch.strokeBounds;
+        function PW(x, y) { if (!poMap) return [x, y]; return poMap.fwd(x, y); }
+        var a1 = PW(sb.left, sb.top), a2 = PW(sb.right, sb.top), a3 = PW(sb.right, sb.bottom), a4 = PW(sb.left, sb.bottom);
+        poItems.push(lineItem(a1, a2, [74, 158, 255, 190], 1 * poZs));
+        poItems.push(lineItem(a2, a3, [74, 158, 255, 190], 1 * poZs));
+        poItems.push(lineItem(a3, a4, [74, 158, 255, 190], 1 * poZs));
+        poItems.push(lineItem(a4, a1, [74, 158, 255, 190], 1 * poZs));
+      });
+      return poItems;
+    }
     if (!selectedPaths.length || typeof orientedSelBox !== 'function') return [];
     // Oriented box (tools.js orientedSelBox — "les boîtes de transformation
     // ne tournent pas avec l'objet quand on rotate"): everything below is

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -4615,7 +4615,10 @@
     lyr.children.forEach(function (ch) {
       if (!ch.data || !ch.data.strokeId || ch.data.groupId) return;
       if (ch.data.isBrushTextureCopy || ch.data.isLinkedFillCompanion || ch.data.isDuplicatorCopy) return;
-      if (ch.data.strokeId === window._motionExpandedElement) return; // has the real gizmo
+      // Skipped only when it IS the active one. With nothing targeted
+      // (_motionExpandedElement null, the "entered the group but picked
+      // nothing yet" state of #176) every shape draws its own box.
+      if (window._motionExpandedElement && ch.data.strokeId === window._motionExpandedElement) return;
       var b = ch.strokeBounds;
       if (!b || !b.width || !b.height) return;
       function P(x, y) { if (!map) return [x, y]; return map.fwd(x, y); }

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -746,34 +746,63 @@
       // work INSIDE the isolation and must not cancel it. What's left here is
       // a click that hit none of that — empty canvas or another shape — which
       // is exactly the "clic ailleurs" that should drop back out.
-      if (window._motionExpandedElement != null) {
+      // The `_perObjBoxes` half of the condition is what covers entering the
+      // group WITHOUT targeting a shape (2026-08-31, feedback #176): that
+      // state leaves _motionExpandedElement null, and Motion cannot fall
+      // through to the Animation 2D reset further down because
+      // shouldIntercept() is false here — Motion's active tool is 'draw', not
+      // 'select'. So without this the Motion side could be entered and never
+      // left. Found by driving; reading the two branches side by side does
+      // not show it, since each looks complete on its own.
+      if (window._motionExpandedElement != null || window._perObjBoxes === state.activeLayerIdx) {
         var lyrEx = userLayers[state.activeLayerIdx];
-        var hitEx = lyrEx ? lyrEx.hitTest(new Point(w0[0], w0[1]), { fill: true, stroke: true, tolerance: 6 / view.zoom }) : null;
+        var ptEx = new Point(w0[0], w0[1]);
+        var hitEx = lyrEx ? lyrEx.hitTest(ptEx, { fill: true, stroke: true, tolerance: 6 / view.zoom }) : null;
         var itEx = hitEx && hitEx.item;
         while (itEx && itEx.parent && itEx.parent !== lyrEx) itEx = itEx.parent;
         var sidEx = itEx && itEx.data && itEx.data.strokeId;
         // Clicking a SIBLING hands the isolation over to it rather than
         // ending it — same continuity Animation 2D's per-object mode has, and
-        // the thing that makes a multi-shape layer workable. Clicking nothing
-        // exits to the whole-layer box.
+        // the thing that makes a multi-shape layer workable. Clicking empty
+        // space still INSIDE the group box drops back to "all boxes, none
+        // targeted" (you are still in the group, Illustrator-style); only a
+        // click outside the box leaves it.
         if (sidEx && sidEx !== window._motionExpandedElement) {
           window._motionExpandedElement = sidEx;
+          window._perObjBoxes = state.activeLayerIdx;
           if (SMMotion.selectShapesByStrokeIds) SMMotion.selectShapesByStrokeIds(state.activeLayerIdx, [sidEx]);
         } else if (!sidEx) {
+          var uEx = (lyrEx && window.perObjectUnionBounds) ? perObjectUnionBounds(lyrEx) : null;
           window._motionExpandedElement = null;
-          window._perObjBoxes = null;
+          if (!uEx || !uEx.contains(ptEx)) window._perObjBoxes = null;
         }
-        if (sidEx || window._motionExpandedElement == null) {
-          window._sceneVersion = (window._sceneVersion || 0) + 1;
-          if (window.renderLayerList) renderLayerList();
-          if (window.renderTimeline) renderTimeline();
-          window.SMEngineBridge.renderNow();
-          e.stopImmediatePropagation(); e.preventDefault();
-          return;
-        }
+        window._sceneVersion = (window._sceneVersion || 0) + 1;
+        if (window.renderLayerList) renderLayerList();
+        if (window.renderTimeline) renderTimeline();
+        window.SMEngineBridge.renderNow();
+        e.stopImmediatePropagation(); e.preventDefault();
+        return;
       }
     }
     if (!shouldIntercept()) return;
+    // Leave the entered group when the click lands OUTSIDE its box
+    // (2026-08-31, feedback #176: "si je clic en dehors alors on revient sur
+    // la premiere bounding box de groupe"). Keyed on _perObjBoxes, not on
+    // _shapeEnteredId: since the double-click can now enter the group
+    // WITHOUT targeting a shape, _shapeEnteredId is null in that state and
+    // the older reset — which required it — could never fire, so the mode
+    // had no way out at all. Found by driving, not by reading.
+    // A click still INSIDE the union keeps the mode: that is how you pick
+    // one element after another without re-entering each time.
+    if (window._perObjBoxes === state.activeLayerIdx && window.perObjectUnionBounds) {
+      var _pw = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
+      var _pu = perObjectUnionBounds(userLayers[state.activeLayerIdx]);
+      if (!_pu || !_pu.contains(new Point(_pw[0], _pw[1]))) {
+        window._perObjBoxes = null;
+        window._shapeEnteredId = null;
+        window._sceneVersion = (window._sceneVersion || 0) + 1;
+      }
+    }
     // Every gesture starts from a clean slate (2026-07-26). onDown has a
     // dozen branches and several of them `return` without ever assigning
     // `mode`, so the PREVIOUS gesture's mode could survive into the new one

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -7568,6 +7568,28 @@ var _shapeEnteredId=null;
 // tool) and the strokes that formed it, so this uses a bounds-overlap
 // heuristic: any stroke-only path whose bounds intersect the fill's bounds
 // is assumed to be part of its outline.
+// Ungrouped, non-synthetic shapes on a layer — the set the per-object
+// "enter the group" mode operates on (2026-08-31, feedback #176). Shared by
+// the Motion and Animation 2D double-click paths so both agree on what
+// counts as an element.
+function perObjectShapesOf(layer){
+  if(!layer)return[];
+  return layer.children.filter(function(c){
+    if(!c.data||!c.data.strokeId||c.data.groupId)return false;
+    if(c.data.isBrushTextureCopy||c.data.isLinkedFillCompanion||c.data.isDuplicatorCopy)return false;
+    return !!(c.strokeBounds&&c.strokeBounds.width&&c.strokeBounds.height);
+  });
+}
+// Union of those shapes — the "group box" a double-click enters from
+// ANYWHERE inside, not only by hitting a shape ("peu importe où je double
+// clic dans la bounding box").
+function perObjectUnionBounds(layer){
+  var sh=perObjectShapesOf(layer),b=null;
+  sh.forEach(function(c){b=b?b.unite(c.strokeBounds):c.strokeBounds.clone();});
+  return sh.length>=2?b:null;
+}
+window.perObjectShapesOf=perObjectShapesOf;
+window.perObjectUnionBounds=perObjectUnionBounds;
 function onViewDoubleClick(event){
   // Re-edit a placed text block in place (2026-07 rework) — checked before
   // the select-only guard below since double-clicking with the Text tool
@@ -7616,7 +7638,27 @@ function onViewDoubleClick(event){
     // this file uses, and it stays constant as you zoom.
     var mTol=8/Math.max(0.0001,view.zoom);
     var mHit=mLayer.hitTest(event.point,{fill:true,stroke:true,tolerance:mTol});
-    if(!mHit||!mHit.item)return;
+    // Enter the group from anywhere INSIDE its box, not only by landing on
+    // a shape (2026-08-31, feedback #176, clarified with the Illustrator
+    // analogy: "peu importe où je double clic dans la bounding box de ces
+    // éléments... ça m'affichera les bounding box séparées des 3 éléments").
+    // Requiring a direct hit is what made it "difficile de rentrer": on a
+    // layer of thin or scattered shapes most of the group box is empty.
+    if(!mHit||!mHit.item){
+      var mUnion=window.perObjectUnionBounds&&perObjectUnionBounds(mLayer);
+      if(mUnion&&mUnion.contains(event.point)){
+        // Inside the group but on no shape: reveal every element's box and
+        // target none of them. The next single click picks one.
+        window._motionExpandedLayer=state.activeLayerIdx;
+        window._motionExpandedElement=null;
+        window._perObjBoxes=state.activeLayerIdx;
+        window._sceneVersion=(window._sceneVersion||0)+1;
+        if(window.renderLayerList)renderLayerList();
+        if(window.renderTimeline)renderTimeline();
+        if(window.SMEngineBridge)SMEngineBridge.renderNow();
+      }
+      return;
+    }
     var mItem=mHit.item;
     while(mItem.parent&&mItem.parent!==mLayer)mItem=mItem.parent;
     var mSid=mItem.data&&mItem.data.strokeId;
@@ -7642,8 +7684,24 @@ function onViewDoubleClick(event){
   // several shapes selected, dblclick on a fill-less stroke did nothing and
   // the union box just stayed. A drawn stroke is as much "an object" as a
   // filled shape, so it gets the same doorway.
-  var hit=layer.hitTest(event.point,{fill:true,stroke:true,tolerance:4/view.zoom});
-  if(!hit||!hit.item)return;
+  // Same screen-space tolerance as the Motion path above — 4/view.zoom is
+  // sub-pixel once you zoom out, which is half of why entering was hard.
+  var hit=layer.hitTest(event.point,{fill:true,stroke:true,tolerance:8/Math.max(0.0001,view.zoom)});
+  if(!hit||!hit.item){
+    // Enter the group from anywhere inside its box (feedback #176) — see the
+    // Motion branch's comment. Reveals every element's box and targets none;
+    // the next single click picks one, and a click outside the union drops
+    // back out (select-bridge's own reset).
+    var uni=window.perObjectUnionBounds&&perObjectUnionBounds(layer);
+    if(uni&&uni.contains(event.point)){
+      clearSel();fsClearSel();
+      _shapeEnteredId=null;
+      window._perObjBoxes=state.activeLayerIdx;
+      renderArcs();updateUI();
+      if(window.SMEngineBridge)SMEngineBridge.renderNow();
+    }
+    return;
+  }
   var fillPath=hit.item;
   // A hit inside a CompoundPath (boolean/fill results with holes) lands on
   // a CHILD Path — climb to the layer-level item, which is the one carrying


### PR DESCRIPTION
Feedback [#176](https://github.com/mysteropodes/nemo/issues/626) — "la fonction marche assez mal je trouve le double clic, j'ai du mal à y accéder et après si je clic ailleurs ça ne sort pas et ne revient pas en box normal".

Clarified with the Illustrator analogy: **double-click anywhere inside the group box** reveals every element's own box (none targeted); the next single click picks one; a click outside comes back to the layer box.

## Changes
- `perObjectShapesOf` / `perObjectUnionBounds` (tools.js) — one definition of "what counts as an element", shared by the Motion and Animation 2D double-click paths.
- Both paths enter the group on a **miss inside the union**, not only on a direct hit. Animation 2D's tolerance goes from `4/view.zoom` to `8` screen px (the old form collapses to sub-pixel once zoomed out — the other half of "difficile d'y accéder").
- engine-bridge's `buildTransformBoxItems` draws every element box when nothing is selected yet; the early return used to take them with it.
- Exit is keyed on `_perObjBoxes`, not `_shapeEnteredId` — entering without a target leaves the latter null, so the old reset could never fire. Motion needed its own copy: `shouldIntercept()` is false there (its active tool is `draw`), so it cannot fall through to the Animation 2D reset.

## Verification
Driven with **real** clicks in both modes (synthetic PointerEvents were misleading — in Motion, draw-bridge eats the pointerdown when the brush is active):

| step | Animation 2D | Motion |
|---|---|---|
| double-click empty space inside union | enters, 3 boxes drawn | enters, 3 boxes drawn |
| click element A | selects it, mode kept | targets it, mode kept |
| click element C | selects it, mode kept | targets it, mode kept |
| click empty space inside union | mode kept | mode kept, no target |
| click outside | exits to layer box | exits to layer box |

Screenshots confirm three separate boxes where the baseline frame has none. 27/27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)