### PR TITLE
fix(elements): premier plan en haut du panneau Éléments + dépôt avant/après (#735)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2052,6 +2052,7 @@ body.mode-motion .layer-inout-bar .layer-inout-handle{width:4px;border-radius:2p
 .cp-eyedrop:hover{color:var(--text);border-color:var(--border2);}
 .ctx-sep{height:1px;background:var(--border);margin:4px 2px;}
 .lrow.drag-over{border-top:2px solid var(--accent);}
+.lrow.drag-over-after{border-bottom:2px solid var(--accent);} /* Elements panel: drop lands BEHIND this row (feedback #735) */
 .lrow.dragging{opacity:.4;}
 
 /* START SCREEN — matches the Home.dc.html design (claude.ai/design project

--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -2059,13 +2059,44 @@
         // Set, not indexOf — this runs once per item per rendered frame, and
         // a big combine group made it items × members per frame.
         var suppressSet = combineRes.suppress.length ? new Set(combineRes.suppress) : null;
-        items.forEach(function (it) {
+        // Where each combined outline goes in z (feedback #735, "c'est
+        // quand c'est mergé que ça marche plus la hiérarchie"): it used
+        // to be pushed at the END of the layer's items, i.e. drawn on top
+        // of every other shape in the layer no matter where the group sat
+        // in the Elements order. It now lands right after the group's
+        // FRONT-most member — the depth the group actually occupies — so
+        // a shape ordered above the group stays above its merge.
+        var frontIdxByGid = {};
+        items.forEach(function (it, ix) {
           if (suppressSet && it.__srcC && suppressSet.has(it.__srcC)) {
             it.fillColor = null; it.strokeColor = null; delete it.strokeWidth; delete it.dashPattern; delete it.dashOffset; delete it.fillGradient;
+            var mg = it.__srcC.data && it.__srcC.data.groupId;
+            if (mg) frontIdxByGid[mg] = ix;
           }
           delete it.__srcC;
         });
-        combineRes.extra.forEach(function (ex) {
+        // A nested member carries its INNER group's id; resolve each
+        // combine's top-level gid to the front-most of ALL its members.
+        var extrasWithIdx = combineRes.extra.map(function (ex) {
+          var gid = ex.groupCombineOf, idx = frontIdxByGid[gid];
+          if (idx === undefined && window.SMGroup && SMGroup.resolveGroupMembers) {
+            var mems = SMGroup.resolveGroupMembers(gid, state.layers[i], userLayers[i]);
+            var memSet = new Set(mems);
+            // items no longer carry __srcC here; fall back to the group's
+            // members' own live indexes, which items mirror in order.
+            var best = -1;
+            userLayers[i].children.forEach(function (ch, cix) { if (memSet.has(ch) && cix > best) best = cix; });
+            idx = best >= 0 ? Math.min(best, items.length - 1) : items.length - 1;
+          }
+          return { ex: ex, idx: idx === undefined ? items.length - 1 : idx };
+        });
+        // Insert from the back-most target forward so earlier splices
+        // don't shift later targets; islands of one group stay in order.
+        extrasWithIdx.sort(function (a, b) { return b.idx - a.idx; });
+        var lastIdx = null, insertCursor = 0;
+        extrasWithIdx.forEach(function (rec) {
+          var ex = rec.ex;
+          if (rec.idx !== lastIdx) { lastIdx = rec.idx; insertCursor = rec.idx + 1; }
           var op2 = ex.path.opacity !== undefined ? ex.path.opacity : 1;
           var exSegs = ex.path.segments.map(function (s) { return { point: [s.point.x, s.point.y], handleIn: [s.handleIn.x, s.handleIn.y], handleOut: [s.handleOut.x, s.handleOut.y] }; });
           // Layer Motion transform (2026-07-29 fix, QA-confirmed "le gizmo/
@@ -2092,7 +2123,7 @@
           };
           var exSc = cssColorToRgba(ex.path.strokeColor ? colorHex8(ex.path.strokeColor) : null, op2);
           if (exSc) { extraItem.strokeColor = exSc; extraItem.strokeWidth = ex.path.strokeWidth || 1; }
-          items.push(extraItem);
+          items.splice(insertCursor++, 0, extraItem);
         });
       } else {
         items.forEach(function (it) { delete it.__srcC; });

--- a/src/js/group-bridge.js
+++ b/src/js/group-bridge.js
@@ -465,6 +465,11 @@
           return bakeElementMotion(p, sd);
         });
         memberDicts.forEach(function (sd) { suppressed.push(sd); });
+        // z-position of the merged result: right after the group's
+        // front-most member dict, not appended after every other stroke
+        // (feedback #735 — twin of buildSceneJson's own fix).
+        var afterIdx = -1;
+        memberDicts.forEach(function (sd) { var ix = strokes.indexOf(sd); if (ix > afterIdx) afterIdx = ix; });
         var styleSource = memberDicts[memberDicts.length - 1];
         var combFill, combStroke;
         if (styleSource.isVectorBrush) {
@@ -495,6 +500,7 @@
         catch (e) { console.warn('[SMGroup] combine failed for group', gid, e); return; }
         islands.forEach(function (isl) {
           extra.push({
+            __afterIdx: afterIdx, // consumed (and removed) by the splice at the end
             segments: isl.segments.map(function (s) { return { point: [s.point.x, s.point.y], handleIn: [s.handleIn.x, s.handleIn.y], handleOut: [s.handleOut.x, s.handleOut.y] }; }),
             closed: isl.closed,
             fillColor: combFill, strokeColor: combStroke, strokeWidth: styleSource.strokeWidth, opacity: styleSource.opacity,
@@ -526,7 +532,17 @@
       }
       return sd;
     });
-    return out.concat(extra);
+    // Splice each merged result right after its group's front-most member
+    // (same depth rule as buildSceneJson's fix) — back-most target first
+    // so earlier splices never shift a later one; islands keep their order.
+    extra.sort(function (a, b) { return b.__afterIdx - a.__afterIdx; });
+    var lastAfter = null, cursor = 0;
+    extra.forEach(function (ex) {
+      if (ex.__afterIdx !== lastAfter) { lastAfter = ex.__afterIdx; cursor = ex.__afterIdx + 1; }
+      delete ex.__afterIdx;
+      out.splice(cursor++, 0, ex);
+    });
+    return out;
   }
 
   window.SMGroup = {

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -9451,6 +9451,23 @@
         out.push({ type: 'shape', strokeId: entry.strokeId, sd: entry.sd });
       }
     });
+    // Feedback #735 ("peu importe l'index cela ne se reflète pas dans le
+    // canvas") — the tree used to list BACK-most first, the reverse of the
+    // layer list right next to it (renderLayerList iterates layers from
+    // the last index down, so the top row IS the front, like AE/Figma/
+    // Illustrator). Front-most first now, reversed HERE so every consumer
+    // (Elements panel, Motion's element rows, both timeline mirrors) flips
+    // together and the CLAUDE.md §11 panel/grid row alignment holds.
+    out.reverse();
+    // Stable "Shape N"/"Image N" numbering (same feedback: two rows both
+    // read "Shape 1"): consumers used to number rows with a running
+    // counter as they rendered, so a shape's label changed with the
+    // expand/collapse state of the groups above it. Numbered once here by
+    // DRAW order (creation order for a hand-drawn layer), independent of
+    // display order and of what is expanded.
+    var labelIdx = {};
+    flat.forEach(function (entry, i) { labelIdx[entry.strokeId] = i; });
+    out.labelIdx = labelIdx;
     return out;
   }
   // Resolves a strokeId back to its LIVE Paper item on layer `li` — the
@@ -9592,7 +9609,7 @@
         return;
       }
       var entry = { strokeId: node.strokeId, sd: node.sd };
-      var idx = shapeIdx++;
+      var idx = tree.labelIdx && tree.labelIdx[entry.strokeId] !== undefined ? tree.labelIdx[entry.strokeId] : shapeIdx++; // stable draw-order label, see buildShapeTree
       var expanded = window._motionExpandedElement === entry.strokeId;
       var row = document.createElement('div'); row.className = 'lrow motion-elem-row';
       var swatch = document.createElement('div'); swatch.className = 'motion-elem-swatch';

--- a/src/js/shapes-panel.js
+++ b/src/js/shapes-panel.js
@@ -409,10 +409,36 @@
   // Puts `items` (given back-to-front, i.e. layer.children order) right in
   // front of `dest`, or right behind it — keeping their own relative
   // order either way. The one z-order primitive both reorder paths use.
+  //
+  // Brush shapes (Cyril, #735: "attention de tester avec des shapes faites
+  // au brush aussi"): one Elements row is SEVERAL live items — the
+  // vector-brush ribbon + its linked-fill companion (shared
+  // data.linkedFillId, draw-bridge.js) and, for a textured brush, its dab
+  // copies (shared data.brushGroupId). layerElements folds them into the
+  // anchor's row, so moving only the anchor left the fill/texture at the
+  // old depth — the shape's outline moved, its fill didn't. Every source
+  // row and the destination are expanded to their full visual block here.
+  function _visualBlock(it, layer) {
+    var d = it.data || {}, out = [it];
+    if (layer && (d.linkedFillId || d.brushGroupId)) {
+      layer.children.forEach(function (c) {
+        if (c === it || !c.data) return;
+        if ((d.linkedFillId && c.data.linkedFillId === d.linkedFillId) || (d.brushGroupId && c.data.brushGroupId === d.brushGroupId)) out.push(c);
+      });
+    }
+    return out;
+  }
   function _placeItems(items, dest, after) {
-    var anchor = dest;
-    if (after) items.slice().reverse().forEach(function (it) { it.insertBelow(anchor); anchor = it; });
-    else items.forEach(function (it) { it.insertAbove(anchor); anchor = it; });
+    var layer = dest.parent;
+    var block = [], seen = [];
+    items.forEach(function (it) { _visualBlock(it, layer).forEach(function (m) { if (seen.indexOf(m) === -1) { seen.push(m); block.push(m); } }); });
+    block.sort(function (a, b) { return a.index - b.index; }); // back-to-front, as in layer.children
+    var destBlock = _visualBlock(dest, layer).filter(function (m) { return seen.indexOf(m) === -1; });
+    if (!destBlock.length) return;
+    destBlock.sort(function (a, b) { return a.index - b.index; });
+    var anchor = after ? destBlock[0] : destBlock[destBlock.length - 1];
+    if (after) block.slice().reverse().forEach(function (it) { it.insertBelow(anchor); anchor = it; });
+    else block.forEach(function (it) { it.insertAbove(anchor); anchor = it; });
   }
   function performMemberReorder(overRow) {
     var destGroupGid = overRow.dataset.groupmember, destStrokeId = overRow.dataset.strokeid, destGid = overRow.dataset.gid;

--- a/src/js/shapes-panel.js
+++ b/src/js/shapes-panel.js
@@ -311,7 +311,7 @@
     }
     moveDragGhost(e);
     var list = document.getElementById('shapes-list'); if (!list) return;
-    Array.prototype.forEach.call(list.querySelectorAll('.lrow'), function (r) { r.classList.remove('drag-over'); });
+    Array.prototype.forEach.call(list.querySelectorAll('.lrow'), function (r) { r.classList.remove('drag-over', 'drag-over-after'); });
     var el = document.elementFromPoint(e.clientX, e.clientY);
     var row = _elDrag.kind === 'paint'
       ? el && el.closest('#shapes-list .lrow[data-paintid]')
@@ -322,19 +322,29 @@
       // own header) — see performMemberReorder's 2026-09 fix.
       ? el && el.closest('#shapes-list .lrow[data-groupmember], #shapes-list .lrow[data-toplevel]')
       : el && el.closest('#shapes-list .lrow[data-toplevel]');
-    if (row) row.classList.add('drag-over');
+    if (row) {
+      // Feedback #735 ("très difficile d'organiser") — a drop used to mean
+      // only "in front of the target", with no way to land BEHIND the
+      // last row and no visual cue of where the item would go. Upper half
+      // of the row = in front of it (insertion line on its top edge),
+      // lower half = behind it (line on its bottom edge). A paint swap has
+      // no before/after — it's a swap.
+      var rr = row.getBoundingClientRect();
+      _elDrag.dropAfter = _elDrag.kind !== 'paint' && e.clientY > rr.top + rr.height / 2;
+      row.classList.add(_elDrag.dropAfter ? 'drag-over-after' : 'drag-over');
+    }
   });
   window.addEventListener('mouseup', function () {
     if (!_elDrag.active) return;
     if (_elDrag.moved) {
       window._elDragJustEnded = true;
       var list = document.getElementById('shapes-list');
-      var overRow = list && list.querySelector('.lrow.drag-over');
+      var overRow = list && list.querySelector('.lrow.drag-over, .lrow.drag-over-after');
       if (overRow) performReorder(overRow);
     }
     stopDragGhost();
     var list2 = document.getElementById('shapes-list');
-    if (list2) Array.prototype.forEach.call(list2.querySelectorAll('.lrow'), function (r) { r.classList.remove('dragging', 'drag-over'); });
+    if (list2) Array.prototype.forEach.call(list2.querySelectorAll('.lrow'), function (r) { r.classList.remove('dragging', 'drag-over', 'drag-over-after'); });
     _elDrag.active = false; _elDrag.moved = false;
   });
   // Fill<->Stroke swap (2026-08, "pourquoi il est pas possible de select
@@ -396,6 +406,14 @@
   // drop target be a member of the exact SAME group as the dragged item
   // (_elDrag.extra, stamped at mousedown — see buildShapeRow's member
   // branch).
+  // Puts `items` (given back-to-front, i.e. layer.children order) right in
+  // front of `dest`, or right behind it — keeping their own relative
+  // order either way. The one z-order primitive both reorder paths use.
+  function _placeItems(items, dest, after) {
+    var anchor = dest;
+    if (after) items.slice().reverse().forEach(function (it) { it.insertBelow(anchor); anchor = it; });
+    else items.forEach(function (it) { it.insertAbove(anchor); anchor = it; });
+  }
   function performMemberReorder(overRow) {
     var destGroupGid = overRow.dataset.groupmember, destStrokeId = overRow.dataset.strokeid, destGid = overRow.dataset.gid;
     if (destStrokeId === _elDrag.id) return;
@@ -403,17 +421,18 @@
     var layer = window.userLayers && userLayers[c.li];
     var srcItem = window.SMMotion.liveItemByStrokeId(c.li, _elDrag.id);
     if (!srcItem || !layer) return;
+    var after = !!_elDrag.dropAfter;
     var sameGroup = destGroupGid && destGroupGid === _elDrag.extra;
     var destItem;
     if (sameGroup) {
       destItem = window.SMMotion.liveItemByStrokeId(c.li, destStrokeId);
     } else if (destGid) {
       // Dropped on a (collapsed or expanded) DIFFERENT group's own header
-      // row — land adjacent to the whole group, same "front-most member"
-      // convention performReorder's own group-destination branch uses.
+      // row — land adjacent to the whole group, same convention as
+      // performReorder's own group-destination branch.
       var destMembers = window.SMMotion.layerElements(c.li, c.ld).filter(function (e) { return e.sd.groupId === destGid; });
       if (!destMembers.length) return;
-      destItem = window.SMMotion.liveItemByStrokeId(c.li, destMembers[destMembers.length - 1].strokeId);
+      destItem = window.SMMotion.liveItemByStrokeId(c.li, destMembers[after ? 0 : destMembers.length - 1].strokeId);
     } else if (destStrokeId) {
       // Either a member row of a DIFFERENT group, or a plain top-level
       // shape — both resolve to that exact item.
@@ -433,7 +452,7 @@
       // Figma: dragging a layer out of its group stack takes it out.
       window.SMGroup.removeMemberFromGroup(srcItem, c.ld, layer, { skipUndo: true, silent: true });
     }
-    srcItem.insertAbove(destItem);
+    _placeItems([srcItem], destItem, after);
     saveActiveLayerFrame();
     renderShapesPanel();
     if (window.renderArcs) renderArcs();
@@ -446,13 +465,15 @@
     var destGid = overRow.dataset.gid, destStrokeId = overRow.dataset.strokeid;
     if (_elDrag.kind === 'group' && destGid === _elDrag.id) return; // dropped on itself
     if (_elDrag.kind === 'shape' && destStrokeId === _elDrag.id) return;
+    var after = !!_elDrag.dropAfter; // lower half of the row = land BEHIND it (see the mousemove handler)
     var destItem;
     if (destGid) {
       var destMembers = window.SMMotion.layerElements(c.li, c.ld).filter(function (e) { return e.sd.groupId === destGid; });
       if (!destMembers.length) return;
-      // Front-most (last) member — the dragged block lands adjacent to the
-      // WHOLE group rather than injected into its middle.
-      destItem = window.SMMotion.liveItemByStrokeId(c.li, destMembers[destMembers.length - 1].strokeId);
+      // The dragged block lands adjacent to the WHOLE group rather than
+      // injected into its middle: in front of its front-most (last)
+      // member, or behind its back-most (first) one.
+      destItem = window.SMMotion.liveItemByStrokeId(c.li, destMembers[after ? 0 : destMembers.length - 1].strokeId);
     } else if (destStrokeId) {
       destItem = window.SMMotion.liveItemByStrokeId(c.li, destStrokeId);
     }
@@ -466,9 +487,9 @@
       srcItems = it ? [it] : [];
     }
     if (!srcItems.length) return;
+    if (srcItems.indexOf(destItem) !== -1) return; // dropped onto (part of) itself
     pushUndo();
-    var anchor = destItem;
-    srcItems.forEach(function (it) { it.insertAbove(anchor); anchor = it; });
+    _placeItems(srcItems, destItem, after);
     saveActiveLayerFrame();
     renderShapesPanel();
     if (window.renderArcs) renderArcs();
@@ -714,12 +735,16 @@
         });
         list.appendChild(grow);
         if (expanded) {
-          memberEntries.forEach(function (me) {
-            buildShapeRow(list, c, { strokeId: me.strokeId, sd: me.sd }, shapeIdx++, 20, false, node.gid);
+          // Front-most member first, same reading direction as the tree
+          // itself (buildShapeTree, feedback #735).
+          memberEntries.slice().reverse().forEach(function (me) {
+            var mIdx = tree.labelIdx && tree.labelIdx[me.strokeId] !== undefined ? tree.labelIdx[me.strokeId] : shapeIdx++;
+            buildShapeRow(list, c, { strokeId: me.strokeId, sd: me.sd }, mIdx, 20, false, node.gid);
           });
         }
       } else {
-        buildShapeRow(list, c, node, shapeIdx++, 0, true);
+        var sIdx = tree.labelIdx && tree.labelIdx[node.strokeId] !== undefined ? tree.labelIdx[node.strokeId] : shapeIdx++;
+        buildShapeRow(list, c, node, sIdx, 0, true);
       }
     });
   }

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -5192,7 +5192,7 @@ function renderShapeTreeRowsInto(list,li,ld){
       list.appendChild(grow);
       return;
     }
-    var idx=shapeIdx++;
+    var idx=tree.labelIdx&&tree.labelIdx[node.strokeId]!==undefined?tree.labelIdx[node.strokeId]:shapeIdx++; // stable draw-order label, see buildShapeTree
     var srow=document.createElement('div');srow.className='lrow motion-elem-row';
     var sswatch=document.createElement('div');sswatch.className='motion-elem-swatch';sswatch.style.background=node.sd.fillColor||node.sd.strokeColor||'transparent';
     var snm=document.createElement('div');snm.className='lnm';snm.textContent=SMMotion.elementLabel(node,idx,ld);


### PR DESCRIPTION
## Résumé

Feedback #735, volets 1 et 2 (+ précisions de Cyril en cours de route : « c'est quand c'est mergé que ça marche plus la hiérarchie », « en union ça casse la hiérarchie », « attention de tester avec des shapes faites au brush »).

- **Ordre** : le panneau Éléments listait l'arrière-plan en premier, à l'inverse de la liste des calques (ligne du haut = premier plan, comme AE/Figma/Illustrator). Inversé dans `buildShapeTree` pour que panneau, lignes Motion et miroirs timeline basculent ensemble (alignement §11 préservé).
- **Combine (union, etc.)** : le contour fusionné était poussé en **fin** des items du calque, donc dessiné au-dessus de tout quelle que soit la position du groupe — c'était le vrai « ça ne se reflète pas dans le canvas ». Inséré maintenant à la profondeur du groupe (juste après son membre le plus en avant), dans `buildSceneJson` **et** son jumeau dict `applyCombinesToStrokes` (export/onion/ghost-all).
- **Déplacement** : moitié haute de la ligne cible = devant (ligne d'insertion en haut), moitié basse = derrière (ligne en bas). Un seul primitif `_placeItems`, qui déplace le **bloc visuel** entier d'une forme brosse (ruban + fill lié + dabs de texture) et vise le bloc entier de la destination.
- **Numérotation « Shape N »** stabilisée par ordre de dessin (les deux « Shape 1 » du trail venaient d'un compteur de rendu dépendant des groupes dépliés).

Le volet 3 (groupes imbriqués, combine enfant = un seul opérande du parent) est une fonctionnalité à part, ouverte séparément.

## Vérification (projet neuf, vrais traits au Brush avec fill, moteur actif)
- rouge+vert groupés via `groupSelection` puis **union**, bleu dessiné en dernier : bleu **devant** l'union (capture) ; drag du bleu sous le groupe → bleu **derrière** l'union (capture)
- ruban + fill lié déplacés ensemble et adjacents dans les deux sens (testF, calque sans duplicateur)
- forme→groupe haut/bas, groupe→forme haut/bas, membre→membre dans son groupe : `layer.children`, panneau et canvas cohérents
- jumeau export : le dict combiné tombe juste après le membre le plus en avant
- aucune erreur console, `npm test` 65/65

🤖 Generated with [Claude Code](https://claude.com/claude-code)