### PR TITLE
Motion: marquee/shift-range select for Parent+Blend keyframes (feedback #221)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -9577,6 +9577,35 @@
               renderTimeline();
               return;
             }
+            // feedback #221 ("impossible de sélectionner... comme les
+            // autres propriétés") — Shift-range, mirroring the numeric
+            // row's own handler: reuse the marquee's rectangle-selection
+            // between the anchor cell and this one, so it picks up
+            // whatever else is in that box too (now that applyMarqueeSelection
+            // itself also scans this row's own .motion-group-row class).
+            if (e.shiftKey) {
+              var anchorCell = null;
+              if (_keyAnchor) {
+                var rowsA = document.querySelectorAll('#frame-grid .motion-track-row, #frame-grid .motion-group-row');
+                for (var ri = 0; ri < rowsA.length; ri++) {
+                  if (rowsA[ri]._smHolder === _keyAnchor.holder && rowsA[ri]._smProp === _keyAnchor.prop) {
+                    anchorCell = rowsA[ri].querySelector('.fc[data-frame="' + _keyAnchor.frame + '"]');
+                    break;
+                  }
+                }
+              }
+              if (anchorCell) {
+                var ar = anchorCell.getBoundingClientRect(), cr = c.getBoundingClientRect();
+                var ax = ar.left + ar.width / 2, ay = ar.top + ar.height / 2;
+                var bx = cr.left + cr.width / 2, by = cr.top + cr.height / 2;
+                applyMarqueeSelection(Math.min(ax, bx), Math.min(ay, by), Math.max(ax, bx), Math.max(ay, by));
+              } else {
+                setKeySel([{ holder: holder, prop: prop, key: k }]);
+                _keyAnchor = { holder: holder, prop: prop, frame: frame };
+              }
+              renderTimeline();
+              return;
+            }
             pushUndo();
             if (isKeySelected(holder, prop, k)) {
               // Already part of the current selection — drag the WHOLE
@@ -9613,6 +9642,18 @@
           });
         })(fi, key);
         c.appendChild(dia);
+      } else {
+        // feedback #221 ("impossible de sélectionner avec rec de
+        // sélection") — a numeric row's own empty cells start a marquee on
+        // mousedown (trackRowHtml); this row's cells never got the same
+        // listener at all, so a drag STARTING on empty space within it
+        // never even called startMarquee. Diamonds keep their own handler
+        // above (dragging one moves it, not a marquee) — this is only for
+        // the gaps between them.
+        c.addEventListener('mousedown', function (e) {
+          e.stopPropagation();
+          startMarquee(e);
+        });
       }
       row.appendChild(c);
     }
@@ -10798,7 +10839,14 @@
   // universe the marquee itself draws over).
   function invertKeySelection() {
     var all = [], prevSel = _motionKeySel;
-    document.querySelectorAll('.motion-track-row').forEach(function (rowEl) {
+    // feedback #221 ("impossible de sélectionner avec rec de sélection les
+    // keyframes comme les autres propriétés") — .motion-group-row also
+    // covers renderDiscreteKeyGridRow's Blend/Parent rows (feedback #214),
+    // tagged with the same _smHolder/_smProp convention; an UNTAGGED
+    // group-row (a plain section header/divider) safely no-ops on the
+    // `if (!holder) return` guards already below, so widening this scan
+    // costs nothing for every other kind of .motion-group-row.
+    document.querySelectorAll('.motion-track-row, .motion-group-row').forEach(function (rowEl) {
       var holder = rowEl._smHolder, prop = rowEl._smProp;
       var track = trackFor(holder, prop);
       if (!track) return;
@@ -10822,7 +10870,8 @@
   }
   function applyMarqueeSelection(x0, y0, x1, y1) {
     var sel = [];
-    document.querySelectorAll('.motion-track-row').forEach(function (rowEl) {
+    // feedback #221 — see invertKeySelection's identical comment just above.
+    document.querySelectorAll('.motion-track-row, .motion-group-row').forEach(function (rowEl) {
       var holder = rowEl._smHolder, prop = rowEl._smProp;
       if (!holder) return;
       rowEl.querySelectorAll('.motion-key').forEach(function (dia) {


### PR DESCRIPTION
## Summary
Follow-up on #214 (click/drag/delete for the discrete-key Parent/Blend rows). Three gaps, all from the row only getting a subset of the numeric row's event wiring:

1. `applyMarqueeSelection`/`invertKeySelection` scanned `.motion-track-row` only — the discrete-key rows use `.motion-group-row`, so neither considered them. Widened both scans (safe: an untagged `.motion-group-row` no-ops on the existing `if (!holder) return` guard).
2. A marquee drag STARTING on empty space within one of these rows never called `startMarquee` at all — #214 only wired a listener onto each diamond, not the empty cells between them. Added the same empty-cell → `startMarquee` call the numeric rows already have.
3. Shift-click range-select was entirely unimplemented here — added, mirroring the numeric row's own handler.

Couldn't reproduce an outright crash from the report's click trail, but it matches this feature area closely, and a completely missing selection path likely read as the timeline "bugging out."

## Test plan
- [x] `npm test` — 27/27 passing
- [x] Verified live via synthetic DOM mouse events at the real elements' own coordinates (sidestepping the Browser pane's documented screenshot-space-vs-CSS-pixel mismatch): a marquee drawn across 3 Blend keyframes selected all 3, with the selected-key visual style applied on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)