### PR TITLE
Motion: Blend Mode reachable from Layer Properties (feedback #201)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -6797,6 +6797,7 @@
     if (ld.isNullLayer && !ld.isFolderLayer) renderNullShapeRow(body, ld);
     renderFollowPathRow(body, ld, state.activeLayerIdx);
     renderTimeLinkRow(body, ld, state.activeLayerIdx);
+    renderBlendRow(body, ld, state.activeLayerIdx);
     renderMatteRow(body, ld, state.activeLayerIdx);
     // A targeted SHAPE shows its own Transform, not the layer's (2026-08-30,
     // feedback #173: "si on select une shape dans elements alors dans layer
@@ -6917,6 +6918,36 @@
   }
   function matteModeLabelSafe(m) {
     return (typeof matteModeLabel === 'function') ? matteModeLabel(m) : m;
+  }
+  // Blend mode, IN Layer Properties (feedback #201, "je n'ai pas de dropdown
+  // menu de blend" — Motion mode genuinely had no way to reach it: the
+  // right-panel #p-blendmode dropdown has been display:none in EVERY
+  // context since #172 folded it into the layer row's right-click menu
+  // (timeline.js), and that replacement was Animation-2D-only — Motion's
+  // own row context menu (this file) never got the equivalent entry, so
+  // the feature was reachable from neither surface here. Same pill-and-
+  // popover idiom as renderMatteRow right below (which got this exact
+  // "buried, no entry point" fix for Matte on 2026-08-30), reusing
+  // window.openBlendDropdownAt/BLEND_MODE_LABELS (timeline.js) rather than
+  // a second dropdown implementation — one writer of ld.blendMode either way.
+  function renderBlendRow(body, ld, li) {
+    var row = document.createElement('div'); row.className = 'lrow motion-prop-row';
+    var label = document.createElement('span');
+    label.textContent = SM.t('fieldBlend'); label.style.minWidth = '70px';
+    row.appendChild(label);
+    var pill = document.createElement('div');
+    var mode = ld.blendMode || 'normal';
+    pill.className = 'lparent motion-parent-pill' + (mode === 'normal' ? ' none' : '');
+    var lab = document.createElement('span'); lab.className = 'mp-label';
+    lab.textContent = (typeof BLEND_MODE_LABELS !== 'undefined' && BLEND_MODE_LABELS[mode]) || mode;
+    pill.appendChild(lab);
+    pill.addEventListener('click', function (e) {
+      e.preventDefault(); e.stopPropagation();
+      window.SM.setActiveLayer(li);
+      if (window.openBlendDropdownAt) window.openBlendDropdownAt(pill);
+    });
+    row.appendChild(pill);
+    body.appendChild(row);
   }
   // One menu: pick the SOURCE layer, then the MODE. Two short lists in one
   // place beat the old split between a right-panel dropdown (mode) and a


### PR DESCRIPTION
## Summary
- Feedback #201: "je n'ai pas de dropdown menu de blend" in Motion's Layer Properties.
- The right-panel `#p-blendmode` dropdown has been `display:none` in every context since #172 folded Blend into the layer row's right-click menu — but that replacement only ever shipped for Animation 2D's own row menu (`timeline.js`). Motion's separate row context menu (`motion.js`) never got the equivalent entry, so the feature was reachable from neither surface in Motion mode.
- Adds a "Blend" row to Motion's Layer Properties panel, right where Matte already got this exact fix ("buried, no entry point", 2026-08-30) — same pill/popover idiom, reusing the existing `window.openBlendDropdownAt`/`BLEND_MODE_LABELS` rather than a second implementation.

Also investigated #201's second complaint ("layer qui n'est pas select reste highlighté à droite") — confirmed via commit history + live repro that this was already fixed by `3e8f1c93` (part of #422, merged earlier the same day, ~49 minutes before #201 was filed). No code change needed for that half.

## Test plan
- [x] `npm test` — 27/27 passing
- [x] Verified live: Motion's Layer Properties panel now shows Parent / Path / Time / **Blend** / Matte, in that order
- [x] Verified live: clicking the Blend pill opens the real dropdown, picking "Multiply" writes `ld.blendMode = 'multiply'` and the pill updates
- [x] Verified live: re-tested the stale-highlight scenario (enter a Motion group via double-click, then click a different layer's row) — grid and list highlight stay in sync
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)