### PR TITLE
Document panel: wraps when narrow (#187), hidden during a selection (#191)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2710,3 +2710,26 @@ body.mode-motion .layer-inout-bar .layer-inout-handle{width:4px;border-radius:2p
 #start-github{display:inline-flex;align-items:center;gap:7px;margin:2px 0 20px;
   font-size:11px;color:var(--text-dim);text-decoration:none;transition:color .15s;}
 #start-github:hover{color:var(--text);}
+
+/* Document's BG + view-toggle row wraps instead of overflowing (2026-08-31,
+   feedback #187: "les bouton de document devrait wrapper si je resize plus
+   petit le panel droit et bg avoir un carré constant"). The row is a flex
+   line of seven 30px icon buttons plus the colour swatch: at the panel's
+   narrowest it needs ~250px, so below that the last buttons were pushed
+   outside the panel and became unreachable rather than moving to a second
+   line. `.pr` sets no flex-wrap, so this is opt-in for THIS row only —
+   the paired W/H and FPS/Frames rows above deliberately stay on one line.
+   row-gap matches the 4px inline gap so a wrapped second line doesn't sit
+   flush against the first. */
+#canvas-sec .doc-bg-row{flex-wrap:wrap;row-gap:4px;}
+/* A constant SQUARE, whatever the panel width — it was 28x22, i.e. a
+   rectangle that also shrank as the row tightened (flex items shrink by
+   default), which is the other half of the same report. flex:none keeps it
+   at its size while the buttons around it wrap. */
+#canvas-sec .doc-bg-row #p-cbg{width:22px;height:22px;flex:none;}
+/* The buttons keep the app-wide 30px. Shrinking them to squeeze all seven
+   onto one line at the default panel width was tried and dropped: it bought
+   one line back at exactly one width while giving this row an icon size
+   nothing else in the app uses. Two lines at the default is the honest
+   result of wrapping, and every button stays reachable — which is the point
+   of the report. */

--- a/src/index.html
+++ b/src/index.html
@@ -802,8 +802,8 @@
              The hidden-label spacer is gone: the real label now sits on the
              same row, and .pr-vsep marks where the colour control ends and
              the view/overlay toggles begin. -->
-        <div class="pr dims-row" style="gap:4px">
-          <span class="pl">BG</span><input type="color" id="p-cbg" value="#ffffff" style="width:28px;height:22px;border:none;cursor:pointer;padding:0;">
+        <div class="pr dims-row doc-bg-row" style="gap:4px">
+          <span class="pl">BG</span><input type="color" id="p-cbg" value="#ffffff" style="border:none;cursor:pointer;padding:0;">
           <span class="pr-vsep" aria-hidden="true"></span>
           <button class="pbtn icon-only-btn" id="btn-fit" data-i18n-title="btnFitTitle" title="Fit — fit the canvas to the viewport"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M21 16v3a2 2 0 0 1-2 2h-3M3 16v3a2 2 0 0 0 2 2h3"/></svg></button>
           <button class="pbtn icon-only-btn" id="btn-resetv" data-i18n-title="btnResetViewTitle" title="Reset View — restore zoom/pan/rotation to default"><svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 1 3 6.7"/><path d="M3 21v-5h5"/></svg></button>

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -2900,15 +2900,22 @@ function updatePropsContext(){
   }else if(hasSel){
     ctx='selection';
     show['sel-props-sec']=show['fill-sec']=show['stroke-sec']=true;
-    // Mockup 2026-07-17 (réordonnancement du panel) : Layer (Blend) et
-    // Document restent visibles pendant une sélection, juste sous le bloc
-    // transform — avant, sélectionner un trait les faisait disparaître.
-    // EXCEPT the Subselect tool (2026-07, "avec subselection le panneau
-    // document n'a pas besoin d'être ouvert") — editing individual vertices
-    // has no use for canvas W/H/FPS/BG, and the panel real estate is more
-    // useful given over to the Position/Size/Rotation-of-selected-vertices
-    // fields (updateSelPropsPanel) that section sits right above.
-    show['canvas-sec']=state.tool!=='subselect';
+    // Document is HIDDEN during a selection (2026-08-31, feedback #191: "si
+    // je clic sur un élement dans animation 2D je vois apparaitre le panel
+    // document comme un onglet qui devrait normalement avoir disparu").
+    //
+    // This reverses the 2026-07-17 panel mockup, which deliberately kept
+    // Layer (Blend) and Document visible under the transform block. The
+    // reversal comes from the same person who asked for that, and the
+    // Subselect tool had already been carved out of it for exactly this
+    // reason ("avec subselection le panneau document n'a pas besoin d'être
+    // ouvert") — canvas W/H/FPS/BG have nothing to do with the shape you
+    // just picked, and the panel real estate belongs to its properties.
+    // Generalising that carve-out to every selection is what #191 asks for.
+    // With nothing selected the panel falls back to Document as before
+    // (ctx==='document' branch below), where it also sits at the top on the
+    // dark ground (#171's follow-up).
+    show['canvas-sec']=false;
     show['layer-sec']=false; // folded into the layer row's context menu (#172)
     // Rig bind (2026-07-29 fix, "on ne sait pas comment select l'élément qui
     // doit y être associé"): #rig-opts-sec (with the "Lier la sélection"


### PR DESCRIPTION
## [#187](https://github.com/mysteropodes/nemo/issues/637) — "les bouton de document devrait wrapper… et bg avoir un carré constant"
The BG + view-toggle row is a flex line with no wrap, so narrowing the panel pushed its last buttons **outside** it — unreachable, not wrapped. The colour swatch was also `28x22` (a rectangle) *and* allowed to shrink: it measured **6x27** once the row tightened.

Now: `flex-wrap` + `row-gap` on that row only (the paired W/H and FPS/Frames rows above deliberately stay on one line), and a fixed `22x22` `flex:none` swatch.

| panel width | buttons out of frame — before | after | swatch |
|---|---|---|---|
| 280px (default) | 1 | **0** | 22×22 |
| 200px | 3–4 | **0** | 22×22 |
| 150px | 5 | **0** | 22×22 |

Shrinking the icons to squeeze the whole row onto one line at the default width was tried and dropped: it bought one line back at exactly one width while giving this row an icon size nothing else in the app uses.

## [#191](https://github.com/mysteropodes/nemo/issues/641) — "je vois apparaitre le panel document comme un onglet qui devrait normalement avoir disparu"
Document is now hidden while anything is selected. This reverses the 2026-07-17 panel mockup, which deliberately kept it visible under the transform block — the reversal comes from the same person, and the Subselect tool had **already** been carved out of that rule for exactly this reason ("avec subselection le panneau document n'a pas besoin d'être ouvert"). With nothing selected the panel falls back to Document as before, still at the top on the dark ground.

Verified with a **parametric shape and a brush stroke**: visible with no selection, gone for either kind, back on deselect.

Both fixes were briefly invisible behind a **cached** `style.css` — the served file had the rules while `getComputedStyle` still said `nowrap`. CLAUDE.md §4 again; re-served on a fresh port before trusting any measurement.

27/27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)