### PR TITLE
Motion: live property field refresh during canvas drags (feedback #211)

### DIFF
--- a/src/js/image-mesh-bridge.js
+++ b/src/js/image-mesh-bridge.js
@@ -206,6 +206,10 @@
     if (window.SMMotion && SMMotion.isMeshVertexAnimated && SMMotion.isMeshVertexAnimated(li, t.meshId, dragIdx)) {
       var sculpt = (t.mesh.offsets && t.mesh.offsets[dragIdx]) || [0, 0];
       SMMotion.setMeshVertexOffset(li, t.meshId, dragIdx, uv[0] - rest[0] - sculpt[0], uv[1] - rest[1] - sculpt[1]);
+      // feedback #211 — same cheap in-place field sync every other canvas
+      // drag now does; this mesh vertex row (CLAUDE.md §12ter) is keyed
+      // through the identical vtxN track machinery.
+      if (SMMotion.liveRefreshVisiblePropertyFields) SMMotion.liveRefreshVisiblePropertyFields();
     } else {
       SMImageMesh.setOffset(t.meshId, dragIdx, uv[0] - rest[0], uv[1] - rest[1]);
     }

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -6012,6 +6012,9 @@
         var dx = local.x - _motionDrag.basePt.x, dy = local.y - _motionDrag.basePt.y;
         setValue(_motionDrag.t.holder, 'vtx' + _motionDrag.vi, [dx, dy]);
       }
+      // feedback #211 — this mode returns early, bypassing the shared tail
+      // below that normally does this refresh for every other drag mode.
+      liveRefreshVisiblePropertyFields();
       if (window.SMEngineBridge) SMEngineBridge.renderNow();
       return true;
     }
@@ -6140,8 +6143,43 @@
       if (_motionDrag.mode === 'handle') k[_motionDrag.which] = [localPointer.x - (pv.x + k.v[0]), localPointer.y - (pv.y + k.v[1])];
       else { k.v[0] = localPointer.x - pv.x; k.v[1] = localPointer.y - pv.y; }
     }
+    liveRefreshVisiblePropertyFields();
     if (window.SMEngineBridge) SMEngineBridge.renderNow();
     return true;
+  }
+  // Cheap live refresh of number fields during a drag (feedback #211, "les
+  // valeurs de propriété dans layer properties ne changent pas en temps
+  // réel pendant les modifications dans le canvas") — every onDrag branch
+  // above writes the new value via setValue/setSelectedKeyDimension, which
+  // updates the DATA and repaints the CANVAS (SMEngineBridge.renderNow),
+  // but never touched the already-built <input> elements showing that same
+  // value in the panel, so they sat stale until the drag ended and some
+  // other action forced a full rebuild. A full renderLayerList()/
+  // renderTimeline() on every pointermove tick would work but is exactly
+  // the "rebuild the whole DOM because ONE value changed" cost CLAUDE.md
+  // §5bis's own perf pass measured and fixed elsewhere in this file —
+  // this only ever touches .value on whichever fields are ALREADY on
+  // screen (bottom Transform group + right-panel mirror both tagged
+  // _smHolder/_smProp by decorateMotionPropertyRow), never rebuilds a row.
+  // Deliberately reads EVERY visible row rather than tracking exactly which
+  // holder/prop the current _motionDrag touched: several branches above
+  // (multiLayerMove/Scale/Rotate) write MANY holders in one tick, and this
+  // stays cheap regardless — typically a handful of rows are ever expanded
+  // at once. Skips a field the user has focused (mid-typing) so a live
+  // refresh can never overwrite a keystroke in progress.
+  function liveRefreshVisiblePropertyFields() {
+    document.querySelectorAll('.lrow.motion-prop-row').forEach(function (pr) {
+      var holder = pr._smHolder, prop = pr._smProp;
+      if (!holder || !prop) return;
+      var inputs = pr.querySelectorAll('.motion-val');
+      if (!inputs.length) return;
+      var vals = isAnimated(holder, prop) ? valueAtFrame(holder, prop, state.currentFrame) : staticValue(holder, prop);
+      for (var i = 0; i < inputs.length; i++) {
+        if (document.activeElement === inputs[i]) continue;
+        if (i >= vals.length) continue;
+        inputs[i].value = fmtVal(vals[i]);
+      }
+    });
   }
   function onUp() {
     if (!_motionDrag) return false;
@@ -12059,6 +12097,10 @@
     layerParentUidAt: layerParentUidAt,
     upsertParentKeyAt: upsertParentKeyAt,
     removeParentKeyAt: removeParentKeyAt,
+    // feedback #211 — select-bridge.js's own layer-body Motion drag writes
+    // Position too, straight through SMMotion.setLayerValue, same staleness
+    // this fixes for every onDrag branch in this file.
+    liveRefreshVisiblePropertyFields: liveRefreshVisiblePropertyFields,
     // rig-widget.js's "+" button (feedback #185) reads the SAME per-layer
     // property list every Motion row already goes through (§11's single-
     // decider invariant), instead of guessing a parallel list, and writes

--- a/src/js/rig-widget.js
+++ b/src/js/rig-widget.js
@@ -314,6 +314,10 @@
       var ndy = drag.startDy + (curLocal.y - drag.startLocal.y);
       SMMotion.setLayerValue(drag.li, 'position', [ndx, ndy]);
       drag.moved = true;
+      // feedback #211 — same cheap in-place field sync motion.js's own
+      // onDrag does after every tick, needed here too since this writes
+      // Position through the identical setLayerValue path.
+      if (window.SMMotion && SMMotion.liveRefreshVisiblePropertyFields) SMMotion.liveRefreshVisiblePropertyFields();
       SMEngineBridge.renderNow();
       return;
     }
