### PR TITLE
feat: Alt+clic sur un trait ajoute un sommet (Subselect)

### DIFF
--- a/src/js/subselect-bridge.js
+++ b/src/js/subselect-bridge.js
@@ -185,6 +185,28 @@
       var nd = pt.getDistance(nh.pos);
       if (nd < bestNd) { bestNd = nd; bestNh = nh; }
     }
+    // Add a vertex (2026-09, the counterpart to the Delete-key removal
+    // that already existed — see insertVertexAt's own header, tools.js):
+    // Alt+click that missed every existing point/handle (bestNh above)
+    // but lands on the edit target's own curve inserts a new anchor
+    // there. Scoped to an ALREADY-selected target (nodeEditTargetPath()
+    // requires selectedPaths.length===1) rather than any path under the
+    // cursor — same "see the handles first, then Alt+click again"
+    // two-step toggleTangentAt already trains the user on, and it means
+    // this can never fire on the SAME click that first selects a path
+    // (which still needs to fall through to the subHit branch below).
+    if (!bestNh && e.altKey) {
+      var insertTarget = nodeEditTargetPath();
+      if (insertTarget) {
+        var newIdx = insertVertexAt(insertTarget, pt);
+        if (newIdx >= 0) {
+          _nodeSel = [newIdx];
+          nodeSelCommitTail(insertTarget);
+          window.SMEngineBridge.renderNow();
+          return;
+        }
+      }
+    }
     if (bestNh) {
       // feedback #216 ("dans motion ajouté une keyframe de path > modifié le
       // path avec subselect ne créer pas un blend de vertex ni de keyframes

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -1012,6 +1012,65 @@ function nodeSelCommitTail(path){
   renderArcs();updateUI();
   if(window.SMEngineBridge)SMEngineBridge.renderNow();
 }
+// Add a vertex on the edit target's own outline (2026-09, "l'ajout/
+// suppression de sommets" — the counterpart the Subselect Delete-key
+// handler, timeline.js, already covers for REMOVAL; addition never
+// existed). Illustrator/Figma convention: Alt+click on a curve BETWEEN
+// two existing points inserts a new anchor there — subselect-bridge.js's
+// onDown already reserves Alt+click on an EXISTING point/handle for
+// "toggle tangent" (toggleTangentAt above), so this only ever fires when
+// the click missed every nodeHandles entry, no ambiguity between the two.
+//
+// getNearestLocation/divideAt (Paper.js) subdivide the exact bezier
+// already there — the curve's visible shape doesn't change, only its
+// point count does, unlike naively lerping a new point onto a straight
+// chord. Returns the new point's index (0-based, matching nodeHandles'
+// own segIndex convention) or -1 if the click landed further than
+// `tolerance` from the curve — a pure, non-mutating query in that case,
+// so a caller can safely try this before committing to pushUndo().
+//
+// Same isVectorBrush/centerSegments branch nodeSelApplyMove/Scale/Rotate
+// already use: a ribbon's editable spine is data.centerSegments, never
+// the baked outline (path.segments) — same reasoning as those three,
+// see nodeSelApplyMove's own header. A disposable {insert:false} Path is
+// built from the raw dict array (Segment already accepts point/handleIn/
+// handleOut as plain [x,y] pairs, same construction rebuildVectorBrushOutline
+// uses for the linked-fill sync above) purely so Paper's own curve-
+// subdivision math can run on it; centerSegments is overwritten from the
+// result and the temp path discarded either way.
+//
+// No Motion-vertex-track (vtxN) reindexing here — the sibling Delete-key
+// removal handler (timeline.js) doesn't do this either (checked before
+// writing this), so a shape with an armed Path vertex track can drift its
+// vtxN-to-point mapping after either an insert or a delete. Consistent
+// with the already-shipped half of this feature; fixing that interaction
+// for both at once is a separate, bigger piece of work if it turns out to
+// matter in practice.
+function insertVertexAt(path,pt,tolerance){
+  var tol=tolerance||8/view.zoom;
+  var isCenter=!!(path.data&&path.data.isVectorBrush&&path.data.centerSegments);
+  var tmp=null,loc;
+  if(isCenter){
+    var cs=path.data.centerSegments;
+    tmp=new Path({insert:false});
+    cs.forEach(function(s){tmp.add(new Segment(new Point(s.point[0],s.point[1]),new Point(s.handleIn[0],s.handleIn[1]),new Point(s.handleOut[0],s.handleOut[1])));});
+    loc=tmp.getNearestLocation(pt);
+  }else{
+    loc=path.getNearestLocation(pt);
+  }
+  if(!loc||loc.distance>tol){if(tmp)tmp.remove();return -1;}
+  pushUndo();
+  if(isCenter){
+    var newSeg=tmp.divideAt(loc);
+    var newIndex=newSeg?newSeg.index:-1;
+    path.data.centerSegments=tmp.segments.map(function(s){return{point:[s.point.x,s.point.y],handleIn:[s.handleIn.x,s.handleIn.y],handleOut:[s.handleOut.x,s.handleOut.y]};});
+    rebuildVectorBrushOutline(path);
+    tmp.remove();
+    return newIndex;
+  }
+  var newSeg2=path.divideAt(loc);
+  return newSeg2?newSeg2.index:-1;
+}
 function nodeSelApplyMove(dx,dy,skipUndo){
   var path=nodeEditTargetPath();
   if((!dx&&!dy)||!path||!_nodeSel.length)return;


### PR DESCRIPTION
## Résumé

Complète l'édition de sommets du Subselect — la **suppression** (Delete/Backspace sur un point sélectionné) existait déjà (timeline.js), l'**ajout** n'existait nulle part dans le codebase.

Convention Illustrator/Figma : Alt+clic sur la courbe ENTRE deux points existants insère une nouvelle ancre là. `subselect-bridge.js` réservait déjà Alt+clic sur un point EXISTANT pour "basculer la tangente" (`toggleTangentAt`), donc aucune ambiguïté entre les deux gestes : l'insertion ne se déclenche que quand le clic a raté tous les `nodeHandles` (points/poignées existants).

## Changements

- **tools.js** : `insertVertexAt(path, pt, tolerance)` — `getNearestLocation` + `Path#divideAt` (Paper.js) subdivisent la bezier EXACTE déjà là ; la courbe ne change pas de forme, seulement son nombre de points. Même branche `isVectorBrush`/`centerSegments` que `nodeSelApplyMove`/`Scale`/`Rotate` (l'édition d'un ruban vectoriel porte sur son spine, jamais le contour tracé) — Path temporaire `{insert:false}` construit depuis `centerSegments`, `divideAt` dessus, puis `rebuildVectorBrushOutline`. Un clic qui rate la courbe (distance > tolérance) ne mute rien et renvoie `-1`.
- **subselect-bridge.js** : Alt+clic qui rate `nodeHandles` ET atterrit sur la courbe de la cible déjà sélectionnée insère le sommet, le sélectionne (`_nodeSel`), et passe par le même commit tail que les autres éditions de sommet (fork/regen fill+texture/save/undo).

Aucun réindexage des clés de vertex Motion (`vtxN`) ici — la suppression existante ne le fait pas non plus (vérifié avant d'écrire ceci), donc même périmètre que ce qui est déjà en prod des deux côtés.

## Vérification en direct

- Chemin droit : 2→3 segments, nouveau point exactement au milieu cliqué.
- Cercle bezier (32 points échantillonnés) : **dérive de courbe nulle** avant/après insertion — la forme visible ne bouge pas d'un pixel.
- Ruban vectorBrush (`centerSegments`) : insertion + `rebuildVectorBrushOutline` fonctionnent, handles interpolés correctement.
- Clic hors-courbe : no-op confirmé (segments inchangés).
- **Geste réel de bout en bout** (rectangle dessiné au tool Rect, sélectionné au Subselect, Alt+clic réel via événement pointer sur le milieu d'une arête) : 4→5 segments, nouveau point exactement sur la position cliquée, sommet auto-sélectionné.

## Tests

`npm test` : 59/59 passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)