### PR TITLE
feat: masquer directement un calque vidéo natif

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2940,13 +2940,22 @@ function unlinkTimeLinkPreserveRange(ld){
 function getEffectiveStrokes(layerIdx,frameIdx,countOnly){
   var ld=state.layers[layerIdx];if(!ld)return[];
   if(layerHasTimeRange(ld)&&(frameIdx<layerInPoint(ld)||frameIdx>layerOutPoint(ld)))return[];
-  // EXPERIMENTAL (native-video-decode): a natively-decoded video layer has
-  // no vector strokes at all — its picture is an engine-side image item
-  // (buildSceneJson, engine-bridge.js), not frame data.
-  if(ld.nativeVideo)return[];
+  // EXPERIMENTAL (native-video-decode): a natively-decoded video layer's
+  // PICTURE is an engine-side image item (buildSceneJson, engine-bridge.js),
+  // never frame data — but a nativeVideo layer CAN legitimately carry mask
+  // strokes now (2026-09, Cyril: "on ne peut pas masquer directement sur la
+  // vidéo ?" — editRefusalReason, tools.js, now lets Mask-mode drawing
+  // through on this exact layer type, the only kind it still allows).
+  // No special-casing needed beyond just NOT early-returning here: none of
+  // montageId/lfsGroup/symbolId below ever apply to a nativeVideo layer
+  // (mutually exclusive creation paths, see this function's own header
+  // comment), so falling through lands directly in the ordinary "plain
+  // layer" tail — which returns f.strokes untouched, exactly what's wanted
+  // since _collectLayerStrokes (below) only ever populates that array with
+  // mask children for this layer type in the first place.
   // Null/Effect layer (2026-07, Motion) — never have real content by
   // design (see SM.addNullLayer/addEffectLayer's own comments); same
-  // "no strokes to speak of" early-return as nativeVideo above.
+  // "no strokes to speak of" early-return nativeVideo used to have above.
   // Widget (rig control) layer (2026-08-30, rig-widget.js) — a joystick or
   // slider you drag on canvas; its picture is an editor-only overlay
   // (buildRigWidgetOverlayItems), never content. This ONE line is what
@@ -4469,7 +4478,15 @@ function _flattenCompoundChildren(li){
 function _collectLayerStrokes(li,ld){
   var strokes=[];
   _flattenCompoundChildren(li);
-  userLayers[li].children.forEach(function(c){if(c.data&&c.data.ghostFrame!==undefined)return;if(c instanceof Path&&c.segments.length>0){enforceChannelStrip(ld,c);strokes.push(serP(c));}else if(c instanceof Raster)strokes.push(serR(c));});
+  // nativeVideo (2026-09): this layer's own picture is engine-side, never a
+  // Paper child (getEffectiveStrokes' own comment) — editRefusalReason
+  // (tools.js) still refuses ordinary drawing on this layer type, so a
+  // mask is the ONLY legitimate child that can ever exist here. Filtered
+  // explicitly rather than trusting that invariant alone (CLAUDE.md §1) —
+  // a stray non-mask child must never get silently baked into persisted
+  // frame data for a layer whose real content is the video decode.
+  var nativeVideoOnly=!!ld.nativeVideo;
+  userLayers[li].children.forEach(function(c){if(c.data&&c.data.ghostFrame!==undefined)return;if(nativeVideoOnly&&!(c.data&&c.data.isMask))return;if(c instanceof Path&&c.segments.length>0){enforceChannelStrip(ld,c);strokes.push(serP(c));}else if(c instanceof Raster)strokes.push(serR(c));});
   return strokes;
 }
 // A hand-edited tween frame is promoted to a full keyframe outright rather
@@ -4547,7 +4564,13 @@ function saveActiveLayerFrame(){
   // Rig tool is the one interaction in this app where "live but
   // uncommitted" is meant to survive far longer than a single gesture
   // (Commit/Reset are deliberate separate actions, not implied by mouseup).
-  var ld=state.layers[state.activeLayerIdx];if(ld.symbolId||ld.nativeVideo||ld.montageId||ld.isNullLayer||ld.isEffectLayer||ld.isGuideLayer||ld.isWidgetLayer||ld.lfsGroup||(ld.duplicator&&!ld._dupEditSource)||ld._rigPoseLive)return;
+  // nativeVideo dropped from this skip list (2026-09) — no longer
+  // unconditionally "synthetic content, real data lives elsewhere" now that
+  // Mask-mode drawing is allowed on this layer type: a real mask CAN live
+  // in userLayers[li].children here, and _collectLayerStrokes below already
+  // filters it to mask-only for this exact layer type, so falling through
+  // to the ordinary save path is correct and safe.
+  var ld=state.layers[state.activeLayerIdx];if(ld.symbolId||ld.montageId||ld.isNullLayer||ld.isEffectLayer||ld.isGuideLayer||ld.isWidgetLayer||ld.lfsGroup||(ld.duplicator&&!ld._dupEditSource)||ld._rigPoseLive)return;
   if(!layerIsEffectivelyVisible(state.activeLayerIdx))return;
   // Same class of bug as the eye/solo guard right above, found live
   // 2026-07-30 (Cyril: "avec plein d'aller retour, scrub, trim de layer
@@ -4581,7 +4604,9 @@ function saveAllLayerFrames(){
   _invalidateSymbolUnionIfEditingSymbol();
   _writeBackGhostProxies(state.activeLayerIdx);
   // duplicator skip: same reason as saveActiveLayerFrame's guard above.
-  for(var i=0;i<state.layers.length;i++){if(state.layers[i].symbolId||state.layers[i].nativeVideo||state.layers[i].montageId||state.layers[i].isNullLayer||state.layers[i].isEffectLayer||state.layers[i].isGuideLayer||state.layers[i].isWidgetLayer||state.layers[i].lfsGroup||(state.layers[i].duplicator&&!state.layers[i]._dupEditSource)||state.layers[i]._rigPoseLive)continue;
+  // nativeVideo dropped from this list too — see the identical comment on
+  // saveActiveLayerFrame's own guard above for why.
+  for(var i=0;i<state.layers.length;i++){if(state.layers[i].symbolId||state.layers[i].montageId||state.layers[i].isNullLayer||state.layers[i].isEffectLayer||state.layers[i].isGuideLayer||state.layers[i].isWidgetLayer||state.layers[i].lfsGroup||(state.layers[i].duplicator&&!state.layers[i]._dupEditSource)||state.layers[i]._rigPoseLive)continue;
   if(!layerIsEffectivelyVisible(i))continue;
   // Trim-range guard — see saveActiveLayerFrame's identical check for the
   // full explanation. Per-layer here (unlike the single active layer

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -1696,7 +1696,14 @@ function editRefusalReason(){
   // button is the actual fix.
   if(ld.duplicator&&!ld._dupEditSource)return 'Calque duplicateur — « Modifier la forme source » (panneau Duplicator) pour éditer';
   if(ld.locked)return 'Calque verrouillé — déverrouille-le (cadenas) pour dessiner dessus';
-  if(ld.nativeVideo)return 'Calque vidéo — dessine sur un calque normal au-dessus';
+  // Mask mode is the one exception (2026-09, Cyril: "on ne peut pas
+  // masquer directement sur la vidéo ?") — a mask never becomes real
+  // CONTENT on this layer (engine-bridge.js pulls any data.isMask child
+  // out into the compositor's clip list, never paints it as an item, see
+  // its own comment), so it doesn't violate "this layer's picture is the
+  // video decode, nothing else" the way ordinary drawing would. Ordinary
+  // drawing stays refused — the message just also points at the new door.
+  if(ld.nativeVideo&&!state.maskMode)return 'Calque vidéo — dessine sur un calque normal au-dessus, ou active Masque pour masquer directement cette vidéo';
   if(ld.montageId)return 'Calque montage — son contenu s\u2019édite dans le StoryBoard';
   return null;
 }


### PR DESCRIPTION
## Résumé

Cyril : « on ne peut pas masqué directement sur la vidéo ? » — jusqu'ici dessiner quoi que ce soit sur un calque vidéo natif (le chemin d'import par défaut) était refusé sans exception, avec le message « dessine sur un calque normal au-dessus ». Le contournement (calque au-dessus + Track Matte) marche mais n'est pas « masquer directement ».

## Pourquoi c'est sûr

Le mode Masque est l'exception qui ne casse rien : un `Path` taggé `isMask` ne devient **jamais** du contenu réel sur son calque — `engine-bridge.js` le sort de la liste `items` (jamais peint) pour le glisser dans `masks` (consommé par le compositeur comme clip). Ça ne viole donc pas l'invariant « l'image de ce calque = le décodage vidéo, rien d'autre » que le dessin normal violerait.

## Changements

- **tools.js** (`editRefusalReason`) : le refus ne s'applique plus quand `state.maskMode` est actif — dessiner sans Masque reste refusé, avec un message mis à jour qui pointe vers les deux options.
- **app.js** (`getEffectiveStrokes`) : ne court-circuite plus à `[]` pour `nativeVideo` — retombe naturellement dans le chemin « calque normal » (rien d'autre dans la chaîne de `if` ne s'applique à ce type de calque), qui relit `f.strokes` tel quel.
- **app.js** (`_collectLayerStrokes`) : pour un calque `nativeVideo`, ne persiste QUE les enfants `isMask` — défensif (CLAUDE.md §1), la seule chose qui peut légitimement exister ici tant que le dessin normal reste refusé.
- **app.js** (`saveActiveLayerFrame`/`saveAllLayerFrames`) : `nativeVideo` retiré de la liste de calques sautés entièrement.

## Vérification en direct

Calque vidéo natif simulé, geste réel via événements pointer :
- Dessin normal → toujours refusé (message inchangé).
- Mode Masque activé → dessin accepté, masque créé.
- `saveActiveLayerFrame()` → persiste correctement (`isMask:true` dans `f.strokes`).
- `loadFrame()` → le masque survit à la reconstruction du calque.
- JSON de scène (`buildSceneJsonForFrame`) → le masque apparaît dans `masks[]` pour ce calque (`mode:"add"`, géométrie réelle via `pathRef`) — exactement comme sur n'importe quel autre type de calque.

## Tests

`npm test` : 59/59 passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)