### PR TITLE
Merge Text/Text-animator panels, icon buttons

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -520,17 +520,6 @@
         <div class="pr"><span class="pl" data-i18n="fieldStarCornerRadius">Coins</span><input type="number" class="pi scrub" id="p-star-corner" value="0" min="0" data-step="1"><span style="font-size:9px;color:var(--text-dim)">px</span></div>
       </div>
     </div>
-    <div class="psec" id="text-actions-sec" style="display:none">
-      <div class="phdr"><span class="ar">☰</span> <span data-i18n="hdrText">Texte</span></div>
-      <div class="pbdy">
-        <div class="pr" style="font-size:10px;color:var(--text-dim)" id="text-split-desc" data-i18n="textSplitDesc">Éclate ce texte en un caractère par élément — chacun devient animable individuellement (Motion, expressions).</div>
-        <div class="pr"><button class="pbtn ac" id="btn-text-split-chars" style="flex:1" data-i18n="textSplitBtn">Découper par caractère</button></div>
-        <!-- Text Animator (2026-08-17, text-animator.js) — shown once the
-             block has per-unit elements to animate: a vector text block
-             (always) or a raster block already split into characters. -->
-        <div class="pr" id="text-animate-row" style="display:none"><button class="pbtn ac" id="btn-text-animate" style="flex:1" data-i18n="textAnimateBtn">Animer le texte…</button></div>
-      </div>
-    </div>
     <!-- Typography panel (2026-08-16) — live re-editable properties for a
          selected VECTOR text root (raster text keeps the popover-only flow;
          see updateTextPropsPanel's own comment, timeline.js, for why). Every
@@ -1090,13 +1079,32 @@
          right above: a static block here, shown/hidden and populated by
          text-animator-panel.js, hooked into updatePropsContext.
          The animator LIST is rebuilt in JS (there can be several), so only
-         the shell and the "add" affordance are markup. -->
+         the shell and the "add" affordance are markup.
+         Merged with the former standalone "Text" section (2026-08-31,
+         Cyril: "on a 2 panel text et text animator... les fusionner et
+         évite les bouton text met plutôt des icon" — two sections for one
+         concept read as two features, and "Split by character"/"Animate
+         text…" were full-width text buttons where every other icon-only
+         action in this panel already uses a pictogram). The two rows below
+         are mutually exclusive with the animator list — a raster block
+         still needs splitting before it has addressable units (see
+         updateTextActionsPanel, timeline.js, which now only toggles these
+         two rows rather than a whole separate section); vector text is
+         already split at creation and never shows text-split-row. -->
     <div class="psec" id="p-textanim-sec" style="display:none">
       <div class="phdr"><span class="ar">☰</span> <span data-i18n="hdrTextAnimators">Text animators</span></div>
       <div class="pbdy">
+        <div class="pr" id="text-split-row" style="display:none">
+          <span class="pl" style="width:auto;opacity:.7;flex:1" data-i18n="textSplitDesc">Éclate ce texte en un caractère par élément — chacun devient animable individuellement (Motion, expressions).</span>
+          <button class="pbtn icon-only-btn" id="btn-text-split-chars" data-i18n-title="textSplitBtn" title="Split by character"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M9 6v12M15 6v12" stroke-dasharray="2 2"/></svg></button>
+        </div>
         <div id="p-textanim-list"></div>
-        <div class="pr">
-          <button class="pbtn" id="p-textanim-add" data-i18n-title="textAnimAddTitle" title="Add an animator: a range selector plus the properties it drives"><span data-i18n="textAnimAdd">Add animator</span></button>
+        <div class="pr" id="p-textanim-add-row">
+          <button class="pbtn" id="p-textanim-add" style="flex:1" data-i18n-title="textAnimAddTitle" title="Add an animator: a range selector plus the properties it drives"><span data-i18n="textAnimAdd">Add animator</span></button>
+          <!-- Old preset-based animator (2026-08-17, text-animator.js) —
+               a one-shot bake, kept reachable but demoted to an icon next
+               to the real (Motion-integrated) "Add animator" action. -->
+          <button class="pbtn icon-only-btn" id="btn-text-animate" style="display:none" data-i18n-title="textAnimateBtn" title="Animate text… (presets)"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v4M12 17v4M3 12h4M17 12h4M5.6 5.6l2.8 2.8M15.6 15.6l2.8 2.8M18.4 5.6l-2.8 2.8M8.4 15.6l-2.8 2.8"/></svg></button>
         </div>
         <div class="pr" id="p-textanim-empty">
           <span class="pl" style="width:auto;opacity:.7" data-i18n="textAnimEmptyHint">Animates by character index, so editing the text never breaks it.</span>

--- a/src/js/text-animator-panel.js
+++ b/src/js/text-animator-panel.js
@@ -38,6 +38,22 @@
     }
     return null;
   }
