### PR TITLE
fix: la texture de brush ne se reshuffle plus pendant le drag

### DIFF
--- a/src/js/draw-bridge.js
+++ b/src/js/draw-bridge.js
@@ -83,10 +83,23 @@
   // submission, but one level earlier — on the JS-side compute itself,
   // which the render-side coalescing alone can't save.
   var _liveDabCache = null, _liveDabCacheAt = 0;
+  // strokeSeed (2026-09, Cyril: "la brush change de forme pendant le
+  // dessin... il faudrait une certaine constance") — allocated fresh per
+  // gesture in onDown, reused for EVERY live rebuild during that same drag
+  // AND the final commit (commitStroke's applyBrushTexture calls). Without
+  // it, every ~16ms rebuild below re-walked the whole growing path with a
+  // fresh Math.random, reshuffling every already-drawn dab's opacity/size/
+  // rotation/edge-noise on every frame instead of just adding new ones at
+  // the tip — and the committed result (also unseeded) wouldn't even match
+  // whatever was last visible right before mouseup. Reusing one seed for
+  // the whole gesture keeps the walk over any already-drawn PREFIX of the
+  // path deterministic as it grows (see buildBrushDabs/roughenPath's own
+  // seeding comments in tools.js), so only the active tip visibly changes.
+  var strokeSeed = 0;
   function liveBrushDabs(pathLike, preset, baseWidth, widthProfile) {
     var now = performance.now();
     if (_liveDabCache && now - _liveDabCacheAt < 16) return _liveDabCache;
-    _liveDabCache = buildBrushDabs(pathLike, preset, baseWidth, null, widthProfile);
+    _liveDabCache = buildBrushDabs(pathLike, preset, baseWidth, seededRng(strokeSeed), widthProfile);
     _liveDabCacheAt = now;
     return _liveDabCache;
   }
@@ -587,6 +600,7 @@
     dragging = true;
     samples = [];
     _liveDabCache = null; _liveDabCacheAt = 0;
+    strokeSeed = (Math.random() * 0xFFFFFFFF) >>> 0;
     lastMoveT = 0; lastWorldPt = null; lastPenPressure = null;
     stabQueue = []; resetPressureFilter();
     var w0 = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
@@ -988,7 +1002,7 @@
       // baseWidth for a shape whose width varies along its length) — now
       // that it accepts a widthProfile, wire it up here too so a preset
       // actually applies to pressure strokes at draw time.