@@ -323,6 +327,10 @@
     var loc = toLocal(g, wpt2[0], wpt2[1]);
     writeFromLocal(g, loc[0], loc[1]);
     drag.moved = true;
+    // feedback #211 — the axis value(s) just written live in an
+    // exprControls row (CLAUDE.md §13), same panel-field-lag bug as every
+    // other canvas drag.
+    if (window.SMMotion && SMMotion.liveRefreshVisiblePropertyFields) SMMotion.liveRefreshVisiblePropertyFields();
     SMEngineBridge.renderNow();
   }
   function onUp(e) {

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -1875,12 +1875,20 @@
       var nulld = pt.subtract(nullStartPt);
       SMMotion.setLayerValue(nullIdx, 'position', [nullStartPos[0] + nulld.x, nullStartPos[1] + nulld.y]);
       window._sceneVersion++;
+      // feedback #211 — same cheap in-place field sync as the layer-body
+      // drag below, needed here too since this writes Position through the
+      // identical setLayerValue path.
+      if (window.SMMotion && SMMotion.liveRefreshVisiblePropertyFields) SMMotion.liveRefreshVisiblePropertyFields();
       window.SMEngineBridge.renderNow();
     } else if (mode === 'nv-drag') {
       if (!nvMoved) { pushUndo(); nvMoved = true; }
       var nvd = pt.subtract(nvStartPt);
       SMMotion.setLayerValue(nvIdx, 'position', [nvStartPos[0] + nvd.x, nvStartPos[1] + nvd.y]);
       window._sceneVersion++;
+      // feedback #211 — same cheap in-place field sync as the layer-body
+      // drag below, needed here too since this writes Position through the
+      // identical setLayerValue path.
+      if (window.SMMotion && SMMotion.liveRefreshVisiblePropertyFields) SMMotion.liveRefreshVisiblePropertyFields();
       window.SMEngineBridge.renderNow();
     } else if (mode === 'nv-scale') {
       // Uniform corner scale around the box center — same ratio-of-
@@ -1890,11 +1898,19 @@
       var nvRatio = pt.getDistance(nvPivot) / nvOrigDist;
       SMMotion.setLayerValue(nvIdx, 'scale', [nvStartScale[0] * nvRatio, nvStartScale[1] * nvRatio]);
       window._sceneVersion++;
+      // feedback #211 — same cheap in-place field sync as the layer-body
+      // drag below, needed here too since this writes Scale through the
+      // identical setLayerValue path.
+      if (window.SMMotion && SMMotion.liveRefreshVisiblePropertyFields) SMMotion.liveRefreshVisiblePropertyFields();
       window.SMEngineBridge.renderNow();
     } else if (mode === 'nv-rotate') {
       var nvAng = Math.atan2(pt.y - nvPivot.y, pt.x - nvPivot.x) * 180 / Math.PI;
       SMMotion.setLayerValue(nvIdx, 'rotation', [nvOrigRot + (nvAng - nvStartAngle)]);
       window._sceneVersion++;
+      // feedback #211 — same cheap in-place field sync as the layer-body
+      // drag below, needed here too since this writes Rotation through the
+      // identical setLayerValue path.
+      if (window.SMMotion && SMMotion.liveRefreshVisiblePropertyFields) SMMotion.liveRefreshVisiblePropertyFields();
       window.SMEngineBridge.renderNow();
     } else if (mode === 'move') {
       // Same ensureKeyframe()+reselect as the scale/rotate grab above (see
@@ -2006,6 +2022,12 @@
         SMMotion.setLayerValue(mvLi, 'position', [mvCur[0] + mvPd[0], mvCur[1] + mvPd[1]]);
         window._sceneVersion++;
         lastPt = pt;
+        // feedback #211, "les valeurs de propriété... ne changent pas en
+        // temps réel pendant les modifications dans le canvas" — same
+        // cheap in-place field sync motion.js's own onDrag now does after
+        // every tick, needed here too since this layer-body drag writes
+        // Position through the identical setLayerValue path.
+        if (window.SMMotion && SMMotion.liveRefreshVisiblePropertyFields) SMMotion.liveRefreshVisiblePropertyFields();
         window.SMEngineBridge.renderNow();
         return;
       }
