### PR TITLE
Fix: align Text Animator timeline rows with established Motion DA

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -9750,11 +9750,10 @@
       renderLayerList(); renderTimeline();
       if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
     });
-    var nm = document.createElement('div'); nm.className = 'lnm'; nm.textContent = label;
+    var nm = document.createElement('div'); nm.className = 'lnm motion-prop-name'; nm.textContent = label;
     decorateMotionPropertyRow(row, holder, prop, nm);
     var input = document.createElement('input');
-    input.type = 'number'; input.className = 'pi scrub'; input.min = min; input.max = max; input.dataset.step = '1';
-    input.style.cssText = 'width:52px;margin-left:auto';
+    input.type = 'number'; input.className = 'pi scrub motion-val'; input.min = min; input.max = max; input.dataset.step = '1';
     var trimDisplay = selectedDimensionDisplay(holder, prop, 0, currentVal());
     input.value = trimDisplay.mixed ? '' : trimDisplay.value;
     var lastTrimScrubValue = trimDisplay.mixed ? 0 : (Number(trimDisplay.value) || 0);
@@ -9773,8 +9772,18 @@
       renderLayerList(); renderTimeline();
       if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
     });
-    row.appendChild(sw); row.appendChild(nm); row.appendChild(input);
-    if (unit) { var u = document.createElement('span'); u.style.cssText = 'font-size:9px;color:var(--text-dim);margin-left:2px'; u.textContent = unit; row.appendChild(u); }
+    // Fields wrapped in .motion-fields (flex-shrink:0) exactly like every
+    // other Transform row (renderWidgetSizeRow, the generic property-row
+    // builder) — .pi itself is flex:1, so without this wrapper it split the
+    // row's free space 50/50 with the flex:1 .lnm label instead of sitting
+    // at its intended 28-34px (found live: measured 90-99px vs the
+    // established 28px). Stopwatch appended LAST to match the row's own
+    // "keyframe button à droite" convention (.motion-prop-row
+    // .motion-stopwatch, 2026-07-29) — this row used to put it first.
+    var fieldWrap = document.createElement('div'); fieldWrap.className = 'motion-fields';
+    fieldWrap.appendChild(input);
+    if (unit) { var u = document.createElement('span'); u.className = 'motion-unit'; u.textContent = unit; fieldWrap.appendChild(u); }
+    row.appendChild(nm); row.appendChild(fieldWrap); row.appendChild(sw);
     list.appendChild(row);
   }
   function renderTrimPathsGroup(list, holder) {
@@ -9833,7 +9842,14 @@
       var row = document.createElement('div'); row.className = 'lrow motion-elem-row';
       var expanded = isTextAnimatorExpanded(an);
       var arrow = document.createElement('div'); arrow.className = 'lico larrow'; arrow.textContent = expanded ? '▾' : '▸';
-      var swatch = document.createElement('div'); swatch.className = 'motion-elem-swatch'; swatch.style.background = 'transparent';
+      // A colorless transparent swatch (no fill/stroke to preview, unlike a
+      // shape row) reads as an empty/broken checkbox — same problem the
+      // Group row already solved with a glyph instead of a color
+      // (renderElementsList's gswatch, textContent '▤'). Reusing that exact
+      // pattern here rather than the unused .motion-elem-swatch.icon
+      // variant, which has zero live usage anywhere to confirm against.
+      var swatch = document.createElement('div'); swatch.className = 'motion-elem-swatch'; swatch.textContent = 'A';
+      swatch.style.cssText = 'background:transparent;font-size:9px;line-height:12px;text-align:center;color:var(--text-dim);';
       if (an.enabled === false) swatch.style.opacity = '0.35';
       var nm = document.createElement('div'); nm.className = 'lnm'; nm.textContent = SM.t('textAnimTitle') + ' ' + (idx + 1);
       row.appendChild(arrow); row.appendChild(swatch); row.appendChild(nm);


### PR DESCRIPTION
## Résumé

Corrige la non-conformité de mise en page signalée sur les nouvelles lignes Text Animator de la timeline Motion (`Start/End/Offset/Amount/EaseHigh/EaseLow/Smoothness`), et retrouve au passage le même bug préexistant sur Trim Paths (jamais signalé).

## Cause racine

`renderTrimScalarRow` — la fonction partagée derrière Trim Paths ET les nouvelles lignes Text Animator — ne wrappait jamais son champ de valeur dans le conteneur `.motion-fields` que toute autre ligne Transform utilise. `.pi` de base est `flex:1` avec `flex-basis:0%` ; posé à côté du label `.lnm` (aussi `flex:1`), il se partageait l'espace libre de la ligne au lieu de tenir ses 28px prévus — mesuré en direct à 90-99px contre 28px sur Position/Rotation/etc.

Le correctif : envelopper l'input (+ le suffixe d'unité, désormais via la classe `.motion-unit` établie plutôt qu'un `<span>` en style inline) dans `.motion-fields` (`flex-shrink:0`) — corrige les deux familles de lignes d'un coup.

Deuxième correction : le chronomètre était en première position sur ces lignes, alors que la convention du 2026-07-29 ("keyframe button à droite") le place en dernier partout ailleurs.

Troisième trouvaille : la pastille de couleur des lignes "Animator N" n'a rien à montrer (un animateur n'a pas de couleur) — une case transparente vide se lisait comme une checkbox cassée. Réutilisé le même précédent que la ligne de Groupe (glyphe à l'intérieur de la pastille transparente) plutôt que la variante CSS `.motion-elem-swatch.icon`, inutilisée nulle part ailleurs dans le code.

## Vérifié en pilotant

Projet réel : texte "NEMO" → Split by character → Add animator, en Motion. Les 15 lignes visibles (6 Transform + 7 Text Animator) mesurent toutes exactement 28px, même ordre DOM (label/fields/chronomètre), suffixe d'unité en `.motion-unit`. 41/41 tests passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)