### PR TITLE
Motion: Subselect writes to armed Path vertex track instead of Animation 2D key (#216)

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -3626,6 +3626,14 @@
     var segs = nodeEditSegmentsData(path);
     var zs = 1 / view.zoom;
     var items = [];
+    // feedback #216 — twin of renderNodeHandles' identical fix (tools.js,
+    // see its own comment): apply an armed Path vertex track's vtxN offset
+    // BEFORE the element/layer/symMatrix transforms below, mirroring
+    // applyPathVertexOffsets' role as the innermost, pre-transform step at
+    // render time (CLAUDE.md §5ter v2) — otherwise the overlay diamond sits
+    // at the vertex's pre-drag position while the shape itself has moved.
+    var vtxSid = path.data && path.data.strokeId;
+    if (vtxSid && window.SMMotion && SMMotion.applyPathVertexOffsetsFor) segs = SMMotion.applyPathVertexOffsetsFor(state.activeLayerIdx, vtxSid, segs, state.currentFrame);
     // Per-ELEMENT Motion (feedback #199, "subselect affiche des vecteurs
     // décalés si la shape est déplacée ou animée") — a single shape keyed
     // on its OWN Position/Scale/Rotation (CLAUDE.md §8's "Motion niveau
@@ -3636,7 +3644,7 @@
     // established element -> layer -> parents order, and reusing the exact
     // same transformSegments/elementMotionAt pair that function already
     // uses for hit-testing, so overlay and hit-test agree by construction.
-    var handleSid = path.data && path.data.strokeId;
+    var handleSid = vtxSid;
     if (handleSid && window.SMMotion && SMMotion.elementMotionAt && SMMotion.transformSegments) {
       var em = SMMotion.elementMotionAt(state.activeLayerIdx, handleSid, state.currentFrame);
       if (em && (em.dx || em.dy || em.rot || em.sx !== 1 || em.sy !== 1)) {

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -4231,6 +4231,22 @@
     if (!ld || !ld.elementMotion || !strokeId) return segments;
     return applyPathVertexOffsets(segments, ld.elementMotion[strokeId], frameIdx);
   }
+  // Writes a Path vertex's ANIMATED offset through the ordinary setValue
+  // path (a key at the playhead when the stopwatch is on, a static override
+  // when it isn't) — the on-canvas counterpart to setMeshVertexOffset below,
+  // for a regular shape's own vtxN track (elementMotion keyed by strokeId,
+  // not meshId). Unlike a mesh vertex the value is in the SAME units as the
+  // segment point itself (applyPathVertexOffsets adds it straight to
+  // s.point) — no percent normalization needed. feedback #216: this is what
+  // subselect-bridge.js's vertex drag calls once the shape's "Path" group
+  // is armed (SMMotion.hasPathVertexMotionFor), instead of falling through
+  // to the Animation 2D keyframe-promotion path.
+  function setPathVertexOffset(li, strokeId, vi, dx, dy) {
+    var ld = state.layers[li];
+    if (!ld || !strokeId) return false;
+    setValue(ensureElementHolder(ld, strokeId), 'vtx' + vi, [dx, dy]);
+    return true;
+  }
 
   // ---- Image mesh vertices (2026-08-30, image-mesh.js) ----
   //
@@ -12566,6 +12582,7 @@
     applyParentChainToSegments: applyParentChainToSegments,
     applyParentChainToImageRect: applyParentChainToImageRect,
     applyPathVertexOffsetsFor: applyPathVertexOffsetsFor,
+    setPathVertexOffset: setPathVertexOffset,
     // Image mesh vertex tracks (2026-08-30) — see meshHolder's own comment
     // for why these are keyed by meshId and expressed in percent.
     hasMeshVertexMotionFor: hasMeshVertexMotionFor,

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -852,6 +852,23 @@
           // single gesture both selects AND drags the sibling, like every
           // other grab in this file already does for the FIRST element.
           SMMotion.onDown({ point: ptEx, altKey: e.altKey });
+        } else if (sidEx === window._motionExpandedElement) {
+          // feedback #216 investigation (2026-08-31): re-clicking the SAME
+          // shape that is already the isolation target hit neither branch
+          // above (not a sibling to retarget to, not empty space to exit
+          // through) — sortiDuGroupe stayed false and the click below got
+          // swallowed for nothing: no retarget happened, no exit happened,
+          // the gesture just vanished. That silently blocked every OTHER
+          // canvas tool (Subselect vertex-dragging chief among them, but
+          // also a plain Select-tool re-drag) from ever reaching its own
+          // hit-test once a single element had been isolated via the
+          // Elements panel (selectShapesByStrokeIds sets
+          // _motionExpandedElement) — the exact state a user is in right
+          // after arming a shape's "Path" vertex Motion group, whose row
+          // only appears for an isolated single element. Nothing to change
+          // about the isolation itself here; just let a click this block
+          // has no work for fall through instead of eating it.
+          sortiDuGroupe = true;
         } else if (!sidEx) {
           var uEx = (lyrEx && window.perObjectUnionBounds) ? perObjectUnionBounds(lyrEx) : null;
           window._motionExpandedElement = null;

--- a/src/js/subselect-bridge.js
+++ b/src/js/subselect-bridge.js
@@ -186,7 +186,31 @@
       if (nd < bestNd) { bestNd = nd; bestNh = nh; }
     }
     if (bestNh) {
+      // feedback #216 ("dans motion ajouté une keyframe de path > modifié le
+      // path avec subselect ne créer pas un blend de vertex ni de keyframes
+      // de path mais une nouvelle clé d'animation 2D"): once a shape's
+      // "Path" group is armed (motion.js's renderPathVertexGroup stopwatch,
+      // CLAUDE.md §12ter's vtxN machinery), a vertex drag must write an
+      // animated per-vertex OFFSET into that track — the ensureKeyframe()/
+      // raw-segment-mutation path below is the Animation 2D system, an
+      // entirely different persistence layer vtxN exists specifically to
+      // bypass (CLAUDE.md §8 "le path est keyable au niveau du VERTEX").
+      // Scoped to 'point' handles only — vtxN has no notion of tangent
+      // handles (applyPathVertexOffsets only ever offsets s.point) — and to
+      // non-vector-brush paths, since a brush's editable geometry lives in
+      // data.centerSegments, a different space this track was never built
+      // to read.
+      var vtxTargetPath = typeof nodeEditTargetPath === 'function' ? nodeEditTargetPath() : null;
+      var vtxStrokeId = (bestNh.type === 'point' && vtxTargetPath && vtxTargetPath.data && !vtxTargetPath.data.isVectorBrush) ? vtxTargetPath.data.strokeId : null;
+      var isMotionVertexDrag = !!(vtxStrokeId && state.appMode === 'motion' && window.SMMotion && SMMotion.hasPathVertexMotionFor(state.activeLayerIdx, vtxStrokeId));
+
       pushUndo();
+      if (isMotionVertexDrag) {
+        _nodeDrag.motionStrokeId = vtxStrokeId;
+        _nodeDrag.motionLi = state.activeLayerIdx;
+        _wasInterpolated = false;
+      } else {
+      _nodeDrag.motionStrokeId = null;
       // Promote a HELD frame to a real keyframe before touching geometry.
       // Without this, editing vertices on a frame that merely inherits an
       // earlier keyframe was silently DISCARDED: saveActiveLayerFrame (app.js)
@@ -217,6 +241,7 @@
           .filter(Boolean);
         if (!selectedPaths.length) return;
         renderNodeHandles();
+      }
       }
       _nodeDrag.active = true; _nodeDrag.path = selectedPaths[0]; _nodeDrag.segIndex = bestNh.segIndex;
       _nodeDrag.dragStartPointer = pt.clone(); _nodeDrag.appliedDelta = new Point(0, 0);
@@ -327,6 +352,19 @@
         dashArray: [4 / view.zoom, 3 / view.zoom], fillColor: new Color(1, 0.72, 0.42, 0.08), insert: true,
       });
       prevA2.activate();
