### PR TITLE
Motion: keyframes locked to in/out point preview live during drag (#217)

### DIFF
--- a/src/js/layer-inout.js
+++ b/src/js/layer-inout.js
@@ -100,6 +100,35 @@
     if (!window.SMMotion || !SMMotion.previewKeyframeShift) return;
     SMMotion.previewKeyframeShift(null, dxFrames, 'selected');
   }
+  // Live preview for the TWO standing-lock mechanisms (feedback #217,
+  // "quand on parent in time les keyframes select et que je drag [...]
+  // l'inPoint les keyframe ne bougent pas en temps réel [...] pendant le
+  // drag"): ld.keyLock (whole layer, Sander van Dijk's "Lock Keyframes to
+  // In and Out Points") and key.lockTo (per-keyframe, feedback #212).
+  // mouseup's own lockOne/lockKeysOne (a few hundred lines down) already
+  // apply these for real at drop — this is the same "cheap transform-only
+  // preview, expensive commit at drop" split livePreviewLayerKeys uses for
+  // the default-retimes case, just never extended to the standing locks
+  // when they were added afterward. Deliberately mirrors lockOne/
+  // lockKeysOne's own gating (mode==='layer' only counts on a body drag,
+  // 'in'/'out' follow their own edge) so the preview never shows a shift
+  // drop won't actually commit.
+  function livePreviewLockedKeys(li, type, ld, origIn, origOut) {
+    if (!window.SMMotion || !SMMotion.previewKeyframeShift) return;
+    if (ld.keyLock && !(ld.keyLock === 'layer' && type !== 'both')) {
+      var movedL = ld.keyLock === 'out' ? outPointOf(ld) - origOut : inPointOf(ld) - origIn;
+      if (movedL) SMMotion.previewKeyframeShift(li, movedL, 'layer');
+    }
+    if (SMMotion.keysLockedTo) {
+      ['in', 'out', 'layer'].forEach(function (mode) {
+        if (mode === 'layer' && type !== 'both') return;
+        var moved = mode === 'out' ? outPointOf(ld) - origOut : inPointOf(ld) - origIn;
+        if (!moved) return;
+        var sel = SMMotion.keysLockedTo(li, mode);
+        if (sel.length) SMMotion.previewKeyframeShift(li, moved, 'keys', sel);
+      });
+    }
+  }
   // A manually-dragged range OR an auto-detected blank-keyframe trim both
   // count as "not full range" for styling — a naturally-shortened bar
   // (layer stops drawing partway through) should read as visually distinct
@@ -835,6 +864,7 @@
           // this specific bar actually moved a few lines up, instead of
           // whichever handle was grabbed to start the whole gesture.
           livePreviewLayerKeys(m.li, m.part || 'both', mld, m.origIn, e.altKey);
+          if (!e.altKey) livePreviewLockedKeys(m.li, m.part || 'both', mld, m.origIn, m.origOut);
         });
       }
       if (anyChanged) {
@@ -869,6 +899,7 @@
       }
     } else {
       livePreviewLayerKeys(_drag.li, _drag.type, ld, _drag.origIn, e.altKey);
+      if (!e.altKey) livePreviewLockedKeys(_drag.li, _drag.type, ld, _drag.origIn, _drag.origOut);
     }
     // Content visibility for the CURRENT frame must reflect the new range
     // live (dragging the out point below the playhead should hide the

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -11417,11 +11417,11 @@
   // target. Purely a transform on existing DOM nodes — the next real
   // renderTimeline() (drop, or anything else that rebuilds the grid) throws
   // these nodes away, so nothing needs undoing on the data side.
