### PR TITLE
Subselect: vertex handles follow per-element Motion (feedback #199)

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -3553,6 +3553,25 @@
     var segs = nodeEditSegmentsData(path);
     var zs = 1 / view.zoom;
     var items = [];
+    // Per-ELEMENT Motion (feedback #199, "subselect affiche des vecteurs
+    // décalés si la shape est déplacée ou animée") — a single shape keyed
+    // on its OWN Position/Scale/Rotation (CLAUDE.md §8's "Motion niveau
+    // SHAPE"), not the whole layer's, was never composed here at all: only
+    // symMatrix and the LAYER's own layerMotionPointMap were (the two fixes
+    // right below, 2026-07-29/2026-08-29). Applied INNERMOST — before
+    // symMatrix/layerMotion — mirroring elementPosedBounds' (tools.js)
+    // established element -> layer -> parents order, and reusing the exact
+    // same transformSegments/elementMotionAt pair that function already
+    // uses for hit-testing, so overlay and hit-test agree by construction.
+    var handleSid = path.data && path.data.strokeId;
+    if (handleSid && window.SMMotion && SMMotion.elementMotionAt && SMMotion.transformSegments) {
+      var em = SMMotion.elementMotionAt(state.activeLayerIdx, handleSid, state.currentFrame);
+      if (em && (em.dx || em.dy || em.rot || em.sx !== 1 || em.sy !== 1)) {
+        var pc = path.bounds.center;
+        var pivotEl = { x: pc.x + (em.ax || 0), y: pc.y + (em.ay || 0) };
+        segs = SMMotion.transformSegments(segs, pivotEl, em);
+      }
+    }
     // 2026-07-29 fix — see subselect-bridge.js's toLocalPoint comment for
     // the full story: path.segments/nodeEditSegmentsData live in raw
     // document space, but the shape itself renders through the active


### PR DESCRIPTION
## Summary
- `buildNodeHandleItems` (engine-bridge.js) — the overlay behind Subselect's vertex/handle points — already composed a Component's `symMatrix` and the LAYER's own Motion transform (two earlier fixes, 2026-07-29 and 2026-08-29), but never a single shape's own **per-element** Motion (CLAUDE.md §8, "Motion niveau SHAPE" — Position/Rotation/Scale keyed on just that one shape, not the whole layer).
- Result: editing the vertices of an individually moved/scaled/animated shape showed the handles at its raw, pre-transform position, floating well off the actual (correctly rendered) shape — exactly the screenshot in the report.
- Fix composes `SMMotion.elementMotionAt` + `SMMotion.transformSegments` first (innermost), before symMatrix/layerMotion — verified this is the exact order `buildSceneJson` (engine-bridge.js:1403-1427) and `elementPosedBounds` (tools.js, already used for this same shape's hit-testing) both use, so overlay/render/hit-test now all agree.

Second complaint in the same report ("les keyframes globales de path ne sont pas bien aligné par rapport au curseur, comme les autres keyframes") — not addressed here. Compared `renderPathGroupTrackRow`'s diamond markup line-by-line against a normal keyframe row's; they're structurally identical (same CSS class, same size-cap logic, same cell markup), so no discernible bug was found by reading. Left a comment on the issue asking for a repro.

## Test plan
- [x] `npm test` — 27/27 passing
- [x] Verified live: a shape with element-level Position (300,-150) + Scale 250% — subselect handles now sit exactly on the rendered (scaled+moved) corners, confirmed against `elementPosedBounds`'s independently-computed bounding box
- [x] Screenshot: handles visually align with the shape
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)