### PR TITLE
feat: tremblement optionnel de la trajectoire (rough.js-style)

### DIFF
--- a/src/js/brush-editor.js
+++ b/src/js/brush-editor.js
@@ -43,6 +43,13 @@
     { key: 'scatter', label: 'Dispersion', min: 0, max: 1, step: 0.05 },
     { key: 'dashGap', label: 'Trous (bord cassé)', min: 0, max: 0.6, step: 0.02 },
     { key: 'edgeNoise', label: 'Bord irrégulier', min: 0, max: 0.4, step: 0.02 },
+    // Tremblement du tracé (2026-09, audit brush) — contrairement à Bord
+    // irrégulier ci-dessus (qui ne perturbe que le contour de CHAQUE dab),
+    // ceci fait onduler la trajectoire ELLE-MÊME avant le tamponnage —
+    // une octave plus bas, quelques ondulations lentes sur tout le trait
+    // plutôt qu'un bruit par dab (roughenPath, tools.js). 0 = trajectoire
+    // parfaitement lisse, identique à avant ce paramètre.
+    { key: 'roughness', label: 'Tremblement du tracé', min: 0, max: 1, step: 0.05 },
     // Bord doux (p5.brush "sharpness", feedback #61) — 1 = net (identique
     // à avant), plus bas = halo dégressif simulé par dabs concentriques
     // (buildBrushDabs, tools.js) puisque tout ici reste 100% vectoriel,
@@ -71,7 +78,7 @@
     { value: 'scribble', label: 'Gribouillis (graphite/fusain)' },
     { value: 'custom', label: 'Personnalisé (dessiné)…' },
   ];
