### PR TITLE
Canvas multi-select: boxes and hit-testing follow what is drawn

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -5473,6 +5473,27 @@
     return null;
   }
   function onDown(event) {
+    // Inside a group with nothing picked yet, a click that lands ON a shape
+    // belongs to that shape (2026-08-31). Without this the whole-LAYER gizmo
+    // claimed it first — its ring, corners and body all sit over the very
+    // shapes you are trying to pick, and the more the layer is rotated or
+    // scaled the more of them fall under the cursor. Measured with the layer
+    // at rotation 25°: clicking a shape inside the group targeted nothing
+    // (_motionExpandedElement stayed empty) and the following drag moved the
+    // whole layer instead, which reads exactly as "I can select an object
+    // but not drag it".
+    //
+    // Deliberately narrow: only while per-object mode is on for THIS layer,
+    // only while no element is targeted yet, and only when the point is
+    // really on a shape. Every other Motion gesture — including the layer
+    // gizmo outside a group, and every grab once an element IS targeted —
+    // is untouched. Returning false hands the click to select-bridge, whose
+    // Motion block does the targeting.
+    if (window._perObjBoxes === state.activeLayerIdx && window._motionExpandedElement == null
+        && window.hitTestPosed && userLayers[state.activeLayerIdx]) {
+      var surForme = hitTestPosed(state.activeLayerIdx, event.point, 6 / Math.max(0.0001, view.zoom));
+      if (surForme && surForme.item && surForme.item.data && surForme.item.data.strokeId) return false;
+    }
     var ml = multiLayerBox();
     if (ml) {
       var mb = ml.bounds, mz = 1 / Math.max(0.0001, view.zoom);
@@ -5695,6 +5716,12 @@
     }
     return false;
   }