-  function previewKeyframeShift(li, dxFrames, mode) {
+  function previewKeyframeShift(li, dxFrames, mode, keyList) {
     if (!dxFrames) return;
     var px = Math.round(dxFrames * FC);
     var holders = null;
-    if (mode !== 'selected') {
+    if (mode !== 'selected' && mode !== 'keys') {
       var ld = state.layers[li];
       if (!ld) return;
       holders = [ld];
@@ -11429,7 +11429,17 @@
     }
     document.querySelectorAll('#frame-grid .motion-track-row').forEach(function (rowEl) {
       var dias;
-      if (mode === 'selected') {
+      // 'keys' mode (feedback #217, standing key.lockTo/ld.keyLock preview
+      // during an in/out drag): an explicit {holder,prop,key} list, same
+      // shape as SMMotion.keysLockedTo's return — unlike 'selected' (reads
+      // the .sel CSS class) this is the caller's own arbitrary set, scoped
+      // per-row to whichever entries belong to THIS row's holder/prop.
+      var rowKeyFrames = null;
+      if (mode === 'keys') {
+        rowKeyFrames = (keyList || []).filter(function (e) { return e.holder === rowEl._smHolder && e.prop === rowEl._smProp; }).map(function (e) { return e.key.frame; });
+        if (!rowKeyFrames.length) return;
+        dias = rowKeyFrames.map(function (fr) { return rowEl.querySelector('.fc[data-frame="' + fr + '"] .motion-key'); }).filter(Boolean);
+      } else if (mode === 'selected') {
         dias = rowEl.querySelectorAll('.motion-key.sel');
       } else {
         if (holders.indexOf(rowEl._smHolder) < 0) return;
@@ -11456,9 +11466,12 @@
       // duration block moves when its own key is selected.
       var rects = rowEl.querySelectorAll('.motion-key-connect, .motion-key-durblock');
       if (!rects.length) return;
-      if (mode === 'selected') {
+      if (mode === 'selected' || mode === 'keys') {
         var track = trackFor(rowEl._smHolder, rowEl._smProp);
         if (!track || !track.keys.length) return;
+        var keyQualifies = mode === 'keys'
+          ? function (k) { return rowKeyFrames.indexOf(k.frame) >= 0; }
+          : function (k) { return isKeySelected(rowEl._smHolder, rowEl._smProp, k); };
         rects.forEach(function (r) {
           var sel;
           // classList.contains, NOT getAttribute('class')===… (2026-08-29
@@ -11483,10 +11496,10 @@
           // live-preview-only bug, not a data bug).
           if (r.classList.contains('motion-key-durblock')) {
             var ki = +r.getAttribute('data-ki');
-            sel = track.keys[ki] && isKeySelected(rowEl._smHolder, rowEl._smProp, track.keys[ki]);
+            sel = track.keys[ki] && keyQualifies(track.keys[ki]);
           } else {
             var i = +r.getAttribute('data-i');
-            sel = track.keys[i] && track.keys[i + 1] && isKeySelected(rowEl._smHolder, rowEl._smProp, track.keys[i]) && isKeySelected(rowEl._smHolder, rowEl._smProp, track.keys[i + 1]);
+            sel = track.keys[i] && track.keys[i + 1] && keyQualifies(track.keys[i]) && keyQualifies(track.keys[i + 1]);
           }
           if (sel) r.style.transform = 'translateX(' + px + 'px)';
         });


### PR DESCRIPTION
## Summary
- \`ld.keyLock\` (whole-layer) and \`key.lockTo\` (per-keyframe, #212) both only applied their shift at drop — the cheap live-preview pass \`layer-inout.js\` runs on every mousemove (\`livePreviewLayerKeys\`) only ever covered the "default retimes" case, so a keyframe parented to a layer's in/out point stayed visually put while dragging and only jumped to its correct position on mouseup.
- \`previewKeyframeShift\` (motion.js) gains a \`'keys'\` mode that shifts an explicit \`{holder,prop,key}\` list — the same shape \`SMMotion.keysLockedTo\` already returns — instead of a whole track (\`'layer'\` mode) or the \`.sel\` selection (\`'selected'\` mode).
- New \`livePreviewLockedKeys\` in \`layer-inout.js\` mirrors mouseup's own \`lockOne\`/\`lockKeysOne\` gating (which edge, which lock mode) to call this live from \`onMove\`, for both the single-bar and group-drag paths.

## Test plan
- [x] \`npm test\` (27/27 pass)
- [x] Verified live in the browser preview: keyframe at frame 20 locked to \`in\`, dragged the in-point handle — the diamond's \`style.transform\` updated on every mousemove (matching the drag delta) while an unlocked key at frame 0 stayed put, and the final drop committed the same shift (key moved 20 → 24 alongside the in point's 0 → 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)