-  var DEFAULT_PARAMS = { nibSize: 1, roundness: 0.9, spacing: 0.4, spaceJitter: 0.2, rotationMode: 'tangent', rotationJitter: 20, sizeJitter: 0.2, opacity: 0.6, opacityJitter: 0.2, scatter: 0.15, dashGap: 0, tipShape: 'ellipse', edgeNoise: 0, polySides: 5, bristleCount: 5, tipCorner: 0.15, scribbleCount: 8, scribbleLen: 1.4, scribbleLenJitter: 0.4, scribbleWidth: 0.12, scribbleSpread: 0.6, scribbleAngleSpread: 70, pressureStart: 1, pressureMid: 1, pressureEnd: 1, sharpness: 1, markerTip: true, grain: 1, noise: 0, valueJitter: 0 };
+  var DEFAULT_PARAMS = { nibSize: 1, roundness: 0.9, spacing: 0.4, spaceJitter: 0.2, rotationMode: 'tangent', rotationJitter: 20, sizeJitter: 0.2, opacity: 0.6, opacityJitter: 0.2, scatter: 0.15, dashGap: 0, tipShape: 'ellipse', edgeNoise: 0, polySides: 5, bristleCount: 5, tipCorner: 0.15, scribbleCount: 8, scribbleLen: 1.4, scribbleLenJitter: 0.4, scribbleWidth: 0.12, scribbleSpread: 0.6, scribbleAngleSpread: 70, pressureStart: 1, pressureMid: 1, pressureEnd: 1, sharpness: 1, markerTip: true, grain: 1, noise: 0, valueJitter: 0, roughness: 0 };
 
   function closePopover() {
     if (!popover) return;

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -4213,6 +4213,15 @@ function _unsliceRingPath(path){
 //                charcoal/chalk family below: a marker or ink line is
 //                supposed to be a flat, consistent color, so those presets
 //                are deliberately left at the implicit default of 0.
+//   roughness  — 0..1, low-frequency wobble applied to the STROKE'S OWN
+//                TRAJECTORY before stamping (roughenPath, above), rough.js's
+//                roughness/bowing idea — distinct from edgeNoise (which only
+//                perturbs each dab's own silhouette, the centerline stays
+//                glass-smooth). Deliberately opt-in and left at 0 on every
+//                built-in preset below (2026-09 brush audit) — this changes
+//                the actual path of the stroke, a more perceptible change
+//                than a color/opacity variation, so it's offered through the
+//                Nib editor rather than defaulted onto anything.
 var BRUSH_PRESETS={
   'chalk-blunt':     {nibSize:1.3,roundness:.85,spacing:.55,spaceJitter:.25,rotationMode:'random',rotationJitter:60, sizeJitter:.25,opacity:.55,opacityJitter:.25,scatter:.18,dashGap:0, valueJitter:.12},
   'chalk-round':     {nibSize:1.1,roundness:1,  spacing:.4, spaceJitter:.2, rotationMode:'random',rotationJitter:30, sizeJitter:.18,opacity:.5, opacityJitter:.2, scatter:.12,dashGap:0, valueJitter:.10},
@@ -4505,10 +4514,60 @@ function sampleGaussian(rand){
   var u1=Math.max(1e-12,rand()),u2=rand();
   return Math.sqrt(-2*Math.log(u1))*Math.cos(2*Math.PI*u2);
 }
+// Trajectory perturbation (2026-09, brush audit priority #4 — rough.js's
+// roughness/bowing): edgeNoise/scatter above only perturb what happens AT
+// each stamp position — the centerline itself stays perfectly smooth no
+// matter how shaky the "hand" is supposed to look. This wobbles the actual
+// path dabs get stamped along, one octave BELOW edgeNoise — a handful of
+// slow bumps over the whole stroke's length instead of independent
+// per-dab jitter, because a real unsteady hand wanders slowly, it doesn't
+// vibrate. Built once per buildBrushDabs call as a small set of random
+// control offsets, cosine-interpolated so consecutive dabs land on a
+// continuous, gently-curving deviation rather than a jagged random walk.
+// Disposable ({insert:false}) — never touches the caller's own path.
+function roughenPath(pathLike,amount,baseWidth,rand){
+  if(!amount)return pathLike;
+  var len=pathLike.length;
+  if(!(len>0))return pathLike;
+  // ~1 bump per 120px of length, clamped 2..8 — enough for a long stroke
+  // to visibly wander without the frequency creeping toward edgeNoise's
+  // per-dab territory.
+  var bumps=Math.max(2,Math.min(8,Math.round(len/120)));
+  var offsets=[];
+  for(var i=0;i<=bumps;i++)offsets.push(rand()*2-1);
+  function smoothAt(frac){
+    var f=frac*bumps,i0=Math.floor(f),i1=Math.min(bumps,i0+1),t=f-i0;
+    var ease=.5-.5*Math.cos(t*Math.PI); // cosine interpolation — smoother than a linear lerp between bumps
+    return offsets[i0]*(1-ease)+offsets[i1]*ease;
+  }
+  var mag=amount*Math.max(1,baseWidth)*.8;
+  var steps=Math.max(bumps*8,24);
+  var out=new Path({insert:false});
+  for(var s=0;s<=steps;s++){
+    var frac=s/steps,at=frac*len;
+    var pt=pathLike.getPointAt(at);
+    var tan=pathLike.getTangentAt(at)||new Point(1,0);
+    var normal=new Point(-tan.y,tan.x);
+    var p=pt.add(normal.multiply(smoothAt(frac)*mag));
+    if(s===0)out.moveTo(p);else out.lineTo(p);
+  }
+  out.smooth({type:'continuous'});
+  return out;
+}
 function buildBrushDabs(pathLike,preset,baseWidth,rng,widthProfile){
   var rand=rng||Math.random;
   var len=pathLike.length;
   if(!(len>0))return[];
+  // Roughness reassigns pathLike to a disposable wobbled copy and
+  // re-measures len off IT — every downstream at/len fractional lookup
+  // (width profile included) then naturally runs along the wobbled
+  // trajectory instead of the original. amount 0 (every preset without
+  // this field, i.e. all of them today) returns pathLike unchanged —
+  // bit-for-bit identical to before this parameter existed.
+  if(preset.roughness){
+    pathLike=roughenPath(pathLike,preset.roughness,baseWidth,rand);
+    len=pathLike.length;
+  }
   var nibScale=preset.nibSize!==undefined?preset.nibSize:1;
   // grain (feedback #61, p5.brush's "grain" — "controls how dense the
   // texture is, higher = smoother/more continuous line"): a MULTIPLIER on


### PR DESCRIPTION
## Résumé

Priorité #4 de l'audit brush (idée roughness/bowing de [rough.js](https://github.com/rough-stuff/rough)) : `edgeNoise`/`scatter` ne perturbent que ce qui se passe À CHAQUE position de tampon — la ligne centrale elle-même reste parfaitement lisse quel que soit le tremblement de main que le preset est censé simuler.

## Changement

- `roughenPath` (tools.js, appelée en tête de `buildBrushDabs`) fait onduler la trajectoire elle-même avant le tamponnage — **une octave plus bas** qu'`edgeNoise` : une poignée d'ondulations lentes sur toute la longueur du trait (interpolation cosinus entre quelques points de contrôle aléatoires), pas un bruit indépendant par dab, parce qu'une vraie main qui tremble dérive lentement, elle ne vibre pas.
- Nouveau paramètre `roughness` (0..1) : **0 par défaut sur tous les presets existants** — contrairement à `valueJitter` (PR précédente), ceci change la trajectoire réelle du trait, un changement plus perceptible qu'une variation de couleur/opacité, donc laissé strictement opt-in via l'éditeur Nib plutôt que préréglé sur quoi que ce soit.
- `amount=0` retourne `pathLike` inchangé — bit-for-bit identique à avant ce paramètre pour tout appelant existant.
- Slider "Tremblement du tracé" ajouté à l'éditeur Nib (brush-editor.js).

## Vérification en direct

- `roughness=0` → déviation exactement nulle de la centerline (401 dabs) — confirme le no-op.
- `roughness=0.6` → déviation visible (~2.2px) sur un trait droit de test, tout en conservant l'étendue du trait (0→400 toujours couvert).
- Le tremblement est bien basse fréquence : delta pas-à-pas entre dabs consécutifs ≤1% de l'amplitude totale sur 801 dabs — pas un bruit par-dab qui aurait juste dupliqué edgeNoise.

## Tests

`npm test` : 59/59 passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)