### PR TITLE
A full trim window trims nothing, and keeps the fill (#182)

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -1829,7 +1829,13 @@
           // reach this branch at all: see its own comment above. The
           // isVectorBrush guard stays for the real anchor item, which IS
           // reached through cPathOpsStrokeId.
+          // ...but NOT when the trim window covers the whole path (#182):
+          // turning the property on without trimming anything must leave the
+          // drawing exactly as it was. trimIsFullWindow is the single place
+          // that decides "nothing is actually trimmed" — applyTrimFor reads
+          // the same helper, so the geometry and the paint can't disagree.
           if (window.SMMotion && cPathOpsStrokeId && SMMotion.hasTrimMotionFor(i, cPathOpsStrokeId)
+              && !(SMMotion.trimIsFullWindow && SMMotion.trimIsFullWindow(i, cPathOpsStrokeId, renderFrame))
               && !(c.data && c.data.isVectorBrush)) {
             item.fillColor = null;
             delete item.fillGradient;

--- a/src/js/export.js
+++ b/src/js/export.js
@@ -218,7 +218,12 @@ function exportBuildFrame(frameIdx,alpha){
         }else{
           var trimmed=SMMotion.applyTrimFor(li,sd.strokeId,sd.segments,sd.closed,frameIdx);
           sd.segments=trimmed.segments;sd.closed=trimmed.closed;
-          if(!sd.isVectorBrush){sd.fillColor=null;delete sd.fillGradient;}
+          // Same "a full window trims nothing" carve-out as the live render
+          // (#182) — this path is the export's own copy of that rule, and the
+          // two must agree or a trim-enabled-but-untrimmed shape would export
+          // without the fill it has on screen.
+          var trimNul=SMMotion.trimIsFullWindow&&SMMotion.trimIsFullWindow(li,sd.strokeId,frameIdx);
+          if(!sd.isVectorBrush&&!trimNul){sd.fillColor=null;delete sd.fillGradient;}
         }
       }
       var p=sd.isRaster?desR(sd,L,sd.opacity!==undefined?sd.opacity:1):desP(sd,L,sd.opacity!==undefined?sd.opacity:1);

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -4258,9 +4258,30 @@
   // and `closed`, which that in-place-mutation shape can't accommodate
   // without a larger rework of that function. A trimmed shape currently
   // exports un-trimmed (full path) until that's addressed.
+  // "Trim Paths is on, but its window covers the whole path" — i.e. nothing
+  // is actually trimmed (2026-08-31, feedback #182: "pourquoi un trim path
+  // peut supprimé le fill d'une shape ?"). Merely ENABLING the property used
+  // to rebuild the shape as an open polyline approximation and drop its
+  // fill, before the artist had trimmed anything: measured on a plain filled
+  // rectangle, 4 closed segments with a fill became 81 open ones with none.
+  // Dropping the fill on a genuinely trimmed shape is deliberate and stays
+  // (see engine-bridge's own comment — AE's convention, and the fix for the
+  // "pac-man wedge" Cyril reported in August); doing it for a window that
+  // trims nothing is just a property that breaks the drawing when switched
+  // on.
+  //
+  // Offset is deliberately ignored: rotating a full window around a path
+  // still keeps the whole path, so it changes nothing either.
+  var TRIM_EPS = 0.001;
+  function trimIsFullWindow(li, strokeId, frameIdx) {
+    var win = trimWindowAt(li, strokeId, frameIdx);
+    if (!win) return true;
+    return (win.start || 0) <= TRIM_EPS && (win.end == null ? 100 : win.end) >= 100 - TRIM_EPS;
+  }
   function applyTrimFor(li, strokeId, segments, closed, frameIdx) {
     var win = trimWindowAt(li, strokeId, frameIdx);
     if (!win) return { segments: segments, closed: closed };
+    if (trimIsFullWindow(li, strokeId, frameIdx)) return { segments: segments, closed: closed };
     return applyTrimSegments(segments, closed, win);
   }
   // Vector-brush ribbon trim (2026-08-20) — "il faudrait mettre en place le
@@ -11735,6 +11756,7 @@
       if (!ld || !ld.elementMotion || !strokeId) return false;
       return hasTrimMotion(ld.elementMotion[strokeId]);
     },
+    trimIsFullWindow: trimIsFullWindow,
     applyTrimToVectorBrush: applyTrimToVectorBrush,
     // Called by the two frame-content writers in app.js — the union is
     // derived from that content, so it must not outlive an edit.


### PR DESCRIPTION
Feedback [#182](https://github.com/mysteropodes/nemo/issues/632) — "pourquoi un trim path peut supprimé le fill d'une shape ?"

## The part that is deliberate (and stays)
Dropping the fill on a genuinely **trimmed** shape is the 2026-08-19 fix for the "pac-man wedge" Cyril reported himself ("ça trim ça comme un fill alors que ça devrait trim comme dans After Effects"), and it matches AE's own convention that Trim Paths is a stroke operation.

## The part that was not defensible
Merely **enabling** the property did it too. The trim ran unconditionally and `applyTrimSegments` always returns an open polyline, so a window of `0 → 100` — which trims nothing — rebuilt the shape and nulled its fill anyway.

Measured on a plain filled rectangle:

| | segments | closed | fill |
|---|---|---|---|
| no trim | 4 | yes | `[224,85,85,255]` |
| trim on, window 0→100 — **before** | 81 | no | `null` |
| trim on, window 0→100 — **after** | 4 | yes | `[224,85,85,255]` |
| trim 0→50 (after) | 41 | no | `null` (by design) |

`trimIsFullWindow` (motion.js) is now the single place that decides "nothing is actually trimmed": `applyTrimFor` skips the trim and both render paths skip the fill-nulling, so geometry and paint cannot disagree. Offset is deliberately ignored — rotating a full window still keeps the whole path.

Both writers updated — engine-bridge (live) **and** export.js, which carries its own copy of the rule; otherwise a trim-enabled-but-untrimmed shape would export without the fill it shows on screen.

Verified by driving with a parametric shape and a brush stroke in the same scene; screenshot shows the rectangle keeping its fill with Trim Paths on. 27/27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)