### PR TITLE
feat: grain de valeur par-dab sur les brush texturés

### DIFF
--- a/src/js/brush-editor.js
+++ b/src/js/brush-editor.js
@@ -35,6 +35,11 @@
     // (échantillonnée une seule fois au tracé), distincte d'opacityJitter
     // ci-dessus qui varie PAR TAMPON — les deux se cumulent. 0 = neutre.
     { key: 'noise', label: 'Var. opacité par trait', min: 0, max: 1, step: 0.05 },
+    // Grain de valeur (2026-09, audit brush) — lerp par-dab vers le noir/blanc
+    // (jitterColorValue, tools.js), le canal de variation MyPaint/Krita qui
+    // manquait : sans lui, un trait texturé reste une couleur plate malgré
+    // toute la variation de forme/opacité déjà présente.
+    { key: 'valueJitter', label: 'Var. valeur (grain)', min: 0, max: 0.5, step: 0.02 },
     { key: 'scatter', label: 'Dispersion', min: 0, max: 1, step: 0.05 },
     { key: 'dashGap', label: 'Trous (bord cassé)', min: 0, max: 0.6, step: 0.02 },
     { key: 'edgeNoise', label: 'Bord irrégulier', min: 0, max: 0.4, step: 0.02 },
@@ -66,7 +71,7 @@
     { value: 'scribble', label: 'Gribouillis (graphite/fusain)' },
     { value: 'custom', label: 'Personnalisé (dessiné)…' },
   ];
