### PR TITLE
Brush Size in Motion actually renders (#178)

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -1550,6 +1550,17 @@
             // applyTextBoundsFollowFor) never ran because `sd` stayed null.
             && !(window.SMMotion && cPathOpsStrokeId && SMMotion.hasPathVertexFollowMotionFor && SMMotion.hasPathVertexFollowMotionFor(i, cPathOpsStrokeId))
             && !(window.SMMotion && cPathOpsStrokeId && SMMotion.hasTextBoundsFollowMotionFor && SMMotion.hasTextBoundsFollowMotionFor(i, cPathOpsStrokeId))
+            // Brush Size (2026-08-31, feedback #178 "le brush size properties
+            // dans motion n'agit pas"): the exact same omission as the two
+            // lines above, one release later. It rebuilds the ribbon's
+            // outline from centerline+width profile in the cold path below,
+            // which a cached pathRef + one affine cannot express — and the
+            // hook is guarded by `sd &&`, so taking the fast path made it
+            // silently do nothing rather than fail. Proved by A/B on rendered
+            // PIXELS: with the retained store ON, 100% and 300% gave the
+            // identical ink count (19714 both); with it OFF the count moved
+            // (19715 -> 20518). Every entry in this list is one of these.
+            && !(window.SMMotion && cPathOpsStrokeId && SMMotion.hasBrushSizeMotionFor && SMMotion.hasBrushSizeMotionFor(i, cPathOpsStrokeId))
             && !(c.data && c.data.fillGradient)
             && !(c.data && c.data.strokeGradientAlongPath)
             && !(includeEditorOverlays && state.currentFrameOutline)


### PR DESCRIPTION
Feedback [#178](https://github.com/mysteropodes/nemo/issues/628) — "le brush size properties dans motion n'agit pas".

## Root cause
The hook was there and correct; it never ran. `buildSceneJson`'s retained-path fast path (CLAUDE.md §5ter) leaves `sd` null when a shape's geometry can be reused as a cached `pathRef` + one affine — and every per-shape op below it is guarded by `sd &&`. Ops that rebuild geometry must therefore disqualify the fast path explicitly. The list already excludes per-vertex offsets, Trim, param shapes, vertex-follow and text-bounds-follow, each with a comment saying exactly that. **Brush Size was added later and never added to it**, so it silently did nothing rather than failing.

## Verification (pixels, not reading)
| | 100% | 300% |
|---|---|---|
| before, retained store ON | 19714 | **19714** (identical) |
| before, retained store OFF | 19715 | 20518 |

After the fix, retained store ON, driving the **real panel row** (not the holder): typing `400` writes `motionStatic.brushSize=[400]` and the ribbon's ink goes **1646 → 7296 px (×4.4)**. Screenshots show the visibly thicker ribbon.

Also audited the whole exclusion list against motion.js's exported `has*MotionFor` predicates — nothing else is missing (`hasMeshVertexMotionFor` is raster-side, which this path never reaches).

27/27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)