### PR TITLE
Engine: fix layer Order colliding with untouched-layer default (feedback #215)

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2214,7 +2214,24 @@
       // this array = painted first = further back). Ties (the default 0,
       // an untouched layer) still keep original document order — that half
       // is orthogonal to which direction an explicit value pushes.
-      var _orderPairs = layers.map(function (entry, idx) { return { entry: entry, idx: idx, ord: SMMotion.layerOrderAt(idx, renderFrame) }; });
+      // feedback #215: 0 (untouched) is numerically smaller than any
+      // positive explicit rank, and this sort is descending -- so an
+      // untouched layer, sharing the sentinel 0, always outranked (sorted
+      // closer to the front than) a layer explicitly set to the
+      // supposedly-frontmost rank 1. Giving a layer order=1 could
+      // therefore only ever send it BEHIND every untouched layer, never
+      // in front of any of them -- the opposite of "1 is the topmost"
+      // (feedback #205, right above). Untouched layers now sort as if
+      // ranked past the back of any rank a user would realistically type
+      // for a document this size (layers.length+1, shared by all of them
+      // so ties still resolve to original document order via the idx
+      // tiebreak, same as before) -- an explicit small rank can now
+      // actually land in front of them, as documented.
+      var _totalOrderLayers = layers.length + 1;
+      var _orderPairs = layers.map(function (entry, idx) {
+        var ord = SMMotion.layerOrderAt(idx, renderFrame);
+        return { entry: entry, idx: idx, ord: ord === 0 ? _totalOrderLayers : ord };
+      });
       _orderPairs.sort(function (a, b) { return (b.ord - a.ord) || (a.idx - b.idx); });
       layers = _orderPairs.map(function (p) { return p.entry; });
     }

--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2214,25 +2214,41 @@
       // this array = painted first = further back). Ties (the default 0,
       // an untouched layer) still keep original document order — that half
       // is orthogonal to which direction an explicit value pushes.
-      // feedback #215: 0 (untouched) is numerically smaller than any
-      // positive explicit rank, and this sort is descending -- so an
-      // untouched layer, sharing the sentinel 0, always outranked (sorted
-      // closer to the front than) a layer explicitly set to the
-      // supposedly-frontmost rank 1. Giving a layer order=1 could
-      // therefore only ever send it BEHIND every untouched layer, never
-      // in front of any of them -- the opposite of "1 is the topmost"
-      // (feedback #205, right above). Untouched layers now sort as if
-      // ranked past the back of any rank a user would realistically type
-      // for a document this size (layers.length+1, shared by all of them
-      // so ties still resolve to original document order via the idx
-      // tiebreak, same as before) -- an explicit small rank can now
-      // actually land in front of them, as documented.
-      var _totalOrderLayers = layers.length + 1;
+      // feedback #215: an untouched layer used to share a flat 0 with
+      // every other untouched layer -- numerically smaller than any
+      // positive explicit rank, which under this descending sort always
+      // outranked (sorted closer to the front than) a layer explicitly
+      // set to the supposedly-frontmost rank 1. Giving a layer order=1
+      // could therefore only ever send it BEHIND every untouched layer,
+      // the opposite of "1 is the topmost" (feedback #205, right above).
+      // Fixed at the source instead of worked around here: layerOrderAt
+      // (motion.js) now returns an untouched layer's own natural
+      // front-to-back rank instead of a flat 0 (feedback #215 follow-up,
+      // "la value si non keyframé... corresponde à son ordre index dans
+      // la timeline") -- every layer, touched or not, now carries a real,
+      // correctly-scaled rank. That reopened a narrower version of the
+      // exact same collision one level down: an untouched layer's natural
+      // rank can legitimately TIE with another layer's EXPLICIT rank (a
+      // 3-layer document's untouched back layer naturally reads "3", but
+      // so would a middle layer explicitly told "put me at rank 3") --
+      // broken by document index alone, the explicit pick silently did
+      // nothing whenever it happened to match a sibling's natural rank
+      // (confirmed live: explicit rank 1 on a middle layer produced ZERO
+      // visible change when the naturally-frontmost layer's own rank was
+      // also 1). layerHasExplicitOrder makes the tiebreak asymmetric: an
+      // explicit rank always wins the front position over an untouched
+      // layer merely reading the same number by coincidence; only a tie
+      // between two layers of the SAME kind (both explicit, or both
+      // untouched) falls back to original document order, as before.
       var _orderPairs = layers.map(function (entry, idx) {
-        var ord = SMMotion.layerOrderAt(idx, renderFrame);
-        return { entry: entry, idx: idx, ord: ord === 0 ? _totalOrderLayers : ord };
+        return { entry: entry, idx: idx, ord: SMMotion.layerOrderAt(idx, renderFrame), explicit: SMMotion.layerHasExplicitOrder(idx) };
       });
