### PR TITLE
Selected Colors: show a linked-fill's own color (feedback #200)

### DIFF
--- a/src/js/color-manager.js
+++ b/src/js/color-manager.js
@@ -40,6 +40,17 @@
       selectedPaths.forEach(function (p) {
         if (p.fillColor) addColor(map, colorHex8(p.fillColor));
         if (p.strokeColor) addColor(map, colorHex8(p.strokeColor));
+        // A vector-brush ribbon drawn with Fill enabled is really TWO Paper.js
+        // items — the ribbon itself (selectable, fillColor holds what reads as
+        // its "stroke") and a separate filled backdrop, data.isLinkedFillCompanion,
+        // excluded from selection everywhere (isSelectablePathChild, app.js) —
+        // so its OWN fillColor (the shape's actual visible fill) never showed up
+        // here at all (feedback #200, "select l'objet... n'affiche pas la couleur
+        // du fill"). Same companion lookup effects-panel.js's syncCompanionEffects
+        // already uses for the identical "fill is a wholly separate item" gap.
+        var companion = (p.data && p.data.linkedFillId && typeof findLinkedFillCompanion === 'function')
+          ? findLinkedFillCompanion(userLayers[state.activeLayerIdx], p) : null;
+        if (companion && companion.fillColor) addColor(map, colorHex8(companion.fillColor));
       });
     } else {
       // Context colors (2026-07, "si on sélectionne rien on voit toutes les
@@ -82,6 +93,13 @@
       selectedPaths.forEach(function (p) {
         if (p.fillColor && colorHex8(p.fillColor).toUpperCase() === oldNorm) p.fillColor = newHex;
         if (p.strokeColor && colorHex8(p.strokeColor).toUpperCase() === oldNorm) p.strokeColor = newHex;
+        // Write-side mirror of computeUsedColors' own companion lookup above —
+        // without this, a fill row sourced from the companion recolors nothing
+        // (the ribbon's own fillColor never matched oldNorm), so the row looked
+        // permanently stuck no matter what was picked.
+        var companion = (p.data && p.data.linkedFillId && typeof findLinkedFillCompanion === 'function')
+          ? findLinkedFillCompanion(userLayers[state.activeLayerIdx], p) : null;
+        if (companion && companion.fillColor && colorHex8(companion.fillColor).toUpperCase() === oldNorm) companion.fillColor = newHex;
       });
       saveActiveLayerFrame();
     } else {


### PR DESCRIPTION
## Summary
- Cyril's repro: "dessine un objet avec brush stroke et fill activé > select l'objet dans le canvas → selected color panel n'affiche pas la couleur du fill."
- A vector-brush stroke drawn with Fill enabled is really **two** Paper.js items: the pressure ribbon (selectable — its `fillColor` is what reads as the "stroke" color) and a separate filled backdrop (`data.isLinkedFillCompanion`), excluded from selection everywhere (`isSelectablePathChild`).
- `computeUsedColors` (color-manager.js) only ever inspected the selected paths themselves, so the companion's own `fillColor` — the shape's actual visible fill — never made it into the panel at all: only the ribbon's single color ("stroke") showed.
- Reuses the exact same `findLinkedFillCompanion` lookup `effects-panel.js`'s `syncCompanionEffects` already uses for the identical "the fill is a wholly separate item" gap (effects used to silently skip the fill for the same reason). Fixed on both sides: `computeUsedColors` (read) and `recolorColor` (write) — a fill row now shows up **and** is actually editable, not just visible.

## Test plan
- [x] `npm test` — 27/27 passing
- [x] Verified live: a synthetic ribbon+companion pair (matching the real drawing pipeline's shape) shows both colors in the panel
- [x] Verified live: editing the fill row's hex value actually recolors the companion (not just the row's own display)
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)