### PR TITLE
Motion: shape selection in Elements drives Layer Properties (feedback #202)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -8589,6 +8589,23 @@
     if (!items.length) return;
     window.SM.setActiveLayer(li);
     selectedPaths = items;
+    // feedback #202, "si je select une shape dans elements ça doit être les
+    // properties de cette shape qui s'affiche dans layer properties" —
+    // renderMotionPropsPanel's "targeted shape" branch (2026-08-30, #173)
+    // only ever reads window._motionExpandedElement/_motionExpandedLayer,
+    // which the LEFT-panel element row already sets itself right after this
+    // call (see its own line below) — but every OTHER caller (the RIGHT-
+    // panel shapes list in shapes-panel.js chief among them, plus the
+    // context-menu "Select" entries and the canvas resolve-to-anchor paths
+    // in select-bridge.js/tools.js) only ever called this shared selector
+    // and never touched those two globals, so Layer Properties kept showing
+    // the LAYER's own Transform no matter which single shape got picked.
+    // Scoped to an unambiguous SINGLE target — a multi-shape pick (group
+    // members) has no one shape's properties to show, so it's left alone.
+    if (strokeIds.length === 1) {
+      window._motionExpandedLayer = li;
+      window._motionExpandedElement = strokeIds[0];
+    }
     // 2026-08 fix, "je select une forme dans le groupe... si j'essaie de
     // bouger/transformer la forme dans le canvas alors ça select le groupe
     // et pas la forme": select-bridge.js's onDown widens ANY click/drag on


### PR DESCRIPTION
## Summary
- Cyril's repro: click a shape in the right-panel "Elements" list (`shapes-panel.js`, `#shapes-list`) in Motion mode → Layer Properties should show that shape's own Transform, not the layer's.
- The "targeted shape" branch in `renderMotionPropsPanel` (already built for #173) only ever reads `window._motionExpandedElement`/`window._motionExpandedLayer`. The LEFT-panel element row (`renderElementsList`, motion.js) sets those two globals itself right after calling the shared `selectShapesByStrokeIds` — but every OTHER caller of that same selector (the right-panel Elements list, context-menu "Select" entries, canvas resolve-to-anchor paths in `select-bridge.js`/`tools.js`) never did, so picking a shape from anywhere except that one row left Layer Properties stuck on the layer's own Transform.
- Moved the two-line assignment inside `selectShapesByStrokeIds` itself, gated on an unambiguous single-shape pick (`strokeIds.length === 1`) — every entry point gets it for free now instead of needing its own copy. A multi-shape pick (group members) is left untouched, matching "no single shape's properties to show."

## Test plan
- [x] `npm test` — 27/27 passing
- [x] Verified live: calling `SMMotion.selectShapesByStrokeIds(li, ['sidB'])` (what the right-panel row's click ultimately calls) correctly sets `_motionExpandedElement`/`_motionExpandedLayer`, and the Layer Properties panel's Transform group header switches from "Transform" to "Transform (element)" for the picked shape
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)