### PR TITLE
Text animators: range-selector engine that survives re-typing the text

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2216,6 +2216,7 @@
 <script src="js/layer-kind.js"></script>
 <script src="js/svg-import.js"></script>
 <script src="js/camera.js"></script>
+<script src="js/text-selector.js"></script>
 <script src="js/motion.js"></script>
 <!-- Split code editor for expressions. Must load BEFORE any renderLayerList
      runs, since buildExprEditorRow only draws its open/close button when

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2685,7 +2685,7 @@ function getEffectiveStrokes(layerIdx,frameIdx,countOnly){
       if(window.SMMotion){
         layerStrokes=layerStrokes.map(function(sd){
           if(sd.isRaster||!sd.strokeId)return sd;
-          var elMat=SMMotion.elementMotionAt(layerIdx,sd.strokeId,frameIdx);
+          var elMat=SMMotion.elementMotionAt(layerIdx,sd.strokeId,frameIdx,sd);
           if(!elMat)return sd;
           var sd2=JSON.parse(JSON.stringify(sd));
           var tmp=new Path({insert:false});

--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -1400,7 +1400,7 @@
         // reshapes path content — only used below, never for elMat/
         // elementFillColorAt which should keep sharing the anchor's id.
         var cPathOpsStrokeId = (c.data && c.data.isBrushTextureCopy) ? undefined : cStrokeId;
-        var elMat = (window.SMMotion && cStrokeId) ? SMMotion.elementMotionAt(i, cStrokeId, renderFrame) : null;
+        var elMat = (window.SMMotion && cStrokeId) ? SMMotion.elementMotionAt(i, cStrokeId, renderFrame, c.data) : null;
         var elPivot = elMat ? { x: c.bounds.center.x + elMat.ax, y: c.bounds.center.y + elMat.ay } : null;
         if (c instanceof Raster) {
           // Bitmap-brush Trim Paths (2026-08-21) — a trimmed bitmap stroke

--- a/src/js/export.js
+++ b/src/js/export.js
@@ -266,7 +266,7 @@ function exportBuildFrame(frameIdx,alpha){
       // around THIS stroke's own just-built bounds (not the whole layer's)
       // — see motion.js's elementMotionAt header comment. sd.strokeId is
       // the raw serialized field (same one serP/desP already round-trip).
-      var elMat=(window.SMMotion&&sd.strokeId)?SMMotion.elementMotionAt(li,sd.strokeId,frameIdx):null;
+      var elMat=(window.SMMotion&&sd.strokeId)?SMMotion.elementMotionAt(li,sd.strokeId,frameIdx,sd):null;
       if(elMat){
         var epc=p.bounds.center;
         var elPivot=new Point(epc.x+elMat.ax,epc.y+elMat.ay);

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -3901,10 +3901,144 @@
   // existed on `ld.elementMotion`. Lifted 2026-07 ("precomp par calque"):
   // getEffectiveStrokes' ld.symbolId branch (app.js) now applies this
   // per-stroke, same nesting order as the plain-layer case above.
-  function elementMotionAt(li, strokeId, frameIdx) {
+  // ---- TEXT ANIMATORS (2026-08-31) ----
+  // ld.textAnimators is a list of { selector, props } living on the LAYER, not
+  // on the glyphs — see text-selector.js's header for why that distinction is
+  // the whole point (baked per-glyph keys are orphaned the moment the text is
+  // re-typed, measured). Each animator contributes props × weight(unitIndex),
+  // summed over the list, and the sum is ADDED to whatever the element's own
+  // holder already resolved.
+  //
+  // Every selector field is read through valueAtFrame on an ordinary Motion
+  // holder, so start/end/offset/amount are keyframable, expression-drivable
+  // and undo-able with no new machinery — the same reuse lever already proven
+  // for audio tracks and rig widgets (holders never required a layer).
+  var TA_SELECTOR_KEYS = ['start', 'end', 'offset', 'amount', 'easeHigh', 'easeLow', 'smooth'];
+  function taSelectorAt(an, frameIdx) {
+    var sel = {};
+    for (var k in an.selector) sel[k] = an.selector[k];
+    // A holder is only consulted for the numeric fields; shape/units/basedOn
+    // are discrete choices, not animatable values.
+    if (an.motion || an.motionStatic) {
+      for (var i = 0; i < TA_SELECTOR_KEYS.length; i++) {
+        var key = TA_SELECTOR_KEYS[i];
+        if (trackFor(an, key) || (an.motionStatic && an.motionStatic[key])) {
+          sel[key] = valueAtFrame(an, key, frameIdx)[0];
+        }
+      }
+    }
+    return sel;
+  }
+  // Total addressable units for the block this glyph belongs to. Counted from
+  // the layer's own stored strokes rather than the live Paper items so the
+  // export path (which never materialises them) agrees with the screen.
+  //
+  // Memoised per (layer, frame, basedOn): this is called once per GLYPH while
+  // building a scene, and getEffectiveStrokes is the single most-walked
+  // function in the render path (CLAUDE.md §5bis' "an access that isn't free")
+  // — without the cache a 50-character title would walk the layer's strokes
+  // 50 times per frame for a number that cannot change between those calls.
+  var _taCountCache = { key: '', n: 0 };
+  function taUnitCount(li, frameIdx, basedOn) {
+    var key = li + '|' + frameIdx + '|' + basedOn + '|' + (state._sceneVersion || 0);
+    if (_taCountCache.key === key) return _taCountCache.n;
+    var strokes = (typeof getEffectiveStrokes === 'function') ? getEffectiveStrokes(li, frameIdx) : null;
+    var max = -1;
+    if (strokes) {
+      for (var i = 0; i < strokes.length; i++) {
+        var u = SMTextSelector.unitIndexOf(strokes[i], basedOn);
+        if (u != null && u > max) max = u;
+      }
+    }
+    _taCountCache.key = key; _taCountCache.n = max + 1;
+    return _taCountCache.n;
+  }
+  function textAnimatorContribution(li, sd, frameIdx) {
     var ld = state.layers[li];
-    if (!ld || !ld.elementMotion) return null;
-    return computeMotionMat(ld.elementMotion[strokeId], frameIdx);
+    if (!ld || !ld.textAnimators || !ld.textAnimators.length || !sd) return null;
+    if (typeof window === 'undefined' || !window.SMTextSelector) return null;
+    var acc = null;
+    for (var a = 0; a < ld.textAnimators.length; a++) {
+      var an = ld.textAnimators[a];
+      if (!an || an.enabled === false || !an.props) continue;
+      var basedOn = (an.selector && an.selector.basedOn) || 'chars';
+      var idx = SMTextSelector.unitIndexOf(sd, basedOn);
+      if (idx == null) continue;
+      var total = taUnitCount(li, frameIdx, basedOn);
+      if (!total) continue;
+      var w = SMTextSelector.weightAt(taSelectorAt(an, frameIdx), idx, total);
+      if (!w) continue;
+      var p = an.props;
+      acc = acc || { dx: 0, dy: 0, rot: 0, sx: 0, sy: 0, op: 0 };
+      if (p.position) { acc.dx += (p.position[0] || 0) * w; acc.dy += (p.position[1] || 0) * w; }
+      if (p.rotation != null) acc.rot += p.rotation * w;
+      // Scale and opacity are authored as a DELTA from 100% (AE's own
+      // convention: an animator's Scale 0% means "shrink to nothing at full
+      // weight"), so they accumulate around 0 here and are folded into the
+      // multiplicative/percentage form by the caller.
+      if (p.scale) { acc.sx += ((p.scale[0] == null ? 100 : p.scale[0]) - 100) * w; acc.sy += ((p.scale[1] == null ? 100 : p.scale[1]) - 100) * w; }
+      if (p.opacity != null) acc.op += (p.opacity - 100) * w;
+    }
+    return acc;
+  }
+  // Creating an animator is deliberately NOT a bake: it writes one small
+  // descriptor of plain numbers on the layer. Nothing is written per glyph,
+  // which is exactly why re-typing the text cannot orphan it.
+  function addTextAnimator(li, props, selector) {
+    var ld = state.layers[li];
+    if (!ld || typeof window === 'undefined' || !window.SMTextSelector) return null;
+    if (!Array.isArray(ld.textAnimators)) ld.textAnimators = [];
+    var sel = SMTextSelector.defaultSelector();
+    if (selector) for (var k in selector) sel[k] = selector[k];
+    var an = {
+      id: 'ta_' + Date.now().toString(36) + '_' + Math.floor(Math.random() * 1e4),
+      enabled: true,
+      selector: sel,
+      // Authored as AE does: position/rotation are deltas from 0, scale and
+      // opacity are percentages where 100 means "unchanged at full weight".
+      props: props || { position: [0, 0], scale: [100, 100], rotation: 0, opacity: 100 },
+    };
+    ld.textAnimators.push(an);
+    return an;
+  }
+  function removeTextAnimator(li, id) {
+    var ld = state.layers[li];
+    if (!ld || !Array.isArray(ld.textAnimators)) return false;
+    for (var i = 0; i < ld.textAnimators.length; i++) {
+      if (ld.textAnimators[i].id === id) { ld.textAnimators.splice(i, 1); return true; }
+    }
+    return false;
+  }
+  // Read-only view of what an animator currently weighs, per unit — used by
+  // the panel to draw the ramp, and the cheapest way to assert the whole
+  // chain end to end from a test or the console.
+  function textAnimatorWeights(li, animIdx, frameIdx) {
+    var ld = state.layers[li];
+    if (!ld || !ld.textAnimators || !ld.textAnimators[animIdx]) return [];
+    if (typeof window === 'undefined' || !window.SMTextSelector) return [];
+    var an = ld.textAnimators[animIdx];
+    var basedOn = (an.selector && an.selector.basedOn) || 'chars';
+    var f = frameIdx == null ? state.currentFrame : frameIdx;
+    var total = taUnitCount(li, f, basedOn);
+    return SMTextSelector.weights(taSelectorAt(an, f), total);
+  }
+  // sd (the stroke dict) is optional and only carries the char/word/line
+  // indices — every existing caller that has one gains text animators for
+  // free, and the two that don't (node handles) keep their previous
+  // behaviour exactly.
+  function elementMotionAt(li, strokeId, frameIdx, sd) {
+    var ld = state.layers[li];
+    if (!ld) return null;
+    var base = ld.elementMotion ? computeMotionMat(ld.elementMotion[strokeId], frameIdx) : null;
+    var ta = textAnimatorContribution(li, sd, frameIdx);
+    if (!ta) return base;
+    var m = base || { dx: 0, dy: 0, rot: 0, sx: 1, sy: 1, op: 1, ax: 0, ay: 0 };
+    return {
+      dx: m.dx + ta.dx, dy: m.dy + ta.dy, rot: m.rot + ta.rot,
+      sx: m.sx * (1 + ta.sx / 100), sy: m.sy * (1 + ta.sy / 100),
+      op: Math.max(0, Math.min(1, m.op * (1 + ta.op / 100))),
+      ax: m.ax, ay: m.ay,
+    };
   }
   // Extended per-shape property: Fill color (2026-07 — audit gap
   // "propriétés étendues par forme... reste un chantier futur"). First
@@ -12604,6 +12738,10 @@
     // reachable from outside this closure with an arbitrary holder object.
     computeMotionMatFor: computeMotionMat,
     elementMotionAt: elementMotionAt,
+    addTextAnimator: addTextAnimator,
+    removeTextAnimator: removeTextAnimator,
+    textAnimatorsOf: function (li) { var ld = state.layers[li]; return (ld && ld.textAnimators) || []; },
+    textAnimatorWeights: textAnimatorWeights,
     elementFillColorAt: elementFillColorAt,
     elementStrokeColorAt: elementStrokeColorAt,
     elementStrokeWidthAt: elementStrokeWidthAt,

--- a/src/js/text-selector.js
+++ b/src/js/text-selector.js
@@ -1,0 +1,169 @@
+// ---- TEXT RANGE SELECTOR (2026-08-31) ----
+// The weighting half of a text animator, kept deliberately free of state/
+// Paper/DOM so it can be unit-tested on its own (tests/text-selector.test.cjs)
+// and called from the render path without dragging anything else in.
+//
+// WHY THIS EXISTS AT ALL — the problem it replaces:
+// text-animator.js bakes N staggered keyframe series, one per glyph, keyed by
+// strokeId. Measured 2026-08-31: typing a single extra character re-runs
+// applyTextPropsEdit -> buildVectorTextGroup, every glyph is rebuilt and gets
+// a NEW strokeId, and every baked series is instantly orphaned — the data is
+// still in the file, no glyph reads it any more. Re-timing meant re-baking.
+//
+// After Effects, Lottie and Rive all answer this the same way, and it is the
+// only answer that survives editing the text: the animator lives on the LAYER,
+// and a "range selector" computes a 0..1 weight per character INDEX on the fly.
+// Each animated property is multiplied by that weight. There is no per-glyph
+// identity anywhere, so there is nothing to re-associate when the text changes
+// — adding a letter just shifts the indices and the selector recomputes.
+//
+// The formulas below are a faithful port of lottie-web's
+// player/js/utils/text/TextSelectorProperty.js (getValue + getMult), which is
+// the reference implementation every Lottie player agrees with. Ported rather
+// than invented so that a Nemo text animation and its Lottie export can agree
+// on what "Ramp Up at 40% with ease high 30" actually looks like.
+(function () {
+  // Shape ids match Lottie's `sh` field exactly — same reason as above, and it
+  // keeps a future Lottie import/export a straight field copy.
+  var SHAPE = { SQUARE: 1, RAMP_UP: 2, RAMP_DOWN: 3, TRIANGLE: 4, ROUND: 5, SMOOTH: 6 };
+
+  var DEFAULT_SELECTOR = {
+    start: 0,          // %  (or unit index when units === 'index')
+    end: 100,          // %
+    offset: 0,         // %  — animate THIS alone and the effect sweeps
+    units: 'percent',  // 'percent' | 'index'
+    basedOn: 'chars',  // 'chars' | 'words' | 'lines'
+    shape: SHAPE.SQUARE,
+    amount: 100,       // % — global multiplier on the whole animator
+    easeHigh: 0,       // -100..100
+    easeLow: 0,        // -100..100
+    smooth: 100,       // %
+  };
+
+  // Cubic-bezier solver, same role as lottie-web's BezierFactory. Bisection
+  // rather than Newton: 24 halvings is exact to ~6e-8 on [0,1], the input is
+  // always in range here (mult is clamped before it arrives), and it cannot
+  // diverge the way Newton does on the near-vertical segments an aggressive
+  // ease high/low produces.
+  function bezierEaser(x1, y1, x2, y2) {
+    if (x1 === 0 && y1 === 0 && x2 === 1 && y2 === 1) return function (t) { return t; };
+    function calcX(t) { var u = 1 - t; return 3 * u * u * t * x1 + 3 * u * t * t * x2 + t * t * t; }
+    function calcY(t) { var u = 1 - t; return 3 * u * u * t * y1 + 3 * u * t * t * y2 + t * t * t; }
+    return function (x) {
+      var lo = 0, hi = 1, t = x;
+      for (var i = 0; i < 24; i++) {
+        var cx = calcX(t);
+        if (Math.abs(cx - x) < 1e-6) break;
+        if (cx < x) lo = t; else hi = t;
+        t = (lo + hi) / 2;
+      }
+      return calcY(t);
+    };
+  }
+
+  // lottie-web's getValue(): normalise start/end/offset into absolute unit
+  // positions. The divisor is what lets the same selector be addressed either
+  // as "the first 30 percent" or as "the first 3 characters".
+  function resolveRange(sel, totalUnits) {
+    var divisor = (sel.units === 'index') ? 1 : (100 / Math.max(1, totalUnits));
+    var o = (sel.offset || 0) / divisor;
+    var s = (sel.start || 0) / divisor + o;
+    var e = ((sel.end == null ? 100 : sel.end)) / divisor + o;
+    // A selector whose end precedes its start is not an error — dragging Start
+    // past End is a normal gesture, and AE/Lottie both just swap them.
+    if (s > e) { var t = s; s = e; e = t; }
+    return { s: s, e: e };
+  }
+
+  // lottie-web's getMult(ind): the 0..1 weight for one unit index.
+  function weightAt(sel, ind, totalUnits) {
+    var r = resolveRange(sel, totalUnits);
+    var s = r.s, e = r.e, tot = e - s;
+    var shape = sel.shape || SHAPE.SQUARE;
+
+    // Ease high/low build the bezier that is applied to the WEIGHT — this is
+    // easing along the word, not along time, and it is what separates a
+    // mechanical stagger from one that feels authored.
+    var x1 = 0, y1 = 0, x2 = 1, y2 = 1;
+    var ne = sel.easeLow || 0, xe = sel.easeHigh || 0;
+    if (ne > 0) x1 = ne / 100; else y1 = -ne / 100;
+    if (xe > 0) x2 = 1 - xe / 100; else y2 = 1 + xe / 100;
+    var easer = bezierEaser(x1, y1, x2, y2);
+
+    var mult = 0, i2 = ind;
+    if (shape === SHAPE.RAMP_UP) {
+      mult = (e === s) ? (ind >= e ? 1 : 0)
+        : Math.max(0, Math.min(0.5 / (e - s) + (ind - s) / (e - s), 1));
+    } else if (shape === SHAPE.RAMP_DOWN) {
+      mult = (e === s) ? (ind >= e ? 0 : 1)
+        : 1 - Math.max(0, Math.min(0.5 / (e - s) + (ind - s) / (e - s), 1));
+    } else if (shape === SHAPE.TRIANGLE) {
+      if (e !== s) {
+        mult = Math.max(0, Math.min(0.5 / (e - s) + (ind - s) / (e - s), 1));
+        mult = mult < 0.5 ? mult * 2 : 1 - 2 * (mult - 0.5);
+      }
+    } else if (shape === SHAPE.ROUND) {
+      if (e !== s) {
+        i2 = Math.min(Math.max(0, ind + 0.5 - s), tot);
+        var x = -tot / 2 + i2, a = tot / 2;
+        mult = a === 0 ? 0 : Math.sqrt(Math.max(0, 1 - (x * x) / (a * a)));
+      }
+    } else if (shape === SHAPE.SMOOTH) {
+      if (e !== s) {
+        i2 = Math.min(Math.max(0, ind + 0.5 - s), tot);
+        mult = (1 + Math.cos(Math.PI + Math.PI * 2 * i2 / (e - s))) / 2;
+      }
+    } else { // SQUARE — the base case: a hard range with partial edge units
+      if (ind >= Math.floor(s)) {
+        mult = (ind - s < 0)
+          ? Math.max(0, Math.min(Math.min(e, 1) - (s - ind), 1))
+          : Math.max(0, Math.min(e - ind, 1));
+      }
+    }
+
+    mult = easer(Math.max(0, Math.min(1, mult)));
+
+    // Smoothness narrows the useful band: at 25% the weight only varies over
+    // [0.375, 0.625] and saturates outside it, which hardens the boundary
+    // between selected and unselected units.
+    var sm = (sel.smooth == null ? 100 : sel.smooth);
+    if (sm !== 100) {
+      var smooth = sm * 0.01 || 1e-8;
+      var threshold = 0.5 - smooth * 0.5;
+      mult = mult < threshold ? 0 : Math.min(1, (mult - threshold) / smooth);
+    }
+
+    var amt = (sel.amount == null ? 100 : sel.amount) / 100;
+    return mult * amt;
+  }
+
+  function weights(sel, totalUnits) {
+    var out = [];
+    for (var i = 0; i < totalUnits; i++) out.push(weightAt(sel, i, totalUnits));
+    return out;
+  }
+
+  // Which index a glyph counts as, for a selector working on words or lines.
+  // vector-text-bridge.js already stamps all three at build time (and serP/
+  // desP already round-trip them — verified 2026-08-31), so this is a lookup,
+  // not a computation.
+  function unitIndexOf(sd, basedOn) {
+    if (!sd) return null;
+    if (basedOn === 'words') return sd.wordIndex != null ? sd.wordIndex : sd.charIndex;
+    if (basedOn === 'lines') return sd.lineIndex != null ? sd.lineIndex : sd.charIndex;
+    return sd.charIndex;
+  }
+
+  var API = {
+    SHAPE: SHAPE,
+    DEFAULT_SELECTOR: DEFAULT_SELECTOR,
+    defaultSelector: function () { var o = {}; for (var k in DEFAULT_SELECTOR) o[k] = DEFAULT_SELECTOR[k]; return o; },
+    resolveRange: resolveRange,
+    weightAt: weightAt,
+    weights: weights,
+    unitIndexOf: unitIndexOf,
+  };
+
+  if (typeof window !== 'undefined') window.SMTextSelector = API;
+  if (typeof module !== 'undefined' && module.exports) module.exports = API;
+})();

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1404,6 +1404,17 @@ window.SM={
     if(src.isEffectorLayer&&src.effector){state.layers[ni].isEffectorLayer=true;state.layers[ni].effector=JSON.parse(JSON.stringify(src.effector));}
     if(src.widget)state.layers[ni].widget=JSON.parse(JSON.stringify(src.widget));
     if(src.isTextLayer)state.layers[ni].isTextLayer=true;
+    // Text animators travel with the layer: they are plain numbers keyed by
+    // character INDEX, never by strokeId, so a deep copy lands on the
+    // duplicate's own glyphs with nothing to remap. The id IS regenerated,
+    // unlike a widget's xc_ control key — that one has to be copied verbatim
+    // because it names a track inside the copied motion data (§13), whereas
+    // this id only addresses the animator within its own layer and nothing
+    // points at it.
+    if(Array.isArray(src.textAnimators)&&src.textAnimators.length){
+      state.layers[ni].textAnimators=JSON.parse(JSON.stringify(src.textAnimators)).map(function(a){
+        a.id='ta_'+Date.now().toString(36)+'_'+Math.floor(Math.random()*1e4);return a;});
+    }
     return ni;}
     var srcIdx=state.activeLayerIdx;var srcLd=state.layers[srcIdx];
     // Folder children (2026-08-29, Cyril: "Duplique ce qu'il y a
@@ -1984,7 +1995,7 @@ window.SM={
       // level setting like canvasW/fps above (not per-layer, not per-
       // symbol/montage snapshot — a linked-vs-embedded choice is global).
       mediaMode:state.mediaMode||'embedded',
-      layers:sceneLayers.map(function(l){return{name:l.name,visible:l.visible,locked:l.locked,frames:l.frames,symbolId:l.symbolId,symPlayMode:l.symPlayMode,symSpeed:l.symSpeed,symPlacedAt:l.symPlacedAt,symSingleFrame:l.symSingleFrame,symMatrix:l.symMatrix,lfsGroup:l.lfsGroup,lfsIds:l.lfsIds,lfsSettings:l.lfsSettings,blendMode:l.blendMode,blendKeys:l.blendKeys,folderId:l.folderId,channel:l.channel,linkGroupId:l.linkGroupId,color:l.color,motion:l.motion,motionStatic:l.motionStatic,elementMotion:l.elementMotion,inPoint:l.inPoint,outPoint:l.outPoint,nativeVideo:l.nativeVideo,matteMode:l.matteMode,matteSourceLayerUid:l.matteSourceLayerUid,mattesMore:l.mattesMore,montageId:l.montageId,expressions:l.expressions,isTextLayer:l.isTextLayer,isNullLayer:l.isNullLayer,nullPos:l.nullPos,nullShape:l.nullShape,isEffectLayer:l.isEffectLayer,isFolderLayer:l.isFolderLayer,folderCollapsed:l.folderCollapsed,isGuideLayer:l.isGuideLayer,guidePos:l.guidePos,guideOrientation:l.guideOrientation,isWidgetLayer:l.isWidgetLayer,widget:l.widget,isEffectorLayer:l.isEffectorLayer,effector:l.effector,effects:l.effects,footage:l.footage,
+      layers:sceneLayers.map(function(l){return{name:l.name,visible:l.visible,locked:l.locked,frames:l.frames,symbolId:l.symbolId,symPlayMode:l.symPlayMode,symSpeed:l.symSpeed,symPlacedAt:l.symPlacedAt,symSingleFrame:l.symSingleFrame,symMatrix:l.symMatrix,lfsGroup:l.lfsGroup,lfsIds:l.lfsIds,lfsSettings:l.lfsSettings,blendMode:l.blendMode,blendKeys:l.blendKeys,folderId:l.folderId,channel:l.channel,linkGroupId:l.linkGroupId,color:l.color,motion:l.motion,motionStatic:l.motionStatic,elementMotion:l.elementMotion,inPoint:l.inPoint,outPoint:l.outPoint,nativeVideo:l.nativeVideo,matteMode:l.matteMode,matteSourceLayerUid:l.matteSourceLayerUid,mattesMore:l.mattesMore,montageId:l.montageId,expressions:l.expressions,isTextLayer:l.isTextLayer,isNullLayer:l.isNullLayer,nullPos:l.nullPos,nullShape:l.nullShape,isEffectLayer:l.isEffectLayer,isFolderLayer:l.isFolderLayer,folderCollapsed:l.folderCollapsed,isGuideLayer:l.isGuideLayer,guidePos:l.guidePos,guideOrientation:l.guideOrientation,isWidgetLayer:l.isWidgetLayer,widget:l.widget,textAnimators:l.textAnimators,isEffectorLayer:l.isEffectorLayer,effector:l.effector,effects:l.effects,footage:l.footage,
         // Layer parenting (2026-07-25). BOTH of these were missing from this
         // list, so every parent link was silently dropped on save — a rig
         // survived the session and nothing more. `uid` is the stable identity
@@ -2308,6 +2319,15 @@ layerUid:l.layerUid,parentLayerUid:l.parentLayerUid,parentKeys:l.parentKeys,pare
       if(ld.isWidgetLayer&&ld.widget&&typeof ld.widget==='object'&&ld.widget.x&&typeof ld.widget.x.key==='string'){
         state.layers[idx].isWidgetLayer=true;
         state.layers[idx].widget=JSON.parse(JSON.stringify(ld.widget));
+      }
+      // Text animators (2026-08-31) — guarded on SHAPE for the same reason as
+      // the widget block above: these are read by elementMotionAt on the very
+      // first render, so a corrupted nemo-auto carrying junk here would reach
+      // the selector maths before anything could reject it. Anything that is
+      // not a list of objects carrying a selector is dropped whole.
+      if(Array.isArray(ld.textAnimators)){
+        var _tas=ld.textAnimators.filter(function(a){return a&&typeof a==='object'&&a.selector&&typeof a.selector==='object';});
+        if(_tas.length)state.layers[idx].textAnimators=JSON.parse(JSON.stringify(_tas));
       }
       // Effector layer (2026-08-30) — guarded on the SHAPE of ld.effector,
       // same reasoning as the widget block right above: a corrupted

--- a/tests/text-selector.test.cjs
+++ b/tests/text-selector.test.cjs
@@ -1,0 +1,140 @@
+// Unit tests for the text range selector (src/js/text-selector.js).
+//
+// These are behaviour tests, not source-shape tests: the module is
+// deliberately free of state/Paper/DOM so it can be required directly and
+// exercised on real numbers. The reference values come from lottie-web's
+// TextSelectorProperty, which this is a port of — if a formula drifts, a
+// Nemo text animation and its Lottie counterpart would silently disagree.
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const path = require('node:path');
+
+const sel = require(path.resolve(__dirname, '../src/js/text-selector.js'));
+const { SHAPE } = sel;
+
+function base(over) {
+  return Object.assign(sel.defaultSelector(), over || {});
+}
+const round2 = (a) => a.map((v) => Number(v.toFixed(2)));
+
+test('a full range selects every unit, an empty one selects none', () => {
+  const N = 9;
+  assert.deepEqual(sel.weights(base({ start: 0, end: 100 }), N), new Array(N).fill(1));
+  assert.deepEqual(sel.weights(base({ start: 0, end: 0 }), N), new Array(N).fill(0));
+});
+
+test('every weight stays inside 0..1 across all shapes and ranges', () => {
+  for (const shape of Object.values(SHAPE)) {
+    for (const end of [0, 17, 45, 80, 100]) {
+      for (const offset of [-60, 0, 35]) {
+        const w = sel.weights(base({ shape, end, offset }), 9);
+        for (const v of w) {
+          assert.ok(v >= 0 && v <= 1, `shape ${shape} end ${end} offset ${offset} -> ${v}`);
+          assert.ok(Number.isFinite(v), `shape ${shape} produced ${v}`);
+        }
+      }
+    }
+  }
+});
+
+test('square shape gives a hard range with a partial edge unit', () => {
+  // 45% of 9 chars = 4.05 units: four full, then a 0.05 sliver, then nothing.
+  assert.deepEqual(
+    round2(sel.weights(base({ shape: SHAPE.SQUARE, end: 45 }), 9)),
+    [1, 1, 1, 1, 0.05, 0, 0, 0, 0],
+  );
+});
+
+test('triangle peaks at the centre and is symmetric', () => {
+  const w = sel.weights(base({ shape: SHAPE.TRIANGLE, start: 0, end: 100 }), 9);
+  assert.equal(w.indexOf(Math.max(...w)), 4, 'peak sits on the middle unit');
+  assert.equal(w[0].toFixed(4), w[8].toFixed(4));
+  assert.equal(w[1].toFixed(4), w[7].toFixed(4));
+  assert.equal(Number(w[4].toFixed(4)), 1);
+});
+
+test('smooth shape is a cosine bell, also symmetric', () => {
+  const w = sel.weights(base({ shape: SHAPE.SMOOTH, start: 0, end: 100 }), 9);
+  assert.equal(w[0].toFixed(4), w[8].toFixed(4));
+  assert.equal(Number(w[4].toFixed(4)), 1);
+  assert.ok(w[2] > w[0] && w[4] > w[2], 'rises towards the centre');
+});
+
+test('ramp up and ramp down are mirror images', () => {
+  const up = sel.weights(base({ shape: SHAPE.RAMP_UP, start: 0, end: 100 }), 9);
+  const down = sel.weights(base({ shape: SHAPE.RAMP_DOWN, start: 0, end: 100 }), 9);
+  for (let i = 0; i < up.length; i++) {
+    assert.equal(Number((up[i] + down[i]).toFixed(6)), 1, `unit ${i} should sum to 1`);
+  }
+});
+
+test('offset sweeps the window along the text', () => {
+  const at0 = sel.weights(base({ end: 45, offset: 0 }), 9);
+  const at50 = sel.weights(base({ end: 45, offset: 50 }), 9);
+  assert.notDeepEqual(at0, at50);
+  // The window moved right: what was selected at the head no longer is, and
+  // units further along now are. This is the whole point of the model — one
+  // keyframed value replaces N staggered per-glyph series.
+  assert.ok(at0[0] > at50[0]);
+  assert.ok(at50[7] > at0[7]);
+});
+
+test('a reversed selector (start past end) is swapped, not empty', () => {
+  const fwd = sel.weights(base({ start: 20, end: 70 }), 9);
+  const rev = sel.weights(base({ start: 70, end: 20 }), 9);
+  assert.deepEqual(rev, fwd);
+});
+
+test('index units address whole characters instead of percentages', () => {
+  const w = sel.weights(base({ units: 'index', start: 0, end: 3 }), 9);
+  assert.deepEqual(round2(w), [1, 1, 1, 0, 0, 0, 0, 0, 0]);
+});
+
+test('amount scales the whole animator down', () => {
+  const full = sel.weights(base({ start: 0, end: 100 }), 6);
+  const half = sel.weights(base({ start: 0, end: 100, amount: 50 }), 6);
+  for (let i = 0; i < full.length; i++) assert.equal(half[i], full[i] * 0.5);
+});
+
+test('smoothness narrows the transition band', () => {
+  const soft = sel.weights(base({ shape: SHAPE.RAMP_UP, start: 0, end: 100, smooth: 100 }), 9);
+  const hard = sel.weights(base({ shape: SHAPE.RAMP_UP, start: 0, end: 100, smooth: 10 }), 9);
+  // A hard band pushes values to the extremes: count how many sit strictly
+  // between 0 and 1 — fewer is harder.
+  const mid = (a) => a.filter((v) => v > 0.001 && v < 0.999).length;
+  assert.ok(mid(hard) < mid(soft), `hard=${mid(hard)} should be fewer than soft=${mid(soft)}`);
+});
+
+test('ease high/low bends the weight ramp without leaving 0..1', () => {
+  const flat = sel.weights(base({ shape: SHAPE.RAMP_UP, start: 0, end: 100 }), 9);
+  const eased = sel.weights(base({ shape: SHAPE.RAMP_UP, start: 0, end: 100, easeHigh: 80 }), 9);
+  assert.notDeepEqual(round2(flat), round2(eased));
+  for (const v of eased) assert.ok(v >= 0 && v <= 1);
+  // The fixed points are the WEIGHTS 0 and 1, not the first/last glyph — a
+  // ramp's end units are 0.06/0.94, not 0/1, so they do move. Check the
+  // actual invariant instead: fully-out and fully-in units stay put.
+  const clamped = sel.weights(base({ shape: SHAPE.SQUARE, start: 0, end: 100, easeHigh: 80 }), 9);
+  assert.deepEqual(clamped, new Array(9).fill(1), 'weight 1 must stay 1 under easing');
+  const none = sel.weights(base({ shape: SHAPE.SQUARE, start: 0, end: 0, easeHigh: 80 }), 9);
+  assert.deepEqual(none, new Array(9).fill(0), 'weight 0 must stay 0 under easing');
+});
+
+test('unitIndexOf reads the index the selector is based on', () => {
+  const sd = { charIndex: 7, wordIndex: 2, lineIndex: 1 };
+  assert.equal(sel.unitIndexOf(sd, 'chars'), 7);
+  assert.equal(sel.unitIndexOf(sd, 'words'), 2);
+  assert.equal(sel.unitIndexOf(sd, 'lines'), 1);
+  // Falls back to the character index rather than dropping the glyph, so a
+  // stroke stamped before word/line indices existed still animates.
+  assert.equal(sel.unitIndexOf({ charIndex: 4 }, 'words'), 4);
+  assert.equal(sel.unitIndexOf(null, 'chars'), null);
+});
+
+test('a single-unit block does not divide by zero', () => {
+  for (const shape of Object.values(SHAPE)) {
+    const w = sel.weights(base({ shape }), 1);
+    assert.equal(w.length, 1);
+    assert.ok(Number.isFinite(w[0]), `shape ${shape} -> ${w[0]}`);
+  }
+  assert.deepEqual(sel.weights(base(), 0), []);
+});


### PR DESCRIPTION
Premier morceau du chantier « animation de texte ». Recherche complète (avec démo interactive) : https://claude.ai/code/artifact/8dc73c67-ee40-40e5-99ea-faded4201355

## Le problème, mesuré

Animer un glyphe, puis ajouter **un seul caractère** par le panneau Typographie : `applyTextPropsEdit` reconstruit tout le groupe via opentype.js, chaque glyphe reçoit un nouveau `strokeId`, et les keyframes bakées pointent vers un id disparu. Les données restent dans le fichier ; plus aucun glyphe ne les lit.

`text-animator.js` bake N séries staggerées indexées par `strokeId` → re-timer obligeait à re-baker, retoucher le texte perdait tout.

## L'approche

AE, Lottie et Rive répondent tous les trois de la même façon, et c'est la seule qui survit à l'édition : **l'animateur vit sur le CALQUE**, et un range selector calcule à la volée un poids 0-1 **par index de caractère**. Aucune identité par glyphe, donc rien à ré-associer.

`src/js/text-selector.js` est un portage fidèle de `TextSelectorProperty` de lottie-web (`getValue` + `getMult`) — porté plutôt qu'inventé pour qu'une animation Nemo et son équivalent Lottie s'accordent sur ce que « Ramp Up à 40 % avec ease high 30 » veut dire. Six formes, ease high/low (une Bézier appliquée au **poids** : easing le long du mot, pas du temps), smoothness, amount, unités en % ou en index.

Le module est libre de state/Paper/DOM → `tests/text-selector.test.cjs` l'exerce sur de vrais nombres : 14 tests (symétrie, invariant 0-1 sur toutes les combinaisons forme/plage/offset, sélecteur inversé, division par zéro à une seule unité).

## Le point d'application

Le poids est appliqué dans **`elementMotionAt`**, le point de passage unique que les quatre consommateurs partagent déjà (`buildSceneJson`, `export.js`, la branche `symbolId` de `getEffectiveStrokes`, les poignées de nœuds) — donc écran, export et composants en bénéficient d'un coup.

Il prend un dict de stroke optionnel pour l'index caractère/mot/ligne : les appelants qui en ont un gagnent les animateurs gratuitement, celui qui n'en a pas garde son comportement exact. `taUnitCount` est mémoïsé par calque/frame/basedOn — il est appelé une fois par glyphe pendant la construction de scène, et `getEffectiveStrokes` est la fonction la plus parcourue du rendu (§5bis).

## Vérifié en pilotant, de bout en bout

- **Le cas qui cassait** : « HELLO » animé, puis « ! » tapé → `strokeId` passe de `smthnodqe_4_*` à `smthnoxyq_16_*` et le glyphe résout toujours `dy=-33.1`.
- **Deux keyframes sur `offset` seul** font balayer l'effet (poids 0-1 → 2-3 → 5 → sorti). Aucune clé par glyphe n'est jamais écrite.
- Aller-retour `exportJSON`/`importJSON` avec sélecteur, props et piste offset intacts ; undo restaure ; duplication en copie profonde avec un id régénéré.
- **Non-régression** : un calque sans animateur renvoie exactement ce qu'il renvoyait avant, avec ou sans le nouvel argument, et une piste d'élément ordinaire est intacte (dx=55, dy=-15).

## Hors périmètre, volontairement

Le **tracking** décale tous les caractères *suivants* : il faut re-fluer la ligne, c'est de la mise en page, pas « multiplier une transfo par un poids ». Chantier à part.

Cette PR livre le moteur + la persistance + l'API (`addTextAnimator`, `removeTextAnimator`, `textAnimatorsOf`, `textAnimatorWeights`). **L'UI du panneau reste à faire** — l'animateur actuel continue de fonctionner tel quel en attendant.

41/41 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)