### PR TITLE
Subselect: fix vertex drag with per-element Motion (feedback #210)

### DIFF
--- a/src/js/subselect-bridge.js
+++ b/src/js/subselect-bridge.js
@@ -96,6 +96,28 @@
       var inv = symMatrixOf(ld).inverted();
       if (inv) p = inv.transform(p);
     }
+    // feedback #210 ("impossible de déplacer les vertex avec subselect dans
+    // motion si la shape est dans un groupe [...] ou si je rentre dans le
+    // groupe aussi") — a shape animated with its OWN per-element Motion
+    // (CLAUDE.md §8 "Motion niveau SHAPE" — exactly what entering a
+    // per-object group and keying one of its members produces) renders
+    // through a THIRD transform beyond symMatrix/layer Motion:
+    // buildNodeHandleItems (engine-bridge.js) already composes it into the
+    // overlay's drawn position (elementMotionAt + transformSegments,
+    // applied innermost, before symMatrix/layer Motion), but this function
+    // never undid it — so a click/drag landed short of nodeHandles[].pos
+    // (renderNodeHandles, tools.js — still raw, untransformed positions) by
+    // exactly the element's Motion delta, and the hit-test tolerance missed
+    // every handle whenever that delta was non-zero. elementLocalPoint
+    // (tools.js) is the exact inverse of transformSegments already used
+    // elsewhere for element-aware hit-testing (hitTestPosed) — undone LAST,
+    // mirroring the forward order (element -> symMatrix -> layer) in
+    // reverse (layer -> symMatrix -> element).
+    if (window.elementLocalPoint && typeof nodeEditTargetPath === 'function') {
+      var tgt = nodeEditTargetPath();
+      var layer = userLayers[layerIdx];
+      if (tgt && layer) p = elementLocalPoint(layer, tgt, p);
+    }
     return p;
   }
 


### PR DESCRIPTION
## Summary
- `subselect-bridge.js`'s `toLocalPoint` inverse-mapped a canvas click through symMatrix and the layer's own Motion transform, but never undid a shape's own per-**element** Motion (CLAUDE.md §8 "Motion niveau SHAPE" — what a shape gets once it's entered individually within a group and keyed on its own Position/Rotation/Scale). `buildNodeHandleItems` (engine-bridge.js) already composes that transform into the drawn handle overlay, so every click/drag landed exactly as far off the real vertex as the element's own Motion delta.
- Fixed by also undoing the element transform via `elementLocalPoint` (tools.js), already used by `hitTestPosed` for the same class of problem — applied last, mirroring the forward composition order (element → symMatrix → layer) in reverse.

## Test plan
- [x] `npm test` — 27/27 passing
- [x] Verified numerically in-browser: built a shape with a 15° per-element rotation + (80,-40) offset, round-tripped a raw vertex through the exact forward chain `buildNodeHandleItems` uses and back through the patched `toLocalPoint` logic — pre-fix inverse landed 318px off the raw vertex (unreachable at any hit-test tolerance), post-fix within 1e-11px (float noise). A sibling shape with no per-element Motion round-trips at 0px either way (no regression on the common case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)