### PR TITLE
Send security headers, and pin the font proxy's upstream host

### DIFF
--- a/src/_headers
+++ b/src/_headers
@@ -1,0 +1,26 @@
+# Security headers for every static asset response.
+#
+# This file exists INSTEAD of setting them in worker/index.js, because Workers
+# serves static assets ahead of the Worker script by default -- the Worker is
+# never invoked for a request that matches a file, so headers set there never
+# reached the actual site. (Confirmed live: the Worker set them and curl saw
+# none.) The alternative, assets.run_worker_first, would invoke the Worker on
+# every asset request just to add four headers; _headers is handled by the
+# asset server itself, so it costs nothing.
+#
+# Worker-generated responses are NOT covered by this file, so /api/google-font
+# sets the same headers in code (withSecurityHeaders, worker/index.js).
+#
+# No script-src/style-src on purpose: the app needs 'unsafe-inline' (an inline
+# <script>, 492 style="" attributes), 'unsafe-eval' (the nemo.* scripting API
+# runs user code via new Function) and wasm eval (the Rust render engine). A
+# policy permissive enough to keep that working would protect nothing while
+# looking like it does. Only directives that are both safe here and actually
+# useful are set. Permissions-Policy leaves clipboard alone -- the app uses it.
+/*
+  Content-Security-Policy: frame-ancestors 'none'; object-src 'none'; base-uri 'self'
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=()
+  Strict-Transport-Security: max-age=31536000

--- a/worker/index.js
+++ b/worker/index.js
@@ -12,15 +12,45 @@
 // (fetch_google_font, src-tauri/src/lib.rs) via reqwest, which can set
 // arbitrary headers.
 
+// ---- Security headers (2026-08) --------------------------------------------
+// Added after an audit found the site sent none at all.
+//
+// There is deliberately NO script-src/style-src here, and that is the whole
+// point of this comment. The app needs 'unsafe-inline' (one inline <script>,
+// 492 style="" attributes), 'unsafe-eval' (the nemo.* scripting API runs user
+// code through new Function) and wasm eval (the Rust render engine). A CSP
+// permissive enough to keep all of that working would protect nothing while
+// looking like it does. So only the directives that are both safe here and
+// genuinely useful are set:
+//   frame-ancestors  no one can frame the app -> no clickjacking
+//   object-src       kills <object>/<embed> as an injection vector
+//   base-uri         stops a <base> tag from re-pointing every relative URL,
+//                    which is what turns a small injection into a big one
+// Permissions-Policy leaves clipboard alone on purpose: the app uses it.
+const SECURITY_HEADERS = {
+  'Content-Security-Policy': "frame-ancestors 'none'; object-src 'none'; base-uri 'self'",
+  'X-Frame-Options': 'DENY',
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=(), usb=()',
+  'Strict-Transport-Security': 'max-age=31536000',
+};
+
+function withSecurityHeaders(resp) {
+  const out = new Response(resp.body, resp);
+  for (const [k, v] of Object.entries(SECURITY_HEADERS)) out.headers.set(k, v);
+  return out;
+}
+
 const ANDROID_UA = 'Mozilla/5.0 (Linux; U; Android 2.2)';
 
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
     if (url.pathname === '/api/google-font') {
-      return handleGoogleFont(url);
+      return withSecurityHeaders(await handleGoogleFont(url));
     }
-    return env.ASSETS.fetch(request);
+    return withSecurityHeaders(await env.ASSETS.fetch(request));
   },
 };
 
@@ -46,7 +76,13 @@ async function handleGoogleFont(url) {
   const css = await cssResp.text();
   const m = css.match(/url\(([^)]+)\)/);
   if (!m) return new Response('no font URL found in Google Fonts response', { status: 404 });
-  const ttfUrl = m[1];
+  const ttfUrl = m[1].replace(/^['"]|['"]$/g, '');
+  // ttfUrl is read out of the upstream response rather than built here, so it
+  // is only as trustworthy as that response. Pin the host instead of fetching
+  // whatever came back.
+  if (!ttfUrl.startsWith('https://fonts.gstatic.com/')) {
+    return new Response('unexpected font host', { status: 502 });
+  }
 
   let ttfResp;
   try {


### PR DESCRIPTION
An audit of nemomotion.org found it sent **no security headers at all**.

### The site itself holds up well

Four vectors checked, all closed:

- **No external JavaScript.** Only Google Fonts (CSS, cannot execute). The classic supply-chain vector doesn't exist here.
- **The font proxy can't be redirected** — `family` goes through `encodeURIComponent` and the host is fixed.
- **The reflected error param is not XSS** — served as `text/plain`, verified live.
- **A shared project file cannot execute code** — plugins load only from an explicit file picker, never at startup, and project JSON can't reference one.

What was missing was the layer underneath: nothing stopped the app being framed, and nothing constrained an injection if one ever appeared.

### Why `src/_headers` and not the Worker

Workers serves **static assets ahead of the Worker script**. A Worker that sets headers is never invoked for a request matching a file — I set them there first, curled it, and got nothing back. That's how this was found.

`assets.run_worker_first` would fix it by invoking the Worker on every asset request just to add six headers. `_headers` is applied by the asset server itself and costs nothing. Worker-generated responses aren't covered by that file, so `/api/google-font` sets the same headers in code.

### No `script-src`, on purpose

The app needs `'unsafe-inline'` (one inline script, 492 `style=""` attributes), `'unsafe-eval'` (the `nemo.*` scripting API runs user code via `new Function`) and wasm eval for the Rust engine. **A policy permissive enough to keep that working would protect nothing while looking like it does.**

So only directives that are both safe here and genuinely useful: `frame-ancestors` (clickjacking), `object-src` (injection vector), `base-uri` (stops a `<base>` tag re-pointing every relative URL). `Permissions-Policy` leaves clipboard alone — the app uses it.

### Verified against a local build

| Check | Result |
|---|---|
| Six headers served | ✅ |
| Font proxy returns a real TrueType font | ✅ 95 KB |
| Project opens, canvas present | ✅ |
| `new Function` still runs | ✅ |
| WebAssembly loads | ✅ |
| Manrope (Google Fonts) resolves | ✅ |
| CSP violations in console | none |

🤖 Generated with [Claude Code](https://claude.com/claude-code)