### PR TITLE
Audio: delete button gets a real icon (feedback #218, partial)

### DIFF
--- a/src/js/audio-bridge.js
+++ b/src/js/audio-bridge.js
@@ -235,8 +235,17 @@
       vol.addEventListener('change', function () { logAudio('volume'); });
       row.appendChild(vol);
 
+      // feedback #218 ("je peux pas le supprimer") — deletion already
+      // worked (splice below, unchanged), but the control was a bare "×"
+      // glyph with none of the affordance every other row icon in this
+      // panel has (mute just above uses a real flat SVG, matching the
+      // panel's own established "flat monochrome SVGs, not emoji/glyphs"
+      // convention) — easy to read as decoration on a tightly-packed row
+      // rather than a clickable delete, which is very likely what actually
+      // read as "can't delete it" live.
       var del = document.createElement('div');
-      del.className = 'lico'; del.textContent = '×'; del.title = window.SM.t('audioDeleteTrack');
+      del.className = 'lico'; del.title = window.SM.t('audioDeleteTrack');
+      del.innerHTML = '<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M9 3h6l1 2h4v2H4V5h4z"/><path d="M6 9h12l-1 12H7z"/></svg>';
       del.addEventListener('click', function (e) {
         e.stopPropagation();
         stopTrack(track);


### PR DESCRIPTION
## Summary
Deletion already worked — the control was just a bare "×" glyph, inconsistent with this panel's own established icon convention (the mute button right next to it uses a real flat SVG). On a tightly-packed row that's very plausibly what read as "can't delete it."

This is the one narrow, low-risk piece of a much larger ask. The rest — select an audio track like a real layer, cut/split it, in/out trim handles, an animatable/keyable volume — is a genuine feature gap: `state.audioTracks` is a separate array entirely outside `state.layers`/the Motion keyframe system by original design. Queued separately rather than attempted here; see the GitHub comment for details.

## Test plan
- [x] `npm test` — 27/27 passing
- [x] Verified live: injected a synthetic audio track, confirmed the row renders with a clear trash icon in Motion mode, and clicking it still removes the track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)