### PR TITLE
Motion's Path vertices are the same points Select shows (#181)

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -1577,7 +1577,12 @@
           // shape's OWN local space, same as elMat's own pivot is computed
           // from `c.bounds` (the pre-offset bounds), matching AE's model
           // where a path's own points are edited before any transform.
-          if (sd && window.SMMotion && cPathOpsStrokeId) sd.segments = SMMotion.applyPathVertexOffsetsFor(i, cPathOpsStrokeId, sd.segments, renderFrame);
+          // Skipped for a vector-brush ribbon (2026-08-31, #181): there the
+          // vtxN indices address the CENTERLINE, not this baked outline, so
+          // applying them here moved outline point N — an arbitrary point on
+          // the ribbon's edge — instead of the stroke's Nth node. The ribbon
+          // is rebuilt from its offset centerline in the branch below.
+          if (sd && window.SMMotion && cPathOpsStrokeId && !(SMMotion.isVectorBrushSd && SMMotion.isVectorBrushSd(sd))) sd.segments = SMMotion.applyPathVertexOffsetsFor(i, cPathOpsStrokeId, sd.segments, renderFrame);
           // Trim Paths (2026-08) — same innermost-layer placement as vertex
           // offsets right above (authored in the shape's own local space,
           // before elMat/motionMat), applied right after so a trimmed
@@ -1620,8 +1625,14 @@
           // the trim's OWN pts/widths as Brush Size's input, not the
           // shape's un-trimmed static data — a real future case, not
           // attempted here. Trim wins when both are set.
