### PR TITLE
Live document resize (#188) and rulers off by default (#189)

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -112,7 +112,9 @@ var state={
   eraserSize:14,selRotAccum:0,tweenSkipManual:true,tweenHarmonizeEdits:false,
   resamplePts:50,tweenStep:1,
   canvasW:1920,canvasH:1080,canvasBg:'#ffffff',canvasClip:false,safetyZones:false,ghostAllFrames:false,currentFrameOutline:false,
-  rulersOn:true,guidesLocked:false,guidesSnap:true,guides:{h:[],v:[]},
+  // OFF by default (2026-08-31, feedback #189) — rulers-bridge.js restores
+  // the user's own choice from localStorage at init when they made one.
+  rulersOn:false,guidesLocked:false,guidesSnap:true,guides:{h:[],v:[]},
   // Live "show transparency" preview (2026-08-27, "il manque un bouton
   // pour afficher ou pas le fond en alpha") — the Export panel already
   // has its own "Fond transparent (alpha)" checkbox (engine-bridge.js's

--- a/src/js/rulers-bridge.js
+++ b/src/js/rulers-bridge.js
@@ -274,9 +274,29 @@
     renderGuides();
   }
 
+  // Rulers are OFF for a fresh install and remembered once you turn them on
+  // (2026-08-31, feedback #189: "rulers par default désactiver pour nouvelle
+  // session. laisser activé lors de l'enregistrement layout si active").
+  // Same mechanism, same storage and same lifetime as the panel widths
+  // (ui.js's restorePanelWidth/savePanelWidth) — this is a workspace
+  // preference, not project data, so it must NOT ride along in the project
+  // file where it would follow the artwork onto someone else's machine.
+  var RULERS_KEY = 'nemo-rulers-on';
+  function saveRulersPref() {
+    try { localStorage.setItem(RULERS_KEY, state.rulersOn ? '1' : '0'); } catch (e) {}
+  }
+  function restoreRulersPref() {
+    var v = null;
+    try { v = localStorage.getItem(RULERS_KEY); } catch (e) {}
+    // Nothing stored = never chosen = the new default (off). An explicit '0'
+    // is honoured too, so turning them back off also sticks.
+    state.rulersOn = v === '1';
+  }
+
   function toggleOn(on) {
     state.rulersOn = on != null ? !!on : !state.rulersOn;
     document.body.classList.toggle('rulers-off', !state.rulersOn);
+    saveRulersPref();
     if (state.rulersOn) { lastZoom = null; } // force a redraw on the next loop tick
     else { renderGuides(); } // collapses the DOM guide elements
   }
@@ -286,6 +306,7 @@
     hCanvas = document.getElementById('ruler-h');
     vCanvas = document.getElementById('ruler-v');
     if (!area || !hCanvas || !vCanvas) return;
+    restoreRulersPref();
     document.body.classList.toggle('rulers-off', !state.rulersOn);
     wireRulerDrag(hCanvas, 'h');
     wireRulerDrag(vCanvas, 'v');

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -9356,19 +9356,28 @@ document.getElementById('btn-dims-lock').addEventListener('click',function(){
   this.classList.toggle('on',on);
   _dimsLockRatio=on?(state.canvasW/state.canvasH):null;
 });
+// Live while the value is being dragged (2026-08-31, feedback #188: "le
+// resize de document n'est pas en temps réel pendant drag de value"). These
+// two handlers already existed but acted ONLY when the aspect-ratio link was
+// on — with the link off, nothing happened until the scrub's final 'change',
+// so the stage jumped to its new size at the END of the gesture instead of
+// following it. The ratio branch is now just the extra work of updating the
+// sibling field; applying the size itself is unconditional.
 document.getElementById('p-cw').addEventListener('input',function(){
+  var w=parseInt(this.value)||1,h=state.canvasH;
   if(_dimsLockRatio){
-    var h=Math.max(1,Math.round(parseFloat(this.value)/_dimsLockRatio));
+    h=Math.max(1,Math.round(parseFloat(this.value)/_dimsLockRatio));
     document.getElementById('p-ch').value=h;
-    window.SM.setCanvasSize(parseInt(this.value)||1,h);
   }
+  window.SM.setCanvasSize(w,h);
 });
 document.getElementById('p-ch').addEventListener('input',function(){
+  var h=parseInt(this.value)||1,w=state.canvasW;
   if(_dimsLockRatio){
-    var w=Math.max(1,Math.round(parseFloat(this.value)*_dimsLockRatio));
+    w=Math.max(1,Math.round(parseFloat(this.value)*_dimsLockRatio));
     document.getElementById('p-cw').value=w;
-    window.SM.setCanvasSize(w,parseInt(this.value)||1);
   }
+  window.SM.setCanvasSize(w,h);
 });
 // Paint the panel's fill swatch from the actual starting state.fillColor/
 // fillEnabled on load — without this it sits at whatever background the


### PR DESCRIPTION
Two small, independent Document/workspace fixes.

## [#188](https://github.com/mysteropodes/nemo/issues/638) — "le resize de document n'est pas en temps réel pendant drag de value"
`#p-cw` / `#p-ch` already had `input` handlers, but they acted **only when the aspect-ratio link was on**. With the link off, nothing happened until the scrub's final `change`, so the stage jumped to its new size at the *end* of the gesture. Applying the size is now unconditional; the ratio branch is just the extra work of updating the sibling field.

## [#189](https://github.com/mysteropodes/nemo/issues/639) — "rulers par default désactiver pour nouvelle session. laisser activé lors de l'enregistrement layout si active"
`rulersOn` now defaults to `false`, and rulers-bridge persists the user's own choice to localStorage and restores it at init. Same mechanism, storage and lifetime as the panel widths (`restorePanelWidth`/`savePanelWidth` in ui.js) — this is a **workspace** preference, so it deliberately does *not* ride in the project file, where it would follow the artwork onto someone else's machine.

## Verification
- Real scrub drag on the width field with the ratio link **off**: canvas follows every tick (1205, 1210, … 1230). Before: only on release.
- Session with nothing stored: rulers off (`body.rulers-off` present). Click the button → stored `'1'`. Reload → back on.

Worth recording: while testing, the browser was running a **cached** `rulers-bridge.js` while the server served the new one — the served file had the fix and the live `SMRulers.toggleOn` did not. CLAUDE.md §4's exact trap; re-served on a fresh port before trusting any result.

27/27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)