### PR TITLE
Motion: fix Blend dropdown position regression (feedback #206)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -6943,8 +6943,21 @@
     pill.appendChild(lab);
     pill.addEventListener('click', function (e) {
       e.preventDefault(); e.stopPropagation();
-      window.SM.setActiveLayer(li);
-      if (window.openBlendDropdownAt) window.openBlendDropdownAt(pill);
+      // feedback #206, "le menu blend ne s'affiche pas là où l'on clic" —
+      // setActiveLayer(li) is a no-op here (li IS already state.activeLayerIdx,
+      // this row only ever renders for the active layer) but it UNCONDITIONALLY
+      // re-renders via updateUI(), which rebuilds #motion-props-body from
+      // scratch — by the time openBlendDropdownAt ran, `pill` was a DETACHED
+      // node from the PREVIOUS render, and its getBoundingClientRect() on a
+      // detached element is all-zero, pinning the popup to the top-left
+      // corner (confirmed live from the screenshot). Same trap
+      // openBlendDropdownAt's own doc comment already calls out ("a captured
+      // DOM node goes stale the moment the list re-renders") and the exact
+      // reason the layer-row context-menu entry (timeline.js) passes a
+      // synthetic rect built from the click instead of the row itself —
+      // mirrored here rather than re-triggering it.
+      var _bx = e.clientX, _by = e.clientY;
+      if (window.openBlendDropdownAt) window.openBlendDropdownAt({ getBoundingClientRect: function () { return { left: _bx, right: _bx, top: _by, bottom: _by, width: 0, height: 0 }; } });
     });
     row.appendChild(pill);
     body.appendChild(row);


### PR DESCRIPTION
## Summary
- My own regression from #429 (the Blend row added for #201): clicking the Blend pill in Motion's Layer Properties opened the mode picker pinned to the top-left corner of the screen instead of under the click — confirmed exactly from the report's screenshot.
- Cause: the click handler called `window.SM.setActiveLayer(li)` before `openBlendDropdownAt(pill)`. `li` is always already `state.activeLayerIdx` here (this row only renders for the active layer) so the call is a value no-op, but `setActiveLayer` unconditionally re-renders via `updateUI()`, which rebuilds `#motion-props-body` from scratch — by the time `openBlendDropdownAt` ran, `pill` was a **detached** node from the previous render, and `getBoundingClientRect()` on a detached element is all-zero.
- This is the exact trap `openBlendDropdownAt`'s own doc comment already warns about ("a captured DOM node goes stale the moment the list re-renders"), and exactly why the layer-row context-menu's own Blend entry (`timeline.js`) passes a synthetic rect built from the click coordinates instead of a captured node. Mirrored that same pattern here instead of re-triggering the render.

## Test plan
- [x] `npm test` — 27/27 passing
- [x] Verified live: dispatching a click on the Blend pill now opens the popup within ~30px of the actual click point, not at (0,0)
- [x] Screenshot: dropdown renders directly under the "Blend" row
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)