### PR TITLE
feat(text): Fill/Stroke Color pour les animateurs de texte

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -1794,6 +1794,22 @@
               if (fcOverride) item.fillColor = fcOverride;
             }
           }
+          // Text animator Fill Color (2026-09 — "Add Property" gap): lerp
+          // toward elMat.fcTarget by elMat.fcBlend, ON TOP of whatever the
+          // block above already produced (an animator pulling toward a
+          // color composes with a manual override exactly the way an
+          // animator's Position composes with elementMotion's own, per
+          // textAnimatorContribution's own comment on why color can't just
+          // accumulate as a delta).
+          if (elMat && elMat.fcBlend && item.fillColor) {
+            var fct = elMat.fcTarget, fcb = elMat.fcBlend;
+            item.fillColor = [
+              item.fillColor[0] + (fct[0] - item.fillColor[0]) * fcb,
+              item.fillColor[1] + (fct[1] - item.fillColor[1]) * fcb,
+              item.fillColor[2] + (fct[2] - item.fillColor[2]) * fcb,
+              item.fillColor[3] + (fct[3] - item.fillColor[3]) * fcb,
+            ];
+          }
           // Gradient fill (2026-07) — takes priority over the flat fillColor
           // above on the Rust side (geometry-wasm's paint_fill), same
           // "richer field wins" precedent as centerline/image. Anchor points
@@ -1897,6 +1913,18 @@
               if (scOverride) item.strokeColor = scOverride;
               var swOverride = SMMotion.elementStrokeWidthAt(i, cStrokeId, renderFrame);
               if (swOverride !== null) item.strokeWidth = swOverride * (item.pathTransform ? 1 : strokeScale);
+            }
+            // Text animator Stroke Color — same lerp-on-top as Fill Color
+            // above, and the same "can't animate a stroke into existence"
+            // scope: only reachable here, inside `if (sc)`.
+            if (elMat && elMat.scBlend && item.strokeColor) {
+              var sct = elMat.scTarget, scb = elMat.scBlend;
+              item.strokeColor = [
+                item.strokeColor[0] + (sct[0] - item.strokeColor[0]) * scb,
+                item.strokeColor[1] + (sct[1] - item.strokeColor[1]) * scb,
+                item.strokeColor[2] + (sct[2] - item.strokeColor[2]) * scb,
+                item.strokeColor[3] + (sct[3] - item.strokeColor[3]) * scb,
+              ];
             }
           }
           if (includeEditorOverlays && state.currentFrameOutline) {

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -4094,6 +4094,29 @@
         if (dsx || dsy) pivotBasedOn = pivotBasedOn || basedOn;
       }
       if (p.opacity != null) acc.op += (p.opacity - 100) * w;
+      // Fill/Stroke color (2026-09 — "Add Property" gap: only Position/
+      // Scale/Rotation/Opacity were wired up). Unlike those, color has no
+      // neutral "delta from 0" — at weight 0 a character must show its OWN
+      // paint, not some baseline color, so this can't accumulate the same
+      // way. Instead: weighted-average the animator's target color (for
+      // when several color animators overlap on one character) and the
+      // weighted-SUM of w as the blend-toward-target strength, applied by
+      // the caller as lerp(base, avgTarget, min(1, sumW)) — one lerp at the
+      // render site, using the SAME [r,g,b,a] 0-255 shape and the SAME
+      // per-element override slot (elementFillColorAt/elementStrokeColorAt,
+      // motion.js) the manual Fill/Stroke color track already writes to,
+      // so a hand-set override and an animator's pull compose exactly the
+      // way position/rotation already do (animator adds on top of a base).
+      if (p.fillColor) {
+        acc.fcR = (acc.fcR || 0) + p.fillColor[0] * w; acc.fcG = (acc.fcG || 0) + p.fillColor[1] * w;
+        acc.fcB = (acc.fcB || 0) + p.fillColor[2] * w; acc.fcA = (acc.fcA || 0) + (p.fillColor[3] == null ? 255 : p.fillColor[3]) * w;
+        acc.fcW = (acc.fcW || 0) + w;
+      }
+      if (p.strokeColor) {
+        acc.scR = (acc.scR || 0) + p.strokeColor[0] * w; acc.scG = (acc.scG || 0) + p.strokeColor[1] * w;
+        acc.scB = (acc.scB || 0) + p.strokeColor[2] * w; acc.scA = (acc.scA || 0) + (p.strokeColor[3] == null ? 255 : p.strokeColor[3]) * w;
+        acc.scW = (acc.scW || 0) + w;
+      }
     }
     // Only rotation/scale need a pivot at all — a pure position/opacity
     // animator leaves ax/ay unset and elementMotionAt below falls back to
