### PR TITLE
feat(perspective): repère fixe + guidage souple au dessin

### DIFF
--- a/src/js/draw-bridge.js
+++ b/src/js/draw-bridge.js
@@ -103,25 +103,11 @@
     _liveDabCacheAt = now;
     return _liveDabCache;
   }
-  // Perspective guide hard-lock (2026-07, perspective-bridge.js's
-  // findVPRayByAngle/projectOnRay). Set once at pointerdown's first real
-  // direction, held for the whole gesture, cleared at pointerup.
-  //
-  // 2026-09 (Cyril, live, two rounds of feedback the same day): first
-  // "ça dessine toujours sur les guides et pas avec les guides d'axe" — a
-  // proximity-to-a-fixed-fan-ray lock used to fire instantly at pointerdown
-  // and permanently skip the angle-toward-the-VP check for the rest of the
-  // gesture. Then, after the fan stopped being DRAWN (buildPerspectiveGuideItems
-  // fix) but its ghost geometry was still a fallback here: "ça dessine pas
-  // dans les guides du gizmo mais encore sur les anciens guides" — the
-  // invisible fan was still catching strokes via magnetSnap/the proximity
-  // fallback. Both are gone now: perspective-bridge.js's findVPRayByAngle is
-  // the ONLY lock source, and its candidate set (axisCandidates) is exactly
-  // the axes the cursor gizmo draws — each VP direction plus vertical — so
-  // there's nothing left to lock onto that isn't visibly shown while you
-  // draw. A stroke whose direction doesn't match any of those within
-  // SNAP_DEG just draws free, for its whole length, same as always.
-  var guideStartPt = null, guideLockDecided = false;
+  // Perspective guide SOFT PULL — see guideConstrain's own comment below
+  // for the full history (hard proximity lock → hard angle lock → this).
+  // guideStartPt anchors the gesture's overall direction; that's the only
+  // state carried between calls now.
+  var guideStartPt = null;
   var lastMoveT = 0, lastWorldPt = null;
   var lastPenPressure = null; // held across a real-pen gesture, see pressureOf()
   // state.stabilizer (position-averaging while drawing) used to only exist
@@ -320,33 +306,47 @@
     var base = isFillBrush() ? state.fillBrushSize : state.brushSize;
     return base * (lo + (hi - lo) * p);
   }
