### PR TITLE
Point the web feedback path at nemo, keep attachments where they are

### DIFF
--- a/src/js/feedback-bridge.js
+++ b/src/js/feedback-bridge.js
@@ -432,17 +432,25 @@
   // below). Reading issues needs no auth at all (public repo); only
   // labeling/closing/commenting needs Cyril's token, entered once in
   // Réglages → Feedback and kept in localStorage on his own machine only. ----
-  var GH_REPO = 'mysteropodes/strokemotion-feedback';
+  var GH_REPO = 'mysteropodes/nemo';
   var GH_TOKEN_KEY = 'nemo-github-triage-token';
   function githubTriageToken() { try { return localStorage.getItem(GH_TOKEN_KEY) || ''; } catch (e) { return ''; } }
   function setGithubTriageToken(token) { try { localStorage.setItem(GH_TOKEN_KEY, token || ''); } catch (e) {} }
 
+  // Uses the Search API rather than /issues, because GH_REPO is now the code
+  // repo: /issues returns pull requests too, and with 700+ PRs the newest 100
+  // items would be almost entirely PRs, so the real reports would fall off the
+  // end and simply not show up. `is:issue` excludes them server-side, so all
+  // 100 slots hold actual feedback. The pull_request filter below is kept as a
+  // belt-and-braces guard.
   async function fetchGithubIssues() {
-    var res = await fetch('https://api.github.com/repos/' + GH_REPO + '/issues?state=all&per_page=100', {
+    var q = encodeURIComponent('repo:' + GH_REPO + ' is:issue');
+    var res = await fetch('https://api.github.com/search/issues?q=' + q + '&per_page=100&sort=created&order=desc', {
       headers: { 'Accept': 'application/vnd.github+json' },
     });
     if (!res.ok) throw new Error('GitHub list failed: ' + res.status);
-    var issues = await res.json();
+    var payload = await res.json();
+    var issues = payload.items || [];
     return issues.filter(function (i) { return !i.pull_request; }).map(function (i) {
       var m = /sm-feedback-id:\s*(\S+)\s*-->/.exec(i.body || '');
       return {

--- a/worker-feedback/src/index.js
+++ b/worker-feedback/src/index.js
@@ -18,7 +18,13 @@
 // (workers.dev preview + any custom domain); wide open by default only
 // because that origin isn't picked yet.
 
-const REPO = 'mysteropodes/strokemotion-feedback';
+// Issues land on the code repo, so a report sits next to the code and the
+// other reports. Attachments stay on the old feedback repo on purpose:
+// committing screenshots into nemo would require Contents:write on the source
+// tree -- the one permission that turns a leaked token into a way to reach
+// main -- and would bloat the repo (44 PNGs already). Two repos, two roles.
+const ISSUE_REPO = 'mysteropodes/nemo';
+const ATTACHMENT_REPO = 'mysteropodes/strokemotion-feedback';
 
 function corsHeaders(request, env) {
   const origin = request.headers.get('Origin') || '';
@@ -42,8 +48,8 @@ function json(data, status, headers) {
   });
 }
 
-async function githubFetch(env, path, init) {
-  return fetch(`https://api.github.com/repos/${REPO}${path}`, {
+async function githubFetch(env, repo, path, init) {
+  return fetch(`https://api.github.com/repos/${repo}${path}`, {
     ...init,
     headers: Object.assign(
       {
@@ -132,7 +138,7 @@ async function handleIssue(request, env, cors) {
   if (spam) {
     return json({ error: `rejected: ${spam}` }, 400, cors);
   }
-  const resp = await githubFetch(env, '/issues', {
+  const resp = await githubFetch(env, ISSUE_REPO, '/issues', {
     method: 'POST',
     body: JSON.stringify({ title, body, labels }),
   });
@@ -165,7 +171,7 @@ async function handleAttachment(request, env, cors) {
     return json({ error: 'invalid or oversized content' }, 400, cors);
   }
   const path = `attachments/${filename}`;
-  const resp = await githubFetch(env, `/contents/${path}`, {
+  const resp = await githubFetch(env, ATTACHMENT_REPO, `/contents/${path}`, {
     method: 'PUT',
     body: JSON.stringify({ message: `Feedback attachment: ${filename}`, content: contentBase64 }),
   });
@@ -173,7 +179,7 @@ async function handleAttachment(request, env, cors) {
     const text = await resp.text();
     return json({ error: `GitHub upload error ${resp.status}: ${text}` }, 502, cors);
   }
-  return json({ url: `https://raw.githubusercontent.com/${REPO}/main/${path}` }, 200, cors);
+  return json({ url: `https://raw.githubusercontent.com/${ATTACHMENT_REPO}/main/${path}` }, 200, cors);
 }
 
 export default {


### PR DESCRIPTION
## ⚠️ Do not merge yet

The Worker token needs **`Issues: write` on `mysteropodes/nemo`** first, or submission fails with a 502. It is currently scoped to `strokemotion-feedback` only.

---

The reports had **already** moved to the code repo — 213 issues live there — but the app was still writing to `strokemotion-feedback`, which now holds a single issue titled *"test"*. New feedback was landing in an abandoned repo named after a product that no longer exists.

### Issues → nemo, attachments stay put

Writing screenshots into `nemo` would need **`Contents: write` on the source tree** — the exact permission that turns a leaked token into a path to `main` — and would bloat the repo with PNGs (44 already). Two repos, two roles.

### The read side was silently broken

This is the part worth a second look. GitHub's `/issues` endpoint **returns pull requests too**. Against `nemo`, with 700+ PRs, the newest 100 items are almost entirely PRs — so real reports fall off the end.

Listing that endpoint returned **25 issues where the repo actually holds 213**. Most of the feedback was invisible to the triage dashboard.

Switching to the Search API with `is:issue` excludes PRs server-side, so all 100 slots hold actual feedback.

Verified live:

| | |
|---|---|
| Total issues found | **213** |
| Returned in one page | 100 |
| Pull requests among them | **none** |
| Labels intact | `pending` / `resolved` ✅ |

### Desktop is deliberately not migrated

It still posts straight to GitHub from Rust with a token **compiled into the binary**. Pointing that at `nemo` would ship a key to the code repo inside every copy of the app. That waits for the Worker migration — which is also the prerequisite for publishing any public release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)