+  // A whole, not-yet-split RASTER text block — the layer/stored-frame
+  // equivalent of updateTextActionsPanel's own selectedPaths-based
+  // isWholeText check (timeline.js), used here only to decide whether the
+  // shared section should stay visible for the split action before any
+  // per-character unit exists yet. Vector text never matches this (it's
+  // already split at creation, so it's always caught by activeTextLayer
+  // above instead).
+  function wholeTextLayerContext() {
+    if (!window.state || !state.layers) return null;
+    var li = state.activeLayerIdx, ld = state.layers[li];
+    if (!ld) return null;
+    var strokes = (typeof getEffectiveStrokes === 'function') ? getEffectiveStrokes(li, state.currentFrame) : null;
+    if (!strokes || strokes.length !== 1) return null;
+    var s = strokes[0];
+    return (s && s.isRaster && s.isText && !s.isTextChar) ? { li: li, ld: ld } : null;
+  }
 
   function commit(ld) {
     if (typeof saveActiveLayerFrame === 'function') saveActiveLayerFrame();
@@ -278,18 +294,37 @@
     }
   }
 
+  // Owns the shared section's overall visibility (merged 2026-08-31 with
+  // the former standalone "Text" section — see index.html's comment on
+  // #p-textanim-sec). Runs LAST in the update chain (updatePropsContext
+  // calls this after updateTextActionsPanel already ran, timeline.js), so
+  // it's the authoritative display decision — updateTextActionsPanel only
+  // ever toggles its own two rows, never the section itself, precisely so
+  // the two can't stomp each other regardless of call order.
   function render() {
     var sec = el('p-textanim-sec');
     if (!sec) return;
     var ctx = activeTextLayer();
-    if (!ctx) { sec.style.display = 'none'; return; }
+    var wholeCtx = ctx ? null : wholeTextLayerContext();
+    if (!ctx && !wholeCtx) { sec.style.display = 'none'; return; }
     sec.style.display = '';
+    var addRow = el('p-textanim-add-row');
+    if (addRow) addRow.style.display = ctx ? '' : 'none';
+    var hint = el('p-textanim-empty');
     var list = el('p-textanim-list');
+    if (!ctx) {
+      // Whole, not-yet-split text: nothing to list or add yet — the
+      // section stays open purely so text-split-row (updateTextActionsPanel)
+      // has somewhere to live, matching this file's own "add" affordance
+      // pattern rather than inventing a second empty-state.
+      if (list) list.innerHTML = '';
+      if (hint) hint.style.display = 'none';
+      return;
+    }
     if (!list) return;
     list.innerHTML = '';
     var anims = (window.SMMotion && SMMotion.textAnimatorsOf) ? SMMotion.textAnimatorsOf(ctx.li) : [];
     for (var i = 0; i < anims.length; i++) buildAnimator(list, ctx.ld, anims[i], i);
-    var hint = el('p-textanim-empty');
     if (hint) hint.style.display = anims.length ? 'none' : '';
   }
 

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -7777,13 +7777,20 @@ function splitTextIntoCharacters(raster){
   raster.remove();
 }
 window.splitTextIntoCharacters=splitTextIntoCharacters;
