### PR TITLE
Desktop feedback goes through the Worker, not a token in the binary

### DIFF
--- a/.github/workflows/deploy-feedback-worker.yml
+++ b/.github/workflows/deploy-feedback-worker.yml
@@ -10,10 +10,12 @@ name: Deploy feedback Worker to Cloudflare
 #   1. The Worker needs its OWN Cloudflare-side secret — NOT a GitHub
 #      Actions secret, set once via the CLI directly against the account:
 #        npx wrangler secret put GITHUB_FEEDBACK_TOKEN --name nemo-feedback
-#      (run locally, with a fine-grained GitHub PAT scoped ONLY to
-#      mysteropodes/strokemotion-feedback, Issues:write + Contents:write —
-#      the same scope src-tauri's STROKEMOTION_FEEDBACK_TOKEN already uses;
-#      can be the same token value or a fresh one).
+#      (run locally, with a fine-grained GitHub PAT covering both repos:
+#      mysteropodes/nemo for Issues:write — reports live with the code —
+#      and mysteropodes/strokemotion-feedback for Contents:write, where
+#      screenshots stay so no token needs write access to the source tree.
+#      This is now the ONLY feedback token: the desktop build no longer
+#      compiles one in, it posts through this Worker like the web build.)
 #   2. CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID (GitHub Actions repo
 #      secrets) — already added for deploy-web.yml, reused here.
 # ALLOWED_ORIGINS (the editor's real origin(s)) and feedback-bridge.js's

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,82 +41,6 @@ async fn run_ffmpeg(app: tauri::AppHandle, window: tauri::Window, args: Vec<Stri
     }
 }
 
-// Beta-tester feedback → public GitHub repo (mysteropodes/strokemotion-feedback),
-// one Issue per feedback entry. The write token is baked in at compile time
-// via env! (same pattern as STROKEMOTION_UPDATER_TOKEN above — export
-// STROKEMOTION_FEEDBACK_TOKEN before `tauri build`), scoped as a
-// fine-grained PAT to ONLY this one repo, ONLY "Issues: write" — nothing
-// else, so an extracted token can at worst spam issues in a repo that
-// contains no app source. The POST happens entirely in Rust (never in JS)
-// so the token never touches the webview's network inspector or any
-// devtools-visible fetch() call — see feedback-bridge.js's comment for why
-// this command exists instead of a plain JS fetch.
-#[tauri::command]
-async fn submit_feedback_issue(title: String, body: String, labels: Vec<String>) -> Result<(), String> {
-    let token = env!("STROKEMOTION_FEEDBACK_TOKEN");
-    let client = reqwest::Client::new();
-    let payload = serde_json::json!({ "title": title, "body": body, "labels": labels });
-    let resp = client
-        .post("https://api.github.com/repos/mysteropodes/strokemotion-feedback/issues")
-        .header("Authorization", format!("Bearer {}", token))
-        .header("Accept", "application/vnd.github+json")
-        .header("User-Agent", "strokemotion-app")
-        .json(&payload)
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-    if resp.status().is_success() {
-        Ok(())
-    } else {
-        let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
-        Err(format!("GitHub API error {}: {}", status, text))
-    }
-}
-
-// Feedback screenshot attachments — committed via the GitHub Contents API
-// into strokemotion-feedback's attachments/ folder, then linked from the
-// issue body via raw.githubusercontent.com (GFM doesn't render data:
-// URIs, so the image has to actually be a file in the repo to show up
-// inline). Needs "Contents: Read and write" on top of submit_feedback_
-// issue's "Issues" permission — a deliberate scope increase on the same
-// embedded, repo-scoped token (see CLAUDE.md's feedback section for the
-// trade-off): a leaked token can now write arbitrary files into this one
-// code-free repo, not just spam issues, but still can't touch anything
-// else. content_base64 is passed straight through — the Contents API's
-// `content` field IS base64 already, no decode/re-encode needed here.
-#[tauri::command]
-async fn upload_feedback_attachment(filename: String, content_base64: String) -> Result<String, String> {
-    let token = env!("STROKEMOTION_FEEDBACK_TOKEN");
-    let client = reqwest::Client::new();
-    let path = format!("attachments/{}", filename);
-    let payload = serde_json::json!({
-        "message": format!("Feedback attachment: {}", filename),
-        "content": content_base64,
-    });
-    let resp = client
-        .put(format!(
-            "https://api.github.com/repos/mysteropodes/strokemotion-feedback/contents/{}",
-            path
-        ))
-        .header("Authorization", format!("Bearer {}", token))
-        .header("Accept", "application/vnd.github+json")
-        .header("User-Agent", "strokemotion-app")
-        .json(&payload)
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-    if resp.status().is_success() {
-        Ok(format!(
-            "https://raw.githubusercontent.com/mysteropodes/strokemotion-feedback/main/{}",
-            path
-        ))
-    } else {
-        let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
-        Err(format!("GitHub upload error {}: {}", status, text))
-    }
-}
 
 // Live Google Fonts (2026-08-28, feedback: "peux t'on avoir d'autre typo
 // sans probleme de droit genre les google fonts ?" then "un vrai catalogue