@@ -4114,6 +4137,22 @@
           acc.ay = shared.cy - (ownB[1] + ownB[3]) / 2;
         }
       }
+    }
+    // Normalize the color weighted-sums into a single target + blend
+    // strength (see the accumulation comment above for why colour can't
+    // just accumulate as a delta like the other properties) and drop the
+    // raw partial sums — elementMotionAt below merges this object with its
+    // own transform fields, and fcTarget/fcBlend is the whole contract the
+    // render site needs.
+    if (acc && acc.fcW) {
+      acc.fcTarget = [acc.fcR / acc.fcW, acc.fcG / acc.fcW, acc.fcB / acc.fcW, acc.fcA / acc.fcW];
+      acc.fcBlend = Math.max(0, Math.min(1, acc.fcW));
+      delete acc.fcR; delete acc.fcG; delete acc.fcB; delete acc.fcA; delete acc.fcW;
+    }
+    if (acc && acc.scW) {
+      acc.scTarget = [acc.scR / acc.scW, acc.scG / acc.scW, acc.scB / acc.scW, acc.scA / acc.scW];
+      acc.scBlend = Math.max(0, Math.min(1, acc.scW));
+      delete acc.scR; delete acc.scG; delete acc.scB; delete acc.scA; delete acc.scW;
     }
     return acc;
   }
@@ -4179,6 +4218,11 @@
       // whatever explicit per-element anchor already existed, same as every
       // other field above.
       ax: m.ax + (ta.ax || 0), ay: m.ay + (ta.ay || 0),
+      // Passed through as-is (not composed with `base` — a manual Fill/
+      // Stroke color track has no "color delta" to combine with, the
+      // render site does base -> lerp(base, fcTarget, fcBlend) in one step,
+      // see textAnimatorContribution's own comment).
+      fcTarget: ta.fcTarget, fcBlend: ta.fcBlend, scTarget: ta.scTarget, scBlend: ta.scBlend,
     };
   }
   // Extended per-shape property: Fill color (2026-07 — audit gap

--- a/src/js/text-animator-panel.js
+++ b/src/js/text-animator-panel.js
@@ -105,6 +105,58 @@
     return i;
   }
 