@@ -2136,6 +2158,10 @@
         SMMotion.setLayerValue(msLi, 'scale', [msCur[0] * stepSx, msCur[1] * stepSy]);
         window._sceneVersion++;
         lastPt = pt;
+        // feedback #211 — same cheap in-place field sync as the layer-body
+        // drag above, needed here too since this writes Scale through the
+        // identical setLayerValue path.
+        if (window.SMMotion && SMMotion.liveRefreshVisiblePropertyFields) SMMotion.liveRefreshVisiblePropertyFields();
         window.SMEngineBridge.renderNow();
         return;
       }
@@ -2266,6 +2292,10 @@
         SMMotion.setLayerValue(mrLi, 'rotation', [mrCur[0] + stepAngle]);
         window._sceneVersion++;
         lastPt = pt;
+        // feedback #211 — same cheap in-place field sync as the layer-body
+        // drag above, needed here too since this writes Rotation through the
+        // identical setLayerValue path.
+        if (window.SMMotion && SMMotion.liveRefreshVisiblePropertyFields) SMMotion.liveRefreshVisiblePropertyFields();
         window.SMEngineBridge.renderNow();
         return;
       }


### PR DESCRIPTION
## Summary
- `liveRefreshVisiblePropertyFields()` (motion.js) does a cheap in-place `.value` sync on every visible `.lrow.motion-prop-row`, using the existing `_smHolder`/`_smProp` tagging, skipping any field the user currently has focused mid-edit.
- Wired into motion.js's `onDrag` shared tail, plus its one early-return branch (`vertex` mode) that bypasses the shared tail.
- Wired into every `SMMotion.setLayerValue(...)` canvas-drag call site that previously only called `renderNow()`: select-bridge.js (`null-drag`, `nv-drag`, `nv-scale`, `nv-rotate`, layer-body `move`, scale-grab, rotate-grab), rig-widget.js (widget body drag + puck axis write), and image-mesh-bridge.js (animated mesh vertex drag).

## Test plan
- [x] `npm test` — 27/27 passing
- [x] Verified live in-browser: selected a layer in Motion mode, called the exact sequence every patched call site now runs (`SMMotion.setLayerValue` then `SMMotion.liveRefreshVisiblePropertyFields()`) — confirmed the Position panel field was stale (`0,0`) immediately after the write and updated to the new value (`42,17`) only after the refresh call, matching the patched behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)