### PR TITLE
Animated fill/stroke colour no longer kills the render engine (#194)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -3806,13 +3806,36 @@
   // channels). Returns null (never overriding the item's own painted
   // color) unless the user has actually keyed or set a static override —
   // same "opt-in, never automatic" contract as vtxN.
+  // A colour CHANNEL is a u8 on the Rust side ([u8; 4] in engine.rs), and an
+  // interpolated track value is a plain float: halfway between two keys the
+  // red channel is 248.3356765206181, and serde refuses it outright —
+  // "invalid type: floating point ..., expected u8". That throw is a WASM
+  // trap, so it does not just drop one frame: it poisons the whole module
+  // and disables the engine for the rest of the session (see the render
+  // catch in engine-bridge.js). Hence feedback #194's symptom, "la couleur
+  // fill de la shape ne s'anime pas dans le canvas": the key frames
+  // themselves are integers and render fine, and the FIRST frame between
+  // two keys kills the renderer, which then silently falls back to Paper.js
+  // — which knows nothing about colour tracks and paints the shape's
+  // original colour.
+  //
+  // Rounded here, at the single place both colour readers return from,
+  // rather than at each engine call site: a fractional colour channel is
+  // meaningless to every consumer, not just this one.
+  function rgba255(v) {
+    if (!v) return v;
+    return v.map(function (c) {
+      var n = Math.round(c);
+      return n < 0 ? 0 : (n > 255 ? 255 : n);
+    });
+  }
   function elementFillColorAt(li, strokeId, frameIdx) {
     var ld = state.layers[li];
     if (!ld || !ld.elementMotion) return null;
     var holder = ld.elementMotion[strokeId];
     if (!holder) return null;
     if (!hasKeys(holder, 'fillColor') && !(holder.motionStatic && holder.motionStatic.fillColor)) return null;
-    return valueAtFrame(holder, 'fillColor', frameIdx);
+    return rgba255(valueAtFrame(holder, 'fillColor', frameIdx));
   }
   // Extended per-shape properties: Stroke color / Stroke width (2026-08 —
   // second slice of the "propriétés étendues par forme" chantier, same
@@ -3827,7 +3850,7 @@
     var holder = ld.elementMotion[strokeId];
     if (!holder) return null;
     if (!hasKeys(holder, 'strokeColor') && !(holder.motionStatic && holder.motionStatic.strokeColor)) return null;
-    return valueAtFrame(holder, 'strokeColor', frameIdx);
+    return rgba255(valueAtFrame(holder, 'strokeColor', frameIdx));
   }
   function elementStrokeWidthAt(li, strokeId, frameIdx) {
     var ld = state.layers[li];


### PR DESCRIPTION
Feedback [#194](https://github.com/mysteropodes/nemo/issues/644) — "la couleur fill de la shape du layer properties de motion ne s'anime pas dans le canvas alors que j'ai posé des clés de couleurs différentes".

## Root cause
A colour channel is a **u8** on the Rust side (`[u8; 4]` in engine.rs); an interpolated track value is a plain float. Halfway between two keys the red channel is `248.3356765206181` and serde refuses it:

```
invalid type: floating point `248.3356765206181`, expected u8 at line 1 column 278
```

That throw is a **WASM trap**, so it doesn't just drop one frame — it poisons the whole module, engine-bridge disables the renderer for the rest of the session and falls back to Paper.js. Paper knows nothing about colour tracks, so the shape reverts to its painted colour: the reported "ne s'anime pas".

The keys themselves hold integers and render fine, which is why this reads as "the colour doesn't animate" rather than "the renderer died" — the very **first** in-between frame kills it.

## Fix
Round and clamp to 0–255 in `elementFillColorAt` / `elementStrokeColorAt`, the single place both readers return from, rather than at each engine call site: a fractional colour channel is meaningless to every consumer.

## Verification
Driven on **both** a parametric shape and a real **brush** stroke, in **Motion** (per Cyril's two notes today), keys at frames 0 and 20, scrubbing every frame 0→20:

| | before | after |
|---|---|---|
| engine survives the scrub | dies at frame 1 | alive through all 21 |
| console | the serde message above | no error |
| override at frame 10 | `127.5` | `128` |

Screenshots show the rectangle going red→green and the brush ribbon red→purple→blue. 27/27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)