@@ -270,8 +194,6 @@ pub fn run() {
         .manage(video_decode::VideoSessions::default())
         .invoke_handler(tauri::generate_handler![
             run_ffmpeg,
-            submit_feedback_issue,
-            upload_feedback_attachment,
             fetch_google_font,
             video_decode::open_video_session,
             video_decode::decode_video_frame,

--- a/src/js/feedback-bridge.js
+++ b/src/js/feedback-bridge.js
@@ -22,12 +22,28 @@
   function tauriOk() { return typeof window.__TAURI__ !== 'undefined'; }
   function projectKey() { return (window.SMProject && window.SMProject.getProjectKey()) || 'untitled-autosave'; }
 
-  // Browser-only transport for the two GitHub calls Tauri does via Rust
-  // (submit_feedback_issue/upload_feedback_attachment) — see worker-feedback/
-  // (repo root).
+  // The single transport for both GitHub calls, desktop included — see
+  // worker-feedback/ (repo root). Desktop used to post to GitHub directly from
+  // Rust with a token compiled into the binary via env!(). That token was
+  // extractable from any copy of the app, could not be rotated without
+  // shipping a new build (both previous ones silently expired), and would have
+  // needed Contents:write on the code repo once feedback moved to nemo. Now
+  // the only token lives as a Cloudflare secret in the Worker and is never
+  // distributed.
+  //
+  // On desktop the request goes through the Tauri HTTP plugin rather than
+  // fetch(), same as kitsu.js already does. That is deliberate: the app's CSP
+  // connect-src does not list the Worker, and the Worker's CORS allowlist
+  // holds the web origins, not tauri://localhost — a plain fetch() would be
+  // blocked twice over. Going through the plugin issues the request from Rust,
+  // so neither applies, and neither guard has to be widened.
   var FEEDBACK_WORKER_URL = 'https://nemo-feedback.mysteropodes-auth.workers.dev';
+  function workerFetch() {
+    var t = window.__TAURI__;
+    return (t && t.http && t.http.fetch) ? t.http.fetch : fetch;
+  }
   async function workerPost(path, payload) {
-    var resp = await fetch(FEEDBACK_WORKER_URL + path, {
+    var resp = await workerFetch()(FEEDBACK_WORKER_URL + path, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
@@ -316,12 +332,10 @@
     // Best-effort: beta testers have no shared Sync folder (that's a local/
     // network-drive mechanism for Cyril's own machines) — this is THEIR
     // transport instead: one GitHub Issue per feedback entry, in the public
-    // mysteropodes/strokemotion-feedback repo. On Tauri the write-scoped
-    // token lives entirely in Rust (submit_feedback_issue, src-tauri/src/
-    // lib.rs) so it never appears in this file or a devtools-visible
-    // fetch(); on the web build there IS no Rust backend to hide it behind,
-    // so the same call instead goes to the nemo-feedback Worker (see
-    // githubIssue()/githubAttachment() below), which holds the token
+    // mysteropodes/nemo repo. Desktop and web now take the same route: the
+    // nemo-feedback Worker, which is the only place the write token exists.
+    // Desktop used to post from Rust with the token compiled into the binary;
+    // see workerPost() above for why that was replaced rather than kept
     // server-side the same way. 2026-08: this used to be Tauri-only and
     // silently no-op on web — a tester's feedback looked "saved" but never
     // reached anyone, see worker-feedback/README for the fix.
@@ -334,10 +348,10 @@
   function fbTagLabelPlain(tag) {
     return { bug: 'bug', perf: 'perf', idee: 'idée', polish: 'polish' }[tag] || tag;
   }
-  // Commits each screenshot into strokemotion-feedback's attachments/
-  // folder via the GitHub Contents API (Rust command upload_feedback_
-  // attachment — same reasoning as submit_feedback_issue for keeping the
-  // token out of JS/devtools) and returns an array of raw.githubusercontent.com
+  // Commits each screenshot into strokemotion-feedback's attachments/ folder
+  // via the Worker (issues live on nemo now, attachments deliberately stay on
+  // the old repo so no token ever needs Contents:write on the source tree)
+  // and returns an array of raw.githubusercontent.com
   // URLs that render inline in the issue body via normal Markdown image
   // syntax — GFM does NOT render data: URIs, so each file has to actually
   // land in the repo, not just be inlined as base64 in the issue text.
@@ -360,14 +374,8 @@
       if (!m) continue;
       var ext = m[1] === 'jpeg' ? 'jpg' : m[1];
       var filename = entry.id + (dataUrls.length > 1 ? '-' + (i + 1) : '') + '.' + ext;
-      var url = null;
-      if (tauriOk()) {
-        var t = window.__TAURI__;
-        url = await t.core.invoke('upload_feedback_attachment', { filename: filename, contentBase64: m[2] });
-      } else {
-        var data = await workerPost('/attachment', { filename: filename, contentBase64: m[2] });
-        url = data && data.url;
-      }
+      var data = await workerPost('/attachment', { filename: filename, contentBase64: m[2] });
+      var url = data && data.url;
       if (url) urls.push(url);
     }
     return urls;
@@ -417,11 +425,6 @@
       '',
       '<!-- sm-feedback-id: ' + entry.id + ' -->',
     ].join('\n');
-    if (tauriOk()) {
-      var t = window.__TAURI__;
-      await t.core.invoke('submit_feedback_issue', { title: title, body: body, labels: labels });
-      return;
-    }
     await workerPost('/issue', { title: title, body: body, labels: labels });
   }
 


### PR DESCRIPTION
## ⚠️ Needs a desktop test before merging

`cargo check` passes and the JS parses, but **the transport itself is untested here** — it needs a running desktop build. This is also the exact area where a silent failure has already happened once (feedback saved locally, *appeared* sent, never left). Send one feedback from `npm run dev` and confirm it lands on `nemo` before trusting it.

---

The desktop build posted to GitHub straight from Rust with a fine-grained PAT **compiled into the binary** via `env!()`. That token shipped inside every copy of the app:

- it could be extracted
- it could not be rotated without publishing a new build
- pointing feedback at `nemo` would have meant shipping **`Contents: write` on the source tree** to every user

**Both previously issued tokens have since expired** — the same failure in slow motion. A binary already in testers' hands quietly stopped being able to report anything, and nothing could be done about it without a re-release.

### What changed

Both transports now use `workerPost()`. The only remaining token is the **Cloudflare secret inside the Worker** — never distributed, rotatable without touching the app.

### Why the Tauri HTTP plugin and not `fetch()`

This isn't a style choice. A plain `fetch()` would have been blocked **twice**:

- the app's CSP `connect-src` doesn't list the Worker
- the Worker's CORS allowlist holds the web origins, not `tauri://localhost`

Routing through the plugin issues the request from Rust, so neither applies — and **neither guard had to be widened**. Same pattern `kitsu.js` already uses.

### Verified

| Check | Result |
|---|---|
| `submit_feedback_issue` / `upload_feedback_attachment` removed | ✅ incl. `invoke_handler` |
| `STROKEMOTION_FEEDBACK_TOKEN` referenced anywhere | **0** |
| Rust compiles with *only* `STROKEMOTION_UPDATER_TOKEN` set | ✅ |
| JS syntax | ✅ |
| Runtime transport | ❌ **needs your desktop test** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)