### PR TITLE
fix(perspective): verrouillage limité aux axes du gizmo

### DIFF
--- a/src/js/draw-bridge.js
+++ b/src/js/draw-bridge.js
@@ -104,35 +104,24 @@
     return _liveDabCache;
   }
   // Perspective guide hard-lock (2026-07, perspective-bridge.js's
-  // findGuideRayNear/projectOnRay — see their own header comment for why
-  // this replaced a pure per-point magnet). Set once at pointerdown, held
-  // for the whole gesture, cleared at pointerup.
-  var lockedGuideRay = null;
-  // Angle-based lock (2026-07 — feedback: "dans sketchbook tu fais tes
-  // traits n'importe où ils vont suivre la perspective"): unlike the
-  // proximity lock above (decided instantly at pointerdown, since distance-
-  // to-a-drawn-line is already known from a single point), the ANGLE lock
-  // needs a couple of pixels of real drag before a direction even exists to
-  // compare against a vanishing point.
+  // findVPRayByAngle/projectOnRay). Set once at pointerdown's first real
+  // direction, held for the whole gesture, cleared at pointerup.
   //
-  // 2026-09 fix (Cyril, live: "ça dessine toujours sur les guides et pas
-  // avec les guides d'axe") — guideConstrain below used to let the
-  // PROXIMITY lock decide instantly at pointerdown and, if it found
-  // anything, permanently skip the angle check for the rest of the
-  // gesture. Measured live: with the default 2pt VP layout, a pointerdown
-  // 1500+ world-px from a VP still landed within LOCK_TOLERANCE_PX (40
-  // SCREEN px, i.e. hundreds of world px once zoomed out) of some
-  // unrelated fan ray at a completely different angle than the one the
-  // user actually dragged toward — so the stroke locked onto whichever
-  // static guide LINE happened to be underfoot, never onto the true
-  // direction toward a vanishing point (the "axis guide" behavior the
-  // cursor crosshair shows). Every fan ray already radiates FROM a vp, so
-  // the angle check below reproduces "start on a drawn ray" correctly on
-  // its own (the ray's own direction points straight at that vp by
-  // construction) — the proximity candidate is now only a FALLBACK for
-  // when no vp matches by angle at all, tried once real drag exists,
-  // instead of preempting the angle check outright.
-  var guideStartPt = null, guideLockDecided = false, guideProximityFallback = null;
+  // 2026-09 (Cyril, live, two rounds of feedback the same day): first
+  // "ça dessine toujours sur les guides et pas avec les guides d'axe" — a
+  // proximity-to-a-fixed-fan-ray lock used to fire instantly at pointerdown
+  // and permanently skip the angle-toward-the-VP check for the rest of the
+  // gesture. Then, after the fan stopped being DRAWN (buildPerspectiveGuideItems
+  // fix) but its ghost geometry was still a fallback here: "ça dessine pas
+  // dans les guides du gizmo mais encore sur les anciens guides" — the
+  // invisible fan was still catching strokes via magnetSnap/the proximity
+  // fallback. Both are gone now: perspective-bridge.js's findVPRayByAngle is
+  // the ONLY lock source, and its candidate set (axisCandidates) is exactly
+  // the axes the cursor gizmo draws — each VP direction plus vertical — so
+  // there's nothing left to lock onto that isn't visibly shown while you
+  // draw. A stroke whose direction doesn't match any of those within
+  // SNAP_DEG just draws free, for its whole length, same as always.
+  var guideStartPt = null, guideLockDecided = false;
   var lastMoveT = 0, lastWorldPt = null;
   var lastPenPressure = null; // held across a real-pen gesture, see pressureOf()
   // state.stabilizer (position-averaging while drawing) used to only exist
@@ -331,50 +320,33 @@
     var base = isFillBrush() ? state.fillBrushSize : state.brushSize;
     return base * (lo + (hi - lo) * p);
   }
-  // Sticks a freehand sample onto the nearest perspective guide line
-  // (perspective-bridge.js) when it's within the magnet tolerance — no-op
-  // (returns the point unchanged) whenever the guide is off or nothing's
-  // close enough, so this is always safe to call unconditionally on every
-  // sample of a Draw/Fillbrush stroke.
-  function magnetSnap(w) {
-    if (!window.perspectiveSnapPointMagnetic) return w;
-    var snapped = window.perspectiveSnapPointMagnetic(new Point(w[0], w[1]));
-    return snapped ? [snapped.x, snapped.y] : w;
-  }
   // Hard directional lock (2026-07, perspective-bridge.js's
