### PR TITLE
fix: la sélection de calque suit le calque après réordonnancement

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -441,6 +441,17 @@ function reorderLayersAtGap(fromIndices,gapIdx){
   var insertIdx=0;
   for(var i=0;i<gapIdx;i++)if(moving.indexOf(i)<0)insertIdx++;
   var activeLd=state.layers[state.activeLayerIdx];
+  // Selection follows the LAYER, not the array slot it used to occupy
+  // (2026-09-01, Cyril: "si on déplace l'order d'un calque select celui
+  // ci ne reste pas select, c'est le premier calque qui est select à
+  // chaque fois") — same identity-capture-then-relocate pattern activeLd
+  // already uses just above, applied to the multi-select array too:
+  // _layerSel/_layerSelAnchor are raw ARRAY INDICES, and the splice below
+  // moves layers between indices, so leaving them untouched pointed the
+  // highlight at whatever layer happened to land on that OLD index
+  // afterward — not necessarily the one the user actually selected.
+  var selLds=(typeof _layerSel!=='undefined'&&_layerSel.length)?_layerSel.map(function(i){return state.layers[i];}):null;
+  var anchorLd=(typeof _layerSelAnchor!=='undefined'&&_layerSelAnchor>=0)?state.layers[_layerSelAnchor]:null;
   var movedLd=moving.map(function(i){return state.layers[i];});
   var movedUL=moving.map(function(i){return userLayers[i];});
   var keptLd=state.layers.filter(function(_l,i){return moving.indexOf(i)<0;});
@@ -459,6 +470,14 @@ function reorderLayersAtGap(fromIndices,gapIdx){
   userLayers.forEach(function(l){l.insertBelow(arcLayer);});
   var newActiveIdx=state.layers.indexOf(activeLd);
   state.activeLayerIdx=newActiveIdx>=0?newActiveIdx:0;
+  if(selLds){
+    _layerSel=selLds.map(function(ld){return state.layers.indexOf(ld);}).filter(function(i){return i>=0;});
+  }
+  if(typeof _layerSelAnchor!=='undefined'&&anchorLd){
+    var newAnchorIdx=state.layers.indexOf(anchorLd);
+    _layerSelAnchor=newAnchorIdx>=0?newAnchorIdx:-1;
+  }
+  if(typeof window!=='undefined'&&window.SMMotion&&window.SMMotion.syncBarSelToLayerSel)window.SMMotion.syncBarSelToLayerSel();
   activateUL(state.activeLayerIdx);
   loadFrame(state.currentFrame);renderOS();renderArcs();updateUI();showToast(SM.t(moving.length>1?'toastLayersReordered':'toastLayerReordered'));
 }

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -12858,6 +12858,12 @@
     // Bar-side Shift/Ctrl selection → layer-list mirror (layer-inout.js
     // onDown calls this; see the function's own comment).
     syncLayerSelFromBarSel: syncLayerSelFromBarSel,
+    // Layer-list selection → bar mirror (the OTHER direction — see this
+    // function's own comment: "call after every _layerSel assignment").
+    // Exported so app.js's reorderLayersAtGap can push a remapped
+    // selection into the Motion frame-grid's own highlight after a drag
+    // reorder, without a second copy of this trivial mapping.
+    syncBarSelToLayerSel: syncBarSelToLayerSel,
     // Menu-based Parent-in-Time creation (timeline.js buildTimeLinkMenuItems
     // — same core-setter split as setLayerParent/buildParentMenuItems).
     setLayerTimeLink: setLayerTimeLink,

--- a/tests/feedback-2026-08-22.test.cjs
+++ b/tests/feedback-2026-08-22.test.cjs
@@ -70,6 +70,44 @@ test('layer gap reorder preserves objects, active layer, and visual bottom drop'
   assert.match(read('src/css/style.css'), /\.layer-drop-indicator\s*\{/);
 });
 
+test('layer gap reorder moves the selection with the layer, not the array slot', () => {
+  // 2026-09-01, Cyril: "si on déplace l'order d'un calque select celui ci
+  // ne reste pas select, c'est le premier calque qui est select à chaque
+  // fois" — _layerSel/_layerSelAnchor are raw ARRAY INDICES, and the
+  // splice inside reorderLayersAtGap moves layers between indices, so an
+  // untouched index just landed on whatever layer happened to be there
+  // afterward instead of following the one the user actually selected.
+  const source = read('src/js/app.js');
+  const start = source.indexOf('function reorderLayersAtGap(');
+  const end = source.indexOf('function drawStage(', start);
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  const layers = ['A', 'B', 'C', 'D'].map((name) => ({ name }));
+  const userLayers = layers.map((layer) => ({ layer, insertBelow() {} }));
+  const state = { layers, activeLayerIdx: 1, currentFrame: 0 };
+  let syncCalls = 0;
+  const sandbox = {
+    state, userLayers, arcLayer: {},
+    // B (index 1) and D (index 3) selected, anchored on B — same shape a
+    // real Shift/Ctrl-click multi-select leaves behind.
+    _layerSel: [1, 3], _layerSelAnchor: 1,
+    saveAllLayerFrames() {}, pushUndoLayers() {}, activateUL() {}, loadFrame() {},
+    renderOS() {}, renderArcs() {}, updateUI() {}, showToast() {},
+    SM: { t(value) { return value; } }, Math, Array,
+    window: { SMMotion: { syncBarSelToLayerSel() { syncCalls++; } } },
+  };
+  vm.runInNewContext(`${source.slice(start, end)}\nthis.reorder = reorderLayersAtGap;`, sandbox);
+  // Move A (index 0, unselected) to the very end — B, C, D each shift down
+  // one slot, so a naive index-only selection would now point at C and
+  // nothing instead of following B and D.
+  sandbox.reorder([0], 4);
+  assert.deepEqual(state.layers.map((l) => l.name), ['B', 'C', 'D', 'A']);
+  const selectedNames = sandbox._layerSel.map((i) => state.layers[i].name).sort();
+  assert.deepEqual(selectedNames, ['B', 'D']);
+  assert.equal(state.layers[sandbox._layerSelAnchor].name, 'B');
+  assert.equal(syncCalls, 1);
+});
+
 test('multi-layer selection has one union overlay and three transforms in both modes', () => {
   const source = read('src/js/motion.js');
   assert.match(source, /function multiLayerBox\(\)/);


### PR DESCRIPTION
## Résumé

Cyril, en parallèle du chantier brush : "si on déplace l'order d'un calque select celui ci ne reste pas select, c'est le premier calque qui est select à chaque fois".

`_layerSel`/`_layerSelAnchor` sont des index de tableau bruts. `reorderLayersAtGap` (app.js) fait un splice qui déplace les calques entre index — `state.activeLayerIdx` était déjà remappé par identité d'objet après le splice, mais pas la multi-sélection ni son ancre. Résultat : après un drag de réordonnancement, la mise en évidence restait sur l'ancien index, donc sur n'importe quel calque qui atterrissait dessus (souvent le premier).

## Correctif

- `reorderLayersAtGap` : capture `selLds`/`anchorLd` (références d'objets calque) AVANT le splice, comme `activeLd` le fait déjà ; remappe `_layerSel`/`_layerSelAnchor` par `indexOf` APRÈS.
- Appel à `window.SMMotion.syncBarSelToLayerSel()` (nouvellement exporté depuis motion.js) pour que la grille Motion reste en phase avec le panneau gauche.
- Nouveau test (`tests/feedback-2026-08-22.test.cjs`) qui reproduit le scénario en sandbox : B et D sélectionnés, A (non sélectionné) déplacé — vérifie que la sélection et l'ancre suivent B/D à leurs nouveaux index.

## Vérification en direct

Projet neuf, 4 calques (A/B/C/D) :
- Sélection simple (B) + réordonnancement d'un autre calque → la ligne mise en évidence (`lrow act sel` / `motion-selected`) suit B à son nouvel index, dans le panneau ET la grille Motion.
- Multi-sélection (B+D, ancre B) + réordonnancement → les deux lignes restent en évidence des deux côtés, ancre toujours sur B.

## Tests

`npm test` : 59/59 passent (58 existants + 1 nouveau).

🤖 Generated with [Claude Code](https://claude.com/claude-code)