### PR TITLE
Colour panel writes to the selected Motion row (#180, second half)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -11575,6 +11575,30 @@
     // setValue is the single writer (CLAUDE.md §13): it keys at the playhead
     // when the stopwatch is on and writes motionStatic when it isn't, so the
     // picker inherits both behaviors for free.
+    // Colour rows the user has SELECTED in the Motion timeline (clicking the
+    // row's label, the same selection the value-edit/ease machinery uses).
+    // The main colour panel writes through the CANVAS selection, which is a
+    // different thing entirely — feedback #180's second half: "select
+    // couleurs ne prend pas en compte la selection de la propriété
+    // impossible de changer la couleurs et de keyframé par là". Returns
+    // [{holder, prop}] for fillColor/strokeColor rows only; every other
+    // selected property is none of the colour panel's business.
+    selectedColorProps: function (which) {
+      if (state.appMode !== 'motion') return [];
+      return _motionPropSel.filter(function (s) {
+        return s.prop === which && s.holder;
+      }).map(function (s) { return { holder: s.holder, prop: s.prop }; });
+    },
+    // Companion writer for the rows above. Same body as
+    // writeElementColorFromPicker minus the (li, strokeId) lookup, since a
+    // selected row already IS a holder — going back through indices would
+    // just be a chance to resolve the wrong one.
+    writeColorToHolder: function (holder, prop, hex) {
+      if (!holder) return false;
+      if (!hasKeys(holder, prop) && !(holder.motionStatic && holder.motionStatic[prop])) return false;
+      setValue(holder, prop, hexToRgba255(hex));
+      return true;
+    },
     writeElementColorFromPicker: function (li, strokeId, prop, hex) {
       var ld = state.layers[li];
       if (!ld || !ld.elementMotion || !strokeId) return false;

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -606,13 +606,15 @@ window.SM={
   // A shape with no track at all — every shape in plain Animation 2D — takes
   // the early `false` and behaves exactly as before.
   setStrokeColor:function(v){state.strokeColor=v;paintStrokeSwatches(v);
-    if((state.tool==='select'||state.tool==='subselect')&&selectedPaths.length){pushUndo();selectedPaths.forEach(function(p){if(p.data&&p.data.isVectorBrush){p.fillColor=v;applyBrushKeyline(p);}else if(p.strokeColor){routeColorToMotion(p,'strokeColor',v);p.strokeColor=v;}});saveActiveLayerFrame();updateUI();}
+    if(routeColorToSelectedMotionRow('strokeColor',v)){}
+    else if((state.tool==='select'||state.tool==='subselect')&&selectedPaths.length){pushUndo();selectedPaths.forEach(function(p){if(p.data&&p.data.isVectorBrush){p.fillColor=v;applyBrushKeyline(p);}else if(p.strokeColor){routeColorToMotion(p,'strokeColor',v);p.strokeColor=v;}});saveActiveLayerFrame();updateUI();}
     // Fill/Stroke Select tool: recolor ONLY the clicked aspect — a 'stroke'
     // selection here means strokeColor, never touches fillColor even on a
     // combined shape (that's the whole point of this tool vs plain Select).
     else if(state.tool==='fsselect'&&_fsSel.some(function(s){return s.kind==='stroke';})){pushUndo();_fsSel=_fsSel.map(function(sel){if(sel.kind!=='stroke')return sel;var arc=fsRealizeStrokeSegment(sel,userLayers[state.activeLayerIdx]);arc.strokeColor=v;return{path:arc,kind:'stroke',segStart:0,segEnd:arc.length,closed:arc.closed};});saveActiveLayerFrame();updateUI();}},
   setFillColor:function(v){state.fillColor=v;paintFillSwatches(v);
-    if((state.tool==='select'||state.tool==='subselect')&&selectedPaths.length){pushUndo();selectedPaths.forEach(function(p){if(p.fillColor){routeColorToMotion(p,'fillColor',v);p.fillColor=v;}});saveActiveLayerFrame();updateUI();}
+    if(routeColorToSelectedMotionRow('fillColor',v)){}
+    else if((state.tool==='select'||state.tool==='subselect')&&selectedPaths.length){pushUndo();selectedPaths.forEach(function(p){if(p.fillColor){routeColorToMotion(p,'fillColor',v);p.fillColor=v;}});saveActiveLayerFrame();updateUI();}
     else if(state.tool==='fsselect'&&_fsSel.some(function(s){return s.kind==='fill'||s.kind==='fillregion';})){pushUndo();_fsSel=_fsSel.map(function(sel){if(sel.kind!=='fill'&&sel.kind!=='fillregion')return sel;if(sel.kind==='fillregion')sel=fsRealizeFillRegion(sel,userLayers[state.activeLayerIdx]);sel.path.fillColor=v;return sel;});saveActiveLayerFrame();updateUI();}},
   // Fill/Stroke on-off is mirrored by TWO eye icons — the right-panel one
   // (#fill-enable-toggle / #stroke-enable-toggle) and the left tool-panel one
@@ -5665,6 +5667,32 @@ function buildParentCell(row,ld,li){
 // image-mesh-bridge's singleRaster() is (CLAUDE.md §12bis): a selectedPaths
 // entry outlives the object it names across loadFrame/undo/importJSON, and a
 // detached item still has its data.strokeId.
+// A colour ROW selected in the Motion timeline is a selection too (2026-08-31,
+// feedback #180's second half: "select couleurs ne prend pas en compte la
+// selection de la propriété impossible de changer la couleurs et de keyframé
+// par là"). The colour panel below only ever consulted `selectedPaths` — the
+// CANVAS selection — so with a Fill row picked and nothing selected on canvas
+// it wrote to nothing at all.
+//
+// Checked BEFORE the canvas-selection branches and returning true when it
+// acted, so the two selections can't both fire on one pick: in Motion the row
+// is the more specific intent, and it is the only one that can key.
+// setValue (motion.js) keys at the playhead when the stopwatch is on and
+// writes the static value otherwise — the "et keyframé par là" half — with no
+// keyframing logic duplicated here.
+function routeColorToSelectedMotionRow(prop,hex){
+  if(!window.SMMotion||!SMMotion.selectedColorProps||!SMMotion.writeColorToHolder)return false;
+  var rows=SMMotion.selectedColorProps(prop);
+  if(!rows.length)return false;
+  pushUndo();
+  var wrote=false;
+  rows.forEach(function(r){ if(SMMotion.writeColorToHolder(r.holder,prop,hex))wrote=true; });
+  if(!wrote)return false;
+  saveActiveLayerFrame();
+  updateUI();
+  if(window.SMEngineBridge)SMEngineBridge.renderNow();
+  return true;
+}
 function routeColorToMotion(p,prop,hex){
   if(!p||!p.data||!p.data.strokeId)return false;
   if(!window.SMMotion||!SMMotion.writeElementColorFromPicker)return false;


### PR DESCRIPTION
Feedback [#180](https://github.com/mysteropodes/nemo/issues/630), the half left open in `df72288` — "select couleurs ne prend pas en compte la selection de la propriété impossible de changer la couleurs et de keyframé par là".

`SM.setFillColor` / `setStrokeColor` only ever consulted `selectedPaths` — the **canvas** selection. With a Fill ROW picked in the Motion timeline and nothing selected on canvas, the colour panel wrote to nothing at all.

- `SMMotion.selectedColorProps(prop)` exposes the `fillColor`/`strokeColor` rows the user actually selected (the same `_motionPropSel` the value-edit and ease machinery already use). `writeColorToHolder` is its writer, taking the holder directly — a selected row already *is* one, and going back through indices would just be a chance to resolve the wrong one.
- Checked **before** the canvas-selection branches and short-circuiting when it acts, so one pick can never write through both selections. In Motion the row is the more specific intent, and it is the only one that can key.
- The "et keyframé par là" half comes free: `setValue` keys at the playhead when the stopwatch is on and writes the static value otherwise.

## Verification
Driven on a real **brush** stroke (per Cyril's note today about not testing only parametric shapes): with **zero** canvas selection and only the Fill row selected, picking a colour at frame 20 creates a key there `[0,204,68,255]` beside the existing frame-0 key `[255,0,0,255]`; frame 10 evaluates to the interpolated `[127.5,102,34,255]`.

Regression: with a canvas selection and no Motion row selected, the old path still applies (`#ff0000` → `#1133ff`), and `selectedColorProps` returns 0 there.

Note: whether that keyed fill colour actually *renders* is a separate open report — [#194](https://github.com/mysteropodes/nemo/issues/644) — and is not touched here.

27/27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)