### PR TITLE
Rig: rotate a shape's bezier handles with its bones, like Shapper does

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1812,8 +1812,29 @@ function rigBindStroke(ld,path,boneIds,radius,rotate,softness){
     });
   }
   var rest=path.segments.map(function(s){return[s.point.x,s.point.y];});
+  // Rest TANGENTS, stored alongside rest points (2026-08-31, Cyril: "le rig
+  // que je trouve pas encore au point... rapproche-toi de Shapper").
+  // applyRigDeform's boundary loop used to move points only, on the stated
+  // assumption that a boundary is "hundreds of near-straight, already-
+  // smoothed segments" — true of a vector-brush ribbon, false of the Pen-
+  // drawn shapes Shapper is actually used on, which have a handful of points
+  // and real bezier handles. Leaving those handles unrotated flattens every
+  // curve the moment a bone turns, which is exactly what Shapper's own
+  // expression does NOT do: it rotates inTangent/outTangent by the same
+  // local angle as the point and applies the delta.
+  //
+  // A SEPARATE parallel array rather than reshaping `rest`: rest is a plain
+  // [x,y] list in every project already saved, and rigs persist. Absent
+  // (old rig) means the previous behaviour exactly, so nothing that works
+  // today changes shape under an old file.
+  var restHandles=path.segments.map(function(s){
+    return {
+      i:(s.handleIn&&(s.handleIn.x||s.handleIn.y))?[s.handleIn.x,s.handleIn.y]:null,
+      o:(s.handleOut&&(s.handleOut.x||s.handleOut.y))?[s.handleOut.x,s.handleOut.y]:null,
+    };
+  });
   var weights=weighForPoints(rest);
-  var bind={strokeId:path.data.strokeId,rest:rest,weights:weights,rotate:!!rotate,_live:path};
+  var bind={strokeId:path.data.strokeId,rest:rest,restHandles:restHandles,weights:weights,rotate:!!rotate,_live:path};
   // Keep centerSegments (the source data any future brush-width edit
   // regenerates the boundary FROM, via rebuildVectorBrushOutline) in sync
   // too — 2026-07-29 fix, Cyril: attaque le chantier of a later width edit