+    } else if (_nodeDrag.active && _nodeDrag.motionStrokeId) {
+      // feedback #216 — armed Path-vertex Motion track: write the total
+      // accumulated drag delta into vtxN (SMMotion.setPathVertexOffset)
+      // instead of mutating path.segments, mirroring image-mesh-bridge.js's
+      // setMeshVertexOffset pattern (same vtxN machinery, CLAUDE.md §12ter).
+      // `desired` is the SAME total-since-mousedown delta the raw-geometry
+      // branches below would have added to the segment point, so this is a
+      // like-for-like swap of destination, not a different gesture.
+      var vtxIndices = _nodeDrag.type === 'group' ? _nodeSel : [_nodeDrag.segIndex];
+      vtxIndices.forEach(function (vi) {
+        SMMotion.setPathVertexOffset(_nodeDrag.motionLi, _nodeDrag.motionStrokeId, vi, desired.x, desired.y);
+      });
+      if (SMMotion.liveRefreshVisiblePropertyFields) SMMotion.liveRefreshVisiblePropertyFields();
     } else if (_nodeDrag.active && _nodeDrag.type === 'group') {
       var gp = _nodeDrag.path;
       if (gp.data && gp.data.isVectorBrush && gp.data.centerSegments) {
@@ -418,6 +456,17 @@
         if (!_nodeSel.length) clearSel();
       } else { clearSel(); }
       _nmq.active = false; renderNodeHandles(); renderArcs(); updateUI();
+    } else if (_nodeDrag.active && _nodeDrag.motionStrokeId) {
+      // feedback #216 — the vtxN write already happened live in onMove
+      // (setValue there handles both the key-at-playhead and static-override
+      // cases); nothing here touches Animation 2D geometry/frames, so none
+      // of the raw-segment commit machinery below applies (fork/fill-regen/
+      // saveActiveLayerFrame/harmonizeAfterEdit are all specific to that
+      // system). updateUI() only — a fresh key may have just appeared on
+      // the Path group's row, which only a full timeline rebuild picks up
+      // (same reasoning as image-mesh-bridge.js's onUp).
+      _nodeDrag.active = false; _nodeDrag.path = null; _nodeDrag.motionStrokeId = null;
+      renderNodeHandles(); updateUI();
     } else if (_nodeDrag.active) {
       var editedPath = _nodeDrag.path; var editedType = _nodeDrag.type; var editedSegIndex = _nodeDrag.segIndex;
       _nodeDrag.active = false; _nodeDrag.path = null;

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -1075,6 +1075,17 @@ function renderNodeHandles(){
   nodeLayer.removeChildren();nodeHandles=[];
   var path=nodeEditTargetPath();if(!path)return;
   var segs=nodeEditSegmentsData(path);
+  // feedback #216: a shape with an armed Motion "Path" vertex track
+  // (CLAUDE.md §12ter's vtxN machinery) renders each vertex at
+  // segment-point + vtxN offset, not at the raw segment point — apply the
+  // same offset here so hit-testing (nodeHandles[].pos, compared against
+  // subselect-bridge's toLocalPoint, which does NOT undo this offset) and
+  // the Paper-native fallback overlay both agree with where the vertex
+  // actually appears. No-op (same array back) for the overwhelmingly common
+  // un-armed case. Twin of engine-bridge.js's buildNodeHandleItems — keep
+  // both in sync (CLAUDE.md §3).
+  var sid0=path.data&&path.data.strokeId;
+  if(sid0&&window.SMMotion&&SMMotion.applyPathVertexOffsetsFor)segs=SMMotion.applyPathVertexOffsetsFor(state.activeLayerIdx,sid0,segs,state.currentFrame);
   nodeLayer.activate();var zs=1/view.zoom;
   segs.forEach(function(s,i){
     var pt=new Point(s.point[0],s.point[1]);


### PR DESCRIPTION
## Summary
- Once a shape's "Path" group is keyframed in Motion (`SMMotion.hasPathVertexMotionFor`, CLAUDE.md §12ter's vtxN machinery), a vertex drag with Subselect always fell through to Animation 2D's `ensureKeyframe()`/raw-segment path instead — creating an unwanted frame key rather than writing an animated per-vertex offset into the armed track.
- `subselect-bridge.js`'s vertex-drag handler now checks `state.appMode === 'motion'` + `SMMotion.hasPathVertexMotionFor` and, when armed, routes the drag through a new `SMMotion.setPathVertexOffset` (mirrors the existing `setMeshVertexOffset` used by image-mesh vertices) instead of `ensureKeyframe()`.
- `tools.js`'s `renderNodeHandles` and `engine-bridge.js`'s `buildNodeHandleItems` (the twin panel-fallback/engine-overlay handle builders, CLAUDE.md §3) now apply the same vtxN offset before drawing/hit-testing, so the node handle sits where the vertex actually renders instead of at its un-offset rest position.
- Also fixes a related gap found while reproducing this live: `select-bridge.js`'s per-object isolation block (entered once a single element is targeted via the Elements panel) silently swallowed any click landing back on that SAME already-isolated element — neither its "retarget to sibling" nor "exit the group" branch applied, so the click vanished before any tool-specific bridge (Subselect included) ever got a chance.

## Test plan
- [x] `npm test` (27/27 pass)
- [x] Verified live in the browser preview: armed a shape's "Path" vertex group, dragged a vertex with Subselect — `ld.elementMotion[strokeId].motion.vtx0` received the drag offset, the raw stored segment stayed untouched, no new Animation 2D keyframe was created, and the shape rendered with the offset applied (node handle overlay lined up with the moved vertex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)