### PR TITLE
Text animator panel: put every row back on the panel's own grid

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2765,10 +2765,11 @@ body.mode-motion .layer-inout-bar .layer-inout-handle{width:4px;border-radius:2p
 
 /* Text animator weight ramp (2026-08-31) — the per-character weight the
    selector currently produces, drawn from the SAME textAnimatorWeights the
-   renderer reads so the two can never disagree. Sized and coloured from the
-   panel's existing tokens rather than new ones. */
-.ta-ramp{display:flex;align-items:flex-end;gap:1px;height:22px;flex:1;min-width:0;
-  padding:2px 3px;background:var(--bg2,#1b1b1f);border:1px solid var(--line,#2c2c33);border-radius:4px;overflow:hidden}
-.ta-ramp i{display:block;flex:1 1 0;min-width:2px;background:var(--acc,#4a9eff);border-radius:1px;opacity:.9}
-.ta-ramp-empty{font-size:10px;opacity:.55;align-self:center;padding-left:2px}
-.ta-sep{height:1px;background:var(--line,#2c2c33);margin:8px 0 6px;opacity:.6}
+   renderer reads so the two can never disagree. Sized like a .pi field so it
+   sits on the panel's own grid: flex:1 fills the column every other row's
+   input occupies, and the tokens are the panel's, not new ones. */
+.ta-ramp{display:flex;align-items:flex-end;gap:1px;height:26px;flex:1;min-width:0;
+  padding:3px 4px;background:var(--panel3);border-radius:5px;overflow:hidden;}
+.ta-ramp i{display:block;flex:1 1 0;min-width:2px;background:var(--accent);border-radius:1px;opacity:.85;min-height:1px;}
+.ta-ramp-empty{font-size:10.5px;color:rgba(236,234,231,.45);align-self:center;padding-left:2px;}
+.ta-sep{height:1px;background:rgba(236,234,231,.10);margin:9px 0 7px;}

--- a/src/js/text-animator-panel.js
+++ b/src/js/text-animator-panel.js
@@ -141,21 +141,22 @@
     var sel = an.selector, props = an.props;
 
     // --- header: name, enable, delete -----------------------------------
-    var head = document.createElement('div');
-    head.className = 'pr';
-    var name = document.createElement('span');
-    name.className = 'pl';
-    name.style.width = 'auto';
-    name.style.fontWeight = '600';
-    name.textContent = t('textAnimTitle', 'Animator') + ' ' + (idx + 1);
-    head.appendChild(name);
+    // An ordinary .pr with the name in .pl and icon buttons on the right,
+    // rather than a bespoke sub-heading: the panel has no sub-group style of
+    // its own, and .pl's fixed 68px column is exactly what keeps every row
+    // below aligned with the rest of the app's sections.
+    var head = row(host, t('textAnimTitle', 'Animator') + ' ' + (idx + 1));
+    var spacer = document.createElement('div');
+    spacer.style.flex = '1';
+    head.appendChild(spacer);
 
-    var eye = document.createElement('div');
-    eye.className = 'lico' + (an.enabled === false ? ' off' : '');
-    eye.style.marginLeft = 'auto';
+    var eye = document.createElement('button');
+    eye.type = 'button';
+    eye.className = 'pbtn icon-only-btn' + (an.enabled === false ? '' : ' active');
     eye.title = t('textAnimToggleTitle', 'Enable / disable this animator');
-    eye.textContent = an.enabled === false ? '○' : '●';
-    eye.style.cursor = 'pointer';
+    eye.innerHTML = an.enabled === false
+      ? '<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><path d="M1 1l22 22"/></svg>'
+      : '<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>';
     eye.addEventListener('click', function () {
       if (typeof pushUndo === 'function') pushUndo();
       an.enabled = an.enabled === false;
@@ -163,21 +164,20 @@
     });
     head.appendChild(eye);
 
-    var del = document.createElement('div');
-    del.className = 'lico';
+    var del = document.createElement('button');
+    del.type = 'button';
+    del.className = 'pbtn icon-only-btn';
     del.title = t('textAnimRemoveTitle', 'Remove this animator');
-    del.style.cursor = 'pointer';
-    del.innerHTML = '<svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18"/></svg>';
+    del.innerHTML = '<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18"/></svg>';
     del.addEventListener('click', function () {
       if (typeof pushUndo === 'function') pushUndo();
       SMMotion.removeTextAnimator(state.activeLayerIdx, an.id);
       commit(ld);
     });
     head.appendChild(del);
-    host.appendChild(head);
 
     // --- selector --------------------------------------------------------
-    var rRange = row(host, t('textAnimRange', 'Range'), 'dims-row');
+    var rRange = row(host, t('textAnimRange', 'Range'));
     numField(rRange, function () { return sel.start; }, function (v, live) { sel.start = v; if (!live) commit(ld); else liveRefresh(ld); }, 1, -200, 200);
     numField(rRange, function () { return sel.end; }, function (v, live) { sel.end = v; if (!live) commit(ld); else liveRefresh(ld); }, 1, -200, 200);
     stopwatch(rRange, an, 'start', ld);
@@ -204,7 +204,7 @@
       sel.basedOn = v; commit(ld);
     });
 
-    var rEase = row(host, t('textAnimEase', 'Ease hi/lo'), 'dims-row');
+    var rEase = row(host, t('textAnimEase', 'Ease hi/lo'));
     numField(rEase, function () { return sel.easeHigh; }, function (v, live) { sel.easeHigh = v; if (!live) commit(ld); else liveRefresh(ld); }, 5, -100, 100);
     numField(rEase, function () { return sel.easeLow; }, function (v, live) { sel.easeLow = v; if (!live) commit(ld); else liveRefresh(ld); }, 5, -100, 100);
 
@@ -213,11 +213,11 @@
     stopwatch(rAmt, an, 'amount', ld);
 
     // --- driven properties ----------------------------------------------
-    var rPos = row(host, t('propPosition', 'Position'), 'dims-row');
+    var rPos = row(host, t('propPosition', 'Position'));
     numField(rPos, function () { return (props.position || [0, 0])[0]; }, function (v, live) { props.position = props.position || [0, 0]; props.position[0] = v; if (!live) commit(ld); else liveRefresh(ld); }, 1);
     numField(rPos, function () { return (props.position || [0, 0])[1]; }, function (v, live) { props.position = props.position || [0, 0]; props.position[1] = v; if (!live) commit(ld); else liveRefresh(ld); }, 1);
 
-    var rScale = row(host, t('propScale', 'Scale'), 'dims-row');
+    var rScale = row(host, t('propScale', 'Scale'));
     numField(rScale, function () { return (props.scale || [100, 100])[0]; }, function (v, live) { props.scale = props.scale || [100, 100]; props.scale[0] = v; if (!live) commit(ld); else liveRefresh(ld); }, 1, 0, 1000);
     numField(rScale, function () { return (props.scale || [100, 100])[1]; }, function (v, live) { props.scale = props.scale || [100, 100]; props.scale[1] = v; if (!live) commit(ld); else liveRefresh(ld); }, 1, 0, 1000);
 


### PR DESCRIPTION
Tu avais raison, ce n'était pas conforme. La cause tient dans **une classe**.

## Le coupable

J'avais utilisé `.dims-row` pour les rangées à deux champs (Range, Ease hi/lo, Position, Scale). Mais `.dims-row` existe pour **un cas précis** — la rangée Size, dont le label doit se rétrécir pour laisser tenir son bouton cadenas — et il fait ça en forçant `.pl { width:auto !important }`.

Résultat : ces quatre rangées perdaient la colonne de label fixe à 68 px pendant que les rangées simples la gardaient. Rien ne s'alignait.

La rangée canonique à deux champs dans cette app, c'est un `.pr` simple avec deux `.pi` — celle de Position, `index.html` ligne 429. Retirer `.dims-row` **est** tout le correctif.

**Mesuré après** : les 11 rangées placent leur champ à `x=607` avec un label de 68 px, contre 4 colonnes différentes avant.

## Deux autres points de la même capture

- **Le toggle d'activation était une puce texte** (`●`) et la suppression un `.lico` non stylé. Les deux sont maintenant des `pbtn icon-only-btn` avec les glyphes œil / œil-barré de l'app — le même contrôle que la visibilité des calques, au lieu d'un caractère qui fait semblant d'être une icône.
- **La rampe de poids** était dimensionnée avec des valeurs inventées. Elle utilise désormais les tokens du panneau (`var(--panel3)`, `var(--accent)`) et `flex:1`, donc elle occupe exactement la colonne qu'occupe l'input de toutes les autres rangées — 152 px de large, 26 px de haut, **sur** la grille et non à côté.

L'en-tête d'animateur est un `.pr` ordinaire avec le nom en `.pl` plutôt qu'un sous-titre sur mesure : le panneau n'a pas de style de sous-groupe, et la colonne fixe de `.pl` est précisément ce qui garde les rangées alignées avec le reste de l'app.

41/41 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)