-      _orderPairs.sort(function (a, b) { return (b.ord - a.ord) || (a.idx - b.idx); });
+      _orderPairs.sort(function (a, b) {
+        var byOrd = b.ord - a.ord;
+        if (byOrd) return byOrd;
+        if (a.explicit !== b.explicit) return a.explicit ? 1 : -1;
+        return a.idx - b.idx;
+      });
       layers = _orderPairs.map(function (p) { return p.entry; });
     }
     // artboard background as the bottom item of a synthetic bottom layer,

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -1077,6 +1077,22 @@
     var def = PROP_DEFAULT[prop];
     return def ? def.slice() : [0, 0];
   }
+  // What a property row should actually DISPLAY right now — the ordinary
+  // animated/static value for everything, except a LAYER holder's
+  // untouched 'order' row (feedback #215 follow-up), which shows the
+  // layer's own natural front-to-back rank (layerOrderAt's fallback, the
+  // exact value the render pipeline now sorts by) instead of staticValue's
+  // flat 0 placeholder. Shared by the panel's initial build and its own
+  // live-drag refresh so the two can never show two different numbers for
+  // the same untouched layer.
+  function displayValueFor(holder, prop) {
+    if (isAnimated(holder, prop)) return valueAtFrame(holder, prop, state.currentFrame);
+    if (prop === 'order') {
+      var li = state.layers.indexOf(holder);
+      if (li >= 0) return [layerOrderAt(li, state.currentFrame)];
+    }
+    return staticValue(holder, prop);
+  }
 
   // Callers clamp before the first/after the last key, so the remaining
   // query is always inside one segment. Motion evaluation runs this lookup
@@ -2626,7 +2642,12 @@
       if (!ld.motionStatic) ld.motionStatic = {};
       ld.motionStatic[prop] = v;
     } else {
-      var cur = staticValue(ld, prop);
+      // feedback #215 follow-up: seed the first key with what the field
+      // was actually SHOWING (displayValueFor — a layer's untouched
+      // 'order' reads as its natural rank, not staticValue's flat 0), so
+      // turning the stopwatch on can never snap the layer to a different
+      // rank than what was on screen the moment before.
+      var cur = displayValueFor(ld, prop);
       ensureTrack(ld, prop).keys = [{ frame: state.currentFrame, v: cur, curvePoints: cloneCurvePts(DEFAULT_CURVE), hOut: [0, 0], hIn: [0, 0] }];
     }
   }
@@ -3905,7 +3926,34 @@
   function layerOrderAt(li, frameIdx) {
     var ld = state.layers[li];
     if (!ld) return 0;
+    // feedback #215 follow-up ("la value si non keyframé... corresponde
+    // à son ordre index dans la timeline") — an untouched layer used to
+    // read as a flat neutral 0 regardless of where it actually sits in
+    // the stack, which collided with any small explicit rank set on
+    // ANOTHER layer (see engine-bridge.js's own comment on the sort that
+    // consumes this). Reading its OWN natural front-to-back position
+    // instead — same "1 = topmost" counting convention explicit values
+    // already use (feedback #205) — means every layer, touched or not,
+    // carries a real, correctly-scaled rank: no collision, and the field
+    // now shows something meaningful instead of a placeholder 0 the
+    // instant you open it.
+    if (!isAnimated(ld, 'order') && !(ld.motionStatic && ld.motionStatic.order)) {
+      return state.layers.length - li;
+    }
     return valueAtFrame(ld, 'order', frameIdx)[0];
+  }
+  // Whether THIS layer's Order was actually set by the user, vs. reading
+  // as its natural-rank fallback above. The z-stack sort needs this
+  // because a natural rank can legitimately tie with another layer's
+  // EXPLICIT rank (a 3-layer document: an untouched back layer naturally
+  // reads as "3", but so would a middle layer explicitly told "put me at
+  // rank 3") — ties broken by document index alone would then leave the
+  // explicit pick indistinguishable from a coincidence, silently doing
+  // nothing. See its one call site (engine-bridge.js) for how the tie
+  // actually resolves once this is known.
+  function layerHasExplicitOrder(li) {
+    var ld = state.layers[li];
+    return !!(ld && (isAnimated(ld, 'order') || (ld.motionStatic && ld.motionStatic.order)));
   }
   function elementOrderAt(li, strokeId, frameIdx) {
     var ld = state.layers[li];
@@ -6184,7 +6232,7 @@
       if (!holder || !prop) return;
       var inputs = pr.querySelectorAll('.motion-val');
       if (!inputs.length) return;
-      var vals = isAnimated(holder, prop) ? valueAtFrame(holder, prop, state.currentFrame) : staticValue(holder, prop);
+      var vals = displayValueFor(holder, prop);
       for (var i = 0; i < inputs.length; i++) {
         if (document.activeElement === inputs[i]) continue;
         if (i >= vals.length) continue;
@@ -8090,7 +8138,7 @@
         });
         pr.appendChild(gridBtn);
       }
