### PR TITLE
Motion timeline: reorder a layer by dragging its in/out bar

### DIFF
--- a/src/js/layer-inout.js
+++ b/src/js/layer-inout.js
@@ -1468,7 +1468,29 @@
     _liToRow[li] = row;
     hleft.addEventListener('mousedown', function (e) { onDown(li, row, 'in', e); });
     hright.addEventListener('mousedown', function (e) { onDown(li, row, 'out', e); });
-    bar.addEventListener('mousedown', function (e) { if (e.target === bar) onDown(li, row, 'both', e); });
+    // Y-dominant drag reorders the layer's stack index, in PARALLEL with
+    // onDown's own move-in-time drag below, not instead of it (2026-09-01,
+    // Cyril: "en y peut importe où l'on prend le calque on peut le
+    // changer d'index comme sur after effects et dans la partie gauche" —
+    // the layer LIST panel already supports grab-anywhere reorder via
+    // this exact mechanism, armLayerReorder/moveLayerReorder,
+    // timeline.js; the frame-grid's own bar never armed it, so the tiny
+    // sticky reorder grip — installLayerReorderGrip, whose own comment
+    // documents the still-imperfect collision it has with an in-handle
+    // sitting at frame 0 — was the ONLY way to reorder from this side).
+    // Safe to arm unconditionally alongside onDown: moveLayerReorder only
+    // ever activates past its own Y-dominance threshold (dy>=4 &&
+    // dy>=dx*.55, timeline.js), so a genuinely horizontal drag leaves it
+    // permanently inert and onDown's move-in-time logic below proceeds
+    // completely unaffected — the two systems never actually compete for
+    // the same drag, only one of them ever measures a nonzero delta for
+    // any given direction. Skipped on a modifier click (selection
+    // gestures below, never a drag at all) so it can't preempt those.
+    bar.addEventListener('mousedown', function (e) {
+      if (e.target !== bar) return;
+      if (!e.metaKey && !e.ctrlKey && !e.shiftKey && window.armLayerReorder) armLayerReorder(e, li, 'grid', row);
+      onDown(li, row, 'both', e);
+    });
     bar.addEventListener('contextmenu', function (e) {
       e.preventDefault(); e.stopPropagation();
       if (!window.showContextMenu) return;


### PR DESCRIPTION
## Résumé

Cyril : « dans motion timeline droite améliorer encore la poignée inpoint d'un calque quand celui est au tout début et se confond avec le déplacement de calque [...] faire en sorte que en y peut importe où l'on prend le calque on peut le changer d'index comme sur after effects et [comme] dans la partie gauche ».

## Constat

Le panneau de LISTE des calques (gauche) supporte déjà le "grab n'importe où pour réordonner" (`armLayerReorder`/`moveLayerReorder`, timeline.js — un drag dominé par Y réordonne, seuil `dy>=4 && dy>=dx*.55`). La barre in/out du frame-grid (droite) n'a jamais armé ce même mécanisme — le seul point d'entrée était la petite poignée collante de réordonnement (`installLayerReorderGrip`), dont le commentaire d'en-tête documente déjà une collision imparfaite, déjà corrigée deux fois, avec la poignée in quand l'inPoint d'un calque est à la frame 0 (les deux tombent sur les mêmes pixels ; feedback 2026-08 et feedback #137).

## Correctif

Le mousedown de la barre arme maintenant AUSSI le système de réordonnement, EN PARALLÈLE de son drag "déplacer dans le temps" existant — pas à sa place. Sans risque : `moveLayerReorder` ne s'active jamais avant son propre seuil de dominance Y, donc un drag vraiment horizontal le laisse inerte et la logique de déplacement temporel continue normalement ; un drag vraiment vertical laisse cette même logique calculer un dx≈0 (no-op). Les deux systèmes ne se disputent jamais le même drag, un seul des deux mesure un delta non-nul selon la direction. Ignoré sur un clic avec modificateur (gestes de sélection, jamais un drag).

Ça règle le vrai problème de Cyril sans toucher à la poignée ni à sa logique d'évitement de collision existante : attraper le corps de la barre n'importe où, loin des petits pixels de la poignée/du grip, est maintenant une alternative complète pour réordonner — la collision à inPoint=0 n'oblige plus à un grab précis. Je n'ai délibérément PAS retiré le grip lui-même : il garde sa raison d'être documentée (rester atteignable quand le corps d'une longue barre est scrollé hors du viewport).

## Vérifié en direct

Via événements souris synthétiques précis (l'espace de coordonnées CSS du viewport de preview diffère de celui de l'outil de capture d'écran — confirmé en croisant `getBoundingClientRect`/`elementFromPoint`/`innerWidth` directement) :
- Un drag dominé par Y (dy=44, dx=2) sur le corps de la barre réordonne bien la pile de calques (ordre du tableau changé, panneau et grille restent synchro).
- Un drag purement horizontal (dx=60, dy=0) sur la même barre décale toujours inPoint/outPoint du bon nombre de frames, sans aucun réordonnement.
- La poignée in (non touchée par ce changement) trim toujours normalement.
- Un ctrl-clic sur la barre n'arme PAS le réordonnement (le garde de modificateur tient).

## Plan de test

- [x] `npm test` (58/58, aucune régression)
- [x] Vérifié en direct (réordonnement, déplacement temporel, trim, garde modificateur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)