### PR TITLE
Text animator panel: match the panel's own 8px row rhythm

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2772,4 +2772,14 @@ body.mode-motion .layer-inout-bar .layer-inout-handle{width:4px;border-radius:2p
   padding:3px 4px;background:var(--panel3);border-radius:5px;overflow:hidden;}
 .ta-ramp i{display:block;flex:1 1 0;min-width:2px;background:var(--accent);border-radius:1px;opacity:.85;min-height:1px;}
 .ta-ramp-empty{font-size:10.5px;color:rgba(236,234,231,.45);align-self:center;padding-left:2px;}
-.ta-sep{height:1px;background:rgba(236,234,231,.10);margin:9px 0 7px;}
+/* #p-textanim-list holds several animators' rows as DIRECT children (no
+   wrapper per animator), so it needs the exact rhythm .pbdy gives its own
+   children — same 8px, same mechanism (flex gap, not per-row margin) — or
+   rows here read at a different cadence than every other section. Found by
+   Cyril comparing a screenshot against Stroke: rows were touching because
+   this list had no gap of its own, only .pbdy's gap between the list-as-a-
+   whole and the Add-animator button below it. */
+#p-textanim-list{display:flex;flex-direction:column;gap:8px;}
+/* No margin of its own now that the list supplies the 8px on both sides —
+   a margin here would have added to that gap instead of replacing it. */
+.ta-sep{height:1px;background:rgba(236,234,231,.10);}


### PR DESCRIPTION
Suite du correctif précédent — même cause, un cran plus bas.

## Le vrai mécanisme d'espacement

`.pbdy` a `gap:8px` — c'est **ça** qui espace toutes les rangées de propriétés dans toutes les sections du panneau. Pas de marge par rangée : un `gap` flex sur le conteneur.

`#p-textanim-list` est un `<div>` simple qui porte les rangées `.pr` de plusieurs animateurs comme enfants directs — et il n'avait **aucun** gap à lui. Celui de `.pbdy` n'espaçait que la liste-dans-son-ensemble par rapport au bouton « Add animator » en dessous, jamais les rangées entre elles à l'intérieur de la liste. Elles se touchaient.

## Le correctif

`#p-textanim-list` reçoit exactement la même règle : `display:flex; flex-direction:column; gap:8px` — même mécanisme, même valeur, pas un nouveau token.

J'ai aussi retiré la marge manuelle de `.ta-sep` (`9px 0 7px`) : avec le gap de la liste qui fournit désormais 8 px des deux côtés du séparateur, cette marge se serait **ajoutée** au lieu de le remplacer — le même piège « deux mécanismes qui se battent » que le reste du panneau évite en n'utilisant que le gap.

## Vérifié en pilotant

Mesuré l'espacement vertical entre chaque paire de rangées consécutives dans le panneau rendu (12 écarts, de Range/Offset/Shape jusqu'à Weights) contre la même mesure sur une section `.pbdy` de référence : **8,0 px des deux côtés**, au pixel près.

41/41 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)