### PR TITLE
Motion: per-selection keyframe lock, not whole-layer (feedback #212)

### DIFF
--- a/src/js/layer-inout.js
+++ b/src/js/layer-inout.js
@@ -1102,6 +1102,44 @@
         lockDx = moved;
       });
     }
+    // Per-KEYFRAME standing lock (feedback #212, "ça devrait être les
+    // keyframes select au clic droit"): same edge-follows-drag semantics as
+    // ld.keyLock just above, and the same "explicit selection wins" and Alt
+    // precedence — but scoped to individually-flagged keys (key.lockTo, set
+    // from the keyframe cell's own right-click menu, buildKeySelectionLock
+    // MenuItems in motion.js) rather than a whole layer's every track. Loops
+    // all three modes (unlike the scalar ld.keyLock above) since different
+    // keys on the SAME layer can each follow a different edge.
+    if (!hasKeySel && !altHeld && window.SMMotion && SMMotion.keysLockedTo && SMMotion.shiftKeySelection) {
+      var lockKeysOne = function (li2, origIn, origOut) {
+        var l2 = state.layers[li2]; if (!l2) return;
+        ['in', 'out', 'layer'].forEach(function (mode) {
+          if (mode === 'layer' && d.type !== 'both') return;
+          var moved = mode === 'out' ? outPointOf(l2) - origOut : inPointOf(l2) - origIn;
+          if (!moved) return;
+          var sel = SMMotion.keysLockedTo(li2, mode);
+          if (!sel.length) return;
+          SMMotion.shiftKeySelection(sel, moved);
+          lockDx = moved;
+        });
+      };
+      if (d.group) d.members.forEach(function (m) { lockKeysOne(m.li, m.origIn, m.origOut); });
+      else lockKeysOne(d.li, d.origIn, d.origOut);
+      (d.linkedOrig || []).forEach(function (m) {
+        var l2 = state.layers[m.li]; if (!l2) return;
+        var nowIn = window.layerInPoint ? layerInPoint(l2) : m.origIn;
+        var nowOut = window.layerOutPoint ? layerOutPoint(l2) : m.origOut;
+        ['in', 'out', 'layer'].forEach(function (mode) {
+          if (mode === 'layer' && d.type !== 'both') return;
+          var moved = mode === 'out' ? nowOut - m.origOut : nowIn - m.origIn;
+          if (!moved) return;
+          var sel = SMMotion.keysLockedTo(m.li, mode);
+          if (!sel.length) return;
+          SMMotion.shiftKeySelection(sel, moved);
+          lockDx = moved;
+        });
+      });
+    }
     var selDx = 0;
     if (hasKeySel && !altHeld) {
       if (d.group) {
@@ -1149,7 +1187,13 @@
         // deliberately don't) — sweeping the rest along would contradict both.
         if (hasKeySel) return;
         var lk = state.layers[li] && state.layers[li].keyLock;
-        if (lk && lockDx) return; // the standing lock above already moved this layer's keys
+        // feedback #212's per-key lock also already-moved SOME of this
+        // layer's keys above (SMMotion.keysLockedTo) — same reasoning as
+        // the whole-layer `lk` check, just scoped to whether THIS layer has
+        // any locked key at all rather than a single scalar field.
+        var hasKeyLocks = !!(window.SMMotion && SMMotion.keysLockedTo &&
+          (SMMotion.keysLockedTo(li, 'in').length || SMMotion.keysLockedTo(li, 'out').length || SMMotion.keysLockedTo(li, 'layer').length));
+        if ((lk || hasKeyLocks) && lockDx) return; // the standing lock(s) above already moved this layer's keys
         if (window.SMMotion && SMMotion.shiftLayerMotionKeys) SMMotion.shiftLayerMotionKeys(li, dx);
       };
       if (d.group) {

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -7762,6 +7762,65 @@
       row('layer', 'ctxKeyLockWholeLayer')
     ];
   }