-          else if (sd && window.SMMotion && cPathOpsStrokeId && SMMotion.hasBrushSizeMotionFor && SMMotion.hasBrushSizeMotionFor(i, cPathOpsStrokeId)) {
-            var bsSegs = SMMotion.applyBrushSizeFor(i, cPathOpsStrokeId, sd, renderFrame);
+          else if (sd && window.SMMotion && cPathOpsStrokeId && SMMotion.hasVectorBrushOutlineMotionFor && SMMotion.hasVectorBrushOutlineMotionFor(i, cPathOpsStrokeId)) {
+            // ONE rebuild carrying both centerline-authored edits — Brush
+            // Size and per-vertex offsets (#181) — instead of two chained
+            // ones, which would have to re-derive a centerline from an
+            // outline. Returns null for anything that isn't a vector-brush
+            // ribbon with real centerline data, so a plain shape falls
+            // through untouched.
+            var bsSegs = SMMotion.applyVectorBrushOutlineFor(i, cPathOpsStrokeId, sd, renderFrame);
             if (bsSegs) { sd.segments = bsSegs; sd.closed = true; }
           }
           // Dynamic shapes phase 2 (2026-08-18) — animated corner radii,

--- a/src/js/export.js
+++ b/src/js/export.js
@@ -243,7 +243,14 @@ function exportBuildFrame(frameIdx,alpha){
       // 2026-07): innermost transform — applied directly to `p`'s own
       // segments before elMat's pivot is even read from p.bounds, same
       // ordering as buildSceneJson's engine-bridge.js branch.
-      if(!sd.isRaster&&window.SMMotion&&sd.strokeId){
+      // Vector-brush ribbons excluded (2026-08-31, #181): their vtxN indices
+      // address the CENTERLINE, and rebuilding the ribbon from an offset
+      // centerline changes the outline's POINT COUNT — something this
+      // point-by-point write cannot express at all. exportHasCenterlineMotion
+      // below routes any project using it through the engine instead, where
+      // the rebuild actually lives; writing a partial result here would be
+      // the silent-wrong-export failure §12 warns about.
+      if(!sd.isRaster&&window.SMMotion&&sd.strokeId&&!(SMMotion.isVectorBrushSd&&SMMotion.isVectorBrushSd(sd))){
         var vtxSegs=SMMotion.applyPathVertexOffsetsFor(li,sd.strokeId,sd.segments,frameIdx);
         for(var vsi=0;vsi<p.segments.length&&vsi<vtxSegs.length;vsi++){
           p.segments[vsi].point.x=vtxSegs[vsi].point[0];
@@ -519,7 +526,33 @@ function exportHasImageMesh(){
   for(var k in m){if(Object.prototype.hasOwnProperty.call(m,k))return true;}
   return false;
 }
-function exportNeedsEngine(){return exportHasActiveEffects()||exportHasLayerCompositing()||exportHasEngineOnlyMotion()||exportHasImageMesh();}
+// Centerline-authored shape motion (2026-08-31) — Brush Size (#178) and
+// per-vertex offsets on a vector-brush ribbon (#181). Both rebuild the
+// ribbon's outline from its centerline, which changes the point count; the
+// plain-Paper.js loop above can only rewrite existing points in place, so it
+// would export the stroke at its recorded width and undeformed while the
+// screen shows it scaled/morphed. Same "engine-only feature" shape as
+// 3D / Motion Blur / Order / Image mesh, and the same silent failure if
+// missed.
+//
+// Deliberately over-inclusive in the SAFE direction, like exportHasImageMesh:
+// it checks the element holders for a brushSize or vtxN entry without also
+// proving the target stroke is a vector brush (which would mean walking every
+// frame of every layer). A plain path's vtxN offsets render identically
+// through the engine, so the worst case is a slower export of the same
+// picture — where the opposite error is a wrong file nobody notices.
+function exportHasCenterlineMotion(){
+  return state.layers.some(function(ld){
+    if(!ld.elementMotion)return false;
+    return Object.keys(ld.elementMotion).some(function(k){
+      var h=ld.elementMotion[k];if(!h)return false;
+      return ['motion','motionStatic','expressions'].some(function(bag){
+        return h[bag]&&Object.keys(h[bag]).some(function(prop){return prop==='brushSize'||prop.indexOf('vtx')===0;});
+      });
+    });
+  });
+}
+function exportNeedsEngine(){return exportHasActiveEffects()||exportHasLayerCompositing()||exportHasEngineOnlyMotion()||exportHasImageMesh()||exportHasCenterlineMotion();}
 // ---- PNG sequence rendering to a working directory (shared by raster exports) ----
 async function exportRenderPNGsToDir(dir,start,end,scale,onProgress,alpha){
   // Effects (blur/vignette/glow/ground shadow/...) only ever rendered in

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -3913,15 +3913,70 @@
   // animated Trim window with an animated Brush Size on the SAME stroke at
   // the same time is a real future case, not attempted here (see the call
   // site's own comment for the exact boundary).
-  function applyBrushSizeFor(li, strokeId, sd, frameIdx) {
+  // A vector-brush ribbon's EDITABLE geometry is its centerline, never the
+  // baked outline. Every other tool in the app already knows this —
+  // nodeEditSegmentsData (tools.js) hands Select/Subselect the centerline —
+  // and Motion was the one place reading the outline instead. Measured on one
+  // ordinary stroke for feedback #181: 5 points under Select, 476 vertex rows
+  // in Motion ("le path dans motion à plus de path que avec l'outil select.
+  // Il faudrait le même nombre de point... même si celui ci est lissé").
+  //
+  // The counts disagreeing was the visible half. The invisible half was
+  // worse: vtx0..vtx4 were being applied to outline points 0..4, so keying
+  // "vertex 0" nudged an arbitrary point on the ribbon's edge instead of the
+  // stroke's first node.
+  function isVectorBrushSd(sd) {
+    return !!(sd && sd.isVectorBrush && sd.centerSegments && sd.centerSegments.length >= 2);
+  }
+  // Row count for the Path accordion — panel AND grid read it through here,
+  // so the §11 alignment invariant cannot drift between the two.
+  function pathVertexRowCount(sd) {
+    return isVectorBrushSd(sd) ? sd.centerSegments.length : ((sd && sd.segments) ? sd.segments.length : 0);
+  }
+  // Same list, from the LIVE Paper item, as {x,y} in the shape's local space:
+  // what the on-canvas vertex dots draw and hit-test against. Mirrors
+  // nodeEditSegmentsData's choice exactly — the two must agree or a dot sits
+  // on a point Motion cannot key.
+  function elementVertexPoints(item) {
+    if (!item) return [];
+    if (item.data && item.data.isVectorBrush && item.data.centerSegments && item.data.centerSegments.length >= 2)
+      return item.data.centerSegments.map(function (s) { return { x: s.point[0], y: s.point[1] }; });
+    return (item.segments || []).map(function (s) { return { x: s.point.x, y: s.point.y }; });
+  }
+  function hasVectorBrushOutlineMotionFor(li, strokeId) {
+    var ld = state.layers[li]; if (!ld) return false;
+    var holder = elementHolder(ld, strokeId);
+    if (!holder) return false;
+    return hasBrushSizeMotionFor(li, strokeId) || hasPathVertexMotion(holder);
+  }
+  // ONE rebuild of the ribbon from its centerline, carrying both Motion edits
+  // that live on that centerline: per-vertex offsets (#181) and Brush Size
+  // (#178). Kept as a single pass rather than two chained ones because both
+  // consume the SAME source (sd.centerSegments + sd.widthProfile) and each
+  // produces an outline — running them in sequence would mean re-deriving a
+  // centerline from an outline, which is exactly the wedge/sliver family of
+  // bug the Trim work already hit.
+  //
+  // sd.centerSegments/sd.widthProfile are the shape's own static recording
+  // (serP's output, app.js) — untouched here, so repeated calls across frames
+  // always start from the same source instead of compounding.
+  function applyVectorBrushOutlineFor(li, strokeId, sd, frameIdx) {
+    if (!isVectorBrushSd(sd)) return null;
     var ld = state.layers[li]; var holder = ld && elementHolder(ld, strokeId);
-    if (!holder || !sd.centerSegments || sd.centerSegments.length < 2) return null;
-    var pct = valueAtFrame(holder, 'brushSize', frameIdx)[0];
+    if (!holder) return null;
     if (!window.sampleVectorBrushCenterline || !window.buildVariableWidthPath) return null;
-    var sampled = window.sampleVectorBrushCenterline(sd.centerSegments, sd.widthProfile);
-    var scale = pct / 100;
-    var scaledWidths = sampled.widths.map(function (w) { return w * scale; });
-    var outline = window.buildVariableWidthPath(sampled.pts, scaledWidths);
+    var center = applyPathVertexOffsets(sd.centerSegments, holder, frameIdx);
+    var sampled = window.sampleVectorBrushCenterline(center, sd.widthProfile);
+    var widths = sampled.widths;
+    // Read brushSize only when it actually carries a value: valueAtFrame
+    // falls back to a prop's PROP_DEFAULT, and brushSize has none, so an
+    // unconditional read returns 0 — a scale of 0, i.e. the ribbon silently
+    // disappearing on every stroke that merely has a keyed vertex.
+    if (isAnimated(holder, 'brushSize') || (holder.motionStatic && holder.motionStatic.brushSize)) {
+      var scale = valueAtFrame(holder, 'brushSize', frameIdx)[0] / 100;
+      widths = widths.map(function (w) { return w * scale; });
+    }
+    var outline = window.buildVariableWidthPath(sampled.pts, widths);
     if (!outline) return null;
     var segs = outline.segments.map(function (s) { return { point: [s.point.x, s.point.y], handleIn: [s.handleIn.x, s.handleIn.y], handleOut: [s.handleOut.x, s.handleOut.y] }; });
     outline.remove();
@@ -4776,11 +4831,16 @@
     // to offer vertices from.
     if (t.strokeId && window._motionExpandedPathHolder === holder) {
       var vItem = findElementItem(t.li, t.strokeId);
-      if (vItem && vItem.segments && mh) {
+      // Through elementVertexPoints, so a vector-brush ribbon shows dots on
+      // its CENTERLINE — the same nodes Select/Subselect show, and the same
+      // ones the Path rows now key (#181). Reading vItem.segments here put
+      // dots on outline points that no vtxN row corresponded to.
+      var vPts = elementVertexPoints(vItem);
+      if (vPts.length && mh) {
         var vg = mh.g, vertCol = [190, 130, 240, 255];
-        vItem.segments.forEach(function (seg, vi) {
+        vPts.forEach(function (seg, vi) {
           var voff = valueAtFrame(holder, 'vtx' + vi, state.currentFrame);
-          var localX = seg.point.x + (voff[0] || 0), localY = seg.point.y + (voff[1] || 0);
+          var localX = seg.x + (voff[0] || 0), localY = seg.y + (voff[1] || 0);
           var wp = vg.fwd(localX, localY);
           var vhs = 4.5 * zs;
           items.push({
@@ -5397,15 +5457,16 @@
     if (t && t.strokeId && window._motionExpandedPathHolder === t.holder) {
       var vItem2 = findElementItem(t.li, t.strokeId);
       var vg2 = motionBoxGeom(t);
-      if (vItem2 && vItem2.segments && vg2) {
+      var vPts2 = elementVertexPoints(vItem2);
+      if (vPts2.length && vg2) {
         var vTol = 9 / view.zoom;
-        for (var vi2 = 0; vi2 < vItem2.segments.length; vi2++) {
-          var seg2 = vItem2.segments[vi2];
+        for (var vi2 = 0; vi2 < vPts2.length; vi2++) {
+          var seg2 = vPts2[vi2];
           var voff2 = valueAtFrame(t.holder, 'vtx' + vi2, state.currentFrame);
-          var wp2 = vg2.fwd(seg2.point.x + (voff2[0] || 0), seg2.point.y + (voff2[1] || 0));
+          var wp2 = vg2.fwd(seg2.x + (voff2[0] || 0), seg2.y + (voff2[1] || 0));
           if (Math.hypot(event.point.x - wp2.x, event.point.y - wp2.y) < vTol) {
             pushUndo();
-            _motionDrag = { mode: 'vertex', t: t, vi: vi2, basePt: { x: seg2.point.x, y: seg2.point.y } };
+            _motionDrag = { mode: 'vertex', t: t, vi: vi2, basePt: { x: seg2.x, y: seg2.y } };
             return true;
           }
         }
@@ -8394,8 +8455,12 @@
       // the element actually has vertex geometry (a Raster/image entry
       // never does) — same "hidden by default, opt-in" convention CLAUDE.md
       // §8 documents for fill/stroke/brush extended properties.
-      if (!entry.sd.isRaster && entry.sd.segments && entry.sd.segments.length) {
-        renderPathVertexGroup(list, ensureElementHolder(ld, entry.strokeId), entry.sd.segments.length);
+      if (!entry.sd.isRaster && pathVertexRowCount(entry.sd)) {
+        // Count through pathVertexRowCount, not entry.sd.segments.length: for
+        // a vector-brush ribbon the vertices are its centerline, not the
+        // baked outline (#181). The grid half below reads the SAME helper —
+        // CLAUDE.md §11.
+        renderPathVertexGroup(list, ensureElementHolder(ld, entry.strokeId), pathVertexRowCount(entry.sd));
       }
       // Image mesh (2026-08-30) — the raster counterpart of the Path group
       // just above: same accordion, same vertex rows, same stopwatches,
@@ -9266,7 +9331,8 @@
             var pathHdrSpacer = document.createElement('div'); pathHdrSpacer.className = 'frow motion-group-row';
             grid.appendChild(pathHdrSpacer);
             if (isPathGroupExpanded(elHolder)) {
-              for (var vi = 0; vi < entry.sd.segments.length; vi++) renderTracksFor(grid, elHolder, 'vtx' + vi);
+              var vtxRows = pathVertexRowCount(entry.sd);
+              for (var vi = 0; vi < vtxRows; vi++) renderTracksFor(grid, elHolder, 'vtx' + vi);
             }
           }
           // Image mesh group — the exact mirror of renderElementsList's own
@@ -11391,7 +11457,10 @@
     layerElementsHaveOrder: layerElementsHaveOrder,
     anyOrderUsedAnywhere: anyOrderUsedAnywhere,
     hasBrushSizeMotionFor: hasBrushSizeMotionFor,
-    applyBrushSizeFor: applyBrushSizeFor,
+    hasVectorBrushOutlineMotionFor: hasVectorBrushOutlineMotionFor,
+    applyVectorBrushOutlineFor: applyVectorBrushOutlineFor,
+    isVectorBrushSd: isVectorBrushSd,
+    pathVertexRowCount: pathVertexRowCount,
     transformSegments: transformSegments,
     transformImageRect: transformImageRect,
     transformImageRectByMatrix: transformImageRectByMatrix,


### PR DESCRIPTION
Feedback [#181](https://github.com/mysteropodes/nemo/issues/631) — "le path dans le layer de shape propertie dans motion à plus de path que avec l'outil select. Il faudrait le même nombre de point de path que avec select même si celui ci est lissé".

## Root cause
A vector-brush ribbon's editable geometry is its **centerline**. Every other tool already knows this — `nodeEditSegmentsData` (tools.js) hands Select/Subselect the centerline — and Motion was the one place reading the baked outline instead. Measured on one ordinary stroke: **5 points under Select, 476 vertex rows in Motion**.

The counts disagreeing was the visible half. The invisible half was worse: `vtx0..vtxN` were applied to **outline** points 0..N, so keying "vertex 0" nudged an arbitrary point on the ribbon's edge instead of the stroke's first node.

## Changes
- `pathVertexRowCount(sd)` / `elementVertexPoints(item)` — one definition of "which points are the vertices", read by the panel, the grid (so §11 alignment can't drift), the on-canvas dots and the drag hit-test alike.
- `applyVectorBrushOutlineFor` replaces `applyBrushSizeFor`: **one** rebuild of the ribbon from its centerline carrying **both** centerline-authored edits — per-vertex offsets and Brush Size. Two chained passes would have to re-derive a centerline from an outline, the wedge/sliver family the Trim work already hit. `brushSize` is read only when it holds a value (it has no `PROP_DEFAULT`, so an unconditional `valueAtFrame` returns 0 — the ribbon vanishing on any stroke that merely has a keyed vertex).
- engine-bridge skips the plain per-vertex path for vector brushes; those indices no longer address that array.
- export.js skips the point-by-point write too — a centerline rebuild changes the outline's **point count**, which that loop cannot express — and routes such projects through the engine (`exportHasCenterlineMotion`), same shape as `exportHasImageMesh`. Brush Size had never been applied in the Paper export at all; this closes that too.

## Verification (driven live)
| | before | after |
|---|---|---|
| Motion rows vs Select nodes | 476 vs 5 | **4 vs 4** |
| panel rows / grid rows (§11) | — | 28 / 28 |
| on-canvas vertex dots | outline points | 4, exactly on the centerline |

Offsets land on the right end: `vtx0 -250Y` moves the top bound 444→269 leaving the bottom; `vtx3 +250Y` moves the bottom 599→804 leaving the top; both compose with Brush Size in one pass. Plain shapes unchanged (4/4/4 rows, `vtx0 +80X` still moves vertex 0). 27/27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)