-  // findGuideRayNear/projectOnRay) — call this instead of magnetSnap at
-  // every point of a Draw/Fillbrush stroke. Locks onto whichever guide ray
-  // is closest at the VERY FIRST call of a gesture (pointerdown) and then
-  // hard-projects every later point onto that same ray for the rest of the
-  // stroke, regardless of distance — falls back to the old per-point
-  // magnetSnap when nothing was close enough to lock at the start (so a
-  // stroke drawn nowhere near the guide still behaves exactly as before).
+  // findVPRayByAngle/projectOnRay) — call this at every point of a Draw/
+  // Fillbrush stroke. Locks onto whichever gizmo axis (a VP direction, or
+  // vertical) is closest once the gesture has a real direction, and hard-
+  // projects every later point onto that same axis for the rest of the
+  // stroke, regardless of distance. A stroke whose direction never matches
+  // any axis within SNAP_DEG just draws free for its whole length — same as
+  // always when the guide is off.
   function guideConstrain(w, isStart) {
     if (isStart) {
       guideStartPt = new Point(w[0], w[1]);
       lockedGuideRay = null;
       guideLockDecided = false;
-      // Remember a proximity candidate (starting right on a drawn ray or
-      // the horizon) but DON'T commit to it yet — the angle-based check
-      // below gets first refusal once a direction exists (see the
-      // 2026-09 comment on this file's own guideStartPt declaration for
-      // why: proximity alone was locking strokes onto whatever line was
-      // underfoot, ignoring the direction actually drawn).
-      guideProximityFallback = window.perspectiveFindGuideRayNear ? window.perspectiveFindGuideRayNear(guideStartPt) : null;
     } else if (!guideLockDecided && guideStartPt) {
       var curPt = new Point(w[0], w[1]);
       // Needs real direction before the angle check means anything — same
       // 4px-of-drag floor snapToVP itself uses (perspective-bridge.js).
       if (curPt.getDistance(guideStartPt) >= 4) {
-        lockedGuideRay = (window.perspectiveFindVPRayByAngle ? window.perspectiveFindVPRayByAngle(guideStartPt, curPt) : null) || guideProximityFallback;
-        guideLockDecided = true; // decided either way — never re-checked again this gesture, so a stroke that isn't aimed at any VP (or a drawn ray) just draws free for its whole length, not just its first few px
+        lockedGuideRay = window.perspectiveFindVPRayByAngle ? window.perspectiveFindVPRayByAngle(guideStartPt, curPt) : null;
+        guideLockDecided = true; // decided either way — never re-checked again this gesture
       }
     }
     if (lockedGuideRay && window.perspectiveProjectOnRay) {
       var p = window.perspectiveProjectOnRay(new Point(w[0], w[1]), lockedGuideRay);
       return [p.x, p.y];
     }
-    return magnetSnap(w);
+    return w;
   }
   function hexToRgba(css, opacityPct) {
     if (!css) return null;
@@ -742,7 +714,7 @@
     // catch-up behavior Photoshop/Clip Studio's stabilized brushes use.
     var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
     w = guideConstrain(w, false);
-    lockedGuideRay = null; guideStartPt = null; guideLockDecided = false; guideProximityFallback = null; // stroke over — next pointerdown re-evaluates from scratch
+    lockedGuideRay = null; guideStartPt = null; guideLockDecided = false; // stroke over — next pointerdown re-evaluates from scratch
     var pressure = smoothPressure(wantsPressure() ? pressureOf(e, w) : 1);
     if (modeler) {
       // The modeler's own end-of-stroke catch-up (physics iterated until

--- a/src/js/labs/labs-float-panel.js
+++ b/src/js/labs/labs-float-panel.js
@@ -448,20 +448,12 @@
       pModeNext.addEventListener('click', function () { cyclePerspMode(1); });
       pModePill.appendChild(pModeLbl); pModePill.appendChild(pModePrev); pModePill.appendChild(pModeVal); pModePill.appendChild(pModeNext);
       paramsWrap.appendChild(pModePill);
-      var densPill = stepperPill('perspective');
-      var densLbl = document.createElement('span'); densLbl.className = 'lfs-label'; densLbl.textContent = SM.t('lfsLabelDensity');
-      var densMinus = document.createElement('button'); densMinus.className = 'lfs-btn'; densMinus.textContent = '−';
-      var densVal = document.createElement('span'); densVal.className = 'lfs-val'; densVal.textContent = state.perspectiveDensity;
-      var densPlus = document.createElement('button'); densPlus.className = 'lfs-btn'; densPlus.textContent = '+';
-      function setDensity(v) {
-        state.perspectiveDensity = Math.max(4, Math.min(72, v));
-        densVal.textContent = state.perspectiveDensity;
-        if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
-      }
-      densMinus.addEventListener('click', function () { setDensity(state.perspectiveDensity - 2); });
-      densPlus.addEventListener('click', function () { setDensity(state.perspectiveDensity + 2); });
-      densPill.appendChild(densLbl); densPill.appendChild(densMinus); densPill.appendChild(densVal); densPill.appendChild(densPlus);
-      paramsWrap.appendChild(densPill);
+      // Density control removed (2026-09) — it tuned the ray count of the
+      // static fan that buildPerspectiveGuideItems no longer draws, and
+      // the snap-while-drawing logic dropped its own dense-fan fallback in
+      // the same pass (perspective-bridge.js's axisCandidates), so nothing
+      // reads state.perspectiveDensity anymore. Left in state/project I/O
+      // as inert legacy data rather than touching the save format.
       var lockPill = stepperPill('perspective');
       var lockBtn = document.createElement('button'); lockBtn.className = 'lfs-btn wide';
       lockBtn.textContent = SM.t('lfsBtnLock'); lockBtn.title = SM.t('lfsLockTitle');

--- a/src/js/perspective-bridge.js
+++ b/src/js/perspective-bridge.js
@@ -65,11 +65,10 @@
   // you're actually about to draw instead of a fixed grid burned across the
   // whole canvas. The VPs themselves stay — draggable, visible, exactly as
   // before — since repositioning them is still how you set the guide up.
-  // `state.perspectiveDensity` and the reach/candidate-ray math it used to
-  // feed here are UNCHANGED and still live in nearestGuideProjection/
-  // findGuideRayNear/buildPerspectiveGuideItems's siblings below — density
-  // still controls how many candidate rays the snap logic considers, it
-  // just no longer controls how many get drawn (nothing does, anymore).
+  // `state.perspectiveDensity` (the old fan's ray count) has no reader left
+  // anywhere in this file as of the very next fix below — the snap-while-
+  // drawing functions no longer use a dense fixed-angle fan either, see
+  // axisCandidates' own 2026-09 comment.
   function buildPerspectiveGuideItems() {
     if (!state.perspectiveEnabled) return [];
     var vps = ensurePerspectiveVPs();
@@ -157,13 +156,31 @@
   }
   window.buildPerspectiveCursorGuideItems = buildPerspectiveCursorGuideItems;
 
-  // Snaps `end` onto whichever vanishing point's ray from `start` is
-  // closest in ANGLE (within SNAP_DEG) — preserves the drawn length (the
-  // point is projected onto the ray, not replaced by the VP itself), so a
-  // short stroke drawn toward a far-off vanishing point still comes out
-  // short, just perfectly straight toward it. Returns `end` unchanged if
-  // guides are off, no VP is close enough in angle, or the drag is too
-  // short to have a meaningful direction yet.
+  // The exact axis set the cursor gizmo (buildPerspectiveCursorGuideItems
+  // above) shows from a given point: one direction per configured VP, plus
+  // the fixed vertical — shared by every snap function below so "what you
+  // can lock onto" is provably the same set as "what the gizmo draws," not
+  // a second, independently-tuned notion of "the guide."
+  function axisCandidates(from) {
+    var vps = ensurePerspectiveVPs();
+    var out = [];
+    vps.forEach(function (vp) {
+      var vx = vp.x - from.x, vy = vp.y - from.y;
+      var vlen = Math.hypot(vx, vy);
+      if (vlen < 1) return; // sitting ON the VP — no meaningful direction
+      out.push({ x: vx / vlen, y: vy / vlen });
+    });
+    out.push({ x: 0, y: 1 }); // vertical — same as the gizmo's own fixed axis
+    return out;
+  }
+
+  // Snaps `end` onto whichever gizmo axis from `start` is closest in ANGLE
+  // (within SNAP_DEG) — preserves the drawn length (the point is projected
+  // onto the axis, not replaced by the VP itself), so a short stroke drawn
+  // toward a far-off vanishing point still comes out short, just perfectly
+  // straight toward it. Returns `end` unchanged if guides are off, no axis
+  // is close enough in angle, or the drag is too short to have a meaningful
+  // direction yet.
   var SNAP_DEG = 6;
   function snapToVP(start, end) {
     if (!state.perspectiveEnabled) return end;
@@ -171,134 +188,53 @@
     var dragLen = Math.hypot(dx, dy);
     if (dragLen < 4) return end;
     var dragAngle = Math.atan2(dy, dx);
-    var vps = ensurePerspectiveVPs();
     var best = null, bestDiff = SNAP_DEG * Math.PI / 180;
-    vps.forEach(function (vp) {
-      var vx = vp.x - start.x, vy = vp.y - start.y;
-      if (Math.hypot(vx, vy) < 1) return; // start point sits ON the VP — no meaningful direction to snap to
-      var vAngle = Math.atan2(vy, vx);
+    axisCandidates(start).forEach(function (ax) {
+      var vAngle = Math.atan2(ax.y, ax.x);
       var diff = Math.abs(Math.atan2(Math.sin(dragAngle - vAngle), Math.cos(dragAngle - vAngle)));
-      if (diff < bestDiff) { bestDiff = diff; best = { x: vx, y: vy }; }
+      if (diff < bestDiff) { bestDiff = diff; best = ax; }
     });
     if (!best) return end;
-    var uLen = Math.hypot(best.x, best.y);
-    var ux = best.x / uLen, uy = best.y / uLen;
-    return new Point(start.x + ux * dragLen, start.y + uy * dragLen);
+    return new Point(start.x + best.x * dragLen, start.y + best.y * dragLen);
   }
   window.perspectiveSnapPoint = snapToVP;
 
-  // Magnetic per-point snapping used by freehand/pressure-brush strokes
-  // (draw-bridge.js) — unlike snapToVP above (which locks a whole straight
-  // Line-tool drag onto a single ray from its start point), this projects
-  // an ARBITRARY point onto the closest guide line (any VP's radiating ray,
-  // or the horizon) if it's within a small screen-pixel tolerance, and
-  // returns the point UNCHANGED otherwise. Called per sample as a freehand
-  // stroke is drawn, so the brush sticks to a guide line when the hand
-  // wanders near one and draws normally everywhere else — same "magnetic"
-  // assist Sketchbook's Perspective Guide gives to any brush, not just a
-  // ruler tool.
-  var MAGNET_PX = 14;
-  function nearestGuideProjection(worldPt) {
-    if (!state.perspectiveEnabled) return null;
-    var vps = ensurePerspectiveVPs();
-    if (!vps.length) return null;
-    var tol = MAGNET_PX / view.zoom;
-    var best = null, bestDist = tol;
-    function tryLine(px, py, dx, dy) {
-      var vx = worldPt.x - px, vy = worldPt.y - py;
-      var t = vx * dx + vy * dy;
-      var projx = px + dx * t, projy = py + dy * t;
-      var dist = Math.hypot(worldPt.x - projx, worldPt.y - projy);
-      if (dist < bestDist) { bestDist = dist; best = new Point(projx, projy); }
-    }
-    var n = Math.max(4, state.perspectiveDensity | 0);
-    vps.forEach(function (vp) {
-      for (var i = 0; i < n; i++) {
-        var a = (i / n) * Math.PI * 2;
-        tryLine(vp.x, vp.y, Math.cos(a), Math.sin(a));
-      }
-    });
-    if (vps.length >= 2) {
-      var dx = vps[1].x - vps[0].x, dy = vps[1].y - vps[0].y;
-      var len = Math.hypot(dx, dy) || 1;
-      tryLine(vps[0].x, vps[0].y, dx / len, dy / len);
-    }
-    return best;
-  }
-  window.perspectiveSnapPointMagnetic = nearestGuideProjection;
-
-  // Hard directional lock (2026-07 — feedback: "la contrainte par rapport
-  // aux guides est légère... ça dépend comment on fait notre trait mais il
-  // peut partir dans une autre direction que le guide"). nearestGuideProjection
-  // above is a per-POINT proximity magnet: it only pulls a sample onto a
-  // guide line while that exact sample is within MAGNET_PX, so a stroke that
-  // starts near a ray but then wanders away keeps drawing free-hand instead
-  // of staying on the ray — not how Sketchbook's Perspective Guide actually
-  // behaves once a stroke commits to a vanishing point. These two functions
-  // let draw-bridge.js instead LOCK a whole stroke onto whichever ray is
-  // closest at pointerdown (generous LOCK_TOLERANCE_PX, wider than the
-  // per-point magnet's own, since committing to a direction should be easy
-  // to trigger deliberately) and hard-project every subsequent point onto
-  // that SAME ray for the rest of the gesture, regardless of how far the
-  // hand later strays from it — matching a ruler-against-the-guide feel.
-  // A stroke that starts far from every ray still draws completely free, by
-  // design (not "near the guide" at all is a real, common intent).
-  var LOCK_TOLERANCE_PX = 40;
-  function findGuideRayNear(worldPt) {
-    if (!state.perspectiveEnabled) return null;
-    var vps = ensurePerspectiveVPs();
-    if (!vps.length) return null;
-    var tol = LOCK_TOLERANCE_PX / view.zoom;
-    var best = null, bestDist = tol;
-    function tryLine(px, py, dx, dy) {
-      var vx = worldPt.x - px, vy = worldPt.y - py;
-      var t = vx * dx + vy * dy;
-      var projx = px + dx * t, projy = py + dy * t;
-      var dist = Math.hypot(worldPt.x - projx, worldPt.y - projy);
-      if (dist < bestDist) { bestDist = dist; best = { px: px, py: py, dx: dx, dy: dy }; }
-    }
-    var n = Math.max(4, state.perspectiveDensity | 0);
-    vps.forEach(function (vp) {
-      for (var i = 0; i < n; i++) {
-        var a = (i / n) * Math.PI * 2;
-        tryLine(vp.x, vp.y, Math.cos(a), Math.sin(a));
-      }
-    });
-    if (vps.length >= 2) {
-      var dx = vps[1].x - vps[0].x, dy = vps[1].y - vps[0].y;
-      var len = Math.hypot(dx, dy) || 1;
-      tryLine(vps[0].x, vps[0].y, dx / len, dy / len);
-    }
-    return best;
-  }
-  window.perspectiveFindGuideRayNear = findGuideRayNear;
   // Angle-based freehand lock (2026-07 — feedback: "dans sketchbook tu fais
-  // tes traits n'importe où ils vont suivre la perspective" — the PROXIMITY
-  // lock above (findGuideRayNear) only fires when the stroke STARTS within
-  // LOCK_TOLERANCE_PX of an already-drawn guide ray, which is exactly the
-  // opposite of Sketchbook's own behavior: there, the guide's ANGLE from a
-  // vanishing point is what matters, not the stroke's distance from any
-  // drawn line — you can start a stroke anywhere on the canvas and, once
-  // its direction reads as "aimed at a VP," it locks onto that VP's ray.
-  // Mirrors snapToVP's angle math above (same SNAP_DEG, same "closest VP
-  // direction wins" logic) but returns a {px,py,dx,dy} ray struct usable by
-  // projectOnRay/draw-bridge.js's guideConstrain, instead of a single
-  // projected point — draw-bridge.js calls this once dragLen has crossed a
-  // few pixels (see its own guideLockDecided comment for why the decision
-  // can't happen at pointerdown, before any direction is known at all).
+  // tes traits n'importe où ils vont suivre la perspective" — the guide's
+  // ANGLE from a point is what matters, not the stroke's distance from any
+  // drawn line: you can start a stroke anywhere on the canvas and, once its
+  // direction reads as "aimed at a VP" — or straight up/down, matching the
+  // gizmo's own vertical axis — it locks onto that axis for the rest of the
+  // gesture). Mirrors snapToVP's angle math above (same SNAP_DEG, same
+  // axisCandidates, same "closest axis wins" logic) but returns a
+  // {px,py,dx,dy} ray struct usable by projectOnRay/draw-bridge.js's
+  // guideConstrain, instead of a single projected point — draw-bridge.js
+  // calls this once dragLen has crossed a few pixels (see its own
+  // guideLockDecided comment for why the decision can't happen at
+  // pointerdown, before any direction is known at all).
+  //
+  // 2026-09 (Cyril, live: "ça dessine pas dans les guides du gizmo mais
+  // encore sur les anciens guides") — this used to only test VP directions,
+  // and draw-bridge.js additionally fell back to findGuideRayNear/
+  // nearestGuideProjection (proximity to one of a DENSE fan of fixed-angle
+  // rays per VP, `state.perspectiveDensity` of them) whenever the angle
+  // check found nothing. That fan stopped being drawn in the previous fix
+  // (buildPerspectiveGuideItems no longer renders it) but kept functioning
+  // invisibly — so a stroke could still lock onto one of dozens of ghost
+  // rays that had never matched the direction the user actually dragged,
+  // let alone anything the gizmo showed. Both of those functions (and the
+  // magnetSnap per-point fallback in draw-bridge.js that used the same fan)
+  // are gone now — axisCandidates above is the SAME finite set of axes as
+  // the gizmo draws (each VP + vertical), nothing invisible left to snap to.
   function findVPRayByAngle(start, currentPt) {
     if (!state.perspectiveEnabled) return null;
     var dx = currentPt.x - start.x, dy = currentPt.y - start.y;
     var dragAngle = Math.atan2(dy, dx);
-    var vps = ensurePerspectiveVPs();
     var best = null, bestDiff = SNAP_DEG * Math.PI / 180;
-    vps.forEach(function (vp) {
-      var vx = vp.x - start.x, vy = vp.y - start.y;
-      var vlen = Math.hypot(vx, vy);
-      if (vlen < 1) return; // start point sits ON the VP — no meaningful direction to compare against
-      var vAngle = Math.atan2(vy, vx);
+    axisCandidates(start).forEach(function (ax) {
+      var vAngle = Math.atan2(ax.y, ax.x);
       var diff = Math.abs(Math.atan2(Math.sin(dragAngle - vAngle), Math.cos(dragAngle - vAngle)));
-      if (diff < bestDiff) { bestDiff = diff; best = { px: start.x, py: start.y, dx: vx / vlen, dy: vy / vlen }; }
+      if (diff < bestDiff) { bestDiff = diff; best = { px: start.x, py: start.y, dx: ax.x, dy: ax.y }; }
     });
     return best;
   }


### PR DESCRIPTION
## Résumé

Suite à #711 (priorité angle) et #712 (retrait de l'éventail visuel), Cyril
a signalé que le dessin accrochait encore sur "les anciens guides" au lieu
des axes du gizmo (viseur qui suit le curseur).

**Cause** : l'éventail avait cessé d'être DESSINÉ (#712) mais continuait de
fonctionner de façon invisible — `findGuideRayNear` (verrouillage de
proximité, fallback) et `nearestGuideProjection` (magnet par point)
testaient toujours la proximité à `state.perspectiveDensity` rayons
fantômes par VP, sans rapport avec les axes réellement affichés par le
gizmo.

## Correctif

Unification complète autour d'un seul ensemble d'axes : `axisCandidates(from)`
(perspective-bridge.js) renvoie exactement ce que le gizmo dessine — une
direction par VP configuré + la verticale fixe. `snapToVP` (outil Ligne) et
`findVPRayByAngle` (verrouillage Draw/Fill Brush) piochent tous les deux
dans ce même ensemble. Plus aucune notion de fan dense nulle part.
`magnetSnap` et le fallback de proximité sont retirés de draw-bridge.js —
sans correspondance d'angle, le trait dessine libre.

Bonus : l'outil Ligne hérite du verrouillage vertical gratuitement (même
fonction `snapToVP`). Contrôle "Density" retiré du panneau Labs (devenu
mort).

## Vérification

Gestes réels simulés (`dispatchEvent`) :
- Vers VP1 → verrouille à 169,65° (attendu 169,65°, exact)
- Proche vertical (92°) → verrouille à 90° pile
- 45° (aucun axe à moins de 6°) → dessine libre à 45°, sans accroche

`npm test` : 59/59.

Un bug numérique sévère du stabilisateur de trait a été trouvé pendant
cette vérification (l'ancien fan proximité-first le masquait en pratique) —
corrigé séparément dans la PR suivante.

🤖 Generated with [Claude Code](https://claude.com/claude-code)