### PR TITLE
Motion: keyframable Blend Mode, Duik-style hold keys (feedback #207)

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2052,7 +2052,11 @@
       // tick()'s catch treats exactly like the screen_to_world Float64Array
       // bug above: setEnabled(false) for the rest of the session, not just
       // a skipped frame.
-      var bm = state.layers[i].blendMode;
+      // layerBlendModeAt (feedback #207) resolves ld.blendKeys when present
+      // (Duik-style hold-only keyframes) and falls back to the plain static
+      // field otherwise — zero behavior change for any layer that never
+      // turned keying on.
+      var bm = (window.SMMotion && SMMotion.layerBlendModeAt) ? SMMotion.layerBlendModeAt(i, renderFrame) : state.layers[i].blendMode;
       if (typeof bm !== 'string') bm = undefined;
       // Track matte (2026-07, scouted from Caddis's Layer.matteMode):
       // AE convention — the matte SOURCE is implicitly the layer directly

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -3888,6 +3888,48 @@
     if (!holder) return 0;
     return valueAtFrame(holder, 'order', frameIdx)[0];
   }
+  // ---- Blend Mode keyframing (2026-08-31, feedback #207: "inspire-toi de
+  // Duik") — Duik's own time-varying rig properties (e.g. re-parenting a
+  // picked-up prop) never interpolate the underlying identity/enum value;
+  // they SNAP at each key and hold until the next one, because there's no
+  // meaningful halfway point between "Multiply" and "Screen" the way there
+  // is between two numbers. ld.blendKeys is a plain [{frame,mode}] array,
+  // sorted by frame — NOT routed through the generic numeric holder.motion
+  // track system (which assumes lerp-able number arrays throughout;
+  // shoehorning a mode NAME through it would need a fragile index<->name
+  // encoding for no real benefit here, since "hold-only" is this whole
+  // feature's point, not an edge case of it).
+  // Opt-in, zero cost unless used: ld.blendKeys is absent for every layer
+  // that has never turned this on, in which case the plain static
+  // ld.blendMode (completely unchanged, still what most consumers read —
+  // see this function's own callers list below) applies at every frame,
+  // same contract Order/3D/Widget layers already establish elsewhere in
+  // this file.
+  function layerBlendModeAt(li, frameIdx) {
+    var ld = state.layers[li];
+    if (!ld) return undefined;
+    var keys = ld.blendKeys;
+    if (!keys || !keys.length) return ld.blendMode;
+    var v = keys[0].mode;
+    for (var i = 0; i < keys.length; i++) {
+      if (keys[i].frame <= frameIdx) v = keys[i].mode; else break;
+    }
+    return v;
+  }
+  function sortBlendKeys(ld) {
+    ld.blendKeys.sort(function (a, b) { return a.frame - b.frame; });
+  }
+  // Add/update the key AT this frame. pushUndo() is the CALLER's job,
+  // matching every other write helper in this file.
+  function upsertBlendKeyAt(ld, frame, mode) {
+    if (!ld.blendKeys) ld.blendKeys = [];
+    var k = ld.blendKeys.filter(function (kk) { return kk.frame === frame; })[0];
+    if (k) k.mode = mode; else { ld.blendKeys.push({ frame: frame, mode: mode }); sortBlendKeys(ld); }
+  }
+  function removeBlendKeyAt(ld, frame) {
+    if (!ld.blendKeys) return;
+    ld.blendKeys = ld.blendKeys.filter(function (k) { return k.frame !== frame; });
+  }
   // Cheap "does ANY layer/element on this layer actually use Order" scans —
   // engine-bridge.js calls these ONCE per buildSceneJson / once per layer
   // respectively, so the stable-sort + per-item lookup below them is fully
