### PR TITLE
Audio layer rows appear in Motion too (#183)

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -3783,6 +3783,17 @@ function renderTimeline(){
     // visible height, which spans exactly the viewport at every scroll
     // position, in both modes, with no second formula to keep in sync.
     syncPlayheadToViewport();
+    // Audio belongs to the document, not to Animation 2D (2026-08-31,
+    // feedback #183: "si j'importe un calque son dans la timeline motion
+    // celui ci apparait à droite de la timeline trés bien mais pas à gauche
+    // comme layer son avec les options qui vont avec"). renderStrip() draws
+    // BOTH halves — the waveform strip on the right AND the synthetic
+    // name/mute/level rows in #layer-list — but it was only called from the
+    // Animation 2D tail below, past this early return. So switching to
+    // Motion left the waveform behind (nothing clears #audio-strip) while
+    // the left rows vanished with the layer list rebuild: exactly "à droite
+    // très bien mais pas à gauche". Same call, same order as the tail.
+    if(window.SMAudio)SMAudio.renderStrip();
     return;
   }
   if(window.SMCamera)SMCamera.renderGridRow(grid);


### PR DESCRIPTION
Feedback [#183](https://github.com/mysteropodes/nemo/issues/633) — "si j'importe un calque son dans la timeline motion celui ci apparait à droite de la timeline trés bien mais pas à gauche comme layer son avec les options qui vont avec".

`renderStrip()` draws **both** halves — the waveform on the right *and* the synthetic name / mute / level / delete rows in `#layer-list` — but it was only called from `renderTimeline`'s Animation 2D tail, past the Motion branch's early `return`. Switching to Motion therefore left the waveform behind (nothing clears `#audio-strip`) while the left rows vanished with the layer-list rebuild: exactly "à droite très bien mais pas à gauche".

Audio belongs to the document, not to one mode — so it's one call, in the same position and order as the Animation 2D tail. The audio rows are synthetic (never `state.layers` entries) and sit outside the per-layer row pairing, so §11's panel/grid alignment is untouched.

## Verification
Imported a generated WAV and driven live:

| | left rows | right rows |
|---|---|---|
| Animation 2D | 1 | 1 |
| Motion — before | **0** | 1 |
| Motion — after | **1** | 1 |

The left row's top sits within 1px of its waveform's. Screenshot shows it with its colour dot, mute icon, name, level slider and delete control. 27/27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)