+  // [r,g,b,a] 0-255 (elementFillColorAt's own contract, motion.js) <-> the
+  // #rrggbbaa string a native <input type=color> + .dataset.hex8 speaks
+  // (CLAUDE.md §2 — .value alone silently drops alpha to ff on read/write).
+  function rgbaArrToHex8(a) {
+    function h(n) { return Math.max(0, Math.min(255, Math.round(n))).toString(16).padStart(2, '0'); }
+    return '#' + h(a[0]) + h(a[1]) + h(a[2]) + h(a[3] == null ? 255 : a[3]);
+  }
+  function hex8ToRgbaArr(hex) {
+    var s = hex.replace('#', '');
+    var a = s.length === 8 ? parseInt(s.slice(6, 8), 16) : 255;
+    return [parseInt(s.slice(0, 2), 16), parseInt(s.slice(2, 4), 16), parseInt(s.slice(4, 6), 16), a];
+  }
+  // A property with no meaningful "neutral" value (unlike Position 0 or
+  // Scale 100%, there's no "does nothing" color) — opt-in via a checkbox
+  // rather than always-shown like the transform rows above. `defaultColor`
+  // seeds a visible starting point the moment it's switched on.
+  function colorPropRow(host, ld, labelText, getArr, setArr, defaultColor) {
+    var r = row(host, labelText);
+    var chk = document.createElement('input');
+    chk.type = 'checkbox';
+    chk.checked = !!getArr();
+    r.insertBefore(chk, r.firstChild.nextSibling); // right after the .pl label
+    var swatch = document.createElement('input');
+    swatch.type = 'color';
+    swatch.style.cssText = 'width:24px;height:22px;border:none;cursor:pointer;padding:0;';
+    function syncSwatch() {
+      var arr = getArr();
+      swatch.disabled = !arr;
+      var hex = rgbaArrToHex8(arr || defaultColor);
+      swatch.value = hex.slice(0, 7);
+      swatch.dataset.hex8 = hex;
+    }
+    syncSwatch();
+    chk.addEventListener('change', function () {
+      if (typeof pushUndo === 'function') pushUndo();
+      setArr(chk.checked ? defaultColor.slice() : null);
+      syncSwatch();
+      commit(ld);
+    });
+    swatch.addEventListener('input', function () {
+      var arr = hex8ToRgbaArr(this.dataset.hex8 || this.value);
+      setArr(arr);
+      liveRefresh(ld);
+    });
+    swatch.addEventListener('change', function () {
+      if (typeof pushUndo === 'function') pushUndo();
+      commit(ld);
+    });
+    r.appendChild(swatch);
+    return r;
+  }
+
   function selField(r, options, get, set) {
     var s = document.createElement('select');
     s.className = 'psel';
@@ -290,6 +342,15 @@
 
     var rOp = row(host, t('propOpacity', 'Opacity'));
     numField(rOp, function () { return props.opacity == null ? 100 : props.opacity; }, function (v, live) { props.opacity = v; if (!live) commit(ld); else liveRefresh(ld); }, 1, 0, 100);
+
+    colorPropRow(host, ld, t('propFill', 'Fill'),
+      function () { return props.fillColor; },
+      function (v) { if (v) props.fillColor = v; else delete props.fillColor; },
+      [255, 80, 80, 255]);
+    colorPropRow(host, ld, t('propStroke', 'Stroke'),
+      function () { return props.strokeColor; },
+      function (v) { if (v) props.strokeColor = v; else delete props.strokeColor; },
+      [255, 255, 255, 255]);
 
     // --- weight ramp preview --------------------------------------------
     // Shows what the selector currently weighs, per unit. It is the one thing


### PR DESCRIPTION
## Résumé

Deuxième morceau du chantier texte (après #717, Wiggly Selector) : ajout
de Fill Color et Stroke Color aux propriétés animables par caractère —
seules Position/Scale/Rotation/Opacity étaient câblées.

## Implémentation

Contrat différent des 4 propriétés existantes : une couleur n'a pas de
valeur neutre à accumuler en delta. `textAnimatorContribution` calcule à
la place une moyenne pondérée de la couleur cible + la somme des poids
comme force de mélange (`fcTarget`/`fcBlend`, `scTarget`/`scBlend`).
`engine-bridge.js` applique un lerp(base, target, blend) au point de rendu,
APRÈS le override manuel existant (`elementFillColorAt`/
`elementStrokeColorAt`) — compose exactement comme Position compose déjà
avec `elementMotion`.

UI : deux lignes opt-in (case à cocher + pastille couleur avec
`.dataset.hex8`, CLAUDE.md §2), réutilisant les clés i18n `propFill`/
`propStroke` déjà existantes.

## Vérification

Calque "COLOR" (base #222222) + animateur Fill Color cyan sur les 40%
premiers caractères → capture confirmant "CO" cyan / "LOR" gris foncé.
Panneau vérifié (case cochée + pastille correcte, coche via vrai événement
DOM). `npm test` : 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)