@@ -6932,11 +6974,42 @@
   // a second dropdown implementation — one writer of ld.blendMode either way.
   function renderBlendRow(body, ld, li) {
     var row = document.createElement('div'); row.className = 'lrow motion-prop-row';
+    // Stopwatch (feedback #207, Duik-inspired): turns ld.blendKeys on/off,
+    // same on/hasKeyHere/click shape renderColorRow's own stopwatch uses —
+    // OFF collapses back to the plain static field (the pre-#207 behavior,
+    // still what most other consumers of ld.blendMode read, see
+    // layerBlendModeAt's own comment), ON seeds a single key at the
+    // playhead with whatever mode was showing.
+    var keyed = !!(ld.blendKeys && ld.blendKeys.length);
+    var hasKeyHere = keyed && ld.blendKeys.some(function (k) { return k.frame === state.currentFrame; });
+    var sw = document.createElement('div');
+    sw.className = 'lico motion-stopwatch' + (keyed ? ' on' : '');
+    sw.title = stopwatchTitle('motionAnimateFill', keyed, hasKeyHere);
+    sw.innerHTML = '<svg viewBox="0 0 24 24" width="12" height="12"><path d="M12 3l9 9-9 9-9-9z" fill="' + (hasKeyHere ? 'currentColor' : 'none') + '" stroke="currentColor" stroke-width="2"/></svg>';
+    sw.addEventListener('click', function (e) {
+      e.stopPropagation(); pushUndo();
+      if (!keyed) {
+        ld.blendKeys = [{ frame: state.currentFrame, mode: ld.blendMode || 'normal' }];
+      } else if (hasKeyHere) {
+        if (ld.blendKeys.length === 1) {
+          var fv = ld.blendKeys[0].mode;
+          ld.blendMode = fv === 'normal' ? undefined : fv;
+          delete ld.blendKeys;
+        } else {
+          SMMotion.removeBlendKeyAt ? SMMotion.removeBlendKeyAt(ld, state.currentFrame) : (ld.blendKeys = ld.blendKeys.filter(function (k) { return k.frame !== state.currentFrame; }));
+        }
+      } else {
+        SMMotion.upsertBlendKeyAt(ld, state.currentFrame, layerBlendModeAt(li, state.currentFrame));
+      }
+      renderLayerList(); renderTimeline();
+      if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+    });
+    row.appendChild(sw);
     var label = document.createElement('span');
     label.textContent = SM.t('fieldBlend'); label.style.minWidth = '70px';
     row.appendChild(label);
     var pill = document.createElement('div');
-    var mode = ld.blendMode || 'normal';
+    var mode = layerBlendModeAt(li, state.currentFrame) || 'normal';
     pill.className = 'lparent motion-parent-pill' + (mode === 'normal' ? ' none' : '');
     var lab = document.createElement('span'); lab.className = 'mp-label';
     lab.textContent = (typeof BLEND_MODE_LABELS !== 'undefined' && BLEND_MODE_LABELS[mode]) || mode;
@@ -11815,6 +11888,9 @@
     // already goes through.
     outerWorldPoint: outerWorldPoint,
     outerLocalPoint: outerLocalPoint,
+    layerBlendModeAt: layerBlendModeAt,
+    upsertBlendKeyAt: upsertBlendKeyAt,
+    removeBlendKeyAt: removeBlendKeyAt,
     // rig-widget.js's "+" button (feedback #185) reads the SAME per-layer
     // property list every Motion row already goes through (§11's single-
     // decider invariant), instead of guessing a parallel list, and writes

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1984,7 +1984,7 @@ window.SM={
       // level setting like canvasW/fps above (not per-layer, not per-
       // symbol/montage snapshot — a linked-vs-embedded choice is global).
       mediaMode:state.mediaMode||'embedded',
-      layers:sceneLayers.map(function(l){return{name:l.name,visible:l.visible,locked:l.locked,frames:l.frames,symbolId:l.symbolId,symPlayMode:l.symPlayMode,symSpeed:l.symSpeed,symPlacedAt:l.symPlacedAt,symSingleFrame:l.symSingleFrame,symMatrix:l.symMatrix,lfsGroup:l.lfsGroup,lfsIds:l.lfsIds,lfsSettings:l.lfsSettings,blendMode:l.blendMode,folderId:l.folderId,channel:l.channel,linkGroupId:l.linkGroupId,color:l.color,motion:l.motion,motionStatic:l.motionStatic,elementMotion:l.elementMotion,inPoint:l.inPoint,outPoint:l.outPoint,nativeVideo:l.nativeVideo,matteMode:l.matteMode,matteSourceLayerUid:l.matteSourceLayerUid,mattesMore:l.mattesMore,montageId:l.montageId,expressions:l.expressions,isTextLayer:l.isTextLayer,isNullLayer:l.isNullLayer,nullPos:l.nullPos,nullShape:l.nullShape,isEffectLayer:l.isEffectLayer,isFolderLayer:l.isFolderLayer,folderCollapsed:l.folderCollapsed,isGuideLayer:l.isGuideLayer,guidePos:l.guidePos,guideOrientation:l.guideOrientation,isWidgetLayer:l.isWidgetLayer,widget:l.widget,isEffectorLayer:l.isEffectorLayer,effector:l.effector,effects:l.effects,footage:l.footage,
+      layers:sceneLayers.map(function(l){return{name:l.name,visible:l.visible,locked:l.locked,frames:l.frames,symbolId:l.symbolId,symPlayMode:l.symPlayMode,symSpeed:l.symSpeed,symPlacedAt:l.symPlacedAt,symSingleFrame:l.symSingleFrame,symMatrix:l.symMatrix,lfsGroup:l.lfsGroup,lfsIds:l.lfsIds,lfsSettings:l.lfsSettings,blendMode:l.blendMode,blendKeys:l.blendKeys,folderId:l.folderId,channel:l.channel,linkGroupId:l.linkGroupId,color:l.color,motion:l.motion,motionStatic:l.motionStatic,elementMotion:l.elementMotion,inPoint:l.inPoint,outPoint:l.outPoint,nativeVideo:l.nativeVideo,matteMode:l.matteMode,matteSourceLayerUid:l.matteSourceLayerUid,mattesMore:l.mattesMore,montageId:l.montageId,expressions:l.expressions,isTextLayer:l.isTextLayer,isNullLayer:l.isNullLayer,nullPos:l.nullPos,nullShape:l.nullShape,isEffectLayer:l.isEffectLayer,isFolderLayer:l.isFolderLayer,folderCollapsed:l.folderCollapsed,isGuideLayer:l.isGuideLayer,guidePos:l.guidePos,guideOrientation:l.guideOrientation,isWidgetLayer:l.isWidgetLayer,widget:l.widget,isEffectorLayer:l.isEffectorLayer,effector:l.effector,effects:l.effects,footage:l.footage,
         // Layer parenting (2026-07-25). BOTH of these were missing from this
         // list, so every parent link was silently dropped on save — a rig
         // survived the session and nothing more. `uid` is the stable identity
@@ -2260,6 +2260,13 @@ window.SM={
       // permanently disables the whole Rust renderer for the session
       // (see engine-bridge.js's tick() catch).
       if(typeof ld.blendMode==='string')state.layers[idx].blendMode=ld.blendMode;
+      // Blend keys (2026-08-31, feedback #207) — same shape-guarded pattern
+      // as mattesMore right below: a corrupted nemo-auto carrying junk here
+      // would otherwise reach layerBlendModeAt/engine-bridge's resolver.
+      if(Array.isArray(ld.blendKeys)){
+        var _bk=ld.blendKeys.filter(function(k){return k&&typeof k.frame==='number'&&typeof k.mode==='string';});
+        if(_bk.length)state.layers[idx].blendKeys=_bk;
+      }
       if(typeof ld.matteMode==='string')state.layers[idx].matteMode=ld.matteMode;
       if(typeof ld.matteSourceLayerUid==='string')state.layers[idx].matteSourceLayerUid=ld.matteSourceLayerUid;
       // Additional mattes (2026-08-30). Guarded on SHAPE, not just presence,
@@ -9819,6 +9826,12 @@ var BLEND_MODE_LABELS={normal:'Normal',multiply:'Multiply',screen:'Screen',overl
   function currentLd(){return state.layers[state.activeLayerIdx];}
   function applyPreview(v){
     var ld=currentLd();if(!ld)return;
+    // Keyed layers (feedback #207, Duik-inspired hold-only Blend keys) skip
+    // the live hover preview here — layerBlendModeAt (motion.js) ignores
+    // ld.blendMode entirely once ld.blendKeys exists, so writing it on
+    // hover would have zero visible effect. The click handler below writes
+    // the real keyed value instead, at commit time.
+    if(ld.blendKeys&&ld.blendKeys.length)return;
     ld.blendMode=v==='normal'?undefined:v;
     window._sceneVersion=(window._sceneVersion||0)+1;
     if(window.SMEngineBridge&&window.SMEngineBridge.renderNow)window.SMEngineBridge.renderNow();
@@ -9836,7 +9849,10 @@ var BLEND_MODE_LABELS={normal:'Normal',multiply:'Multiply',screen:'Screen',overl
   // the click — a captured DOM node goes stale the moment the list re-renders.
   function open(anchorEl){
     var ld=currentLd();if(!ld)return;
-    origMode=ld.blendMode||'normal';
+    // Keyed layers show/revert-to the value AT THE PLAYHEAD (feedback
+    // #207), not the (irrelevant once keyed) static field.
+    var keyedAtOpen=!!(ld.blendKeys&&ld.blendKeys.length);
+    origMode=keyedAtOpen?((window.SMMotion&&SMMotion.layerBlendModeAt)?SMMotion.layerBlendModeAt(state.activeLayerIdx,state.currentFrame):(ld.blendMode||'normal')):(ld.blendMode||'normal');
     pop.innerHTML='';
     Object.keys(BLEND_MODE_LABELS).forEach(function(v){
       var it=document.createElement('div');
@@ -9845,14 +9861,29 @@ var BLEND_MODE_LABELS={normal:'Normal',multiply:'Multiply',screen:'Screen',overl
       it.addEventListener('mouseenter',function(){applyPreview(v);});
       it.addEventListener('click',function(e){
         e.stopPropagation();
-        // Restore the original first so pushUndo snapshots the true
-        // pre-preview state, then commit the pick on top of it.
-        var ld2=currentLd();if(ld2)ld2.blendMode=origMode==='normal'?undefined:origMode;
-        pushUndo();
-        applyPreview(v);
+        var ld2=currentLd();if(!ld2){close(false);return;}
+        if(ld2.blendKeys&&ld2.blendKeys.length){
+          // Duik-style hold key: SNAP the mode at the current frame instead
+          // of overwriting the static field — see upsertBlendKeyAt's own
+          // comment (motion.js).
+          pushUndo();
+          if(window.SMMotion&&SMMotion.upsertBlendKeyAt)SMMotion.upsertBlendKeyAt(ld2,state.currentFrame,v);
+          window._sceneVersion=(window._sceneVersion||0)+1;
+          if(window.SMEngineBridge&&window.SMEngineBridge.renderNow)window.SMEngineBridge.renderNow();
+        }else{
+          // Restore the original first so pushUndo snapshots the true
+          // pre-preview state, then commit the pick on top of it.
+          ld2.blendMode=origMode==='normal'?undefined:origMode;
+          pushUndo();
+          applyPreview(v);
+        }
         setLabel(v);
         origMode=null;
         close(false);
+        // Refresh Motion's own panel/grid so the pill label and any new key
+        // marker show up immediately, not just on the next unrelated redraw.
+        if(window.SMMotion&&SMMotion.renderMotionPropsPanel)SMMotion.renderMotionPropsPanel();
+        if(window.renderTimeline)renderTimeline();
       });
       pop.appendChild(it);
     });


### PR DESCRIPTION
## Summary
- Cyril: "je ne vois pas où le parentage ni le blend serait keyframables dans layer properties... je t'avais parlé de duik qui faisait ça, inspire toi en."
- Duik's own time-varying rig properties never interpolate the underlying identity/enum value — they SNAP at each key and hold until the next one (no meaningful halfway point between "Multiply" and "Screen"). Implemented the same idea for Blend Mode: `ld.blendKeys` is a plain `[{frame,mode}]` array, sorted by frame, resolved via `layerBlendModeAt` (motion.js) as "most recent key at or before this frame" — falling back to the plain static `ld.blendMode` when absent (zero behavior change for any layer that never turns this on). Deliberately NOT routed through the generic numeric `holder.motion` track system, which assumes lerp-able numbers throughout.
- Stopwatch on Motion's Blend row toggles keying on/off; picking a mode from the dropdown while keyed upserts a key at the playhead instead of overwriting the static field (same shared dropdown all 3 entry points already use).
- Persisted (exportJSON/importJSON, shape-guarded like `mattesMore`) and covered by undo for free (`_cloneLayersForUndo` deep-clones the whole layer — no live references in `blendKeys`).

**Scope notes** (documented in code, not silently incomplete):
- `ld.blendMode` is still read directly (not frame-aware) by a few secondary consumers not touched here: Lottie/PNG export (`export.js`), `duplicateLayer`/`transplant`'s clone helpers, and the `nemo-script` scripting API. Follow-up work if needed.
- **Parenting** ("le parentage") from the same feedback is intentionally NOT addressed in this PR — `ld.parentLayerUid` is read directly in a dozen+ places (multi-parent weighted blending, cycle detection, self-expression views, pickwhip menus), a much bigger blast radius that needs its own scoped pass rather than a rushed add-on here.

## Test plan
- [x] `npm test` — 27/27 passing
- [x] Verified live end-to-end: stopwatch toggle seeds/collapses keys correctly; `upsertBlendKeyAt` + `layerBlendModeAt` resolve hold semantics correctly across 3 keys at 3 frames; `buildSceneJsonForFrame` picks up the resolved mode; dropdown-commit while keyed upserts (doesn't overwrite the static field); stopwatch-off on a multi-key layer removes just the current-frame key; full exportJSON → importJSON round-trip preserves and correctly re-resolves keys; undo restores a removed key
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)