-  var DEFAULT_PARAMS = { nibSize: 1, roundness: 0.9, spacing: 0.4, spaceJitter: 0.2, rotationMode: 'tangent', rotationJitter: 20, sizeJitter: 0.2, opacity: 0.6, opacityJitter: 0.2, scatter: 0.15, dashGap: 0, tipShape: 'ellipse', edgeNoise: 0, polySides: 5, bristleCount: 5, tipCorner: 0.15, scribbleCount: 8, scribbleLen: 1.4, scribbleLenJitter: 0.4, scribbleWidth: 0.12, scribbleSpread: 0.6, scribbleAngleSpread: 70, pressureStart: 1, pressureMid: 1, pressureEnd: 1, sharpness: 1, markerTip: true, grain: 1, noise: 0 };
+  var DEFAULT_PARAMS = { nibSize: 1, roundness: 0.9, spacing: 0.4, spaceJitter: 0.2, rotationMode: 'tangent', rotationJitter: 20, sizeJitter: 0.2, opacity: 0.6, opacityJitter: 0.2, scatter: 0.15, dashGap: 0, tipShape: 'ellipse', edgeNoise: 0, polySides: 5, bristleCount: 5, tipCorner: 0.15, scribbleCount: 8, scribbleLen: 1.4, scribbleLenJitter: 0.4, scribbleWidth: 0.12, scribbleSpread: 0.6, scribbleAngleSpread: 70, pressureStart: 1, pressureMid: 1, pressureEnd: 1, sharpness: 1, markerTip: true, grain: 1, noise: 0, valueJitter: 0 };
 
   function closePopover() {
     if (!popover) return;
@@ -181,6 +186,23 @@
     syncCaptureRowVisibility();
     syncMarkerTipVisibility();
 
+    // Canvas-2D mirror of jitterColorValue (tools.js): that helper works on a
+    // Paper.js Color, and getComputedStyle hands back a plain "rgb(...)"
+    // string here — cheaper to lerp the channels directly than to round-trip
+    // through Paper's Color parser for a debug preview.
+    function jitterCssColor(cssColor, delta) {
+      if (!delta) return cssColor;
+      var m = cssColor.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i), r, g, b;
+      if (m) { r = +m[1]; g = +m[2]; b = +m[3]; }
+      else {
+        var hex = cssColor.replace('#', '');
+        if (hex.length === 3) hex = hex.split('').map(function (c) { return c + c; }).join('');
+        r = parseInt(hex.substr(0, 2), 16); g = parseInt(hex.substr(2, 2), 16); b = parseInt(hex.substr(4, 2), 16);
+      }
+      var mixWith = delta < 0 ? 0 : 255, amt = Math.min(1, Math.abs(delta));
+      r += (mixWith - r) * amt; g += (mixWith - g) * amt; b += (mixWith - b) * amt;
+      return 'rgb(' + (r | 0) + ',' + (g | 0) + ',' + (b | 0) + ')';
+    }
     function renderPreview() {
       var ctx = canvas.getContext('2d'), w = canvas.width, h = canvas.height;
       ctx.clearRect(0, 0, w, h);
@@ -190,7 +212,7 @@
       var textColor = getComputedStyle(document.documentElement).getPropertyValue('--text').trim() || '#eee';
       dabs.forEach(function (dab) {
         ctx.globalAlpha = dab.data.dabOpacity;
-        ctx.fillStyle = textColor;
+        ctx.fillStyle = jitterCssColor(textColor, dab.data.dabValueDelta);
         traceOnCanvas2D(ctx, dab);
         ctx.fill();
         dab.remove();

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -4205,31 +4205,39 @@ function _unsliceRingPath(path){
 //   dashGap    — 0..1 probability a given dab is skipped entirely (broken/
 //                torn edge, replaces the old preset system's literal dash
 //                array)
+//   valueJitter — 0..1, per-dab lerp toward black/white (jitterColorValue,
+//                see applyBrushTexture) so a textured stroke reads as real
+//                grain instead of a flat wash of one color — the one
+//                MyPaint/Krita color-variation channel this engine was
+//                missing (2026-09 brush audit). Only given to the pencil/
+//                charcoal/chalk family below: a marker or ink line is
+//                supposed to be a flat, consistent color, so those presets
+//                are deliberately left at the implicit default of 0.
 var BRUSH_PRESETS={
-  'chalk-blunt':     {nibSize:1.3,roundness:.85,spacing:.55,spaceJitter:.25,rotationMode:'random',rotationJitter:60, sizeJitter:.25,opacity:.55,opacityJitter:.25,scatter:.18,dashGap:0},
-  'chalk-round':     {nibSize:1.1,roundness:1,  spacing:.4, spaceJitter:.2, rotationMode:'random',rotationJitter:30, sizeJitter:.18,opacity:.5, opacityJitter:.2, scatter:.12,dashGap:0},
-  'chalk-scribble':  {nibSize:1.0,roundness:.7, spacing:.7, spaceJitter:.4, rotationMode:'random',rotationJitter:180,sizeJitter:.4, opacity:.4, opacityJitter:.3, scatter:.3, dashGap:.15},
-  'charcoal-feather':{nibSize:1.4,roundness:.6, spacing:.6, spaceJitter:.35,rotationMode:'random',rotationJitter:90, sizeJitter:.45,opacity:.3, opacityJitter:.35,scatter:.35,dashGap:.1},
-  'charcoal-pencil': {nibSize:.8, roundness:.9, spacing:.3, spaceJitter:.15,rotationMode:'tangent',rotationJitter:15, sizeJitter:.15,opacity:.7, opacityJitter:.15,scatter:.08,dashGap:0},
-  'charcoal-rough':  {nibSize:1.5,roundness:.65,spacing:.65,spaceJitter:.45,rotationMode:'random',rotationJitter:180,sizeJitter:.55,opacity:.4, opacityJitter:.35,scatter:.4, dashGap:.18},
-  'charcoal-rounded':{nibSize:1.3,roundness:1,  spacing:.45,spaceJitter:.2, rotationMode:'random',rotationJitter:45, sizeJitter:.15,opacity:.55,opacityJitter:.2, scatter:.15,dashGap:0},
-  'charcoal-smooth': {nibSize:1.2,roundness:1,  spacing:.25,spaceJitter:.1, rotationMode:'random',rotationJitter:20, sizeJitter:.1, opacity:.65,opacityJitter:.1, scatter:.06,dashGap:0},
-  'charcoal-soft':   {nibSize:1.6,roundness:.75,spacing:.5, spaceJitter:.3, rotationMode:'random',rotationJitter:90, sizeJitter:.3, opacity:.32,opacityJitter:.3, scatter:.25,dashGap:.05},
-  'charcoal-tapered':{nibSize:1.2,roundness:.8, spacing:.45,spaceJitter:.2, rotationMode:'tangent',rotationJitter:25, sizeJitter:.2, opacity:.55,opacityJitter:.2, scatter:.15,dashGap:0},
-  'charcoal-thick':  {nibSize:2.2,roundness:.9, spacing:.4, spaceJitter:.2, rotationMode:'random',rotationJitter:40, sizeJitter:.15,opacity:.6, opacityJitter:.15,scatter:.12,dashGap:0},
-  'charcoal-thin':   {nibSize:.6, roundness:.9, spacing:.35,spaceJitter:.15,rotationMode:'random',rotationJitter:30, sizeJitter:.15,opacity:.65,opacityJitter:.15,scatter:.1, dashGap:0},
-  'charcoal-varied': {nibSize:1.3,roundness:.7, spacing:.6, spaceJitter:.5, rotationMode:'random',rotationJitter:180,sizeJitter:.65,opacity:.4, opacityJitter:.4, scatter:.3, dashGap:.12},
-  'pencil-feather':  {nibSize:.7, roundness:.6, spacing:.6, spaceJitter:.35,rotationMode:'random',rotationJitter:90, sizeJitter:.3, opacity:.3, opacityJitter:.3, scatter:.2, dashGap:.15},
-  'pencil-thick':    {nibSize:1.8,roundness:.9, spacing:.3, spaceJitter:.15,rotationMode:'tangent',rotationJitter:15, sizeJitter:.15,opacity:.7, opacityJitter:.15,scatter:.08,dashGap:0},
-  'pencil-thin':     {nibSize:.5, roundness:.9, spacing:.3, spaceJitter:.1, rotationMode:'tangent',rotationJitter:10, sizeJitter:.1, opacity:.8, opacityJitter:.1, scatter:.05,dashGap:0},
+  'chalk-blunt':     {nibSize:1.3,roundness:.85,spacing:.55,spaceJitter:.25,rotationMode:'random',rotationJitter:60, sizeJitter:.25,opacity:.55,opacityJitter:.25,scatter:.18,dashGap:0, valueJitter:.12},
+  'chalk-round':     {nibSize:1.1,roundness:1,  spacing:.4, spaceJitter:.2, rotationMode:'random',rotationJitter:30, sizeJitter:.18,opacity:.5, opacityJitter:.2, scatter:.12,dashGap:0, valueJitter:.10},
+  'chalk-scribble':  {nibSize:1.0,roundness:.7, spacing:.7, spaceJitter:.4, rotationMode:'random',rotationJitter:180,sizeJitter:.4, opacity:.4, opacityJitter:.3, scatter:.3, dashGap:.15,valueJitter:.15},
+  'charcoal-feather':{nibSize:1.4,roundness:.6, spacing:.6, spaceJitter:.35,rotationMode:'random',rotationJitter:90, sizeJitter:.45,opacity:.3, opacityJitter:.35,scatter:.35,dashGap:.1, valueJitter:.14},
+  'charcoal-pencil': {nibSize:.8, roundness:.9, spacing:.3, spaceJitter:.15,rotationMode:'tangent',rotationJitter:15, sizeJitter:.15,opacity:.7, opacityJitter:.15,scatter:.08,dashGap:0, valueJitter:.08},
+  'charcoal-rough':  {nibSize:1.5,roundness:.65,spacing:.65,spaceJitter:.45,rotationMode:'random',rotationJitter:180,sizeJitter:.55,opacity:.4, opacityJitter:.35,scatter:.4, dashGap:.18,valueJitter:.15},
+  'charcoal-rounded':{nibSize:1.3,roundness:1,  spacing:.45,spaceJitter:.2, rotationMode:'random',rotationJitter:45, sizeJitter:.15,opacity:.55,opacityJitter:.2, scatter:.15,dashGap:0, valueJitter:.10},
+  'charcoal-smooth': {nibSize:1.2,roundness:1,  spacing:.25,spaceJitter:.1, rotationMode:'random',rotationJitter:20, sizeJitter:.1, opacity:.65,opacityJitter:.1, scatter:.06,dashGap:0, valueJitter:.08},
+  'charcoal-soft':   {nibSize:1.6,roundness:.75,spacing:.5, spaceJitter:.3, rotationMode:'random',rotationJitter:90, sizeJitter:.3, opacity:.32,opacityJitter:.3, scatter:.25,dashGap:.05,valueJitter:.13},
+  'charcoal-tapered':{nibSize:1.2,roundness:.8, spacing:.45,spaceJitter:.2, rotationMode:'tangent',rotationJitter:25, sizeJitter:.2, opacity:.55,opacityJitter:.2, scatter:.15,dashGap:0, valueJitter:.10},
+  'charcoal-thick':  {nibSize:2.2,roundness:.9, spacing:.4, spaceJitter:.2, rotationMode:'random',rotationJitter:40, sizeJitter:.15,opacity:.6, opacityJitter:.15,scatter:.12,dashGap:0, valueJitter:.10},
+  'charcoal-thin':   {nibSize:.6, roundness:.9, spacing:.35,spaceJitter:.15,rotationMode:'random',rotationJitter:30, sizeJitter:.15,opacity:.65,opacityJitter:.15,scatter:.1, dashGap:0, valueJitter:.09},
+  'charcoal-varied': {nibSize:1.3,roundness:.7, spacing:.6, spaceJitter:.5, rotationMode:'random',rotationJitter:180,sizeJitter:.65,opacity:.4, opacityJitter:.4, scatter:.3, dashGap:.12,valueJitter:.15},
+  'pencil-feather':  {nibSize:.7, roundness:.6, spacing:.6, spaceJitter:.35,rotationMode:'random',rotationJitter:90, sizeJitter:.3, opacity:.3, opacityJitter:.3, scatter:.2, dashGap:.15,valueJitter:.12},
+  'pencil-thick':    {nibSize:1.8,roundness:.9, spacing:.3, spaceJitter:.15,rotationMode:'tangent',rotationJitter:15, sizeJitter:.15,opacity:.7, opacityJitter:.15,scatter:.08,dashGap:0, valueJitter:.09},
+  'pencil-thin':     {nibSize:.5, roundness:.9, spacing:.3, spaceJitter:.1, rotationMode:'tangent',rotationJitter:10, sizeJitter:.1, opacity:.8, opacityJitter:.1, scatter:.05,dashGap:0, valueJitter:.08},
   // Non-circular tip shapes (tipShape, added alongside the original
   // deformed-ellipse dabs) — the vector answer to Photoshop's flat/chisel,
   // angular, splatter and bristle tip families. See buildDabShape/
   // buildBrushDabs (above) for how each shape is actually constructed.
   'marker-flat':     {nibSize:1.6,roundness:.4, spacing:.25,spaceJitter:.05,rotationMode:'fixed',fixedAngle:35,rotationJitter:4,  sizeJitter:.05,opacity:.85,opacityJitter:.05,scatter:.02,dashGap:0, tipShape:'rect',tipCorner:.1},
   'ink-chisel':      {nibSize:1.2,roundness:.3, spacing:.3, spaceJitter:.08,rotationMode:'tangent',rotationJitter:8,  sizeJitter:.1, opacity:.9, opacityJitter:.05,scatter:.03,dashGap:0, tipShape:'rect',tipCorner:.05},
-  'pastel-chip':     {nibSize:1.7,roundness:.85,spacing:.5, spaceJitter:.3, rotationMode:'random',rotationJitter:180,sizeJitter:.3, opacity:.5, opacityJitter:.25,scatter:.2, dashGap:.05,tipShape:'polygon',polySides:6,edgeNoise:.12},
-  'chalk-facet':     {nibSize:1.3,roundness:.9, spacing:.45,spaceJitter:.25,rotationMode:'random',rotationJitter:180,sizeJitter:.25,opacity:.45,opacityJitter:.3, scatter:.15,dashGap:0, tipShape:'polygon',polySides:5,edgeNoise:.18},
+  'pastel-chip':     {nibSize:1.7,roundness:.85,spacing:.5, spaceJitter:.3, rotationMode:'random',rotationJitter:180,sizeJitter:.3, opacity:.5, opacityJitter:.25,scatter:.2, dashGap:.05,tipShape:'polygon',polySides:6,edgeNoise:.12,valueJitter:.12},
+  'chalk-facet':     {nibSize:1.3,roundness:.9, spacing:.45,spaceJitter:.25,rotationMode:'random',rotationJitter:180,sizeJitter:.25,opacity:.45,opacityJitter:.3, scatter:.15,dashGap:0, tipShape:'polygon',polySides:5,edgeNoise:.18,valueJitter:.12},
   'ink-splatter':    {nibSize:1.4,roundness:1,  spacing:1.1,spaceJitter:.6, rotationMode:'random',rotationJitter:180,sizeJitter:.7, opacity:.75,opacityJitter:.2, scatter:.5, dashGap:.1, tipShape:'splatter',edgeNoise:.08},
   'drybrush-bristle':{nibSize:2.2,roundness:1,  spacing:.35,spaceJitter:.15,rotationMode:'tangent',rotationJitter:12, sizeJitter:.3, opacity:.55,opacityJitter:.3, scatter:.6, dashGap:0, tipShape:'bristle',bristleCount:7},
   'watercolor-edge': {nibSize:2.6,roundness:.7, spacing:.5, spaceJitter:.2, rotationMode:'random',rotationJitter:60, sizeJitter:.35,opacity:.22,opacityJitter:.3, scatter:.3, dashGap:0, tipShape:'ellipse',edgeNoise:.25},
@@ -4241,7 +4249,7 @@ var BRUSH_PRESETS={
   // Scribble-fill tip (tipShape:'scribble', buildBrushDabs above) — a woven
   // patch of short independently-angled marks instead of a line of blobs,
   // the graphite/charcoal "scribbled shading" look from the reference pack.
-  'graphite-scribble':{nibSize:1.4,roundness:1,  spacing:.5, spaceJitter:.25,rotationMode:'tangent',rotationJitter:0, sizeJitter:0,   opacity:.5, opacityJitter:.3, scatter:0,   dashGap:0, tipShape:'scribble',scribbleCount:9,scribbleLen:1.5,scribbleLenJitter:.4,scribbleWidth:.1,scribbleSpread:.7,scribbleAngleSpread:75},
+  'graphite-scribble':{nibSize:1.4,roundness:1,  spacing:.5, spaceJitter:.25,rotationMode:'tangent',rotationJitter:0, sizeJitter:0,   opacity:.5, opacityJitter:.3, scatter:0,   dashGap:0, tipShape:'scribble',scribbleCount:9,scribbleLen:1.5,scribbleLenJitter:.4,scribbleWidth:.1,scribbleSpread:.7,scribbleAngleSpread:75,valueJitter:.10},
   // p5.brush-inspired (2026-08, feedback #61) — the two settings p5.brush
   // exposes that nothing above did: a fixed start/mid/end width curve
   // ("pressure", independent of the stylet) and a soft/blurred edge
@@ -4321,6 +4329,26 @@ function seededRng(seed){
 // vector" requirement. `edgeNoise` perturbs any shape's own segment
 // points radially and re-smooths — a cheap, fully-vector way to get an
 // organic broken edge (torn paper / dry-media chip) without a texture map.
+// Value jitter (2026-09-01, brush audit: "rendre les texture existante
+// plus proche de trait de crayon" — real graphite is never a perfectly
+// flat tone, individual grains catch/miss the paper's tooth). `delta` in
+// [-1,1]: negative blends the color toward BLACK, positive toward WHITE,
+// by that fraction — a proper lighten/darken lerp rather than a naive
+// channel multiply (which can only ever darken a bright color and can
+// never lighten a pure black one, since 0×anything is still 0). Small
+// deltas (the only ones any preset below actually uses) read as the
+// subtle per-grain density variation real pencil/charcoal has; large ones
+// still degrade gracefully toward solid black/white rather than an
+// out-of-gamut color.
+function jitterColorValue(color,delta){
+  if(!color||!delta)return color;
+  var c=color.clone();
+  var mixWith=delta<0?0:1,amt=Math.min(1,Math.abs(delta));
+  c.red=c.red+(mixWith-c.red)*amt;
+  c.green=c.green+(mixWith-c.green)*amt;
+  c.blue=c.blue+(mixWith-c.blue)*amt;
+  return c;
+}
 function buildDabShape(w,h,preset,rand){
   var shape=preset.tipShape||'ellipse';
   var path;
@@ -4591,7 +4619,7 @@ function buildBrushDabs(pathLike,preset,baseWidth,rng,widthProfile){
           // real scribbling gets darker), not through each mark being
           // opaque on its own; a full-opacity mark here would read as one
           // solid stripe instead of a woven texture.
-          mark.data={dabOpacity:Math.max(0,Math.min(1,(preset.opacity!==undefined?preset.opacity:.5)*(1+(rand()*2-1)*(preset.opacityJitter||0))*.6*strokeNoiseMul))};
+          mark.data={dabOpacity:Math.max(0,Math.min(1,(preset.opacity!==undefined?preset.opacity:.5)*(1+(rand()*2-1)*(preset.opacityJitter||0))*.6*strokeNoiseMul)),dabValueDelta:(rand()*2-1)*(preset.valueJitter||0)};
           dabs.push(mark);
         }
       }else if(preset.tipShape==='bristle'){
@@ -4611,7 +4639,7 @@ function buildBrushDabs(pathLike,preset,baseWidth,rng,widthProfile){
           var dab=buildDabShape(w,h,preset,rand);
           dab.rotate(angle);
           dab.position=center;
-          dab.data={dabOpacity:Math.max(0,Math.min(1,(preset.opacity!==undefined?preset.opacity:.5)*(1+(rand()*2-1)*(preset.opacityJitter||0))*.7*strokeNoiseMul))};
+          dab.data={dabOpacity:Math.max(0,Math.min(1,(preset.opacity!==undefined?preset.opacity:.5)*(1+(rand()*2-1)*(preset.opacityJitter||0))*.7*strokeNoiseMul)),dabValueDelta:(rand()*2-1)*(preset.valueJitter||0)};
           dabs.push(dab);
         }
       }else{
@@ -4622,11 +4650,15 @@ function buildBrushDabs(pathLike,preset,baseWidth,rng,widthProfile){
         var h2=Math.max(.3,w2*roundness);
         var angle2=angleBase+(rand()*2-1)*(preset.rotationJitter||0);
         var baseOp=Math.max(0,Math.min(1,(preset.opacity!==undefined?preset.opacity:.5)*(1+(rand()*2-1)*(preset.opacityJitter||0))*strokeNoiseMul));
+        // One draw per STAMP POSITION, not per sharpness layer below — the
+        // concentric soft-edge copies are one logical dab, they should all
+        // share the same grain darkness rather than each rolling its own.
+        var valDelta=(rand()*2-1)*(preset.valueJitter||0);
         if(sharpness>=1){
           var dab2=buildDabShape(w2,h2,preset,rand);
           dab2.rotate(angle2);
           dab2.position=center2;
-          dab2.data={dabOpacity:baseOp};
+          dab2.data={dabOpacity:baseOp,dabValueDelta:valDelta};
           dabs.push(dab2);
         }else{
           // Soft edge (feedback #61, p5.brush's "sharpness") simulated in
@@ -4651,7 +4683,7 @@ function buildBrushDabs(pathLike,preset,baseWidth,rng,widthProfile){
             layerDab.position=center2;
             // opMul is already exactly 1 at lt=0 (the center layer) — no
             // sl===0 special case needed, the formula covers it.
-            layerDab.data={dabOpacity:baseOp*opMul};
+            layerDab.data={dabOpacity:baseOp*opMul,dabValueDelta:valDelta};
             dabs.push(layerDab);
           }
         }
@@ -4682,7 +4714,7 @@ function buildBrushDabs(pathLike,preset,baseWidth,rng,widthProfile){
         var buildDab=buildDabShape(nibDiam*bMul,nibDiam*roundness*bMul,preset,rand);
         buildDab.rotate(tan.angle);
         buildDab.position=pt;
-        buildDab.data={dabOpacity:Math.min(1,baseOp*1.4)};
+        buildDab.data={dabOpacity:Math.min(1,baseOp*1.4),dabValueDelta:(rand()*2-1)*(preset.valueJitter||0)};
         dabs.push(buildDab);
       }
     });
@@ -4748,7 +4780,12 @@ function applyBrushTexture(basePath,presetKey){
   var groupId='bg'+Date.now().toString(36)+'_'+Math.floor(Math.random()*1e6);
   var dabs=buildBrushDabs(pathLike,preset,baseWidth,null,widthProfile);
   var companions=dabs.map(function(dab){
-    dab.fillColor=baseColor;dab.strokeColor=null;dab.opacity=dab.data.dabOpacity;
+    // dabValueDelta (buildBrushDabs) is per-DAB grain: a light lerp toward
+    // black/white so a textured stroke isn't a flat wash of one color, closer
+    // to how a real pencil/charcoal mark varies with grain and pressure. Must
+    // be read HERE, before dab.data is overwritten to the isBrushTextureCopy
+    // marker below — there is no other point in the pipeline where it survives.
+    dab.fillColor=jitterColorValue(baseColor,dab.data.dabValueDelta);dab.strokeColor=null;dab.opacity=dab.data.dabOpacity;
     dab.data={isBrushTextureCopy:true,brushGroupId:groupId};
     // Above, not below: when basePath also carries a fill (kept visible,
     // see the fill-case branch just below), inserting dabs UNDER it left


### PR DESCRIPTION
## Résumé

Priorité #1 de l'audit brush publié plus tôt cette session (comparaison avec MyPaint/libmypaint et Krita) : le canal de variation de couleur PAR-DAB — sans lui, un trait texturé reste une couleur plate malgré toute la variation de forme/opacité/rotation déjà en place, ce qui l'empêchait de vraiment lire comme un trait de crayon/fusain/craie.

## Changements

- `jitterColorValue(color, delta)` (tools.js) : lerp vers noir/blanc plutôt qu'une multiplication de canal naïve — cette dernière ne peut pas éclaircir le noir ni assombrir le blanc proprement.
- `dabValueDelta` calculé par dab dans `buildBrushDabs` (5 points de tampon : scribble, bristle, dab plat, couches sharpness, marker-buildup), consommé dans `applyBrushTexture` juste avant que `dab.data` soit écrasé par le marqueur `isBrushTextureCopy` — seul point du pipeline où il survit.
- `valueJitter` ajouté aux 19 presets pencil/charcoal/chalk/pastel/graphite (0.08-0.15, valeurs tassées à la main). Marker/ink/splatter/airbrush laissés à 0 intentionnellement — un trait marqueur doit rester une couleur plate et cohérente.
- Slider "Var. valeur (grain)" dans l'éditeur Nib (brush-editor.js), avec un mini lerp CSS local pour l'aperçu canvas 2D (pas de dépendance au parsing `Color` de Paper.js pour une simple preview).

## Vérification en direct

- `applyBrushTexture(path, 'charcoal-pencil')` sur un trait de test → 217 dabs, 22 teintes distinctes, plage exacte prédite par le delta ±0.08 (min 29 / max 50 autour d'une base à 32).
- Même trait avec `marker-flat` → 135 dabs, 1 seule teinte (aucune régression sur les presets non concernés).
- Éditeur Nib ouvert sur `charcoal-pencil` : slider présent, pré-rempli à 0.08 ; aperçu canvas à 257 teintes distinctes par défaut, remis à 0 → 84 (dominées par une seule couleur cœur + antialiasing).

## Tests

`npm test` : 59/59 passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)