### PR TITLE
Motion: no phantom Stroke row on fill-only shapes (feedback #203)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -8774,7 +8774,21 @@
       // comes from THIS shape's own current width, same "per-shape, not
       // one shared constant" principle ensureElementHolder's corner-radii
       // seeding already establishes for paramShapeKind.
-      if (entry.sd.strokeColor) {
+      // hasRealStroke, not the mere truthiness of sd.strokeColor (feedback
+      // #203, "le fill properties... agit aussi sur le stroke, il devrait y
+      // avoir une propriété keyframable de stroke séparée") — serP (app.js)
+      // bakes a '#ffffff' FALLBACK into strokeColor for every ordinary
+      // fill-only shape (CLAUDE.md §1's own documented gotcha; the same trap
+      // color-manager.js's computeUsedColors and shapes-panel.js's own
+      // hasRealStroke check already guard against). Without this, EVERY
+      // plain filled shape got a phantom "Stroke" row seeded with that white
+      // fallback — keying it created a real (if invisible-until-then) white
+      // stroke track sitting right next to Fill's own row, which is what
+      // reads as "the fill row is also touching the stroke": both rows are
+      // always there and both look keyable, on a shape that never actually
+      // had a stroke to animate.
+      var hasRealStrokeEl = entry.sd.hasRealStroke !== undefined ? entry.sd.hasRealStroke : !!entry.sd.strokeColor;
+      if (hasRealStrokeEl) {
         var strokeHolder = ensureElementHolder(ld, entry.strokeId);
         renderStrokeColorRow(list, strokeHolder, entry.sd.strokeColor);
         if (entry.sd.strokeWidth !== undefined) {
@@ -9785,7 +9799,11 @@
           // Stroke color/width (mirrors renderElementsList's own Stroke
           // block exactly — same condition, same order: color row then,
           // only if the shape also reports a width, the width row).
-          if (entry.sd.strokeColor) {
+          // hasRealStroke, not sd.strokeColor's truthiness — mirrors
+          // renderElementsList's own Stroke block above exactly, same
+          // condition (feedback #203, see that block's own comment).
+          var hasRealStrokeElGrid = entry.sd.hasRealStroke !== undefined ? entry.sd.hasRealStroke : !!entry.sd.strokeColor;
+          if (hasRealStrokeElGrid) {
             renderTracksFor(grid, elHolder, 'strokeColor');
             if (entry.sd.strokeWidth !== undefined) renderTracksFor(grid, elHolder, 'strokeWidth');
           }


### PR DESCRIPTION
## Summary
- Cyril's repro: "le fill properties dans motion > timeline > layer > shape agit aussi sur le stroke, il devrait y avoir une propriété keyframable de stroke séparé."
- Root cause: the per-shape extended "Stroke" row (Path group / Elements list, both panel and grid) was gated on `sd.strokeColor`'s mere truthiness — but `serP` (app.js) bakes a `'#ffffff'` fallback into every plain shape's `strokeColor` field even when it has **no real stroke at all** (documented in CLAUDE.md §1; the exact same trap `computeUsedColors`/`shapes-panel.js` already guard against with `hasRealStroke`). Every ordinary fill-only shape got a phantom "Stroke" row seeded with that white fallback, sitting right next to Fill's own row — both always present and both looking equally keyable on a shape that never had a stroke to animate. Confirmed the underlying data directly: a fill-only shape reports `strokeColor: "#ffffff"` / `hasRealStroke: false`, and the render-side override logic (`elementFillColorAt`/`elementStrokeColorAt` in engine-bridge.js) is itself correctly independent — the bug was purely in which row the panel decided to show.
- Fixed both the panel (`renderElementsList`) and its grid mirror (`renderTimelineMotion`) with the same `hasRealStroke` check, keeping the two in lockstep per CLAUDE.md §11's panel/grid alignment invariant.

## Test plan
- [x] `npm test` — 27/27 passing
- [x] Verified the gate logic directly against representative shape data: fill-only (`hasRealStroke:false`) → Stroke row hidden; real-stroke shape (`hasRealStroke:true`) → Stroke row shown; legacy data with no flag → falls back to old `!!strokeColor` behavior
- [x] Confirmed the render-side fill/stroke overrides (`elementFillColorAt`/`elementStrokeColorAt`) are correctly independent — not the source of any color bleed
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)