### PR TITLE
Double-click on a brush shape, and a group box that follows (#193)

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2870,7 +2870,10 @@
       var poZs = 1 / view.zoom;
       var poMap = (window.SMMotion && SMMotion.layerMotionPointMap) ? SMMotion.layerMotionPointMap(state.activeLayerIdx) : null;
       (window.perObjectShapesOf ? perObjectShapesOf(userLayers[state.activeLayerIdx]) : []).forEach(function (ch) {
-        var sb = ch.strokeBounds;
+        // Posed bounds (#193) — see elementPosedBounds in tools.js: a shape
+        // moved through Motion keeps its RAW geometry, so a box built from
+        // strokeBounds stays where the shape used to be.
+        var sb = window.elementPosedBounds ? elementPosedBounds(userLayers[state.activeLayerIdx], ch) : ch.strokeBounds;
         function PW(x, y) { if (!poMap) return [x, y]; return poMap.fwd(x, y); }
         var a1 = PW(sb.left, sb.top), a2 = PW(sb.right, sb.top), a3 = PW(sb.right, sb.bottom), a4 = PW(sb.left, sb.bottom);
         poItems.push(lineItem(a1, a2, [74, 158, 255, 190], 1 * poZs));

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -4697,7 +4697,10 @@
       // (_motionExpandedElement null, the "entered the group but picked
       // nothing yet" state of #176) every shape draws its own box.
       if (window._motionExpandedElement && ch.data.strokeId === window._motionExpandedElement) return;
-      var b = ch.strokeBounds;
+      // Posed bounds, not raw (#193): a sibling that has been moved through
+      // Motion must carry its box with it, exactly like the active element's
+      // own gizmo already does.
+      var b = window.elementPosedBounds ? elementPosedBounds(lyr, ch) : ch.strokeBounds;
       if (!b || !b.width || !b.height) return;
       function P(x, y) { if (!map) return [x, y]; return map.fwd(x, y); }
       var c1 = P(b.left, b.top), c2 = P(b.right, b.top), c3 = P(b.right, b.bottom), c4 = P(b.left, b.bottom);

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -7583,12 +7583,50 @@ function perObjectShapesOf(layer){
 // Union of those shapes — the "group box" a double-click enters from
 // ANYWHERE inside, not only by hitting a shape ("peu importe où je double
 // clic dans la bounding box").
+// An element's bounds AFTER its own element-level Motion transform
+// (2026-08-31, feedback #193: "Quand on reviens à la bounding box de groupe
+// celle ci ne s'est pas réadapter au nouveau position des éléments"). A shape
+// moved/rotated/scaled through Motion leaves its RAW geometry untouched — the
+// transform is applied at render time — so every box computed from
+// strokeBounds alone stayed where the shape used to be, both the per-element
+// boxes and the group box built from their union. That also made the
+// enter/exit hit test for the group (feedback #176) disagree with what is
+// actually on screen once anything had been animated.
+//
+// The maths are NOT re-derived here: the four corners go through the exact
+// same SMMotion.transformSegments the renderer uses, around the same pivot
+// (the item's own bounds centre offset by the anchor), so this box can never
+// drift from what is drawn. Falls back to the raw bounds whenever there is no
+// transform to apply — the overwhelmingly common case, and one object
+// allocation cheaper.
+function elementPosedBounds(layer,c){
+  var b=c.strokeBounds;
+  if(!window.SMMotion||!SMMotion.elementMotionAt||!SMMotion.transformSegments)return b;
+  var li=userLayers.indexOf(layer);
+  var sid=c.data&&c.data.strokeId;
+  if(li<0||!sid)return b;
+  var m=SMMotion.elementMotionAt(li,sid,state.currentFrame);
+  if(!m)return b;
+  if(!m.dx&&!m.dy&&!m.rot&&m.sx===1&&m.sy===1)return b;
+  var pc=c.bounds.center;
+  var pivot={x:pc.x+(m.ax||0),y:pc.y+(m.ay||0)};
+  var corners=[[b.left,b.top],[b.right,b.top],[b.right,b.bottom],[b.left,b.bottom]]
+    .map(function(pt){return {point:[pt[0],pt[1]],handleIn:[0,0],handleOut:[0,0]};});
+  var out=SMMotion.transformSegments(corners,pivot,m);
+  var minX=Infinity,minY=Infinity,maxX=-Infinity,maxY=-Infinity;
+  out.forEach(function(sg){
+    var x=sg.point[0],y=sg.point[1];
+    if(x<minX)minX=x; if(x>maxX)maxX=x; if(y<minY)minY=y; if(y>maxY)maxY=y;
+  });
+  return new Rectangle(new Point(minX,minY),new Point(maxX,maxY));
+}
 function perObjectUnionBounds(layer){
   var sh=perObjectShapesOf(layer),b=null;
-  sh.forEach(function(c){b=b?b.unite(c.strokeBounds):c.strokeBounds.clone();});
+  sh.forEach(function(c){var eb=elementPosedBounds(layer,c);b=b?b.unite(eb):eb.clone();});
   return sh.length>=2?b:null;
 }
 window.perObjectShapesOf=perObjectShapesOf;
+window.elementPosedBounds=elementPosedBounds;
 window.perObjectUnionBounds=perObjectUnionBounds;
 function onViewDoubleClick(event){
   // Re-edit a placed text block in place (2026-07 rework) — checked before
@@ -7661,6 +7699,18 @@ function onViewDoubleClick(event){
     }
     var mItem=mHit.item;
     while(mItem.parent&&mItem.parent!==mLayer)mItem=mItem.parent;
+    // Resolve a synthetic hit back to the real stroke BEFORE refusing it
+    // (2026-08-31, feedback #193: "Le double clic marche bien avec des shape
+    // paramétrique mais pas avec des shape de brush"). What you SEE of a
+    // filled brush stroke is mostly its linkedFill backdrop — a companion
+    // item — and of a textured one, its dab stamps; the refusal below then
+    // dropped the gesture entirely, so double-clicking the coloured part of
+    // a brush stroke did nothing at all while a rectangle worked. Every
+    // other click path in the app already goes through resolveBrushAnchor
+    // (select-bridge, subselect-bridge, fill/stroke select, tweens); the
+    // double-click was the one that didn't. The refusal stays for what
+    // genuinely has no anchor to reach — a duplicator copy.
+    mItem=resolveBrushAnchor(mItem,mLayer)||mItem;
     var mSid=mItem.data&&mItem.data.strokeId;
     if(!mSid)return;
     if(mItem.data.isBrushTextureCopy||mItem.data.isLinkedFillCompanion||mItem.data.isDuplicatorCopy)return;
@@ -7707,6 +7757,9 @@ function onViewDoubleClick(event){
   // a CHILD Path — climb to the layer-level item, which is the one carrying
   // data.strokeId and the one every consumer (§1) expects in selectedPaths.
   while(fillPath.parent&&fillPath.parent!==layer)fillPath=fillPath.parent;
+  // Then map a dab stamp / linkedFill backdrop onto the stroke it belongs
+  // to — see the Motion branch above for why (feedback #193).
+  fillPath=resolveBrushAnchor(fillPath,layer)||fillPath;
   if(!(fillPath instanceof Path)&&!(fillPath instanceof CompoundPath))return;
   if(!fillPath.fillColor&&!fillPath.strokeColor)return;
   // Synthetic companions are not objects to isolate (§1) — a dab or a


### PR DESCRIPTION
Feedback [#193](https://github.com/mysteropodes/nemo/issues/643). Two independent bugs — and the first was hiding the third symptom.

## 1. Double-click did nothing on a brush shape
`onViewDoubleClick` was the **one** click path in the app that never ran its hit through `resolveBrushAnchor`. What you *see* of a filled brush stroke is mostly its `linkedFill` backdrop — a companion item — and of a textured one, its dab stamps. The synthetic-item refusal right below then dropped the gesture entirely, so double-clicking the coloured part of a brush stroke did nothing at all while a rectangle worked, in **both** modes.

Every other path (select-bridge, subselect-bridge, fill/stroke select, tweens) already resolves; this one now does too. The refusal stays for what genuinely has no anchor to reach — a duplicator copy.

## 2. The group box didn't re-adapt
Every per-object box came from raw `strokeBounds`. A shape moved through Motion leaves its raw geometry untouched (the transform is applied at render), so the boxes — and the group box built from their union — stayed where the shape used to be. That also made the enter/exit hit test from mysteropodes/nemo#626 disagree with what is on screen.

`elementPosedBounds` (tools.js) maps the four corners through the **same** `SMMotion.transformSegments` the renderer uses, around the same pivot, so the box cannot drift from what is drawn, and returns the raw bounds untouched when there is no transform. Used by `perObjectUnionBounds` and by both box builders (motion.js's sibling boxes, engine-bridge's).

## 3. "cela doit changer les properties de shape dans le calque de motion"
No code needed — it was simply unreachable because (1) blocked the double-click. With that fixed, dragging the element's body writes `position` onto the **element** holder and leaves the layer's own untouched.

## Verification
Driven with real clicks, **two layers**, each holding a **parametric shape AND a brush stroke**, in **both** Animation 2D and Motion:

| | before | after |
|---|---|---|
| dbl-click the filled part of a brush | nothing (`perObj` null) | enters the group, targets the ribbon |
| union after moving an element | `[1098,200,1462,651]` (stale) | `[1100,200,1706,471]` |
| drag element body | — | `motionStatic.position = [243.3, -180]` on the element, layer untouched |

Screenshot shows the panel reading `TRANSFORM (ELEMENT) → Position X 243,3 Y -180` with the group box spanning both shapes at their real positions. 27/27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)