### PR TITLE
Motion: the camera layer is now visible (feedback #186)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -6316,6 +6316,19 @@
   }
   function renderLayerListMotion(list) {
     ensureMotionHeaderTools();
+    // Camera row (2026-08-31, feedback #186: "le layer camera n'apparait
+    // pas dans motion il faudrait le mettre avec ses propre properties
+    // ainsi que dans layer properties"). renderPanelRow (camera.js) is
+    // already mode-agnostic — icon, eye toggle, click to switch to the
+    // camera tool, right-click menu — the ONLY reason it never showed here
+    // is that Animation 2D's own renderLayerList calls it, and this
+    // function is Motion's own early-return replacement for that whole
+    // function (see renderLayerList's own comment), so the call was simply
+    // never reached. Same row, unmodified: clicking it sets state.tool =
+    // 'camera', which already shows the SAME #camera-sec panel (properties:
+    // position/width/rotation keys, ease curve) regardless of appMode —
+    // updateCameraPanel's own show condition never checked appMode either.
+    if (window.SMCamera) SMCamera.renderPanelRow(list);
     if (!list._motionEmptySelectBound) {
       list._motionEmptySelectBound = true;
       list.addEventListener('pointerdown', function (e) {

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -3825,6 +3825,15 @@ function renderTimeline(){
   // reads the ACTUAL rendered content height after renderTimelineMotion
   // populates it, which stays correct regardless of how many tracks render.
   if(state.appMode==='motion'){
+    // Camera row (2026-08-31, feedback #186: "le layer camera n'apparait
+    // pas dans motion") — same early-return shape as the bug this comment
+    // block already documents twice over (playhead, audio strip): Motion's
+    // branch returns before ever reaching SMCamera.renderGridRow further
+    // down, so the camera's own keyframe row simply never rendered here.
+    // Grid isn't cleared per-branch (renderTimelineMotion appends, same as
+    // this call), so prepending it here — same position Animation 2D's own
+    // tail below uses — is a straight, un-risky addition.
+    if(window.SMCamera)SMCamera.renderGridRow(grid);
     if(window.SMMotion)SMMotion.renderTimelineMotion(grid);
     var mph=document.getElementById('playhead');
     mph.style.left=playheadLeftPx(state.currentFrame)+'px';


### PR DESCRIPTION
## Summary
- Feedback: https://github.com/mysteropodes/nemo/issues/636
- The camera row (keyframes, speed-curve overlay, right-panel properties) never rendered in Motion mode — both `renderLayerList` and `renderTimeline` have an early-return Motion-specific branch that never reached `SMCamera.renderPanelRow`/`renderGridRow`.
- Purely additive: those two calls now also run from Motion's own render path, at the same position Animation 2D already uses. No change to camera.js itself — it was already appMode-agnostic.

## Test plan
- [x] `npm test` (27/27)
- [x] Live: camera row + keyframe diamond + speed-curve line render correctly in Motion's timeline; `#camera-sec` panel (key count, add/delete key, easing curve) opens correctly
- [x] Live: added a second key, confirmed the eased curve renders across both
- [x] Live: confirmed Animation 2D still shows the row too (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)