### PR TITLE
fix(elements): sortir une forme d'un groupe par drag dans le panneau Éléments

### DIFF
--- a/src/js/shapes-panel.js
+++ b/src/js/shapes-panel.js
@@ -316,7 +316,11 @@
     var row = _elDrag.kind === 'paint'
       ? el && el.closest('#shapes-list .lrow[data-paintid]')
       : _elDrag.kind === 'member'
-      ? el && el.closest('#shapes-list .lrow[data-groupmember]')
+      // A member row can land on another member row (same OR a different
+      // group — performMemberReorder ejects it from its own group when the
+      // two differ) or on any top-level row (a plain shape, or a group's
+      // own header) — see performMemberReorder's 2026-09 fix.
+      ? el && el.closest('#shapes-list .lrow[data-groupmember], #shapes-list .lrow[data-toplevel]')
       : el && el.closest('#shapes-list .lrow[data-toplevel]');
     if (row) row.classList.add('drag-over');
   });
@@ -391,18 +395,44 @@
   // the top-level shape/group reorder above, just gated to require the
   // drop target be a member of the exact SAME group as the dragged item
   // (_elDrag.extra, stamped at mousedown — see buildShapeRow's member
-  // branch). Dropping on a member of a DIFFERENT group, or anywhere with
-  // no data-groupmember at all, is a no-op rather than silently moving a
-  // shape out of its group — that's a distinct, bigger feature (dragging
-  // INTO/OUT of a group) nobody asked for here.
+  // branch).
   function performMemberReorder(overRow) {
-    var destGroupGid = overRow.dataset.groupmember, destStrokeId = overRow.dataset.strokeid;
-    if (!destGroupGid || destGroupGid !== _elDrag.extra || destStrokeId === _elDrag.id) return;
+    var destGroupGid = overRow.dataset.groupmember, destStrokeId = overRow.dataset.strokeid, destGid = overRow.dataset.gid;
+    if (destStrokeId === _elDrag.id) return;
     var c = currentLayer(); if (!c.ld) return;
+    var layer = window.userLayers && userLayers[c.li];
     var srcItem = window.SMMotion.liveItemByStrokeId(c.li, _elDrag.id);
-    var destItem = window.SMMotion.liveItemByStrokeId(c.li, destStrokeId);
-    if (!srcItem || !destItem) return;
+    if (!srcItem || !layer) return;
+    var sameGroup = destGroupGid && destGroupGid === _elDrag.extra;
+    var destItem;
+    if (sameGroup) {
+      destItem = window.SMMotion.liveItemByStrokeId(c.li, destStrokeId);
+    } else if (destGid) {
+      // Dropped on a (collapsed or expanded) DIFFERENT group's own header
+      // row — land adjacent to the whole group, same "front-most member"
+      // convention performReorder's own group-destination branch uses.
+      var destMembers = window.SMMotion.layerElements(c.li, c.ld).filter(function (e) { return e.sd.groupId === destGid; });
+      if (!destMembers.length) return;
+      destItem = window.SMMotion.liveItemByStrokeId(c.li, destMembers[destMembers.length - 1].strokeId);
+    } else if (destStrokeId) {
+      // Either a member row of a DIFFERENT group, or a plain top-level
+      // shape — both resolve to that exact item.
+      destItem = window.SMMotion.liveItemByStrokeId(c.li, destStrokeId);
+    }
+    if (!destItem) return;
     pushUndo();
+    if (!sameGroup && srcItem.data && srcItem.data.groupId && window.SMGroup) {
+      // Bug #730 ("une shape par dessus un groupe ça ne réordonné pas la
+      // visibilité") — dragging a shape OUT of its group and dropping it
+      // elsewhere (a different group, or a plain top-level shape) used to
+      // be a hard no-op: this function required the SAME source group,
+      // and the hover-detection below didn't even highlight a valid drop
+      // target outside it, so nothing ever ran. Ejecting the shape from
+      // its group first (same helper Cmd+Shift+G's per-member variant
+      // uses, group-bridge.js) then reordering matches AE/Illustrator/
+      // Figma: dragging a layer out of its group stack takes it out.
+      window.SMGroup.removeMemberFromGroup(srcItem, c.ld, layer, { skipUndo: true, silent: true });
+    }
     srcItem.insertAbove(destItem);
     saveActiveLayerFrame();
     renderShapesPanel();


### PR DESCRIPTION
## Résumé

Corrige #730 — "si je reorder shape dans éléments par exemple une shape par dessus un groupe ça ne réordonné pas la visibilité dans le canvas".

Root cause trouvée en pilotant, pas en relisant : `performMemberReorder` (shapes-panel.js) exigeait que la cible du drop soit un membre du **même** groupe que la forme glissée — et la détection de survol (`mousemove`) ne posait même `.drag-over` QUE sur d'autres lignes-membres, donc glisser une forme groupée vers une AUTRE destination (une autre forme, un autre groupe) n'affichait aucun retour visuel et `performReorder` n'était jamais appelé. Silencieux de bout en bout, exactement le symptôme rapporté.

- Test direct (drag synthétique bout en bout) confirme le repro : `red1` membre de GroupA glissé sur GroupB → `layer.children` inchangé, `.drag-over` jamais posé.
- Deux scénarios "simples" (forme plate ↔ groupe, au niveau top-level) fonctionnaient déjà correctement — data, rendu ET persistance (save/reload) vérifiés — donc le bug était bien scopé au cas "membre de groupe glissé hors de son groupe".

## Correctif

- `performMemberReorder` : si la cible n'est pas dans le même groupe, éjecte la forme de son groupe source via `SMGroup.removeMemberFromGroup` (dissout aussi le groupe s'il tombe sous 2 membres, même invariant que `groupSelection`) puis la repositionne — comportement AE/Illustrator/Figma : glisser un layer hors de son groupe l'en sort.
- Détection de survol (`mousemove`) : pour un drag de type `member`, reconnaît maintenant aussi les lignes top-level (`[data-toplevel]`) comme cibles valides, pas seulement les autres lignes-membres.

## Test plan

- [x] `npm test` (65/65)
- [x] Drag synthétique bout-en-bout : forme membre de GroupA → GroupB → éjectée de GroupA (groupId supprimé), GroupA dissous (2→1 membre), repositionnée devant GroupB
- [x] Régression : réordonnancement DANS un même groupe (feature 2026-08) toujours correct
- [x] Régression : réordonnancement forme plate ↔ groupe au niveau top-level toujours correct
- [x] Persistance : ordre + ejection survivent à un aller-retour de frame (`saveActiveLayerFrame` → `goToFrame` → reconstruction)
- [x] Aucune erreur console

🤖 Generated with [Claude Code](https://claude.com/claude-code)