-      if (!state.shadowMode && state.brushPreset && state.brushPreset !== 'none') applyBrushTexture(path, state.brushPreset);
+      if (!state.shadowMode && state.brushPreset && state.brushPreset !== 'none') applyBrushTexture(path, state.brushPreset, strokeSeed);
     } else {
       path = new Path();
       // Left-panel stroke eye honored here too (it always was for the
@@ -1018,7 +1032,7 @@
       // Raster companion instead of many vector dabs; the path committed
       // above (fill included) stays as the real, subselect-editable anchor.
       if (!state.shadowMode && state.strokeEnabled && state.bitmapBrushOn && window.SMBitmapBrush) window.SMBitmapBrush.applyToPath(path, null, samples);
-      else if (!state.shadowMode && state.strokeEnabled && state.brushPreset && state.brushPreset !== 'none') applyBrushTexture(path, state.brushPreset);
+      else if (!state.shadowMode && state.strokeEnabled && state.brushPreset && state.brushPreset !== 'none') applyBrushTexture(path, state.brushPreset, strokeSeed);
       if (state.drawMode === 'behind') {
         userLayers[state.activeLayerIdx].insertChild(0, path);
         // Same re-anchor need as the linkedFill case a few lines up in the

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -4317,8 +4317,20 @@ function resolveBrushPreset(key){
 // must be reproducible across calls — tween generation re-stamps the dabs
 // on every generated inbetween frame from the interpolated centerline, and
 // a fresh Math.random each frame would make the texture "boil" violently
-// instead of sticking to the morphing stroke. Interactive application keeps
-// true randomness (rng omitted → Math.random).
+// instead of sticking to the morphing stroke. A LIVE stroke has the exact
+// same problem while it's being drawn (2026-09, Cyril: "la brush change de
+// forme pendant le dessin... il faudrait une certaine constance") — the
+// live preview re-walks the whole growing path on every rebuild
+// (draw-bridge.js's liveBrushDabs), so an unseeded rng was reshuffling
+// every already-drawn dab's opacity/size/rotation/edge-noise on every
+// frame, not just adding NEW ones at the tip. draw-bridge.js now allocates
+// one seed per gesture (at pointerdown) and reuses it for every live
+// rebuild AND the final commit, so the already-drawn portion of a stroke
+// stays visually still while dragging, and what's shown right before
+// mouseup matches exactly what gets committed. Every other caller
+// (brush-preset-picker.js, brush-editor.js, brush-menu-bridge.js, a preset
+// re-applied later via timeline.js) still omits rng/seed and keeps true
+// per-call randomness — unaffected.
 function seededRng(seed){
   var t=seed>>>0;
   return function(){
@@ -4521,38 +4533,70 @@ function sampleGaussian(rand){
 // path dabs get stamped along, one octave BELOW edgeNoise — a handful of
 // slow bumps over the whole stroke's length instead of independent
 // per-dab jitter, because a real unsteady hand wanders slowly, it doesn't
-// vibrate. Built once per buildBrushDabs call as a small set of random
-// control offsets, cosine-interpolated so consecutive dabs land on a
-// continuous, gently-curving deviation rather than a jagged random walk.
-// Disposable ({insert:false}) — never touches the caller's own path.
+// vibrate.
+//
+// Returns a duck-typed {length,getPointAt,getTangentAt} object, not a real
+// Path — buildBrushDabs only ever calls those three members on pathLike
+// (see its own parameter comment: "works equally on a throwaway preview
+// path"), so an analytic wrapper is a legal substitute and, critically,
+// avoids ever discretizing+smoothing a new Path. An earlier version built
+// a fixed-resolution resampled Path and called Path#smooth on it — smooth
+// is a GLOBAL fit over every point in that build, so a live drag (which
+// rebuilds this every ~16ms over a GROWING path, see buildBrushDabs'
+// seeding comment) got a measurably different curve under the SAME
+// already-drawn prefix on every rebuild (~2.4px measured) even with a
+// fixed seed. Evaluating the wobble analytically per query removes that
+// source of drift entirely: bumpOffset(i) is a pure, stateless hash of
+// (bumpSeed, i) — same mixing as seededRng, just index-addressable instead
+// of sequential — and smoothAt keys off ABSOLUTE arc-length divided by a
+// FIXED spacing constant, never off a fraction of the CURRENT total
+// length. So the offset at any given absolute position on the stroke is
+// fixed for good the moment the path first reaches that far; a longer
+// path afterward only reveals FURTHER offsets, it never reinterprets ones
+// already drawn under. The only rand() draw is the single bumpSeed below —
+// constant count regardless of stroke length, so it doesn't shift
+// whatever else the shared stream produces afterward either.
 function roughenPath(pathLike,amount,baseWidth,rand){
   if(!amount)return pathLike;
   var len=pathLike.length;
   if(!(len>0))return pathLike;
-  // ~1 bump per 120px of length, clamped 2..8 — enough for a long stroke
-  // to visibly wander without the frequency creeping toward edgeNoise's
-  // per-dab territory.
-  var bumps=Math.max(2,Math.min(8,Math.round(len/120)));
-  var offsets=[];
-  for(var i=0;i<=bumps;i++)offsets.push(rand()*2-1);
-  function smoothAt(frac){
-    var f=frac*bumps,i0=Math.floor(f),i1=Math.min(bumps,i0+1),t=f-i0;
+  var bumpSeed=(rand()*0xFFFFFFFF)>>>0;
+  function bumpOffset(i){
+    var h=(bumpSeed^Math.imul(i+1,0x9E3779B1))>>>0;
+    h=Math.imul(h^h>>>15,1|h);
+    h=h+Math.imul(h^h>>>7,61|h)^h;
+    return(((h^h>>>14)>>>0)/4294967296)*2-1;
+  }
+  // Spacing between control points, in px of ARC LENGTH (not a fraction of
+  // total length) — "one octave below edgeNoise", a slow wander rather
+  // than per-dab noise.
+  var BUMP_SPACING=120;
+  function smoothAt(at){
+    var f=at/BUMP_SPACING,i0=Math.floor(f),t=f-i0;
     var ease=.5-.5*Math.cos(t*Math.PI); // cosine interpolation — smoother than a linear lerp between bumps
-    return offsets[i0]*(1-ease)+offsets[i1]*ease;
+    return bumpOffset(i0)*(1-ease)+bumpOffset(i0+1)*ease;
   }
   var mag=amount*Math.max(1,baseWidth)*.8;
-  var steps=Math.max(bumps*8,24);
-  var out=new Path({insert:false});
-  for(var s=0;s<=steps;s++){
-    var frac=s/steps,at=frac*len;
-    var pt=pathLike.getPointAt(at);
-    var tan=pathLike.getTangentAt(at)||new Point(1,0);
+  function offsetPointAt(at){
+    var clamped=Math.max(0,Math.min(len,at));
+    var pt=pathLike.getPointAt(clamped);
+    var tan=pathLike.getTangentAt(clamped)||new Point(1,0);
     var normal=new Point(-tan.y,tan.x);
-    var p=pt.add(normal.multiply(smoothAt(frac)*mag));
-    if(s===0)out.moveTo(p);else out.lineTo(p);
+    return pt.add(normal.multiply(smoothAt(clamped)*mag));
   }
-  out.smooth({type:'continuous'});
-  return out;
+  // Small finite-difference step (arc-length units) to estimate the
+  // wobbled tangent — fine enough to track BUMP_SPACING's own low
+  // frequency without amplifying float noise.
+  var eps=Math.max(.01,len/2000);
+  return{
+    length:len,
+    getPointAt:offsetPointAt,
+    getTangentAt:function(at){
+      var a=Math.max(0,at-eps),b=Math.min(len,at+eps);
+      var d=offsetPointAt(b).subtract(offsetPointAt(a));
+      return d.length>1e-9?d.normalize():(pathLike.getTangentAt(at)||new Point(1,0));
+    },
+  };
 }
 function buildBrushDabs(pathLike,preset,baseWidth,rng,widthProfile){
   var rand=rng||Math.random;
@@ -4830,7 +4874,12 @@ function buildBrushDabs(pathLike,preset,baseWidth,rng,widthProfile){
 // relinkBrushCompanions() after every layer rebuild — see that function's
 // own comment in app.js for why a live object-reference array can't
 // survive a save/reload on its own).
-function applyBrushTexture(basePath,presetKey){
+// seed (optional, 2026-09 — "la brush change de forme pendant le dessin",
+// Cyril): omitted, this reproduces the exact prior behavior (fresh
+// Math.random per call — every caller except draw-bridge.js's live-drag
+// commit, which now passes the SAME seed it used for the gesture's live
+// preview, see liveBrushDabs there). Threaded straight to buildBrushDabs.
+function applyBrushTexture(basePath,presetKey,seed){
   var preset=resolveBrushPreset(presetKey);
   if(!preset||!basePath.segments||basePath.segments.length<2)return basePath;
   // Pressure (vectorBrush) ribbons are a FILLED SHAPE whose width varies
@@ -4872,7 +4921,7 @@ function applyBrushTexture(basePath,presetKey){
   // come out colorless.
   var baseColor=basePath.strokeColor||(basePath.data&&basePath.data.preTextureStroke?new Color(basePath.data.preTextureStroke):null)||(isPressure?basePath.fillColor:null);
   var groupId='bg'+Date.now().toString(36)+'_'+Math.floor(Math.random()*1e6);
-  var dabs=buildBrushDabs(pathLike,preset,baseWidth,null,widthProfile);
+  var dabs=buildBrushDabs(pathLike,preset,baseWidth,seed!==undefined?seededRng(seed):null,widthProfile);
   var companions=dabs.map(function(dab){
     // dabValueDelta (buildBrushDabs) is per-DAB grain: a light lerp toward
     // black/white so a textured stroke isn't a flat wash of one color, closer


### PR DESCRIPTION
## Résumé

Cyril : « j'ai l'impression pendant le drag de la brush lorsqu'il y a des formes un peu aléatoire du coup la brush change de forme pendant le dessin alors qu'il faudrait une certaine constance ».

## Cause

Le live preview (`draw-bridge.js`'s `liveBrushDabs`, coalescé à ~16ms) re-marchait **tout** le chemin déjà dessiné à chaque reconstruction avec un `Math.random` **frais** — donc chaque dab déjà posé (opacité, taille, rotation, bord irrégulier) était retiré au hasard à chaque frame pendant qu'on dessine, pas seulement les nouveaux dabs à la pointe. Le commit final (`applyBrushTexture`) était lui aussi non-seedé, donc le résultat final ne correspondait même pas à ce qui était affiché juste avant le relâcher.

## Changements

- **draw-bridge.js** : `strokeSeed` alloué une fois par geste (`onDown`), réutilisé pour chaque reconstruction live pendant ce même drag ET pour le commit final. `applyBrushTexture` reçoit maintenant un 3ᵉ paramètre optionnel `seed` — omis, comportement exactement inchangé pour tous les autres appelants (brush-preset-picker.js, brush-menu-bridge.js, timeline.js).
- **tools.js** : `roughenPath` (priorité #4, PR précédente) réécrite en wrapper analytique `{length,getPointAt,getTangentAt}` au lieu de rééchantillonner+lisser un nouveau `Path`. La version précédente souffrait du **même** problème dans un cas plus subtil : `Path#smooth` est un fit global, donc rééchantillonner à une résolution différente à chaque frame (liée à la longueur croissante) faisait dériver la courbe sous le préfixe déjà dessiné même avec un seed fixe (~2,4px mesuré). Le décalage bump→position est maintenant en longueur d'arc **absolue** (pas une fraction de la longueur totale courante), et chaque décalage de bump est un hash pur et indexable, pas un tirage séquentiel.

## Vérification en direct

- `buildBrushDabs` avec `seededRng` (exactement le mécanisme que `liveBrushDabs` utilise) : préfixe identique entre deux « reconstructions » d'un chemin qui grandit (20 pts puis 60 pts, même seed) — delta de position **0px**, delta de rotation **0°** sur 53 dabs comparés.
- Même test sur le cas `roughness` traversant un changement de nombre de bumps : delta **2,4px → ~0** après le fix analytique.
- Sans seed (`Math.random`), le même test donne **2,75px** de dérive — confirme que le test détecte bien le bug d'origine.
- Drag réel via événements pointer synthétiques (`charcoal-rough`, 25 points, délais réels) : trait commité avec succès, 331 enfants de calque, `brushGroupId` posé, aucune erreur.

## Tests

`npm test` : 59/59 passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)