### PR TITLE
fix: le curseur du guide de perspective était invisible

### DIFF
--- a/src/js/perspective-bridge.js
+++ b/src/js/perspective-bridge.js
@@ -154,7 +154,16 @@
     var items = [];
     var zs = 1 / Math.max(0.0001, view.zoom);
     var reach = CURSOR_GUIDE_REACH_PX * zs;
-    var col = [255, 255, 255, 210];
+    // 2026-09 fix (Cyril, live: "va sur brush perspective guide" showed
+    // nothing) — this was pure white [255,255,255,210], invisible against
+    // the default white canvas (state.canvasBg) that the overwhelming
+    // majority of projects start on. Every OTHER element this same file
+    // draws (the static fan, the horizon, the VP markers below) already
+    // uses a saturated, opaque-ish color for exactly this reason — matched
+    // to the VP markers' own orange/coral (they're both "live, interactive"
+    // elements: the point you're aiming at and the guide following your
+    // cursor toward it, as opposed to the fan's soft passive blue).
+    var col = [255, 150, 100, 220];
     var cx = cursorWorld.x, cy = cursorWorld.y;
     function addAxis(dx, dy) {
       var len = Math.hypot(dx, dy);


### PR DESCRIPTION
## Résumé

Cyril : « va sur brush perspective guide » — la fonctionnalité livrée hier (le curseur croix 3 axes façon Sketchbook, commit `4c51ee3`/PR #458) semblait absente. Elle ne l'était pas : `buildPerspectiveCursorGuideItems` calculait bien les 4 segments corrects (bon nombre d'axes, bonne position, bon `dashPattern`) — c'est leur **couleur** qui était le bug.

## Cause

`strokeColor` était `[255,255,255,210]`, blanc pur, sur un canevas dont le fond par défaut (`state.canvasBg`) est LUI AUSSI blanc — invisible dans le cas le plus courant (un nouveau projet). Chaque AUTRE élément dessiné par ce même fichier (l'éventail statique, l'horizon, les points de fuite) utilise déjà une couleur saturée bien visible sur fond blanc ; seul le curseur était resté blanc.

## Changement

Remplacé par `[255,150,100,220]` — le même orange/corail déjà utilisé pour les points de fuite (cohérence : « orange = élément vivant/interactif » vs le bleu passif de l'éventail statique).

## Vérification en direct

- Avant le fix : `buildPerspectiveCursorGuideItems()` renvoyait bien 4 items avec la bonne géométrie, mais invisibles à l'écran (confirmé par capture, fond blanc uniforme).
- Après le fix : la croix orange en pointillés apparaît clairement centrée sur le curseur, avec ses axes vers les points de fuite + l'axe vertical fixe.

## Tests

`npm test` : 59/59 passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)