-      var vals = isAnimated(holder, prop) ? valueAtFrame(holder, prop, state.currentFrame) : staticValue(holder, prop);
+      var vals = displayValueFor(holder, prop);
       var fieldWrap = document.createElement('div'); fieldWrap.className = 'motion-fields';
       var DIM_LABEL = PROP_DIM[prop] > 1 ? (PROP_DIM_LABELS[prop] || ['X', 'Y', 'Z']) : null;
       // Expression controls (2026-08-30): two of the five types want a
@@ -9938,7 +9986,9 @@
           var menu = [
             key
               ? { label: SM.t('ctxDeleteThisKey'), action: function () { pushUndo(); var tr = trackFor(ld, prop); tr.keys.splice(tr.keys.indexOf(key), 1); renderTimeline(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow(); } }
-              : { label: SM.t('ctxAddKeyHere'), action: function () { pushUndo(); setKeyAtCurrentFrame(ld, prop, isAnimated(ld, prop) ? valueAtFrame(ld, prop, frameIdx) : staticValue(ld, prop)); renderLayerList(); renderTimeline(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow(); } },
+              // feedback #215 follow-up: displayValueFor, not staticValue —
+              // see toggleAnimated's own comment on the same seeding gap.
+              : { label: SM.t('ctxAddKeyHere'), action: function () { pushUndo(); setKeyAtCurrentFrame(ld, prop, isAnimated(ld, prop) ? valueAtFrame(ld, prop, frameIdx) : displayValueFor(ld, prop)); renderLayerList(); renderTimeline(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow(); } },
           ];
           if (track && track.keys.length) {
             // A single-key track auto-creates its missing second key on open
@@ -12386,6 +12436,7 @@
       return true;
     },
     layerOrderAt: layerOrderAt,
+    layerHasExplicitOrder: layerHasExplicitOrder,
     elementOrderAt: elementOrderAt,
     anyLayerHasOrder: anyLayerHasOrder,
     layerElementsHaveOrder: layerElementsHaveOrder,


### PR DESCRIPTION
## Summary
- **Core fix (#215)**: `0` (untouched) was numerically smaller than any positive explicit rank, and the z-stack sort is descending — so an untouched layer always outranked a layer explicitly set to the documented frontmost rank `1` (feedback #205). Setting a layer's Order to `1` could therefore only ever send it BEHIND every untouched layer.
- **Follow-up, same PR** (explicit user ask: "vu que tu travail là-dessus il faudrait que la value si non keyframé d'un layer pour order corresponde à son ordre index dans la timeline"): an untouched layer's Order now displays and sorts by its own natural front-to-back rank instead of a flat `0` — both fixes converge on `layerOrderAt` returning `layers.length - li` for an untouched layer, which let the sort drop the sentinel workaround from the first commit and go back to a plain numeric compare.
- **Edge case found while verifying the follow-up**: an untouched layer's natural rank can tie with another layer's *explicit* rank (a 3-layer doc's untouched back layer naturally reads "3", but so would a middle layer explicitly told "rank 3"). `layerHasExplicitOrder` makes the tiebreak asymmetric — an explicit rank always wins the front position over an untouched layer that merely reads the same number by coincidence.

## Test plan
- [x] `npm test` — 27/27 passing
- [x] Verified live: 3 layers, natural stacking red(back)/green(mid)/blue(front).
  - Setting green's Order to 1 correctly brought it in front of both red and blue (the original #215 repro).
  - Selecting each untouched layer showed its natural rank (3, 2, 1) in the Order field instead of 0.
  - The explicit/natural tie case: explicit order=1 on green while blue (naturally frontmost) stays untouched at its own natural rank 1 — green now correctly renders in front of both (previously this tie produced zero visible change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)