@@ -2046,6 +2067,12 @@ function applyRigDeform(ld){
     var segs=b._live.segments;
     for(var i=0;i<segs.length&&i<b.rest.length;i++){
       var restPt=b.rest[i],dx=0,dy=0,sumW=0;
+      // Weighted-average local rotation for this vertex, accumulated in its
+      // OWN pair of accumulators (sumDaW/sumWRot) exactly as the
+      // centerSegments block below does: sumW is the position-normalisation
+      // divisor and is filled in both modes, these two only fill in rotate
+      // mode and would wrongly read 0 otherwise.
+      var sumDaW=0,sumWRot=0;
       (b.weights[i]||[]).forEach(function(wentry){
         var bp=bonePaths(wentry.boneId);
         var curLoc=bp.cur.getLocationAt(wentry.offset),restLoc=bp.rest.getLocationAt(wentry.offset);
@@ -2066,6 +2093,7 @@ function applyRigDeform(ld){
           var rOffX=offX*cosA-offY*sinA,rOffY=offX*sinA+offY*cosA;
           dx+=wentry.w*((curLoc.point.x+rOffX)-restPt[0]);
           dy+=wentry.w*((curLoc.point.y+rOffY)-restPt[1]);
+          sumDaW+=da*wentry.w;sumWRot+=wentry.w;
         }else{
           dx+=wentry.w*(curLoc.point.x-restLoc.point.x);
           dy+=wentry.w*(curLoc.point.y-restLoc.point.y);
@@ -2087,6 +2115,24 @@ function applyRigDeform(ld){
       // scaled back down.
       var norm=sumW>1?sumW:1;
       segs[i].point=new Point(restPt[0]+dx/norm,restPt[1]+dy/norm);
+      // Rotate this vertex's bezier handles by the same weighted-average
+      // local angle, ALWAYS from the immutable rest handles and never from
+      // the current live ones — the same idempotence contract the
+      // centerSegments block states: applyRigDeform runs on every pose
+      // change, and rotating an already-rotated handle would compound.
+      // Guarded on b.restHandles so a rig bound before this existed keeps
+      // its exact previous behaviour.
+      var rh=b.restHandles&&b.restHandles[i];
+      if(rh){
+        if(sumWRot>0){
+          var avgDa=sumDaW/sumWRot,hc=Math.cos(avgDa),hs=Math.sin(avgDa);
+          if(rh.i)segs[i].handleIn=new Point(rh.i[0]*hc-rh.i[1]*hs,rh.i[0]*hs+rh.i[1]*hc);
+          if(rh.o)segs[i].handleOut=new Point(rh.o[0]*hc-rh.o[1]*hs,rh.o[0]*hs+rh.o[1]*hc);
+        }else{
+          if(rh.i)segs[i].handleIn=new Point(rh.i[0],rh.i[1]);
+          if(rh.o)segs[i].handleOut=new Point(rh.o[0],rh.o[1]);
+        }
+      }
     }
     // Vector-brush companion sync (2026-07-29, "les points de vecteurs
     // suivent les bones comme dans Shapper") — copy the ribbon's OWN just-


### PR DESCRIPTION
Premier écart comblé après lecture de l'expression Shapper que tu m'as donnée.

## Le manque

Shapper fait tourner `inTangent`/`outTangent` par **le même angle local** que le point auquel elles appartiennent, puis applique le delta :

```js
ni = add(ni, mul(rotP([o.inTangentX, o.inTangentY], ra), inf));
...
ni.push(add(bi[i], sub(curr.inTs[i], ref.inTs[i])));
```

Chez nous, la boucle du contour dans `applyRigDeform` n'écrivait **que** `segs[i].point`. C'était un choix assumé, et son commentaire le dit : les handles sont laissés tranquilles parce qu'un contour serait « des centaines de segments quasi-droits, déjà lissés ».

Vrai pour un ruban de pinceau vectoriel — **faux pour exactement les formes sur lesquelles Shapper s'utilise**, celles au Pen de tes captures : quelques points et de vraies courbes bézier. Plier un os dessus aplatissait chaque courbe, puisque les points bougeaient et les tangentes restaient sur place.

## Le correctif

Le contour tourne désormais ses handles comme le bloc `centerSegments` juste en dessous le faisait déjà : par l'angle local moyen pondéré propre à ce sommet, accumulé dans sa propre paire d'accumulateurs (`sumW` est le diviseur de position et se remplit dans les deux modes ; ces deux-là ne se remplissent qu'en mode rotation et vaudraient 0 sinon — la même séparation que `cSumW`/`cTotalW`).

La rotation part **toujours des handles de repos immuables**, jamais des handles courants : c'est ce qui la rend idempotente, puisque `applyRigDeform` tourne à chaque changement de pose et que tourner un handle déjà tourné composerait.

Les handles de repos vont dans un **nouveau tableau parallèle** plutôt que dans `rest` : `rest` est une liste `[x,y]` dans tous les projets déjà enregistrés, et les rigs persistent. Absent = comportement précédent exact, donc un vieux rig ne peut pas changer de forme sous un nouveau build.

## Vérifié en pilotant

Sur une forme à 3 points avec de vraies tangentes, liée à un os plié d'environ 40° :

- les handles tournent et **leur longueur est préservée** (80 → 79,8 ; 89,4 → 89,9) : rotation pure, pas un étirement ;
- appeler `applyRigDeform` trois fois de suite donne un résultat identique au chiffre près ;
- remettre l'os sur sa pose de repos **restaure la forme exactement**, tangentes comprises — la neutralité au repos que donne la formulation `curr - ref` de Shapper ;
- non-régression sur un vrai ruban de 524 segments : aucun NaN, bornes saines.

41/41 tests.

## Ce qui reste (noté pour une passe séparée)

Deux autres écarts avec Shapper, que je n'ai pas touchés ici :

1. **Les poids d'influence par point de contrôle.** Shapper stocke une influence en % par point du squelette (éditable) ; nous utilisons un offset continu le long de la courbe de l'os. Le modèle Shapper est plus prévisible et directement éditable.
2. **La normalisation.** Shapper divise toujours par la somme des influences ; nous bornons volontairement le diviseur à `max(1, sumW)` — avec une bonne raison documentée (préserver l'atténuation d'un os isolé), donc à discuter plutôt qu'à aligner mécaniquement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)