-// Contextual panel (mirrors updateRevisionPanel's exact shape/precedent) —
-// shown for a whole (not-yet-split) raster text block (split action) AND
-// for anything already granular enough to animate per-unit (vector text,
-// or an already-split raster character) — see text-animator.js.
+// Toggles the two rows this function owns inside the shared #p-textanim-sec
+// (merged 2026-08-31 — see that block's own comment in index.html): the
+// split action for a whole, not-yet-split raster text block, and the icon
+// opening the old preset-based animator for anything already granular
+// enough to animate per-unit (vector text, or an already-split raster
+// character) — see text-animator.js. This function no longer owns the
+// section's own display: text-animator-panel.js's render() does (it runs
+// later in the same update chain, from updatePropsContext), using its own
+// layer/stored-frame based detection to decide whether the section shows
+// at all — this one only ever touches its two rows' visibility, so the
+// order between them can't stomp either one's decision.
 function updateTextActionsPanel(){
-  var sec=document.getElementById('text-actions-sec');
-  if(!sec)return;
+  var splitRow=document.getElementById('text-split-row');
+  if(!splitRow)return;
   var p=(state.tool==='select'&&selectedPaths.length===1)?selectedPaths[0]:null;
   var isWholeText=!!(p&&p.data&&p.data.isText&&!p.data.isTextChar&&!p.data.isVectorText);
   // Multi-glyph selection (feedback #87, "je n'ai toujours pas d'option
@@ -7800,16 +7807,16 @@ function updateTextActionsPanel(){
   var SMTA=window.SMTextAnimator;
   var animGroupId=(SMTA&&state.tool==='select'&&selectedPaths.length)?SMTA.groupIdForItem(selectedPaths[0]):null;
   if(animGroupId&&!selectedPaths.every(function(sp){return SMTA.groupIdForItem(sp)===animGroupId;}))animGroupId=null;
-  sec.style.display=(isWholeText||animGroupId)?'':'none';
-  document.getElementById('text-split-desc').style.display=isWholeText?'':'none';
-  document.getElementById('btn-text-split-chars').parentElement.style.display=isWholeText?'':'none';
+  splitRow.style.display=isWholeText?'':'none';
   if(isWholeText)document.getElementById('btn-text-split-chars').onclick=function(){splitTextIntoCharacters(p);};
-  var animRow=document.getElementById('text-animate-row');
-  animRow.style.display=animGroupId?'':'none';
-  if(animGroupId){
-    document.getElementById('btn-text-animate').onclick=function(){
-      window.SMTextAnimator.openPanel(state.activeLayerIdx,animGroupId);
-    };
+  var animBtn=document.getElementById('btn-text-animate');
+  if(animBtn){
+    animBtn.style.display=animGroupId?'':'none';
+    if(animGroupId){
+      animBtn.onclick=function(){
+        window.SMTextAnimator.openPanel(state.activeLayerIdx,animGroupId);
+      };
+    }
   }
 }
 // Typography panel (2026-08-16, "le panneau droite pour le texte") — live,


### PR DESCRIPTION
## Résumé

Cyril : « on a 2 panel text et text animator voir pour les fusionner et évite les bouton text met plutôt des icon apriorié ». La section "Text" (Split by character / l'ancien « Animer le texte… » à préréglages) était juste au-dessus de "Text animators" (le nouveau moteur par sélecteur de plage) — deux sections qui se lisaient comme deux fonctionnalités concurrentes plutôt qu'un seul flux avec une étape préalable.

## Ce qui change

Fusionnées dans une seule `#p-textanim-sec`, mutuellement exclusives selon l'état : un bloc raster entier pas encore découpé montre seulement l'action de découpage (le texte vectoriel est déjà découpé à la création, il n'atteint jamais cet état) ; une fois découpé, la section montre la vraie liste d'animateurs + bouton d'ajout. Les deux boutons pleine-largeur en texte de l'ancienne section (« Découper par caractère », « Animer le texte… ») sont maintenant des boutons icône seule, comme toutes les autres actions de ce panneau (œil/suppression sur une ligne d'animateur, `p-widget-yadd`…) — un glyphe de rectangle divisé pour le split, une étincelle pour l'ouverture de l'ancien préréglage, les deux avec une infobulle portant le texte qui était auparavant le libellé du bouton.

Deux fonctions indépendantes partagent maintenant la même section DOM sans se marcher dessus : `updateTextActionsPanel` (timeline.js) ne touche plus que ses deux lignes propres (`text-split-row`, `btn-text-animate`) via sa propre détection basée sur `selectedPaths` ; `text-animator-panel.js`'s `render()` — qui tourne plus tard dans la même chaîne de mise à jour (`updatePropsContext` l'appelle en dernier) — est désormais seul propriétaire de l'affichage de la section, étendu avec un nouveau `wholeTextLayerContext()` pour qu'un bloc raster pas encore découpé garde la section ouverte pour l'action de split seule.

## Vérifié en pilotant

Testé les deux états : un bloc raster "HELLO" entier montre la section fusionnée avec seulement l'icône de split + description, aucune liste d'animateurs ; l'icône le découpe et la sélection suivante montre "Add animator" + l'icône de préréglage rétrogradée, UI d'animateur complète inchangée. Un texte vectoriel "HI" (déjà découpé à la création) va directement à la liste d'animateurs, comme avant. 41/41 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)