### PR TITLE
fix(groups): Combine/Flatten décalait un membre animé par element Motion

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2055,7 +2055,7 @@
       // own ld.groups, cheap no-op for the overwhelmingly common case of no
       // combine-groups at all.
       if (window.SMGroup && state.layers[i].groups && Object.keys(state.layers[i].groups).length) {
-        var combineRes = SMGroup.renderCombinesFromChildren(userLayers[i], state.layers[i]);
+        var combineRes = SMGroup.renderCombinesFromChildren(userLayers[i], state.layers[i], renderFrame);
         var suppressArr = combineRes.suppress;
         items.forEach(function (it) {
           if (suppressArr.length && it.__srcC && suppressArr.indexOf(it.__srcC) !== -1) {

--- a/src/js/group-bridge.js
+++ b/src/js/group-bridge.js
@@ -244,7 +244,16 @@
     pushUndo();
     var style = members[members.length - 1];
     var mode = grp.combineMode === 'none' ? 'unite' : grp.combineMode;
-    var folded = foldBooleanOp(mode, members, layer);
+    // Bake per-shape element Motion into a disposable clone before the
+    // boolean op sees it (2026-09 fix, see elementMotionBakedClone's own
+    // comment in tools.js) — this call used to go straight to foldBooleanOp
+    // with the members' raw, un-animated segments, silently snapping any
+    // Motion-transformed member back to its un-transformed position the
+    // moment the group was flattened.
+    var li = window.userLayers ? userLayers.indexOf(layer) : -1;
+    var motionMembers = li >= 0 ? members.map(function (m) { return elementMotionBakedClone(li, m, state.currentFrame); }) : members;
+    var folded = foldBooleanOp(mode, motionMembers, layer);
+    var disposable = motionMembers === members ? [] : motionMembers.filter(function (m, idx) { return m !== members[idx]; });
     var insertAt = layer.children.indexOf(members[0]);
     // Stroke-only style source (2026-07-29 fix, same as booleanOp's own —
     // insertBooleanResult always drops the stroke on its islands, so a
@@ -263,6 +272,7 @@
     var islands = insertBooleanResult(layer, insertAt, folded.result, flattenFill, style.opacity, null, fillSource.data);
     members.forEach(function (m) { m.remove(); });
     folded.companions.forEach(function (c) { if (!c.removed) c.remove(); });
+    disposable.forEach(function (c) { if (!c.removed) c.remove(); });
     delete ld.groups[gid];
     selectedPaths = islands; state.selectedStrokeIndices = [];
     fillRegenerateLinked(layer, islands[0]);
@@ -285,7 +295,7 @@
   // on (in the JSON item only, never on the item itself) plus the extra
   // combined-result path(s) to append, styled from the topmost member
   // ("what's on top wins", matching AE/Illustrator/Figma's own convention).
-  function renderCombinesFromChildren(layer, ld) {
+  function renderCombinesFromChildren(layer, ld, frameIdx) {
     var suppress = [], extra = [];
     if (!ld || !ld.groups) return { suppress: suppress, extra: extra };
     Object.keys(ld.groups).forEach(function (gid) {
@@ -309,7 +319,7 @@
         members.forEach(function (m) { suppress.push(m); });
         var styleSource = members[members.length - 1];
         var islands;
-        try { islands = computeGroupCombine(members, grp.combineMode, layer); }
+        try { islands = computeGroupCombine(members, grp.combineMode, layer, frameIdx); }
         catch (e) { console.warn('[SMGroup] combine failed for group', gid, e); return; }
         // Vector-brush ribbon style source (2026-08 fix, feedback: "les
         // combine gère mal stroke plus fill" for Pressure-brush shapes) —

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -6340,6 +6340,44 @@ function flattenBooleanResult(result,preserveGeometry){
   result.remove();
   return islands;
 }
+// 2026-09 fix (Cyril: "quand j'essaie de merge le groupe dans éléments le
+// rectangle de droite se décale") — foldBooleanOp/Paper.js's own .unite()
+// etc. only ever see a Path's RAW stored segments. A member animated via
+// per-shape element Motion (Position/Scale/Rotation keyed on
+// ld.elementMotion, §12/12bis-era "propriétés étendues par forme") is drawn
+// on screen through a SEPARATE transform applied only at render time
+// (elementMotionAt, motion.js) — the live Paper.js item itself never moves,
+// confirmed live: for a shape with `elementMotion.motionStatic.position:
+// [299,-11]`, `c.bounds` sat at its UN-shifted raw position while the
+// canvas correctly showed it 299px to the right. Combine/Flatten fed that
+// raw, unshifted geometry straight into the boolean op, so the merged
+// result silently snapped that member back to where it'd be with no Motion
+// at all — a real, silent geometry corruption, not just a stale preview.
+//
+// Fixed by baking each member's elementMotionAt transform into a DISPOSABLE
+// clone before the boolean op ever sees it — same scale/rotate/translate-
+// around-pivot recipe app.js's own component-flattening code already uses
+// for the identical problem (elMat.ax/ay pivot, then scale, rotate,
+// translate, in that order). Clones (not live-item mutation) so
+// foldBooleanOp's internal findLinkedFillCompanion lookup — which matches
+// by `data.linkedFillId` against the LIVE layer — still finds the real
+// companion via the id Paper's .clone() preserves on `.data`; only the
+// GEOMETRY changes, nothing about the live document is touched, matching
+// this file's own "never touch the live document" contract for the
+// non-destructive preview path.
+function elementMotionBakedClone(li,p,frameIdx){
+  if(li==null||!window.SMMotion||!p.data||!p.data.strokeId)return p;
+  var elMat=SMMotion.elementMotionAt(li,p.data.strokeId,frameIdx==null?state.currentFrame:frameIdx,p.data);
+  if(!elMat)return p;
+  var noop=elMat.dx===0&&elMat.dy===0&&elMat.rot===0&&elMat.sx===1&&elMat.sy===1;
+  if(noop)return p;
+  var clone=p.clone({insert:false});
+  var pivot=new Point(clone.bounds.center.x+(elMat.ax||0),clone.bounds.center.y+(elMat.ay||0));
+  clone.scale(elMat.sx,elMat.sy,pivot);
+  clone.rotate(elMat.rot,pivot);
+  clone.translate(elMat.dx,elMat.dy);
+  return clone;
+}
 // Non-destructive combine-group core (2026-07-29): given N live/transient
 // Paths and a mode, returns the combined result as detached flat Paths —
 // NEVER removes or mutates the sources, and never inserts anything into a
@@ -6347,10 +6385,16 @@ function flattenBooleanResult(result,preserveGeometry){
 // hard-won correctness work (vector-brush companion pre-union, hole-merging,
 // degenerate-loop cleanup) the destructive tool already has, with zero
 // duplicated boolean-op logic (CLAUDE.md §3: don't duplicate a matcher/loop).
-function computeGroupCombine(paths,mode,layer){
+function computeGroupCombine(paths,mode,layer,frameIdx){
   if(paths.length<2)return paths.slice();
-  var folded=foldBooleanOp(mode,paths,layer);
-  return flattenBooleanResult(folded.result);
+  var li=window.userLayers?userLayers.indexOf(layer):-1;
+  var motionAware=li>=0?paths.map(function(p){return elementMotionBakedClone(li,p,frameIdx);}):paths;
+  var folded=foldBooleanOp(mode,motionAware,layer);
+  var disposable=[];
+  if(motionAware!==paths)motionAware.forEach(function(m,idx){if(m!==paths[idx])disposable.push(m);});
+  var out=flattenBooleanResult(folded.result);
+  disposable.forEach(function(c){if(!c.removed)c.remove();});
+  return out;
 }
 
 // ---- DYNAMIC SHAPES, phase 1 (2026-08-18) — Rectangle, independent


### PR DESCRIPTION
## Résumé

Repro fourni par Cyril (merge.json) : "quand j'essaie de merge le groupe
dans éléments le rectangle de droite se décale". Confirmé — Combiner
(Union, non destructif) ET Aplatir (destructif) cassaient l'alignement
d'un groupe dont un membre avait une Position/Scale/Rotation keyée via
l'element Motion.

## Cause

`elementMotionAt` (propriétés étendues par forme) n'est appliqué QU'AU
RENDU — jamais aux segments réels du Path Paper.js live. Confirmé en
pilotant : pour un membre avec `motionStatic.position:[299,-11]`,
`c.bounds` restait à sa position brute alors que le canvas l'affichait
décalé de 299px. `computeGroupCombine`/`foldBooleanOp` lisaient ces
segments bruts directement — le résultat de l'union reflétait la
géométrie NON animée, une vraie corruption silencieuse.

## Correctif

`elementMotionBakedClone` (tools.js) : clone jetable avec l'element Motion
appliqué (même recette pivot+scale+rotate+translate que le "precomp par
calque" d'app.js), utilisé par `computeGroupCombine` (aperçu Combine +
Flatten) avant `foldBooleanOp`. Clone, pas mutation live — la recherche de
companion par `data.linkedFillId` continue de fonctionner sans changement.

⚠️ **Portée assumée** : `applyCombinesToStrokes` (jumeau dict-based pour
export/storyboard/onion-skin) a le même défaut mais demande de threader
`li`/`frameIdx` à travers 5 points d'appel — laissé non corrigé (le bug
rapporté est en édition live, pas à l'export), noté en mémoire.

## Vérification

merge.json chargé en pilotant. Avant fix : Combine ET Flatten décalaient
visiblement le membre animé. Après fix : capture confirmant la forme
identique avant/après les deux opérations. `npm test` : 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)