### PR TITLE
Motion: remove the reorder grip instead of patching its handle collision

### DIFF
--- a/src/js/layer-inout.js
+++ b/src/js/layer-inout.js
@@ -512,22 +512,22 @@
   // or shrinks the range from the SAME fixed end rather than drifting.
   var _barAnchorLi = null;
   // forceHandleEl (2026-08, feedback: "quand les calques sont calé au tout
-  // début c'est compliqué d'attraper le in point avec la souris") — the
-  // sticky reorder grip (installLayerReorderGrip, timeline.js) sits at
-  // z-index:9, ABOVE this bar's own z-index:2 stacking context, so the
-  // instant a bar's inPoint lands near frame 0 (or a scroll parks the
-  // viewport's left edge inside a bar), the in-handle physically
-  // coincides with the grip and every mousedown resolves to the grip
-  // first — the handle becomes literally unclickable, not just fiddly.
-  // Raising the WHOLE bar's z-index above the grip was rejected: the
-  // grip's sole reason to exist is staying reachable even while a long
-  // bar's BODY covers the viewport's left edge after scrolling — that
-  // would trade one unreachable target for another. Instead the grip's
-  // own handler (installLayerReorderGrip) hit-tests for a handle first
-  // and, when the click is really on one, calls this SAME onDown with
-  // the real handle element passed explicitly — forceHandleEl lets that
-  // caller's e.target (the grip, not the handle) not leak into the
-  // handle's own hover-lock behavior (.hot class below).
+  // début c'est compliqué d'attraper le in point avec la souris") — lets a
+  // caller whose own e.target ISN'T the handle (a hand-off from something
+  // else entirely) pass the real handle element explicitly, so it doesn't
+  // leak into the handle's own hover-lock behavior (.hot class below).
+  // Historically this existed because Motion's sticky reorder grip
+  // (installLayerReorderGrip, timeline.js) sat at z-index:9, ABOVE this
+  // bar's own z-index:2, so a bar whose inPoint landed near frame 0 put
+  // its in-handle physically under the grip — every mousedown resolved to
+  // the grip first, and the grip's own handler hit-tested for a handle and
+  // handed off here when it found one. 2026-09-01 (Cyril: "enlève ce qui
+  // gêne pour attraper le in point"): Motion stopped installing that grip
+  // at all — see renderTimelineMotion's own comment — so this exact
+  // collision can no longer happen there. The parameter stays (Animation
+  // 2D's frame-grid still installs the same grip, on rows that never have
+  // a handle to begin with, so its own hand-off branch is a permanent
+  // no-op there rather than genuinely dead code).
   function onDown(li, row, type, e, forceHandleEl) {
     e.stopPropagation(); e.preventDefault();
     var ld = state.layers[li]; if (!ld) return;
@@ -1473,11 +1473,18 @@
     // Cyril: "en y peut importe où l'on prend le calque on peut le
     // changer d'index comme sur after effects et dans la partie gauche" —
     // the layer LIST panel already supports grab-anywhere reorder via
-    // this exact mechanism, armLayerReorder/moveLayerReorder,
-    // timeline.js; the frame-grid's own bar never armed it, so the tiny
-    // sticky reorder grip — installLayerReorderGrip, whose own comment
-    // documents the still-imperfect collision it has with an in-handle
-    // sitting at frame 0 — was the ONLY way to reorder from this side).
+    // this exact mechanism, armLayerReorder/moveLayerReorder, timeline.js;
+    // the frame-grid's own bar never armed it, so the tiny sticky reorder
+    // grip — installLayerReorderGrip, whose z-index-9 stacking put an
+    // in-handle at frame 0 physically underneath it — was the ONLY way to
+    // reorder from this side. First pass just patched the grip's own
+    // hand-off logic and left it installed; still wasn't enough (Cyril,
+    // same day: "tu as n'as pas enlever ce qui gêne") — the grip itself
+    // was still there, still sitting on top of the handle. Motion no
+    // longer installs that grip at ALL (renderTimelineMotion, motion.js),
+    // which is what actually removes the collision rather than patching
+    // around it once more; Animation 2D's frame-grid still uses the grip,
+    // since it has no in/out bar of its own to arm reordering from here.
     // Safe to arm unconditionally alongside onDown: moveLayerReorder only
     // ever activates past its own Y-dominance threshold (dy>=4 &&
     // dy>=dx*.55, timeline.js), so a genuinely horizontal drag leaves it

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -10793,7 +10793,23 @@
       var spacer = document.createElement('div');
       spacer.className = 'frow' + (_layerSel.indexOf(li) >= 0 ? ' act motion-selected' : '');
       spacer.dataset.layer = li;
-      if (window.installLayerReorderGrip) installLayerReorderGrip(spacer, li);
+      // No installLayerReorderGrip call here anymore (2026-09-01, Cyril:
+      // "enlève ce qui gêne pour attraper le in point quand celui est
+      // calé à la première image") — that sticky grip sat at z-index:9,
+      // ABOVE the in/out bar buildBar is about to insert (z-index:2), so a
+      // layer whose inPoint landed at frame 0 had its in-handle physically
+      // UNDER the grip: every native click there resolved to the grip
+      // first. Two rounds of hand-off patches (a click-point distance
+      // test, then a rect-overlap test; feedback 2026-08 and feedback
+      // #137) narrowed that collision but never actually removed it,
+      // since the grip kept existing at exactly the pixels the handle
+      // needed. buildBar's own mousedown now arms the SAME reorder system
+      // itself (layer-inout.js, in parallel with its move-in-time drag) —
+      // grabbing the bar body ANYWHERE, including well away from the
+      // handle, reorders the layer on a Y-dominant drag, so the frame-0
+      // collision has nothing left in Motion to collide with. Animation
+      // 2D's frame-grid (timeline.js) still installs this same grip —
+      // it has no in/out bar of its own to grab instead.
       if (window.SMLayerInOut) SMLayerInOut.buildBar(spacer, li);
       grid.appendChild(spacer);
       if (!expanded) return;
@@ -12780,27 +12796,11 @@
       // THIS function on every attempt, zero trace of the rect's own
       // listener ever running.
       //
-      // .layer-reorder-grip (feedback #137, found live while investigating
-      // "difficile d'attraper le in point... interfère avec le déplacement
-      // de layer en index"): the grip (timeline.js, installLayerReorderGrip)
-      // was added 2026-08-24 with its OWN mousedown/pointerdown listener but
-      // was never added to THIS exemption list — same missing-exemption bug
-      // as every entry above, just in a different file, so it was easy to
-      // miss. The practical effect was worse than "hard to grab": since this
-      // CAPTURE-phase listener always runs first and this class wasn't
-      // exempted, EVERY mousedown on the grip was swallowed into a marquee-
-      // select before the grip's own handler ever ran — verified live via
-      // dispatchEvent trace (grip's own listener never fired, not even
-      // once) and by dragging the grip a full 65px vertically, which is
-      // normally more than enough to reorder, and nothing moved. So
-      // dragging the grip to reorder a layer directly in the frame-grid
-      // didn't actually work AT ALL, frame 0 or not — only the layer-list
-      // panel's own row-drag (a separate, unaffected code path) did. The
-      // SAME-DAY fix for the frame-0 handle-vs-grip overlap (dd7a202) was
-      // therefore built and shipped on top of a handler that could never
-      // run in the first place. Exempting the grip here is what actually
-      // makes both that fix and normal grid-side reordering reachable.
-      if (e.target.closest('.fc.motion-fc, .layer-inout-handle, .layer-inout-key, .layer-inout-bar, .motion-key-connect, .layer-reorder-grip, #frame-hdr, #playhead-flag, #bars-row, #motion-graph-resize')) return;
+      // .layer-reorder-grip is NOT in this list (2026-09-01): Motion no
+      // longer installs that grip at all — see renderTimelineMotion's own
+      // comment on why (the bar's mousedown arms reordering itself now).
+      // .layer-inout-bar's own exemption below is what that relies on.
+      if (e.target.closest('.fc.motion-fc, .layer-inout-handle, .layer-inout-key, .layer-inout-bar, .motion-key-connect, #frame-hdr, #playhead-flag, #bars-row, #motion-graph-resize')) return;
       // Scrollbar clicks land on the wrap itself but outside its client
       // area — intercepting them would break scrollbar dragging.
       var r = wrap.getBoundingClientRect();

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -5241,7 +5241,7 @@ function renderShapeTreeRowsInto(list,li,ld){
 // are v1-unsupported (mirrors engine.rs's is_folder_layer doc comment):
 // rather than silently losing its own children's rows from the list, a
 // folder-shaped layer always renders as its own independent top-level-ish
-// row. The UI drop handler (installLayerReorderGrip) additionally refuses
+// row. The UI drop handler (moveLayerReorder) additionally refuses
 // to let you create this situation via drag in the first place.
 function folderLayerChildMap(){
   var folderUidByIdx={},childrenOf={},childOf={};
@@ -6346,6 +6346,15 @@ function armLayerReorder(e,srcIdx,origin,sourceRow){
   _layerDrag.origin=origin||'panel';
   _layerDrag.grabOffsetY=r?Math.max(0,Math.min(r.height,e.clientY-r.top)):17;
 }
+// Sticky reorder grip — Animation 2D's frame-grid ONLY (2026-09-01: MOTION
+// stopped calling this; motion.js's rows no longer have a grip at all, see
+// installLayerReorderGrip's own call-site comment below for why). Animation
+// 2D's rows have no in/out bar to grab instead (renderTimeline's own comment
+// a few hundred lines up: "the in/out bar is Motion-mode-only visually"), so
+// this stays their only frame-grid reorder entry point — and since an
+// Animation 2D row never has a `.layer-inout-handle` in the first place, the
+// hand-off branch below is permanently a no-op there, not dead code kept
+// around for nothing.
 function installLayerReorderGrip(row,li){
   if(!row||row.querySelector('.layer-reorder-grip'))return;
   var grip=document.createElement('div');
@@ -6353,38 +6362,13 @@ function installLayerReorderGrip(row,li){
   grip.title=(window.SM&&SM.t)?SM.t('titleDragReorderLayer'):'Drag vertically to reorder the layer';
   function begin(e){
     if(e.button!==0)return;
-    // Grip sits at z-index:9 (sticky, always reachable even while a long
-    // bar's body scrolls under it) — ABOVE the in/out bar's own z-index:2,
-    // so a bar whose inPoint lands near frame 0 puts its in-handle
-    // physically under this grip: every native click there resolves to
-    // the grip first, making the handle unclickable (feedback 2026-08:
-    // "quand les calques sont calé au tout début c'est compliqué
-    // d'attraper le in point"). Hit-test for a handle FIRST and hand off
-    // to its real onDown instead of reordering when one is really there;
-    // native reordering is unaffected everywhere else, including the
-    // long-bar-scrolled-under-the-grip case this grip exists for (a
-    // handle is never physically there in that case).
-    //
-    // feedback #137 ("des difficultés à attraper le in point... et va
-    // interférer avec le déplacement de layer en index"): the original
-    // version of this hand-off distance-tested the CLICK POINT against
-    // each handle's rect with a fixed ±6px tolerance — reachable in
-    // theory, but fragile in practice. A click that misses that radius by
-    // a hair (real mouse/trackpad imprecision, HiDPI rounding) falls
-    // through to armLayerReorder below; armLayerReorder itself stays
-    // inert for a purely-horizontal drag (moveLayerReorder requires
-    // dy>=4 AND dy>=dx*.55 before it actually reorders anything), but a
-    // real hand's natural vertical wobble while dragging "horizontally"
-    // is often enough to cross that threshold — turning a missed trim
-    // grab into a genuinely unwanted reorder, exactly the interference
-    // reported. Testing rect OVERLAP instead of click-point distance
-    // removes the magic-number fragility: whenever a handle is visually
-    // co-located with the grip at all (the only time this ambiguity can
-    // exist in the first place), every click anywhere on the grip
-    // unconditionally favors that handle — there is no legitimate "I
-    // meant reorder" click in that overlapping region anyway, and the
-    // layer-list panel's own row-drag (a separate, non-overlapping
-    // affordance) still reorders layers normally in the meantime.
+    // Hand-off to a real handle when one happens to be physically under the
+    // grip (rect-overlap test, not click-point distance — see feedback #137
+    // in this function's git history for why the earlier ±6px version was
+    // fragile). Motion no longer installs this grip at all (frame-0 handle
+    // collision fixed by removing the grip from that side entirely, not by
+    // improving this hand-off further) — this only still matters if a FUTURE
+    // caller ever reuses this grip somewhere handles also exist.
     if(window.SMLayerInOut&&window.SMLayerInOut.onDown){
       var gripRect=grip.getBoundingClientRect();
       var handles=row.querySelectorAll('.layer-inout-handle');

--- a/tests/feedback-2026-08-22.test.cjs
+++ b/tests/feedback-2026-08-22.test.cjs
@@ -132,12 +132,18 @@ test('Motion key drags provide snapping guides and scroll-aware deltas', () => {
 test('layer order drag works from both timeline halves with one outline ghost', () => {
   const timeline = read('src/js/timeline.js');
   const motion = read('src/js/motion.js');
+  const layerInout = read('src/js/layer-inout.js');
   const css = read('src/css/style.css');
+  // Animation 2D's frame-grid still installs the sticky grip (it has no
+  // in/out bar of its own to arm reordering from) — Motion (below) does not,
+  // 2026-09-01, so a layer's inPoint sitting at frame 0 can never again put
+  // that grip on top of the in-handle in Motion specifically.
   assert.match(timeline, /function installLayerReorderGrip\(/);
   assert.match(timeline, /window\.installLayerReorderGrip=installLayerReorderGrip/);
   assert.match(timeline, /\.lrow\[data-layer\],#frame-grid \.frow\[data-layer\]/);
   assert.match(timeline, /className='layer-drag-ghost'/);
-  assert.match(motion, /installLayerReorderGrip\(spacer, li\)/);
+  assert.doesNotMatch(motion, /installLayerReorderGrip\(spacer, li\)/);
+  assert.match(layerInout, /armLayerReorder\(e, li, 'grid', row\)/);
   assert.match(css, /\.layer-reorder-grip\{/);
   assert.match(css, /\.layer-drag-ghost\{[^}]*background:transparent/);
 });


### PR DESCRIPTION
## Résumé

Suite directe de [PR #695](https://github.com/mysteropodes/nemo/pull/695) — Cyril : « tu as n'as pas enlever ce qui gêne pour attraper le in point quand celui ci est calé à la première image ». Correct : la passe précédente donnait une alternative pour réordonner (drag Y sur le corps de la barre), mais laissait le grip lui-même installé, exactement là où il a toujours été — z-index:9, au-dessus de la poignée in, à la frame 0. Deux passes ANTÉRIEURES de patchs de hand-off (test de distance au point de clic, puis test de recouvrement de rect — feedback 2026-08 et feedback #137) avaient déjà essayé de faire céder le grip à la poignée en cas de recouvrement, sans jamais suffire, parce que le grip était toujours là pour entrer en collision en premier lieu.

## Correctif

Les lignes du frame-grid Motion (`renderTimelineMotion`, motion.js) n'installent plus le grip du tout — le drag Y sur le corps de la barre (PR précédente) le remplace complètement, il n'y a plus rien qui en a besoin de ce côté. Le frame-grid d'Animation 2D (timeline.js) installe toujours exactement le même grip, inchangé : ces lignes n'ont pas de barre in/out à attraper à la place (Motion-only visuellement, commentaire déjà existant de `renderTimeline`), donc ça reste leur seul point d'entrée de réordonnement côté frame-grid — et comme une ligne Animation 2D n'a jamais de poignée, la branche de hand-off du grip y a toujours été un no-op, jamais la source de cette collision.

Le test de régression qui figeait l'ancien appel `installLayerReorderGrip(spacer, li)` dans motion.js a été mis à jour pour vérifier son absence, plus le nouveau câblage `armLayerReorder` dans layer-inout.js ; nettoyage des commentaires devenus obsolètes (le `forceHandleEl`/`onDown` de layer-inout.js, la liste d'exemption du marquee-starter de motion.js, l'attribution du refus de dossier imbriqué dans timeline.js) qui décrivaient la collision comme atténuée-mais-présente plutôt que supprimée.

## Vérifié en direct

0 élément `.layer-reorder-grip` dans tout le frame-grid Motion (3 calques, tous à inPoint=0 par défaut) alors qu'Animation 2D en a toujours exactement 3 (un par calque, inchangé). `document.elementFromPoint` à la position écran exacte de la poignée in résout maintenant vers la poignée elle-même, pas un élément concurrent — confirmé directement, pas déduit. La poignée trim toujours correctement (0→1 frame via un vrai drag) et le corps de la barre réordonne toujours correctement via un drag dominé par Y, les deux via événements synthétiques.

## Plan de test

- [x] `npm test` (58/58, aucune régression)
- [x] Vérifié en direct (0 grip en Motion, 3 en Animation 2D, poignée directement cliquable, trim + réordonnement fonctionnels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)