+  // Local accessor for the layer point map — layerMotionPointMap is defined
+  // on the exported SMMotion object at the bottom of this file, not as a
+  // closure function, so callers inside the closure go through window.
+  function layerMotionPointMapFor(li) {
+    return (window.SMMotion && window.SMMotion.layerMotionPointMap) ? window.SMMotion.layerMotionPointMap(li) : null;
+  }
   function onDrag(event) {
     if (!_motionDrag) return false;
     if (_motionDrag.mode === 'elementMove') {
@@ -5702,9 +5729,25 @@
       // for — same setValue every other Motion drag uses, so it keys at the
       // playhead when the stopwatch is on and writes motionStatic when it
       // isn't, with no second writer.
+      // The pointer delta is WORLD space; an element's Position is applied
+      // to its geometry BEFORE the layer's own transform, so it has to be
+      // pulled back through that transform first (2026-08-31). Without it
+      // the delta got rotated a second time at render: measured with the
+      // layer at 25°, a drag of (200,140) moved the element (122,211) —
+      // exactly (200,140) rotated by 25°.
+      //
+      // Note the asymmetry with the LAYER's own Position a few files over
+      // (select-bridge): that one deliberately does NOT invert, because a
+      // layer's dx/dy is a plain translation applied on top of its own
+      // rotation, i.e. it already lives in post-rotation space. An
+      // ELEMENT's does not — it sits underneath the layer transform.
+      var dxEl = event.point.x - _motionDrag.start.x;
+      var dyEl = event.point.y - _motionDrag.start.y;
+      var mapEl = layerMotionPointMapFor(_motionDrag.t.li);
+      if (mapEl && mapEl.invVec) { var vEl = mapEl.invVec(dxEl, dyEl); dxEl = vEl[0]; dyEl = vEl[1]; }
       setValue(_motionDrag.t.holder, 'position', [
-        _motionDrag.basePos[0] + (event.point.x - _motionDrag.start.x),
-        _motionDrag.basePos[1] + (event.point.y - _motionDrag.start.y)
+        _motionDrag.basePos[0] + dxEl,
+        _motionDrag.basePos[1] + dyEl
       ]);
       // The DOCUMENT changed, so say so (2026-08-30, "n'est pas en temps
       // reel, il bouge pas sur le canvas pendant le drag que au

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -3333,7 +3333,16 @@
     indices.forEach(function (li) {
       var ld = state.layers[li], layer = window.userLayers && userLayers[li];
       if (!ld || !layer) return;
-      var b = layer.bounds;
+      // POSED bounds, not raw (2026-08-31, feedback en Motion: "la box de
+      // hover n'est pas à jour si je bouge un éléments dans le groupe").
+      // layer.bounds is the untransformed geometry, so a layer whose
+      // elements carry their own Motion offsets reported its OLD extent —
+      // the hover box, and every other consumer of this union, stayed where
+      // the shapes used to be. perObjectPosedUnionLocal (tools.js) applies
+      // each element's own transform and stops there, which is exactly this
+      // function's input space: the layer transform and the parent chain
+      // are applied just below, as before.
+      var b = (window.perObjectPosedUnionLocal && perObjectPosedUnionLocal(layer)) || layer.bounds;
       if (!b || !isFinite(b.width) || !isFinite(b.height) || (b.width === 0 && b.height === 0)) return;
       var corners = [[b.left, b.top], [b.right, b.top], [b.right, b.bottom], [b.left, b.bottom]];
       var pts = corners.map(function (c) { return { point: c, handleIn: [0, 0], handleOut: [0, 0] }; });
@@ -5932,6 +5941,17 @@
     if (!_motionDrag) return false;
     _motionDrag = null;
     renderLayerList(); // scrub fields must reflect the dragged position/handle
+    // ...and the GRID half, or a key the drag just created is invisible
+    // until something unrelated happens to repaint it (2026-08-31, feedback
+    // en Motion: "si j'ai mis des keyframes à une des shape dans le groupe
+    // que je la bouge cela ne créer pas de keyframes tout de suite dans le
+    // propertie en question dans la timeline"). setValue DOES write the key
+    // — isAnimated is true, so it goes through setKeyAtCurrentFrame — the
+    // diamond simply had no repaint to appear in. Once per gesture END, not
+    // per tick: renderTimeline rebuilds every row (CLAUDE.md §5bis measured
+    // 27.7ms at 40 layers), which is exactly why the drag itself must not
+    // call it.
+    renderTimeline();
     if (window.SMEngineBridge) SMEngineBridge.renderNow();
     return true;
   }

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -4699,6 +4699,14 @@
   // layer gets a dim outline, so each one reads as individually targetable
   // — clicking its row, or double-clicking it on canvas, makes it active.
   function perObjectBoxItems() {
+    // MOTION ONLY. Animation 2D draws its own per-object boxes from
+    // buildTransformBoxItems (engine-bridge) — this builder exists because
+    // that one returns [] in Motion. Without this gate both fired in
+    // Animation 2D and every element got TWO boxes, in two slightly
+    // different blues ([74,158,255,190] over [63,107,245,120]); found by
+    // reading the emitted overlay layers, not by looking, because at a
+    // 1px stroke the pair reads as one slightly-wrong box.
+    if (state.appMode !== 'motion') return [];
     if (window._perObjBoxes !== state.activeLayerIdx) return [];
     var lyr = userLayers[state.activeLayerIdx];
     if (!lyr) return [];
@@ -5145,8 +5153,18 @@
       // Only when a strokeId is actually targeted; the whole-layer case
       // (t.strokeId null) keeps the union it always used, and a Component
       // keeps symbolUnionBounds' duration-stable box.
+      // The whole-LAYER box is built from the elements' POSED bounds, not
+      // the layer's raw ones (2026-08-31): moving two elements apart with
+      // their own Motion left this box at its old size while they visibly
+      // spread outside it. perObjectPosedUnionLocal returns the union after
+      // each element's own transform but BEFORE the layer's, which is
+      // exactly this function's input space — it applies the layer transform
+      // itself just below. Falls back to the raw bounds when the layer has
+      // no usable shapes (an empty layer, a Null, a Guide).
+      var posedLb = (!t.strokeId && !(ld && ld.symbolId) && window.perObjectPosedUnionLocal)
+        ? perObjectPosedUnionLocal(userLayers[t.li]) : null;
       lb = (t.strokeId && t.bounds) ? t.bounds
-        : ((ld && ld.symbolId) ? symbolUnionBounds(t.li) : (userLayers[t.li] && userLayers[t.li].bounds));
+        : (posedLb || ((ld && ld.symbolId) ? symbolUnionBounds(t.li) : (userLayers[t.li] && userLayers[t.li].bounds)));
     }
     if (!lb) return null;
     var anc = valueAtFrame(t.holder, 'anchor', state.currentFrame);

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -4639,6 +4639,10 @@
   // unified multi-target box, or nothing selected at all) via the thin
   // wrapper below, not threaded through each of those branches.
   var _hoverLi = -1;
+  // Cheap fingerprint of the hovered layer's CURRENT bounds (2026-08-31) —
+  // see onHoverMove's own comment for why this exists alongside _hoverLi.
+  function hoverBoundsSig(b) { return b ? (b.x + ',' + b.y + ',' + b.w + ',' + b.h) : null; }
+  var _hoverBoundsSig = null;
   function hitTestLayerAt(pt, frame) {
     // Reverse (topmost-drawn-first) — same z-order convention the Null
     // marker hit-test already uses (select-bridge.js). Skips locked/hidden/
@@ -4657,11 +4661,34 @@
   }
   // Returns true when the hover target changed (caller re-renders only
   // then, avoiding a redraw on every pixel of idle mouse movement).
+  //
+  // "changed" used to mean ONLY "the hovered LAYER INDEX is different from
+  // last time" — but the box this drives (hoverOverlayItems) is drawn from
+  // that layer's CURRENT bounds, which can change out from under an
+  // unmoving mouse: drag that layer's elements apart in one gesture, exit,
+  // dive into a DIFFERENT layer's group, then come back to hover the first
+  // one — the index round-trips to the same value it already was (no drag
+  // ever runs onHoverMove at all, per the caller's own onDrag-first gate),
+  // so the box never got the redraw its now-stale geometry needed. Found
+  // live chasing Cyril's report + screenshot: a group's hover box stopped
+  // short of a rotated element sitting well outside the box's own stale
+  // extent. A second fingerprint (the bounds themselves, not just which
+  // layer they belong to) catches exactly this without paying for a
+  // redraw on every idle pixel of movement — the common case (mouse
+  // drifting inside one static layer) still short-circuits on the index
+  // check before this ever runs a comparison.
   function onHoverMove(pt) {
-    if (state.appMode !== 'motion') { var had = _hoverLi !== -1; _hoverLi = -1; return had; }
+    if (state.appMode !== 'motion') { var had = _hoverLi !== -1; _hoverLi = -1; _hoverBoundsSig = null; return had; }
     var li = hitTestLayerAt(pt, state.currentFrame);
-    if (li === _hoverLi) return false;
-    _hoverLi = li;
+    if (li !== _hoverLi) {
+      _hoverLi = li;
+      _hoverBoundsSig = li >= 0 ? hoverBoundsSig(layerWorldBoundsUnion([li], state.currentFrame)) : null;
+      return true;
+    }
+    if (li < 0) return false;
+    var sig = hoverBoundsSig(layerWorldBoundsUnion([li], state.currentFrame));
+    if (sig === _hoverBoundsSig) return false;
+    _hoverBoundsSig = sig;
     return true;
   }
   function hoverOverlayItems() {

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -5708,7 +5708,26 @@
           // rotated/scaled, so comparing a world point against it directly
           // would hit-test a rectangle that isn't the one on screen. inv()
           // exists for exactly this (it was added for vertex dragging).
-          var lp = gBody.inv(event.point.x, event.point.y);
+          //
+          // event.point must go through outerLocalPoint FIRST (2026-08-31
+          // fix) — motionBoxGeom's own inv is explicitly LOCAL-only (see its
+          // comment: "no outer wrapping... every caller composes that
+          // separately via outerWorldPoint/outerLocalPoint"), but this is
+          // the one caller in this file that fed it the raw world point
+          // directly. Every sibling grab just above (handles, position
+          // dots, anchor, effector) already wraps through outerWorldPoint/
+          // outerLocalPoint; this one, added later for feedback #170, never
+          // got the same treatment. Invisible as long as the CONTAINING
+          // layer had no Motion of its own — the two points coincide then —
+          // which is why it went unnoticed until Cyril moved a whole group
+          // and then tried to drag one of its elements: the box still drew
+          // in the right (rotated) place, but a click dead-center on it
+          // computed `lp` as if the layer had never moved, missing the
+          // element's own local bounds entirely. Measured: layer rotated
+          // 76.8°, click at the element's true rendered center — old code
+          // path declined every time; onDown now grabs it.
+          var outerPt = outerLocalPoint(t, { x: event.point.x, y: event.point.y });
+          var lp = gBody.inv(outerPt.x, outerPt.y);
           var bb = gBody.bounds;
           var insideEl = lp && lp.x >= bb.left && lp.x <= bb.right && lp.y >= bb.top && lp.y <= bb.bottom;
           if (insideEl) {

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -757,7 +757,18 @@
       if (window._motionExpandedElement != null || window._perObjBoxes === state.activeLayerIdx) {
         var lyrEx = userLayers[state.activeLayerIdx];
         var ptEx = new Point(w0[0], w0[1]);
-        var hitEx = lyrEx ? lyrEx.hitTest(ptEx, { fill: true, stroke: true, tolerance: 6 / view.zoom }) : null;
+        // Hit-test in the LAYER's own space (2026-08-31): its geometry never
+        // moves, the Motion transform is applied at render, so testing the
+        // raw world point misses every shape as soon as the layer is
+        // animated. perObjectUnionBounds below is already world-space and
+        // keeps ptEx. Measured with the layer moved/rotated/scaled: clicking
+        // a shape dead-centre targeted nothing.
+        // hitTestPosed undoes the layer's transform AND each element's own,
+        // per element — a plain layer.hitTest tests one point against
+        // geometry that several independent transforms have moved, so once
+        // two elements had been dragged apart inside the group, clicking
+        // either of them at its visible position matched nothing.
+        var hitEx = (lyrEx && window.hitTestPosed) ? hitTestPosed(state.activeLayerIdx, ptEx, 6 / view.zoom) : null;
         var itEx = hitEx && hitEx.item;
         while (itEx && itEx.parent && itEx.parent !== lyrEx) itEx = itEx.parent;
         var sidEx = itEx && itEx.data && itEx.data.strokeId;
@@ -1085,7 +1096,13 @@
     // handles above (xformMap) — so testing against geometry that never
     // actually moved uses a point in the space it still lives in.
     var hitPt = pt;
-    if (state.appMode === 'motion' && window.SMMotion) {
+    // No longer gated on Motion mode (2026-08-31): buildSceneJson applies a
+    // layer's motionMat in EITHER mode (CLAUDE.md §8), so an animated layer
+    // renders moved in Animation 2D too — and there the click was still
+    // tested against the un-moved geometry, so nothing could be selected
+    // where it visibly sits. Both call sites (left click and right click)
+    // get it, or the two would disagree about what is under the cursor.
+    if (window.SMMotion) {
       var hitMap = SMMotion.layerMotionPointMap(state.activeLayerIdx);
       // 3D layers (2026-07-29 fix) — layerMotionPointMap returns null for a
       // 3D-toggled layer even with real rotationX/rotationY set (it only
@@ -1095,8 +1112,19 @@
       if (!hitMap && SMMotion.layerMotion3DPointMap) hitMap = SMMotion.layerMotion3DPointMap(state.activeLayerIdx);
       if (hitMap) { var hg = hitMap.inv(pt.x, pt.y); hitPt = new Point(hg[0], hg[1]); }
     }
-    var hit = (activeLdForLock.locked && !activeLdForLock.symbolId) ? null : layer.hitTest(hitPt, { stroke: true, fill: true, tolerance: 8 / view.zoom });
-    if (hit && !combineHitConfirm(hit, hitPt, state.activeLayerIdx)) hit = null;
+    // Per-ELEMENT transforms on top of the layer's (2026-08-31): hitTestPosed
+    // undoes each child's own Motion for that child alone, which a single
+    // layer.hitTest cannot do — it tests one point against geometry that
+    // several independent transforms have moved. Measured in Animation 2D
+    // with the layer transformed AND the two elements dragged apart:
+    // clicking either at its visible position selected nothing. hitPt
+    // (layer-space) stays the fallback, and the posed test hands back the
+    // point in the element's own space for combineHitConfirm.
+    var posedHit = (window.hitTestPosed && !(activeLdForLock.locked && !activeLdForLock.symbolId))
+      ? hitTestPosed(state.activeLayerIdx, pt, 8 / view.zoom) : null;
+    var hit = posedHit || ((activeLdForLock.locked && !activeLdForLock.symbolId) ? null : layer.hitTest(hitPt, { stroke: true, fill: true, tolerance: 8 / view.zoom }));
+    var confirmPt = (posedHit && posedHit.localPoint) ? posedHit.localPoint : hitPt;
+    if (hit && !combineHitConfirm(hit, confirmPt, state.activeLayerIdx)) hit = null;
     var hitOtherLayerIdx = -1;
     // If nothing on the active layer, check every OTHER normal (non-
     // component) layer too — clicking a stroke that lives on layer 1 while
@@ -2435,7 +2463,13 @@
     // layer whole-instance click, brush-anchor resolution) so right-click
     // selects exactly what a left-click would.
     var hitPt = pt;
-    if (state.appMode === 'motion' && window.SMMotion) {
+    // No longer gated on Motion mode (2026-08-31): buildSceneJson applies a
+    // layer's motionMat in EITHER mode (CLAUDE.md §8), so an animated layer
+    // renders moved in Animation 2D too — and there the click was still
+    // tested against the un-moved geometry, so nothing could be selected
+    // where it visibly sits. Both call sites (left click and right click)
+    // get it, or the two would disagree about what is under the cursor.
+    if (window.SMMotion) {
       var hitMap = SMMotion.layerMotionPointMap(state.activeLayerIdx);
       // 3D layers (2026-07-29 fix) — layerMotionPointMap returns null for a
       // 3D-toggled layer even with real rotationX/rotationY set (it only
@@ -2445,8 +2479,19 @@
       if (!hitMap && SMMotion.layerMotion3DPointMap) hitMap = SMMotion.layerMotion3DPointMap(state.activeLayerIdx);
       if (hitMap) { var hg = hitMap.inv(pt.x, pt.y); hitPt = new Point(hg[0], hg[1]); }
     }
-    var hit = (activeLdForLock.locked && !activeLdForLock.symbolId) ? null : layer.hitTest(hitPt, { stroke: true, fill: true, tolerance: 8 / view.zoom });
-    if (hit && !combineHitConfirm(hit, hitPt, state.activeLayerIdx)) hit = null;
+    // Per-ELEMENT transforms on top of the layer's (2026-08-31): hitTestPosed
+    // undoes each child's own Motion for that child alone, which a single
+    // layer.hitTest cannot do — it tests one point against geometry that
+    // several independent transforms have moved. Measured in Animation 2D
+    // with the layer transformed AND the two elements dragged apart:
+    // clicking either at its visible position selected nothing. hitPt
+    // (layer-space) stays the fallback, and the posed test hands back the
+    // point in the element's own space for combineHitConfirm.
+    var posedHit = (window.hitTestPosed && !(activeLdForLock.locked && !activeLdForLock.symbolId))
+      ? hitTestPosed(state.activeLayerIdx, pt, 8 / view.zoom) : null;
+    var hit = posedHit || ((activeLdForLock.locked && !activeLdForLock.symbolId) ? null : layer.hitTest(hitPt, { stroke: true, fill: true, tolerance: 8 / view.zoom }));
+    var confirmPt = (posedHit && posedHit.localPoint) ? posedHit.localPoint : hitPt;
+    if (hit && !combineHitConfirm(hit, confirmPt, state.activeLayerIdx)) hit = null;
     var clickedPath = null;
     if (hit && (hit.item instanceof Path || hit.item instanceof Raster)) {
       clickedPath = resolveBrushAnchor(hit.item, layer);

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -68,6 +68,15 @@
   // fresh scan rather than trusting the last hover result). Topmost child
   // first, same z-order convention as Paper's own hitTest.
   function hitTestOrientedBoxA2D(pt, targetLayer) {
+    // The boxes are built from RAW geometry (orientedBoxForPath), so the
+    // world click has to come back into the layer's own space first
+    // (2026-08-31). Without it, a layer under any Motion transform drew its
+    // boxes in one place and tested clicks in another: measured with the
+    // layer moved +300/-200, a click dead on the shape landed at world
+    // (2269,142) against a box at [1820,301,2060,481] — no hit, so the drag
+    // never started and the shape "could be selected but not moved".
+    var liOB = userLayers.indexOf(targetLayer);
+    if (liOB >= 0 && window.layerLocalPoint) pt = layerLocalPoint(liOB, pt);
     var kids = targetLayer.children;
     for (var i = kids.length - 1; i >= 0; i--) {
       var c = kids[i];
@@ -377,6 +386,16 @@
   var rotCenter = null, rotStartAngle = 0, rotLastAngle = 0;
   var marqueeStart = null;
   var moveStarted = false;
+  // The grabbed point, in the LAYER's own space, tracked through the whole
+  // move gesture (2026-08-31). Needed because a layer's Motion pivot is
+  // userLayers[i].bounds.center — DERIVED FROM THE CONTENT — so translating
+  // a shape moves the pivot, which rotates/scales the whole layer around a
+  // new centre and lands the dragged shape somewhere other than under the
+  // cursor. Measured with the layer at rotation 25°: a geometry delta of
+  // (240,42) drifted the pivot by (154,21) and moved the shape (223,76) on
+  // screen where (200,139) was asked for. Knowing where the grab point
+  // WENT lets the move correct itself against where it should be.
+  var moveGrabLocal = null;
   var draggingArc = null;
   var arcDragCache = null;
   var ANCHOR_MAP = { nw: 'se', ne: 'sw', sw: 'ne', se: 'nw', n: 's', s: 'n', e: 'w', w: 'e' };
@@ -515,6 +534,15 @@
   function hitTestHandles(pt, altHeld) {
     var h = computeHandles();
     if (!h) return null;
+    // NOTE (2026-08-31): `pt` stays in WORLD space here on purpose.
+    // computeHandles already maps its corners/ring/anchor through the
+    // layer's Motion transform (its own `WP` helper), so both sides are
+    // world-space and agree. Converting the point here — as
+    // hitTestOrientedBoxA2D genuinely must, since orientedBoxForPath is
+    // raw geometry — was tried and broke the drag outright: with a
+    // selection live, the mismatched point matched a handle, onDown took
+    // the handle branch and never reached the branch that sets mode
+    // 'move', so a shape could be selected and then not moved at all.
     var tol = 9 / view.zoom;
     // Anchor crosshair — checked FIRST/exclusively, but ONLY while Alt is
     // held (live feedback 2026-07: "ça peut être confusant quand il faut
@@ -1775,6 +1803,8 @@
           o.layer.children.forEach(function (c) { if (c.data && c.data.strokeId === o.strokeId && selectedPaths.indexOf(c) < 0) selectedPaths.push(c); });
         });
         moveStarted = true;
+        moveGrabLocal = (window.layerLocalPoint && state.appMode !== 'motion')
+          ? layerLocalPoint(state.activeLayerIdx, lastPt) : null;
       }
       var delta = pt.subtract(lastPt);
       // Layer under a Motion transform: the pointer moves in RENDERED
@@ -1839,6 +1869,11 @@
       // space), so switch to it here rather than touching every one of
       // the several `delta` reads below individually.
       delta = geomDelta;
+      // Applied through a function so the residual correction below can run
+      // the exact same work a second time — every companion, gradient,
+      // centerline and anchor has to move with it, and a correction that
+      // skipped any of them would tear the drawing apart.
+      var appliquerDelta = function (d) {
       // translate(delta), not position=position.add(delta) — .position is
       // a bounds-CENTER getter/setter, so a move via .position re-derives
       // bounds on every single tick of the drag (many times per gesture)
@@ -1853,15 +1888,15 @@
       // N ticks of translate(delta) is always bit-identical to one
       // translate(delta*N) — zero accumulated drift by construction.
       selectedPaths.forEach(function (p) {
-        p.translate(delta);
-        if (window.syncParamShapeBoxOnTranslate) window.syncParamShapeBoxOnTranslate(p, delta.x, delta.y);
-        transformFillGradient(p, function (gp) { return gp.add(delta); });
+        p.translate(d);
+        if (window.syncParamShapeBoxOnTranslate) window.syncParamShapeBoxOnTranslate(p, d.x, d.y);
+        transformFillGradient(p, function (gp) { return gp.add(d); });
         if (p.data && p.data.isVectorBrush && p.data.centerSegments) {
-          p.data.centerSegments.forEach(function (s) { s.point = [s.point[0] + delta.x, s.point[1] + delta.y]; });
+          p.data.centerSegments.forEach(function (s) { s.point = [s.point[0] + d.x, s.point[1] + d.y]; });
         }
-        if (p.data && p.data.linkedFill && !p.data.linkedFill.removed) p.data.linkedFill.translate(delta);
+        if (p.data && p.data.linkedFill && !p.data.linkedFill.removed) p.data.linkedFill.translate(d);
         if (p.data && p.data.brushCompanions) {
-          p.data.brushCompanions.forEach(function (c) { if (!c.removed) c.translate(delta); });
+          p.data.brushCompanions.forEach(function (c) { if (!c.removed) c.translate(d); });
         }
         // Custom anchor point (2026-07: "on déplace un point d'ancrage avec
         // alt et l'on bouge l'objet après ... celui-ci ne se déplace pas
@@ -1871,17 +1906,38 @@
         // translated explicitly here or it's left stranded at its old
         // position the moment the shape moves out from under it.
         if (p.data && p.data.xformAnchorCustom) {
-          p.data.xformAnchorCustom = [p.data.xformAnchorCustom[0] + delta.x, p.data.xformAnchorCustom[1] + delta.y];
+          p.data.xformAnchorCustom = [p.data.xformAnchorCustom[0] + d.x, p.data.xformAnchorCustom[1] + d.y];
         }
       });
-      // Same fix for the session-level anchor (state.xformAnchorCustom) the
-      // on-canvas crosshair/gizmo actually reads (tools.js's xformAnchorPoint)
-      // — a single global value, translated once per move tick rather than
-      // once per selected path.
       if (state.xformAnchorCustom) {
-        state.xformAnchorCustom = [state.xformAnchorCustom[0] + delta.x, state.xformAnchorCustom[1] + delta.y];
+        state.xformAnchorCustom = [state.xformAnchorCustom[0] + d.x, state.xformAnchorCustom[1] + d.y];
       }
-      symGestureAccumulate(new Matrix().translate(delta));
+      symGestureAccumulate(new Matrix().translate(d));
+      if (moveGrabLocal) moveGrabLocal = moveGrabLocal.add(d);
+      };
+      appliquerDelta(delta);
+      // Residual correction: aim at the RESULT ON SCREEN, not at the
+      // geometry. Only when the layer actually rotates or scales — with a
+      // pure translation the pivot drift cancels out exactly (the maths
+      // reduce to screen delta == geometry delta), which is why a moved
+      // layer always dragged correctly and a rotated one never did.
+      // Two passes are enough: each one removes the pivot drift caused by
+      // the previous, and the drift is a fraction of the delta, so it
+      // converges immediately. Bailing out under half a pixel keeps a
+      // normal drag at exactly one pass.
+      if (moveGrabLocal && window.SMMotion && SMMotion.layerMotionPointMap) {
+        for (var passe = 0; passe < 2; passe++) {
+          var mapNow = SMMotion.layerMotionPointMap(state.activeLayerIdx);
+          if (!mapNow || !mapNow.fwd || !mapNow.invVec) break;
+          var atterri = mapNow.fwd(moveGrabLocal.x, moveGrabLocal.y);
+          var ax = (atterri.x !== undefined ? atterri.x : atterri[0]);
+          var ay = (atterri.y !== undefined ? atterri.y : atterri[1]);
+          var rx = pt.x - ax, ry = pt.y - ay;
+          if (Math.abs(rx) < 0.5 && Math.abs(ry) < 0.5) break;
+          var cv2 = mapNow.invVec(rx, ry);
+          appliquerDelta(new Point(cv2[0], cv2[1]));
+        }
+      }
     } else if (mode === 'xform-scale') {
       // Geometry-space pointer (NOT reassigning pt — lastPt at the end of
       // this handler must stay world-space).

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -811,6 +811,28 @@
           window._motionExpandedElement = sidEx;
           window._perObjBoxes = state.activeLayerIdx;
           if (SMMotion.selectShapesByStrokeIds) SMMotion.selectShapesByStrokeIds(state.activeLayerIdx, [sidEx]);
+          // Re-run onDown now that the target has actually switched to the
+          // sibling under the cursor (2026-08-31 follow-up, "je déplace un
+          // éléments et que dans le même groupe je déplace un autre élément
+          // l'autre éléments ne déplace que la box et pas la shape"). The
+          // SMMotion.onDown call above (this file's own top-of-onDown, a few
+          // lines up) ran BEFORE _motionExpandedElement was updated, so its
+          // body-hit-test always compared the click against the OLD target's
+          // box — a click on a sibling is never inside that box, so it fell
+          // through to plain re-targeting every time and this whole block
+          // just consumed the event. A click-and-drag done as one continuous
+          // gesture (mousedown then move without releasing — the normal way
+          // to select-and-drag in any design tool) therefore relocated the
+          // box to the sibling's real, UNMOVED position and then dragged
+          // nothing: no _motionDrag was ever created, so the following
+          // pointermoves had nothing to act on and setValue was never
+          // called — confirmed live, ld.elementMotion[sidEx] stayed `{}`
+          // after a full press-drag-release. One retry with the NOW-current
+          // target lets onDown's own body-hit-test (bottom of the function)
+          // match this same click and start 'elementMove' properly, so the
+          // single gesture both selects AND drags the sibling, like every
+          // other grab in this file already does for the FIRST element.
+          SMMotion.onDown({ point: ptEx, altKey: e.altKey });
         } else if (!sidEx) {
           var uEx = (lyrEx && window.perObjectUnionBounds) ? perObjectUnionBounds(lyrEx) : null;
           window._motionExpandedElement = null;

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -1300,6 +1300,52 @@
         }
       }
     }
+    // Motion's own version of the fallback just above (2026-08-31 follow-up
+    // to the same feedback that built it — "peu importe où on clic dans la
+    // boîte de hover si celle-ci est affiché ça doit select le group"). The
+    // gate above assumed SMMotion.onDown() already covered every Motion
+    // click, but onDown only grabs handles/dots/anchors on the CURRENT
+    // target; a plain click elsewhere within a layer's own shown box
+    // (layerWorldBoundsUnion — the exact bounds hoverOverlayItems draws,
+    // motion.js) still fell through to the precise per-child hitTest above,
+    // which misses in the gap between two elements or near a corner the box
+    // covers but no ink reaches. Found live chasing "impossible de
+    // reselect parfois, j'arrive pas à savoir quand": once two elements
+    // inside a group have been dragged apart, their combined box has a lot
+    // of empty middle that LOOKS selectable (it's the box actually drawn)
+    // but wasn't. Null/native-video/Component layers are excluded — each
+    // already has its own dedicated, better-tailored hit-test a few lines
+    // below (nullHit/nvHit/compHit), which only runs `if (!hit)`; matching
+    // them here first would silently skip that specialized handling.
+    if (!hit && state.appMode === 'motion' && window.SMMotion && window.SMMotion.layerWorldBoundsUnion) {
+      var motionLayerBoxHit = function (li) {
+        var mld = state.layers[li];
+        if (!mld || mld.locked || !mld.visible || mld.threeD || mld.symbolId || mld.isNullLayer || mld.nativeVideo) return null;
+        var mb = SMMotion.layerWorldBoundsUnion([li], state.currentFrame);
+        if (!mb || pt.x < mb.x || pt.x > mb.x + mb.w || pt.y < mb.y || pt.y > mb.y + mb.h) return null;
+        var mul = userLayers[li];
+        if (!mul) return null;
+        for (var mci = mul.children.length - 1; mci >= 0; mci--) {
+          var mc = mul.children[mci];
+          if (!(mc instanceof Path || mc instanceof Raster)) continue;
+          if (mc.data && (mc.data.isLinkedFillCompanion || mc.data.isBrushTextureCopy || mc.data.isDuplicatorCopy)) continue;
+          return mc;
+        }
+        return null;
+      };
+      var mActiveHit = motionLayerBoxHit(state.activeLayerIdx);
+      if (mActiveHit) {
+        hit = { item: mActiveHit };
+      } else {
+        for (var mpli = project.layers.length - 1; mpli >= 0; mpli--) {
+          var mpl = project.layers[mpli];
+          var moli = userLayers.indexOf(mpl);
+          if (moli < 0 || moli === state.activeLayerIdx) continue;
+          var mItemHit = motionLayerBoxHit(moli);
+          if (mItemHit) { hit = { item: mItemHit }; hitOtherLayerIdx = moli; break; }
+        }
+      }
+    }
 
     if (!hit) {
       // Selected video's transform handles FIRST (2026-07, full gizmo —

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -806,6 +806,7 @@
         // space still INSIDE the group box drops back to "all boxes, none
         // targeted" (you are still in the group, Illustrator-style); only a
         // click outside the box leaves it.
+        var sortiDuGroupe = false;
         if (sidEx && sidEx !== window._motionExpandedElement) {
           window._motionExpandedElement = sidEx;
           window._perObjBoxes = state.activeLayerIdx;
@@ -813,14 +814,23 @@
         } else if (!sidEx) {
           var uEx = (lyrEx && window.perObjectUnionBounds) ? perObjectUnionBounds(lyrEx) : null;
           window._motionExpandedElement = null;
-          if (!uEx || !uEx.contains(ptEx)) window._perObjBoxes = null;
+          if (!uEx || !uEx.contains(ptEx)) { window._perObjBoxes = null; sortiDuGroupe = true; }
         }
         window._sceneVersion = (window._sceneVersion || 0) + 1;
         if (window.renderLayerList) renderLayerList();
         if (window.renderTimeline) renderTimeline();
         window.SMEngineBridge.renderNow();
-        e.stopImmediatePropagation(); e.preventDefault();
-        return;
+        // Leaving the group must NOT eat the click (2026-08-31, feedback en
+        // Motion: "je ressort en cliquant ailleurs ... j'essaye de clic sur
+        // l'autre groupe dans l'autre layer alors il select le premier
+        // groupe"). Exiting is a side effect of clicking somewhere else, not
+        // the point of the gesture: the click still means "select whatever
+        // is here", which may well be a shape on another layer. Consuming it
+        // forced a second click, and the first one appeared to do nothing —
+        // or worse, left the old group selected. Every other outcome of this
+        // block (targeting a sibling, dropping the target while staying in
+        // the group) IS the whole gesture, so those still consume it.
+        if (!sortiDuGroupe) { e.stopImmediatePropagation(); e.preventDefault(); return; }
       }
     }
     if (!shouldIntercept()) return;
@@ -1148,9 +1158,17 @@
     // clicking either at its visible position selected nothing. hitPt
     // (layer-space) stays the fallback, and the posed test hands back the
     // point in the element's own space for combineHitConfirm.
-    var posedHit = (window.hitTestPosed && !(activeLdForLock.locked && !activeLdForLock.symbolId))
-      ? hitTestPosed(state.activeLayerIdx, pt, 8 / view.zoom) : null;
-    var hit = posedHit || ((activeLdForLock.locked && !activeLdForLock.symbolId) ? null : layer.hitTest(hitPt, { stroke: true, fill: true, tolerance: 8 / view.zoom }));
+    var posedDispo = !!window.hitTestPosed && !(activeLdForLock.locked && !activeLdForLock.symbolId);
+    var posedHit = posedDispo ? hitTestPosed(state.activeLayerIdx, pt, 8 / view.zoom) : null;
+    // No raw fallback once the posed test has spoken (2026-08-31): it tests
+    // the shapes where they are DRAWN, so "no hit" means the cursor really is
+    // over nothing on this layer. Falling back to layer.hitTest(hitPt) then
+    // re-tested the same click against the layer's UN-posed geometry, which
+    // for a transformed layer sits somewhere else entirely — a click on
+    // another layer's shape matched a shape of the active layer and selected
+    // it instead. That is the "il select le premier groupe" report. The raw
+    // test only remains for the case where the posed one could not run.
+    var hit = posedDispo ? posedHit : ((activeLdForLock.locked && !activeLdForLock.symbolId) ? null : layer.hitTest(hitPt, { stroke: true, fill: true, tolerance: 8 / view.zoom }));
     var confirmPt = (posedHit && posedHit.localPoint) ? posedHit.localPoint : hitPt;
     if (hit && !combineHitConfirm(hit, confirmPt, state.activeLayerIdx)) hit = null;
     var hitOtherLayerIdx = -1;
@@ -2543,9 +2561,17 @@
     // clicking either at its visible position selected nothing. hitPt
     // (layer-space) stays the fallback, and the posed test hands back the
     // point in the element's own space for combineHitConfirm.
-    var posedHit = (window.hitTestPosed && !(activeLdForLock.locked && !activeLdForLock.symbolId))
-      ? hitTestPosed(state.activeLayerIdx, pt, 8 / view.zoom) : null;
-    var hit = posedHit || ((activeLdForLock.locked && !activeLdForLock.symbolId) ? null : layer.hitTest(hitPt, { stroke: true, fill: true, tolerance: 8 / view.zoom }));
+    var posedDispo = !!window.hitTestPosed && !(activeLdForLock.locked && !activeLdForLock.symbolId);
+    var posedHit = posedDispo ? hitTestPosed(state.activeLayerIdx, pt, 8 / view.zoom) : null;
+    // No raw fallback once the posed test has spoken (2026-08-31): it tests
+    // the shapes where they are DRAWN, so "no hit" means the cursor really is
+    // over nothing on this layer. Falling back to layer.hitTest(hitPt) then
+    // re-tested the same click against the layer's UN-posed geometry, which
+    // for a transformed layer sits somewhere else entirely — a click on
+    // another layer's shape matched a shape of the active layer and selected
+    // it instead. That is the "il select le premier groupe" report. The raw
+    // test only remains for the case where the posed one could not run.
+    var hit = posedDispo ? posedHit : ((activeLdForLock.locked && !activeLdForLock.symbolId) ? null : layer.hitTest(hitPt, { stroke: true, fill: true, tolerance: 8 / view.zoom }));
     var confirmPt = (posedHit && posedHit.localPoint) ? posedHit.localPoint : hitPt;
     if (hit && !combineHitConfirm(hit, confirmPt, state.activeLayerIdx)) hit = null;
     var clickedPath = null;

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -799,6 +799,25 @@
         var hitEx = (lyrEx && window.hitTestPosed) ? hitTestPosed(state.activeLayerIdx, ptEx, 6 / view.zoom) : null;
         var itEx = hitEx && hitEx.item;
         while (itEx && itEx.parent && itEx.parent !== lyrEx) itEx = itEx.parent;
+        // Route through resolveBrushAnchor (tools.js) before reading strokeId
+        // (2026-08-31 follow-up) — a vector brush's linked-fill companion
+        // (data.isLinkedFillCompanion) is a separate live Paper item with its
+        // OWN strokeId, and topmost z-order sometimes puts it in front of the
+        // anchor at the exact pixel clicked (same "des fois ça sélectionne le
+        // tout des fois juste le fill" inconsistency resolveBrushAnchor was
+        // already written to fix for every OTHER click path — this isolation
+        // block had its own separate itEx.data.strokeId read that never went
+        // through it). Per-element Motion is only ever recorded under the
+        // ANCHOR's strokeId (motion.js's layerElements folds the companion
+        // out of the Elements list) — without this, a click that happened to
+        // land on the companion created a SECOND, independent
+        // ld.elementMotion entry keyed by the companion's own strokeId, and
+        // now that a click-drag actually moves things (the fix above this
+        // block), dragging it split the fill away from its own outline.
+        // Found live: after two drags the companion's motionStatic.position
+        // was [-96.9,192.1] while the anchor's was [-101.5,338.8] — same
+        // stroke, two different places, reading as two separate wavy shapes.
+        itEx = (window.resolveBrushAnchor && lyrEx) ? resolveBrushAnchor(itEx, lyrEx) : itEx;
         var sidEx = itEx && itEx.data && itEx.data.strokeId;
         // Clicking a SIBLING hands the isolation over to it rather than
         // ending it — same continuity Animation 2D's per-object mode has, and

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -1317,6 +1317,10 @@
     // already has its own dedicated, better-tailored hit-test a few lines
     // below (nullHit/nvHit/compHit), which only runs `if (!hit)`; matching
     // them here first would silently skip that specialized handling.
+    // Set when the fallback below is the ONLY reason `hit` is truthy — read
+    // much further down (mode = ... 'move') to keep this a pure SELECT, not
+    // also a drag start. See that read site's own comment for why.
+    var motionBoxFallbackOnly = false;
     if (!hit && state.appMode === 'motion' && window.SMMotion && window.SMMotion.layerWorldBoundsUnion) {
       var motionLayerBoxHit = function (li) {
         var mld = state.layers[li];
@@ -1336,13 +1340,14 @@
       var mActiveHit = motionLayerBoxHit(state.activeLayerIdx);
       if (mActiveHit) {
         hit = { item: mActiveHit };
+        motionBoxFallbackOnly = true;
       } else {
         for (var mpli = project.layers.length - 1; mpli >= 0; mpli--) {
           var mpl = project.layers[mpli];
           var moli = userLayers.indexOf(mpl);
           if (moli < 0 || moli === state.activeLayerIdx) continue;
           var mItemHit = motionLayerBoxHit(moli);
-          if (mItemHit) { hit = { item: mItemHit }; hitOtherLayerIdx = moli; break; }
+          if (mItemHit) { hit = { item: mItemHit }; hitOtherLayerIdx = moli; motionBoxFallbackOnly = true; break; }
         }
       }
     }
@@ -1596,7 +1601,24 @@
         if (!skipGroupWiden) clickedSet.forEach(function (m) { if (selectedPaths.indexOf(m) < 0) selectedPaths.push(m); });
       }
       state.selectedStrokeIndices = selectedPaths.map(getSI).filter(function (i2) { return i2 >= 0; });
-      mode = selectedPaths.length ? 'move' : null;
+      // motionBoxFallbackOnly (set above): this hit came ONLY from clicking
+      // inside a layer's shown box, not from landing on real ink — the
+      // fallback's own job is SELECT ("ça doit select le group"), same as
+      // its A2D precedent. Letting it also arm a drag turned every
+      // near-miss inside (or just after leaving) a group into a silent
+      // WHOLE-LAYER move: found live chasing "entrée double clic >
+      // impossible de déplacer les éléments" — a click aimed at an element
+      // but landing outside its own small box exits the group (previous
+      // commit) and, with mode='move' armed here, immediately started
+      // dragging the entire layer on the very same gesture instead of
+      // either grabbing the element or doing nothing. ld.elementMotion for
+      // both elements stayed `{}` while ld.motionStatic.position picked up
+      // every one of these misses — moving together is not the same bug as
+      // not moving at all, but it read exactly like "impossible de
+      // déplacer les éléments" from the canvas. A precise hit (this flag
+      // false) is unaffected — that path already worked and still starts a
+      // drag immediately, matching every other grab in this file.
+      mode = (selectedPaths.length && !(state.appMode === 'motion' && motionBoxFallbackOnly)) ? 'move' : null;
       moveStarted = false;
       _multiLayerDrag = null;
     } else {

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -855,7 +855,26 @@
         } else if (!sidEx) {
           var uEx = (lyrEx && window.perObjectUnionBounds) ? perObjectUnionBounds(lyrEx) : null;
           window._motionExpandedElement = null;
-          if (!uEx || !uEx.contains(ptEx)) { window._perObjBoxes = null; sortiDuGroupe = true; }
+          if (!uEx || !uEx.contains(ptEx)) {
+            window._perObjBoxes = null;
+            sortiDuGroupe = true;
+            // _motionExpandedLayer is a THIRD flag (tools.js's double-click
+            // group entry sets it alongside _perObjBoxes, motion.js:5409) —
+            // activeMotionTarget() prefers it over state.activeLayerIdx
+            // whenever it's non-null, so leaving it behind here meant the
+            // canvas gizmo kept drawing THIS layer's box forever after
+            // exiting, even once a different layer had genuinely become
+            // active (row highlight, Layer Properties panel, selectedPaths
+            // all correctly showed the new layer — only the canvas box and
+            // the timeline's own row highlight, which reads this same flag,
+            // stayed stuck). Found live: exit Layer 2's group, click Layer
+            // 1's shape — state.activeLayerIdx became 0 right away, but
+            // window._motionExpandedLayer stayed 1, so the gizmo kept
+            // hugging Layer 2 no matter what got selected afterward. Scoped
+            // to the layer actually being exited, matching _perObjBoxes'
+            // own scoping just above.
+            if (window._motionExpandedLayer === state.activeLayerIdx) window._motionExpandedLayer = null;
+          }
         }
         window._sceneVersion = (window._sceneVersion || 0) + 1;
         if (window.renderLayerList) renderLayerList();

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1429,6 +1429,23 @@ window.SM={
     });
     activateUL(ni);_layerSel=[ni];_layerSelAnchor=ni;loadFrame(state.currentFrame);updateUI();},
   setActiveLayer:function(idx,preserveLayerSel){if(idx<0||idx>=state.layers.length)return;saveAllLayerFrames();activateUL(idx);clearSel();
+    // Release Motion's per-element group isolation when it belongs to a
+    // DIFFERENT layer than the one being picked (2026-08-31, Cyril: "quand
+    // je select le groupe de gauche pourquoi le layer 2 reste highlighté
+    // dans la timeline" — no double-click involved, a plain row click).
+    // select-bridge.js's canvas click path already clears these three flags
+    // on exit, but this function is the CANONICAL entry point for every
+    // OTHER way to switch layers (a timeline row click chief among them,
+    // per this function's own comment below) — none of those ever went
+    // through that canvas code, so a group entered on layer N stayed
+    // "entered" (_perObjBoxes/_motionExpandedLayer still N) forever after,
+    // even once a totally different layer's row was clicked straight in
+    // the panel — its Elements tree kept rendering expanded with no way to
+    // close it short of re-entering and manually backing out. Scoped to
+    // "picking a DIFFERENT layer" so re-clicking the currently-isolated
+    // layer's own row is still a no-op, same as the canvas path.
+    if (window._perObjBoxes != null && window._perObjBoxes !== idx) { window._perObjBoxes = null; window._motionExpandedElement = null; }
+    if (window._motionExpandedLayer != null && window._motionExpandedLayer !== idx) window._motionExpandedLayer = null;
     window._layerActiveExplicit=true; // see clearSel()'s own comment — an explicit timeline row click, not a canvas deselect
     // canonical entry point: every caller (canvas hit, camera/media-library/nemo-script/shapes-panel)
     // gets the row highlight for free. preserveLayerSel=true is for the row's own Cmd/Shift-click

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -1144,11 +1144,35 @@ function selBoxAngleOf(){
   }
   return a||0;
 }
+// Posed union of the current selection, or null when nothing in it carries
+// an element-level Motion transform (2026-08-31). Deliberately narrow: the
+// DRAWN box has to sit on the artwork once an element has been moved with
+// Motion, but xformSelBounds also feeds the panel's Position/Size fields and
+// the move/scale WRITE math, which operate on raw geometry — so this is used
+// for the box only, and only in the case that was actually wrong.
+function posedSelBoundsIfMoved(){
+  if(!window.elementPosedBounds||!selectedPaths.length)return null;
+  var b=null,bouge=false;
+  for(var i=0;i<selectedPaths.length;i++){
+    var p=selectedPaths[i];
+    if(!p||!p.bounds||!p.parent)continue;
+    var eb=elementPosedBounds(p.parent,p);
+    if(Math.abs(eb.x-p.strokeBounds.x)>0.01||Math.abs(eb.y-p.strokeBounds.y)>0.01
+      ||Math.abs(eb.width-p.strokeBounds.width)>0.01||Math.abs(eb.height-p.strokeBounds.height)>0.01)bouge=true;
+    b=b?b.unite(eb):eb.clone();
+  }
+  return bouge?b:null;
+}
 function orientedSelBox(){
   if(!selectedPaths.length)return null;
-  var b0=xformSelBounds();if(!b0)return null;
+  var posed=posedSelBoundsIfMoved();
+  var b0=posed||xformSelBounds();if(!b0)return null;
   var ang=selBoxAngleOf();
   if(!ang)return{b:b0,angle:0,pivot:b0.center};
+  // A posed selection keeps the axis-aligned posed union: the per-path
+  // counter-rotation below reads each path's RAW geometry, which is exactly
+  // what the pose has moved away from.
+  if(posed)return{b:posed,angle:ang,pivot:posed.center};
   var pivot=b0.center,b=null;
   selectedPaths.forEach(function(p){
     if(!p||!p.bounds)return;
@@ -7620,11 +7644,114 @@ function elementPosedBounds(layer,c){
   });
   return new Rectangle(new Point(minX,minY),new Point(maxX,maxY));
 }
+// Union of the layer's elements AFTER their own transforms but BEFORE the
+// layer's — i.e. still in the layer's own space. This is the box the layer
+// gizmo should hug: Motion's motionBoxGeom and Animation 2D's selection box
+// both applied the layer transform themselves to a RAW union, so moving two
+// elements apart inside the group left the global box at its old size while
+// the elements visibly spread out of it (measured: drawn box unchanged at
+// [830,332,1772,447] while the real extent grew to [510,-240,2112,1039]).
+// Returns null when the layer has fewer than one usable shape, so callers
+// can fall back to their previous source.
+function perObjectPosedUnionLocal(layer){
+  var sh=perObjectShapesOf(layer),b=null;
+  sh.forEach(function(c){var eb=elementPosedBounds(layer,c);b=b?b.unite(eb):eb.clone();});
+  return sh.length?b:null;
+}
+window.perObjectPosedUnionLocal=perObjectPosedUnionLocal;
 function perObjectUnionBounds(layer){
   var sh=perObjectShapesOf(layer),b=null;
   sh.forEach(function(c){var eb=elementPosedBounds(layer,c);b=b?b.unite(eb):eb.clone();});
-  return sh.length>=2?b:null;
+  if(sh.length<2)return null;
+  // ...then through the LAYER's own Motion transform (2026-08-31): moving the
+  // LAYER left this region behind while the per-element boxes drawn on screen
+  // followed it, so after a layer move you had to double-click where the
+  // shapes USED to be to enter the group, and clicking on them counted as
+  // "outside" and exited. Measured in both modes: boxes moved +400/-300 with
+  // the layer, this union did not move at all.
+  //
+  // elementPosedBounds deliberately stays element-only: engine-bridge and
+  // motion.js apply layerMotionPointMap themselves on top of it when drawing,
+  // so folding the layer map in there would apply it twice. Composed once,
+  // here, for the hit region — which is the one consumer that needs the full
+  // chain in a single value.
+  if(!(window.SMMotion&&SMMotion.layerMotionPointMap))return b;
+  var li=userLayers.indexOf(layer);
+  if(li<0)return b;
+  var map=SMMotion.layerMotionPointMap(li);
+  if(!map||!map.fwd)return b;
+  var pts=[map.fwd(b.left,b.top),map.fwd(b.right,b.top),map.fwd(b.right,b.bottom),map.fwd(b.left,b.bottom)];
+  var xs=pts.map(function(p){return p.x!==undefined?p.x:p[0];});
+  var ys=pts.map(function(p){return p.y!==undefined?p.y:p[1];});
+  return new Rectangle(new Point(Math.min.apply(null,xs),Math.min.apply(null,ys)),
+                       new Point(Math.max.apply(null,xs),Math.max.apply(null,ys)));
 }
+// A world point expressed in a layer's OWN (raw, untransformed) space —
+// the space its geometry actually lives in (2026-08-31). A layer's Motion
+// transform is applied at RENDER time and never touches the stored points,
+// so hit-testing a click straight against layer.hitTest tests the shape
+// where it used to be. Measured with the layer moved +380/-260, rotated 18°
+// and scaled 120%: clicking a shape dead-centre on screen selected nothing,
+// in BOTH modes.
+//
+// Same inverse select-bridge's main click path already used — but it applied
+// it only when state.appMode==='motion', even though buildSceneJson applies
+// motionMat to any layer in any mode (CLAUDE.md §8). 3D layers need the
+// dedicated perspective-correct map, exactly as that call site documents.
+function layerLocalPoint(li,pt){
+  if(!window.SMMotion||!SMMotion.layerMotionPointMap)return pt;
+  var map=SMMotion.layerMotionPointMap(li);
+  if(!map&&SMMotion.layerMotion3DPointMap)map=SMMotion.layerMotion3DPointMap(li);
+  if(!map||!map.inv)return pt;
+  var g=map.inv(pt.x,pt.y);
+  return new Point(g[0],g[1]);
+}
+window.layerLocalPoint=layerLocalPoint;
+// A point already in LAYER space, expressed in ONE element's own space —
+// i.e. undoing that element's own Motion transform (2026-08-31). Exact
+// inverse of transformSegments (motion.js): scale about the pivot, rotate
+// about the pivot, translate last, so undoing means subtracting the
+// translation, unrotating and unscaling about that same pivot. The pivot is
+// the item's own bounds centre offset by the anchor — the same one
+// buildSceneJson and export.js compute.
+function elementLocalPoint(layer,c,pt){
+  if(!window.SMMotion||!SMMotion.elementMotionAt)return pt;
+  var li=userLayers.indexOf(layer);
+  var sid=c.data&&c.data.strokeId;
+  if(li<0||!sid)return pt;
+  var m=SMMotion.elementMotionAt(li,sid,state.currentFrame);
+  if(!m)return pt;
+  if(!m.dx&&!m.dy&&!m.rot&&m.sx===1&&m.sy===1)return pt;
+  var pc=c.bounds.center;
+  var px=pc.x+(m.ax||0), py=pc.y+(m.ay||0);
+  var x=pt.x-(m.dx||0)-px, y=pt.y-(m.dy||0)-py;
+  var a=-(m.rot||0)*Math.PI/180, ca=Math.cos(a), sa=Math.sin(a);
+  var rx=x*ca-y*sa, ry=x*sa+y*ca;
+  var sx=m.sx||1, sy=m.sy||1;
+  return new Point(px+(sx?rx/sx:rx), py+(sy?ry/sy:ry));
+}
+// Hit-test a WORLD point against what is actually DRAWN: the layer's own
+// transform undone once, then each child's own transform undone for that
+// child alone. layer.hitTest cannot do this — it tests one point against
+// geometry that several different transforms may have moved independently.
+// Symptom without it: after dragging two elements apart inside a group,
+// clicking either of them at its visible position targeted nothing.
+// Topmost-first, matching Paper's own hitTest z-order convention.
+function hitTestPosed(li,worldPt,tol){
+  var layer=userLayers[li];
+  if(!layer)return null;
+  var lp=layerLocalPoint(li,worldPt);
+  for(var i=layer.children.length-1;i>=0;i--){
+    var c=layer.children[i];
+    if(!c||!c.data)continue;
+    var ep=elementLocalPoint(layer,c,lp);
+    var h=c.hitTest(ep,{fill:true,stroke:true,tolerance:tol});
+    if(h)return {item:c,localPoint:ep};
+  }
+  return null;
+}
+window.elementLocalPoint=elementLocalPoint;
+window.hitTestPosed=hitTestPosed;
 window.perObjectShapesOf=perObjectShapesOf;
 window.elementPosedBounds=elementPosedBounds;
 window.perObjectUnionBounds=perObjectUnionBounds;
@@ -7675,7 +7802,8 @@ function onViewDoubleClick(event){
     // shape. 8 screen px is the same order of slack every other hit-test in
     // this file uses, and it stays constant as you zoom.
     var mTol=8/Math.max(0.0001,view.zoom);
-    var mHit=mLayer.hitTest(event.point,{fill:true,stroke:true,tolerance:mTol});
+    // Through the layer's own transform first — see layerLocalPoint.
+    var mHit=hitTestPosed(state.activeLayerIdx,event.point,mTol);
     // Enter the group from anywhere INSIDE its box, not only by landing on
     // a shape (2026-08-31, feedback #176, clarified with the Illustrator
     // analogy: "peu importe où je double clic dans la bounding box de ces
@@ -7683,6 +7811,8 @@ function onViewDoubleClick(event){
     // Requiring a direct hit is what made it "difficile de rentrer": on a
     // layer of thin or scattered shapes most of the group box is empty.
     if(!mHit||!mHit.item){
+      // perObjectUnionBounds is already in WORLD space (it composes the
+      // layer transform itself), so this one tests the raw event point.
       var mUnion=window.perObjectUnionBounds&&perObjectUnionBounds(mLayer);
       if(mUnion&&mUnion.contains(event.point)){
         // Inside the group but on no shape: reveal every element's box and
@@ -7736,7 +7866,7 @@ function onViewDoubleClick(event){
   // filled shape, so it gets the same doorway.
   // Same screen-space tolerance as the Motion path above — 4/view.zoom is
   // sub-pixel once you zoom out, which is half of why entering was hard.
-  var hit=layer.hitTest(event.point,{fill:true,stroke:true,tolerance:8/Math.max(0.0001,view.zoom)});
+  var hit=hitTestPosed(state.activeLayerIdx,event.point,8/Math.max(0.0001,view.zoom));
   if(!hit||!hit.item){
     // Enter the group from anywhere inside its box (feedback #176) — see the
     // Motion branch's comment. Reveals every element's box and targets none;


### PR DESCRIPTION
Chantier branch for the double-click / per-element selection work, from Cyril's brief: *"encore beaucoup d'erreur, entre les bounding box qui se mettent pas à jour en aller retour de group, si on ajoute des éléments dans le groupe entre paramétric shape ou brush, déplacement ciblage, zoom, position du canvas faut que ça soit au poil dans tous les cas de figure"*, plus *"bouger les layer à l'intérieur et voir les box… et la box globale se resize"*.

**Four real defects**, each measured before and after, in **both** modes.

### 1. Doubled boxes in Animation 2D
`motion.js`'s `perObjectBoxItems` had no mode gate, so it drew a second set of per-element boxes on top of engine-bridge's — two slightly different blues (`[74,158,255,190]` over `[63,107,245,120]`). At 1px it doesn't read as two boxes, just as a box that looks slightly wrong. My own regression from the #170/#176 work.

### 2. The group box ignored the layer's transform
`perObjectUnionBounds` — the region deciding "double-click inside to enter" / "click outside to leave" — was built from element-posed bounds only. Moving the **layer** left it behind while the drawn boxes followed:

| | boxes | enter/exit region |
|---|---|---|
| layer moved +400/−300 | moved | **unchanged** |

It now composes the layer transform once, at the end. `elementPosedBounds` deliberately stays element-only — both box builders apply the layer map themselves, so folding it in there would apply it twice.

### 3. Hit-testing tested geometry that had moved
A layer's Motion transform is applied at render and never touches the stored points; each element can carry its own on top. `layer.hitTest` cannot express that — it tests one point against geometry that several independent transforms have moved. `hitTestPosed` (tools.js) undoes the layer's transform once, then each child's own for that child alone.

Measured: layer moved/rotated/scaled **and** the two elements dragged apart → clicking either at its visible position selected **nothing**, in both modes. Wired into both double-click paths, select-bridge's Motion per-object block, and its main left/right click paths — the last of which also stopped gating the layer inverse on Motion mode, since `buildSceneJson` applies `motionMat` in either mode (CLAUDE.md §8).

### 4. The global box did not resize
Motion's `motionBoxGeom` built the layer box from `userLayers[i].bounds`, Animation 2D's `orientedSelBox` from raw path bounds. Moving elements apart left it at its old size while they spread outside it: drawn box unchanged at `[830,332,1772,447]` while the real extent had grown to `[510,-240,2112,1039]`. Both now build from posed bounds.

Animation 2D's is deliberately narrow — only when something in the selection actually carries an element transform — because `xformSelBounds` also feeds the panel fields and the move/scale **write** math, which work on raw geometry. No drag regression: deltas of 200/120 and −180/−100 land exactly, with and without a pose elsewhere.

## Verification
A matrix driven in **both** modes: 2 layers, each with a **parametric shape AND a brush stroke**; enter by double-clicking empty space inside the group, exit outside, re-enter; target each element; add an element while inside (box count and union grow, new shape targetable without re-entering); move elements apart individually then re-target them; move/rotate/scale the layer; **three zoom levels**; pan; then select an object on the **other** layer. All green.

Two of my own test artifacts, recorded so they are not re-found as "bugs": dispatching `mousedown` unconditionally after `pointerdown` replayed the Paper-native path and wiped the selection the pointerdown had just made (a real browser suppresses the compatibility mouse events when `pointerdown` is `preventDefault()`ed); and aiming at a wavy stroke's bounds **centre** misses the ink at high zoom, where the world-space tolerance shrinks.

**Still open on this branch:** text selection in a multi-layer canvas.

27/27 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)