+  // Per-KEYFRAME standing lock (feedback #212, "le lock in point, out point
+  // et layer affecte toute les keyframes alors que ça devrait être les
+  // keyframes select au clic droit") — reusing ld.keyLock's 3 labels above
+  // was a deliberate earlier call (buildKeyLockMenuItems' own header
+  // comment: "the keyframe selection itself is incidental context, confirmed
+  // with Cyril"), but re-asked directly this time: the keyframe cell's own
+  // menu should lock ONLY whatever's selected at the moment it's opened, not
+  // the whole layer. Stored right on each key (key.lockTo, same footprint as
+  // the existing key.hold flag) rather than on the layer, so several keys on
+  // the same layer can each follow a DIFFERENT edge. Persists for free:
+  // ld.motion/ld.elementMotion are written into exportJSON wholesale
+  // (timeline.js), not field-by-field, so a new key field needs no separate
+  // whitelist entry.
+  function buildKeySelectionLockMenuItems() {
+    if (!_motionKeySel.length) return [];
+    function allLockedTo(mode) { return _motionKeySel.every(function (s) { return s.key && s.key.lockTo === mode; }); }
+    function row(mode, key) {
+      var active = allLockedTo(mode);
+      return {
+        label: SM.t(key) + (active ? '  ✓' : ''),
+        action: function () {
+          pushUndo();
+          var next = active ? null : mode;
+          _motionKeySel.forEach(function (s) { if (s.key) s.key.lockTo = next; });
+          renderTimeline();
+        }
+      };
+    }
+    return [
+      { label: SM.t('ctxLockKeyframesOnColon'), disabled: true, action: function () {} },
+      row('in', 'ctxKeyLockInPoint'),
+      row('out', 'ctxKeyLockOutPoint'),
+      row('layer', 'ctxKeyLockWholeLayer')
+    ];
+  }
+  // Every key across a layer's own track set (+ each element holder's own
+  // tracks — CLAUDE.md §8's per-shape Motion) currently flagged to follow
+  // `mode` ('in'/'out'/'layer'). Same holder/track reach as shiftLayerMotionKeys'
+  // shiftHolder (propsFor, not the base PROPS — a 3D/duplicator/multi-parent
+  // -blend/timeLink holder has tracks beyond the base 5), minus timeRemap/
+  // effects: those aren't reachable through the same keyframe-cell menu this
+  // lock is set from, so they're out of scope for it, unlike the whole-layer
+  // lock which sweeps everything on purpose.
+  function keysLockedTo(li, mode) {
+    var ld = state.layers[li];
+    if (!ld) return [];
+    var out = [];
+    function scan(h) {
+      if (!h || !h.motion) return;
+      propsFor(h).forEach(function (prop) {
+        var t = h.motion[prop];
+        if (!t || !t.keys) return;
+        t.keys.forEach(function (k) { if (k.lockTo === mode) out.push({ holder: h, prop: prop, key: k }); });
+      });
+    }
+    scan(ld);
+    if (ld.elementMotion) Object.keys(ld.elementMotion).forEach(function (id) { scan(ld.elementMotion[id]); });
+    return out;
+  }
   function setLayerTimeLink(li, targetIdx, mode, srcAnchor) {
     var ld = state.layers[li], src = state.layers[targetIdx];
     if (!ld || !src || targetIdx === li) return false;
@@ -9857,13 +9916,17 @@
             menu.push({ label: SM.t('ctxParentInTimeLinkTimeEllipsis'), action: function () {
               window.showContextMenu(e.clientX + 8, e.clientY + 8, window.buildTimeLinkMenuItems(state.activeLayerIdx, state.layers[state.activeLayerIdx], function () { renderLayerList(); renderTimeline(); }));
             } });
-            // The standing keyframe lock belongs next to it, on the same
-            // target and by the same rule (the active layer — a keyframe row
-            // always belongs to the expanded active layer's tracks). Asked
-            // for directly: this is the surface you're on when you care
-            // whether your keys follow a retimed in/out point.
-            buildKeyLockMenuItems(state.activeLayerIdx, state.layers[state.activeLayerIdx]).forEach(function (it) { menu.push(it); });
           }
+          // feedback #212 ("le lock in point, out point et layer affecte
+          // toute les keyframes alors que ça devrait être les keyframes
+          // select au clic droit") — this used to reuse buildKeyLockMenuItems
+          // (the whole-LAYER ld.keyLock, same as the layer row's own menu).
+          // Re-asked directly: this surface now locks ONLY whatever's
+          // selected when the menu opens (key.lockTo, see its own header
+          // comment) — independent of Parent-in-Time's own availability
+          // gate above, so it's not folded into that block anymore.
+          var lockItems = buildKeySelectionLockMenuItems();
+          if (lockItems.length) { menu.push({ sep: true }); lockItems.forEach(function (it) { menu.push(it); }); }
           window.showContextMenu(e.clientX, e.clientY, menu);
         });
       })(fi, k);
@@ -12352,6 +12415,9 @@
     registerExposedPropMeta: registerExposedPropMeta,
     distributeKeys: distributeKeys, flipKeys: flipKeys, selectEveryNthKey: selectEveryNthKey, invertKeySelection: invertKeySelection,
     getKeySelection: function () { return _motionKeySel.slice(); },
+    // feedback #212 — per-keyframe standing lock (key.lockTo), used by
+    // layer-inout.js's drag-drop alongside the whole-layer ld.keyLock pass.
+    keysLockedTo: keysLockedTo,
     // Move an explicit set of keys by dx frames — used by layer-inout.js so
     // that dragging a layer's in/out point carries the SELECTED keyframes
     // with it (2026-07-25: "il faut pouvoir bouger les in/out point de


### PR DESCRIPTION
## Summary
- The keyframe cell's own right-click "Lock keyframes to in/out/layer" menu reused the whole-layer `ld.keyLock` mechanism (same menu the layer row offers), so toggling it from a keyframe moved every keyframe on every track of the layer with the next in/out trim, not just the keys selected at the time.
- Re-confirmed with the user directly (this reverses an earlier "confirmed with Cyril" call documented in motion.js) rather than silently deciding either way.
- New: `key.lockTo` (per-key flag, same footprint as the existing `key.hold`), a `keysLockedTo(li, mode)` query, and a dedicated `buildKeySelectionLockMenuItems()` for the keyframe-cell surface — the layer row's own menu is untouched and still locks the whole layer.
- `layer-inout.js`'s drag-drop gained a parallel pass alongside the standing `ld.keyLock` pass, looping all three modes since different keys on the same layer can each follow a different edge. The wholesale-shift fallback in `retimeOne` now also checks per-key locks before falling through, so a locked key never gets shifted twice.

## Test plan
- [x] `npm test` — 27/27 passing
- [x] Verified in-browser: created two Position keyframes (frame 0, frame 20), flagged only the frame-20 key `lockTo:'in'`, confirmed `keysLockedTo` finds only that key, and confirmed `shiftKeySelection` on that result moves only the flagged key (20→35) while the unflagged one stays at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)