-  // Hard directional lock (2026-07, perspective-bridge.js's
-  // findVPRayByAngle/projectOnRay) — call this at every point of a Draw/
-  // Fillbrush stroke. Locks onto whichever gizmo axis (a VP direction, or
-  // vertical) is closest once the gesture has a real direction, and hard-
-  // projects every later point onto that same axis for the rest of the
-  // stroke, regardless of distance. A stroke whose direction never matches
-  // any axis within SNAP_DEG just draws free for its whole length — same as
-  // always when the guide is off.
+  // Perspective guide, freehand PULL — history: a proximity-to-fan lock
+  // ("ça dessine toujours sur les guides et pas avec les guides d'axe"),
+  // then a hard ANGLE lock that froze onto one axis and force-projected
+  // every point exactly onto it for the rest of the gesture. Cyril's next
+  // round of feedback rejected the whole HARD-LOCK premise, not just which
+  // axis it picked: "il faut du dessin libre mais que les axes guide la
+  // brush tout le long vers les points de fuites" — free drawing, with the
+  // axes influencing the brush throughout, not replacing the hand.
+  //
+  // 2026-09 rewrite: every point past a 4px-of-drag floor is blended
+  // PART-WAY toward its projection onto whichever gizmo axis (a VP
+  // direction, or vertical) best matches the OVERALL direction from
+  // guideStartPt — never snapped fully onto it. The blend fraction eases
+  // from GUIDE_PULL_STRENGTH down to 0 as the angular gap widens toward
+  // GUIDE_PULL_MAX_DEG, so the pull is strongest when already roughly
+  // aimed at a vanishing point and fades out (not cuts out) as the hand
+  // drifts away — the stroke keeps its own wobble/character, it just
+  // trends toward the VP the way a hand-drawn perspective line does,
+  // never ruler-straight. Re-evaluated every point rather than decided
+  // once, so if the overall direction drifts toward a different axis
+  // partway through, the pull can follow it — no single frozen verdict a
+  // few pixels into the gesture.
+  var GUIDE_PULL_MAX_DEG = 30;
+  var GUIDE_PULL_STRENGTH = 0.55;
   function guideConstrain(w, isStart) {
-    if (isStart) {
-      guideStartPt = new Point(w[0], w[1]);
-      lockedGuideRay = null;
-      guideLockDecided = false;
-    } else if (!guideLockDecided && guideStartPt) {
-      var curPt = new Point(w[0], w[1]);
-      // Needs real direction before the angle check means anything — same
-      // 4px-of-drag floor snapToVP itself uses (perspective-bridge.js).
-      if (curPt.getDistance(guideStartPt) >= 4) {
-        lockedGuideRay = window.perspectiveFindVPRayByAngle ? window.perspectiveFindVPRayByAngle(guideStartPt, curPt) : null;
-        guideLockDecided = true; // decided either way — never re-checked again this gesture
-      }
-    }
-    if (lockedGuideRay && window.perspectiveProjectOnRay) {
-      var p = window.perspectiveProjectOnRay(new Point(w[0], w[1]), lockedGuideRay);
-      return [p.x, p.y];
-    }
-    return w;
+    if (isStart) { guideStartPt = new Point(w[0], w[1]); return w; }
+    if (!guideStartPt || !window.perspectiveFindVPRayByAngle || !window.perspectiveProjectOnRay) return w;
+    var raw = new Point(w[0], w[1]);
+    var dx = raw.x - guideStartPt.x, dy = raw.y - guideStartPt.y;
+    // Needs real direction before "closest axis" means anything — same
+    // 4px-of-drag floor snapToVP itself uses (perspective-bridge.js).
+    if (Math.hypot(dx, dy) < 4) return w;
+    var ray = window.perspectiveFindVPRayByAngle(guideStartPt, raw, GUIDE_PULL_MAX_DEG);
+    if (!ray) return w;
+    var curAngle = Math.atan2(dy, dx);
+    var axAngle = Math.atan2(ray.dy, ray.dx);
+    var diffDeg = Math.abs(Math.atan2(Math.sin(curAngle - axAngle), Math.cos(curAngle - axAngle))) * 180 / Math.PI;
+    var t = Math.max(0, 1 - diffDeg / GUIDE_PULL_MAX_DEG) * GUIDE_PULL_STRENGTH;
+    if (t <= 0) return w;
+    var proj = window.perspectiveProjectOnRay(raw, ray);
+    return [raw.x + (proj.x - raw.x) * t, raw.y + (proj.y - raw.y) * t];
   }
   function hexToRgba(css, opacityPct) {
     if (!css) return null;
@@ -714,7 +714,7 @@
     // catch-up behavior Photoshop/Clip Studio's stabilized brushes use.
     var w = window.SMEngineBridge.screenToWorld(e.clientX, e.clientY);
     w = guideConstrain(w, false);
-    lockedGuideRay = null; guideStartPt = null; guideLockDecided = false; // stroke over — next pointerdown re-evaluates from scratch
+    guideStartPt = null; // stroke over — next pointerdown re-anchors from scratch
     var pressure = smoothPressure(wantsPressure() ? pressureOf(e, w) : 1);
     if (modeler) {
       // The modeler's own end-of-stroke catch-up (physics iterated until

--- a/src/js/perspective-bridge.js
+++ b/src/js/perspective-bridge.js
@@ -52,27 +52,57 @@
     if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
   };
 
-  // Builds the overlay items — the VP markers only. Used to also draw N
-  // static radiating lines per VP (+ a horizon line, + fisheye's concentric
-  // rings) spanning the whole canvas at all times.
+  // Builds the overlay items: the VP markers, a line connecting every pair
+  // of VPs, and a permanent vertical line through each VP. Used to also
+  // draw N dense radiating rays per VP (+ a horizon line stretching well
+  // past the VPs, + fisheye's concentric rings) — a full-canvas fan burned
+  // in at all times.
   //
-  // 2026-09 removed (Cyril, live: "j'ai toujours les guides bleu, le but
-  // c'est de pouvoir dessiner partout dans les axes avec le gizmo plus les
-  // guides d'avant sauf les points de perspective que l'on peut bouger") —
-  // that permanent fan was exactly the clutter he wanted gone: the moving
-  // cursor crosshair (buildPerspectiveCursorGuideItems below, "le gizmo")
-  // is now the ONLY axis indicator while drawing, always centered on where
-  // you're actually about to draw instead of a fixed grid burned across the
-  // whole canvas. The VPs themselves stay — draggable, visible, exactly as
-  // before — since repositioning them is still how you set the guide up.
-  // `state.perspectiveDensity` (the old fan's ray count) has no reader left
-  // anywhere in this file as of the very next fix below — the snap-while-
-  // drawing functions no longer use a dense fixed-angle fan either, see
-  // axisCandidates' own 2026-09 comment.
+  // 2026-09, first removed the dense fan entirely (Cyril, live: "j'ai
+  // toujours les guides bleu, le but c'est de pouvoir dessiner partout dans
+  // les axes avec le gizmo plus les guides d'avant sauf les points de
+  // perspective que l'on peut bouger") — that permanent fan was exactly the
+  // clutter he wanted gone, replaced by the moving cursor crosshair
+  // (buildPerspectiveCursorGuideItems below, "le gizmo") as the only axis
+  // indicator while actually drawing.
+  //
+  // Then brought back a MINIMAL static reference, same day (Cyril: "ça
+  // serait bien qu'il soit relié par un repère et que chaque point est un
+  // repère vertical aussi") — two thin, fixed marks, not a dense grid: one
+  // line per VP PAIR (so 2pt gets a single connecting line — effectively
+  // the old horizon, just no longer reaching 4x past the canvas — and 3pt
+  // gets a full triangle), plus one vertical line through EVERY vp (not
+  // just wherever the cursor happens to be, unlike the gizmo). 1pt/fisheye
+  // has no pair to connect, so only the vertical(s) apply.
+  // `state.perspectiveDensity` (the old dense fan's ray count) has no
+  // reader left anywhere in this file — the snap-while-drawing functions
+  // don't use a dense fixed-angle fan either, see axisCandidates' own
+  // 2026-09 comment.
   function buildPerspectiveGuideItems() {
     if (!state.perspectiveEnabled) return [];
     var vps = ensurePerspectiveVPs();
     var items = [];
+    var reach = Math.max(state.canvasW, state.canvasH) * 2; // long enough to read as a real reference line past the canvas edge, short of the old 4x full-fan reach
+    var repereCol = [255, 200, 80, 130]; // same amber the old horizon line used — "this is a fixed reference," distinct from the VP markers' own orange/coral
+    for (var i = 0; i < vps.length; i++) {
+      for (var j = i + 1; j < vps.length; j++) {
+        var a = vps[i], b = vps[j];
+        var dx = b.x - a.x, dy = b.y - a.y;
+        var len = Math.hypot(dx, dy) || 1;
+        var ux = dx / len, uy = dy / len;
+        items.push({
+          segments: [{ point: [a.x - ux * reach, a.y - uy * reach] }, { point: [b.x + ux * reach, b.y + uy * reach] }],
+          closed: false, fillColor: null, strokeColor: repereCol, strokeWidth: 1.4, strokeCap: 'butt',
+        });
+      }
+    }
+    vps.forEach(function (vp) {
+      items.push({
+        segments: [{ point: [vp.x, vp.y - reach] }, { point: [vp.x, vp.y + reach] }],
+        closed: false, fillColor: null, strokeColor: repereCol, strokeWidth: 1, strokeCap: 'butt',
+        dashPattern: [6, 5],
+      });
+    });
     // VP markers themselves — draggable-point handles, Sketchbook-style
     // (feedback: "dans sketchbook on a des points que l'on peut
     // déplacer... regarde bien sketchbook" — a ring + filled center dot
@@ -226,11 +256,18 @@
   // magnetSnap per-point fallback in draw-bridge.js that used the same fan)
   // are gone now — axisCandidates above is the SAME finite set of axes as
   // the gizmo draws (each VP + vertical), nothing invisible left to snap to.
-  function findVPRayByAngle(start, currentPt) {
+  //
+  // toleranceDeg lets a caller widen the catch angle beyond SNAP_DEG — the
+  // Line tool (snapToVP above) wants a tight, ruler-like snap, but
+  // draw-bridge.js's freehand PULL (see its own 2026-09 comment) wants a
+  // much wider capture zone since it's blending toward the axis rather than
+  // locking onto it outright, so a hand that's merely "roughly aimed at" a
+  // VP should still feel the influence.
+  function findVPRayByAngle(start, currentPt, toleranceDeg) {
     if (!state.perspectiveEnabled) return null;
     var dx = currentPt.x - start.x, dy = currentPt.y - start.y;
     var dragAngle = Math.atan2(dy, dx);
-    var best = null, bestDiff = SNAP_DEG * Math.PI / 180;
+    var best = null, bestDiff = (toleranceDeg || SNAP_DEG) * Math.PI / 180;
     axisCandidates(start).forEach(function (ax) {
       var vAngle = Math.atan2(ax.y, ax.x);
       var diff = Math.abs(Math.atan2(Math.sin(dragAngle - vAngle), Math.cos(dragAngle - vAngle)));


### PR DESCRIPTION
## Résumé

Deux demandes de Cyril suite aux fixes précédents (#711-#714) :

1. "ça serait bien qu'il soit relié par un repère et que chaque point est
   un repère vertical aussi" — les points de fuite n'avaient plus aucune
   ligne de référence entre eux depuis le retrait du fan (#712).
2. "quand je dessine avec la brush et perspective tool activé la brush
   n'est pas locké sur les axes, il faut du dessin libre mais que les axes
   guide la brush tout le long vers les points de fuite" — rejet du
   principe même du lock rigide (#711/#713), pas juste de son fallback.

## Changements

**Repère statique** (perspective-bridge.js) : une ligne entre chaque paire
de VP (2pt → 1 ligne, 3pt → triangle) + une verticale fixe à travers
CHAQUE VP. Portée 2x la diagonale du canvas (contre 4x pour l'ancien fan) —
un repère minimal, pas une grille.

**Guidage souple** (draw-bridge.js) : `guideConstrain` ne verrouille plus
le trait sur un axe. À chaque point, le brut est mélangé PROPORTIONNELLEMENT
vers sa projection sur l'axe le plus proche (VP ou verticale, mêmes
candidats que le viseur/gizmo) — force qui décroît de 0,55 à 0 entre 0° et
30° d'écart angulaire. Réévalué à chaque point, jamais décidé une fois pour
toutes.

## Vérification

- Geste avec wobble perpendiculaire injecté (amplitude 18) vers un point de
  fuite : déviation moyenne **5,98 avec le guide contre 10,74 sans**
  (ratio 0,556 ≈ la force de pull) — tiré vers l'axe sans s'y coller.
- Geste à 45° (hors zone de 30°) : angle final exact, aucune influence.
- Même geste + stabilisateur par défaut : toujours stable (fix #714 intact).
- `npm test` : 59/59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)