### PR TITLE
Groupes imbriqués : un groupe combiné compte comme un seul opérande du parent (#738)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2057,7 +2057,11 @@ body.mode-motion .layer-inout-bar .layer-inout-handle{width:4px;border-radius:2p
 .cp-eyedrop:hover{color:var(--text);border-color:var(--border2);}
 .ctx-sep{height:1px;background:var(--border);margin:4px 2px;}
 .lrow.drag-over{border-top:2px solid var(--accent);}
-.lrow.drag-over-after{border-bottom:2px solid var(--accent);} /* Elements panel: drop lands BEHIND this row (feedback #735) */
+.lrow.drag-over-after{border-bottom:2px solid var(--accent);}
+/* Drop INTO a group (2026-09, nested groups) — a filled outline instead
+   of an insertion line, since the drop lands inside the row, not between
+   two of them. */
+.lrow.drag-into{outline:2px solid var(--accent);outline-offset:-2px;background:color-mix(in srgb,var(--accent) 14%,transparent);} /* Elements panel: drop lands BEHIND this row (feedback #735) */
 .lrow.dragging{opacity:.4;}
 
 /* START SCREEN — matches the Home.dc.html design (claude.ai/design project

--- a/src/js/group-bridge.js
+++ b/src/js/group-bridge.js
@@ -24,29 +24,123 @@
 // below, and from there the EXISTING shared-transform-box code just works
 // unmodified on whatever `selectedPaths` now contains.
 (function () {
+  // ---- NESTING (2026-09, issue #738 — Cyril: "si on a un groupe avec
+  // merge qui est dans un sous groupe alors celui-ci est considéré comme
+  // un seul élément pour le merge du groupe parent") ----
+  // The DATA model already allowed it: a group's `order` may hold child
+  // GIDs as well as leaf strokeIds, and collectGroupStrokeIds/
+  // resolveGroupMembers below have always recursed through them. What was
+  // missing was (a) any UI that creates the nesting, (b) the upward link
+  // needed to answer "which group is the outermost one for this stroke",
+  // and (c) a combine that treats a combined CHILD as one operand.
+  // The upward link is `parent` on the CHILD's own ld.groups entry — the
+  // per-stroke `data.groupId` tag keeps meaning the stroke's INNERMOST
+  // group, so every existing consumer of that tag is untouched.
+  function groupMeta(gid, ld) { return (ld && ld.groups && ld.groups[gid]) || null; }
+  function parentGroupOf(gid, ld) { var g = groupMeta(gid, ld); return (g && g.parent && groupMeta(g.parent, ld)) ? g.parent : null; }
+  // Outermost ancestor of `gid` (itself when it has no parent). Depth-capped
+  // like resolveGroupMembers, so a corrupt parent cycle can never hang.
+  function rootGroupOf(gid, ld) {
+    var cur = gid, seen = {};
+    for (var i = 0; i < 32 && cur; i++) {
+      if (seen[cur]) { console.warn('[SMGroup] cyclic group parent, stopping at', cur); return cur; }
+      seen[cur] = true;
+      var up = parentGroupOf(cur, ld);
+      if (!up) return cur;
+      cur = up;
+    }
+    return cur;
+  }
+  function rootGroupOfItem(p, ld) {
+    var gid = p && p.data && p.data.groupId;
+    return gid && groupMeta(gid, ld) ? rootGroupOf(gid, ld) : (gid || null);
+  }
+  // Detaches one leaf strokeId from whatever group entry currently lists
+  // it, dissolving that group if it drops below 2 entries — the shared
+  // core of removeMemberFromGroup and of re-grouping a shape that already
+  // belonged somewhere else.
+  function detachLeaf(sid, ld, layer) {
+    if (!sid || !ld || !ld.groups) return;
+    Object.keys(ld.groups).forEach(function (gid) {
+      var grp = ld.groups[gid]; if (!grp || !grp.order) return;
+      var ix = grp.order.indexOf(sid); if (ix === -1) return;
+      grp.order.splice(ix, 1);
+      if (grp.order.length < 2) dissolveGroup(gid, ld, layer);
+    });
+  }
+  // Dissolves ONE level: leaf members lose their tag, child groups are
+  // promoted to wherever this group sat (its own parent, or top level).
+  function dissolveGroup(gid, ld, layer) {
+    var grp = groupMeta(gid, ld); if (!grp) return;
+    var up = grp.parent && groupMeta(grp.parent, ld) ? grp.parent : null;
+    (grp.order || []).forEach(function (entry) {
+      if (groupMeta(entry, ld)) {
+        if (up) ld.groups[entry].parent = up; else delete ld.groups[entry].parent;
+      } else {
+        var item = findByStrokeId(layer, entry);
+        if (item && item.data) { if (up) item.data.groupId = up; else delete item.data.groupId; }
+      }
+    });
+    if (up) {
+      var pOrder = ld.groups[up].order || [];
+      var ix = pOrder.indexOf(gid);
+      if (ix !== -1) pOrder.splice.apply(pOrder, [ix, 1].concat(grp.order || []));
+    }
+    delete ld.groups[gid];
+  }
   function groupSelection() {
     if ((state.tool !== 'select' && state.tool !== 'subselect') || !window.selectedPaths || selectedPaths.length < 2) {
       if (window.showToast) showToast(SM.t('toastSelectAtLeast2ElementsToGroup'));
       return;
     }
+    var li = state.activeLayerIdx, ld = state.layers[li], layer = window.userLayers ? userLayers[li] : null;
+    if (!ld) return;
+    ensureLayerGroups(ld);
+    // UNITS, not shapes (2026-09, #738): a selection that contains every
+    // member of an existing group nests that WHOLE group as one entry
+    // instead of dissolving it into loose members — which is what made
+    // "group a group with a shape" flatten before. A group only PARTLY
+    // selected still contributes its selected shapes as loose leaves
+    // (they leave their old group on the way, which is what the old code
+    // did implicitly, minus the dangling `order` entries it left behind).
+    var ordered = selectedPaths.slice();
+    if (layer) ordered.sort(function (a, b) { return layer.children.indexOf(a) - layer.children.indexOf(b); });
+    var selSet = ordered;
+    var units = [], seenGid = {};
+    ordered.forEach(function (p) {
+      var root = rootGroupOfItem(p, ld);
+      if (root && groupMeta(root, ld)) {
+        if (seenGid[root]) return;
+        var leaves = resolveGroupMembers(root, ld, layer);
+        var whole = leaves.length > 0 && leaves.every(function (m) { return selSet.indexOf(m) !== -1; });
+        if (whole) { seenGid[root] = true; units.push({ kind: 'group', gid: root }); return; }
+      }
+      units.push({ kind: 'leaf', p: p });
+    });
+    if (units.length < 2) {
+      // Everything selected already belongs to one and the same group —
+      // grouping it again would just wrap a single unit, which is a no-op
+      // the user would read as "Cmd+G does nothing".
+      if (window.showToast) showToast(SM.t('toastSelectAtLeast2ElementsToGroup'));
+      return;
+    }
     pushUndo();
     var gid = 'grp_' + Date.now().toString(36) + '_' + Math.floor(Math.random() * 1e6);
-    var li = state.activeLayerIdx, ld = state.layers[li];
-    selectedPaths.forEach(function (p) { if (!p.data) p.data = {}; p.data.groupId = gid; ensureStrokeId(p); });
-    // Named from the moment it's created (2026-07-31, group/shape tree
-    // panel — Cyril: "vrai panel de gestion de group") — a plain Cmd+G
-    // group used to have NO ld.groups entry at all, only the members'
-    // data.groupId tag; a combine-group (below) had metadata but no name.
-    // Unified here so both kinds of group show up named in the tree panel
-    // from day one, not just after an explicit rename.
-    if (ld) {
-      ensureLayerGroups(ld);
-      // 2026-08 fix: hardcoded French default name, shown regardless of locale.
-      ld.groups[gid] = { name: SM.t('autoNameGroup'), combineMode: 'none', order: selectedPaths.map(function (p) { return p.data.strokeId; }) };
-    }
+    var order = [];
+    units.forEach(function (u) {
+      if (u.kind === 'group') { ld.groups[u.gid].parent = gid; order.push(u.gid); return; }
+      var p = u.p;
+      if (!p.data) p.data = {};
+      var sid = ensureStrokeId(p);
+      detachLeaf(sid, ld, layer);
+      p.data.groupId = gid;
+      order.push(sid);
+    });
+    // 2026-08 fix: hardcoded French default name, shown regardless of locale.
+    ld.groups[gid] = { name: SM.t('autoNameGroup'), combineMode: 'none', order: order };
     saveActiveLayerFrame(); updateUI();
     if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
-    if (window.showToast) showToast(SM.t('toastGroupCreatedSuffix') + selectedPaths.length + SM.t('toastElementsCloseParen'));
+    if (window.showToast) showToast(SM.t('toastGroupCreatedSuffix') + units.length + SM.t('toastElementsCloseParen'));
   }
   function ungroupSelection() {
     // Both refusals were silent while groupSelection's own ("Sélectionnez au
@@ -62,7 +156,16 @@
       return;
     }
     pushUndo();
-    selectedPaths.forEach(function (p) { if (p.data) delete p.data.groupId; });
+    // One LEVEL at a time (2026-09, #738): dissolve the outermost group of
+    // each selected shape, which promotes its child groups instead of
+    // erasing the whole nested structure in one keystroke — Cmd+Shift+G
+    // pressed again then peels the next level, matching Illustrator/Figma.
+    var uli = state.activeLayerIdx, uld = state.layers[uli], ulayer = window.userLayers ? userLayers[uli] : null;
+    var roots = {};
+    selectedPaths.forEach(function (p) { var r = rootGroupOfItem(p, uld); if (r && groupMeta(r, uld)) roots[r] = true; });
+    var rootKeys = Object.keys(roots);
+    if (rootKeys.length) rootKeys.forEach(function (r) { dissolveGroup(r, uld, ulayer); });
+    else selectedPaths.forEach(function (p) { if (p.data) delete p.data.groupId; });
     saveActiveLayerFrame(); updateUI();
     if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
     if (window.showToast) showToast(SM.t('toastGroupUngrouped'));
@@ -73,6 +176,18 @@
   function membersOf(p, layer) {
     var gid = p.data && p.data.groupId;
     if (!gid || !layer) return [p];
+    // Nested groups (2026-09, #738): clicking any shape selects its
+    // OUTERMOST group, the same "click selects the top-level group, you
+    // step inside from the tree" convention Figma/Illustrator use — with
+    // the flat model these two were always the same thing, so this is the
+    // one behavioural change nesting brings to canvas selection.
+    var li = window.userLayers ? userLayers.indexOf(layer) : -1;
+    var ld = li >= 0 ? state.layers[li] : null;
+    var root = ld ? rootGroupOfItem(p, ld) : gid;
+    if (ld && root && groupMeta(root, ld)) {
+      var leaves = resolveGroupMembers(root, ld, layer);
+      if (leaves.length) return leaves;
+    }
     return layer.children.filter(function (c) { return c.data && c.data.groupId === gid; });
   }
 
@@ -218,15 +333,11 @@
     var sid = p.data.strokeId;
     grp.order = (grp.order || []).filter(function (e) { return e !== sid; });
     delete p.data.groupId;
-    // Mirrors groupSelection's own "a group needs >=2 members" invariant —
-    // one member left isn't a group anymore.
-    if (grp.order.length < 2) {
-      grp.order.forEach(function (e) {
-        var item = findByStrokeId(layer, e);
-        if (item && item.data) delete item.data.groupId;
-      });
-      delete ld.groups[gid];
-    }
+    // Mirrors groupSelection's own ">=2 entries" invariant — one entry left
+    // isn't a group anymore. dissolveGroup (not an inline loop) since an
+    // entry may now be a child GROUP, which has to be promoted rather than
+    // untagged (2026-09, #738).
+    if (grp.order.length < 2) dissolveGroup(gid, ld, layer);
     if (!opts.silent) {
       saveActiveLayerFrame(); updateUI();
       if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
@@ -273,7 +384,15 @@
     members.forEach(function (m) { m.remove(); });
     folded.companions.forEach(function (c) { if (!c.removed) c.remove(); });
     disposable.forEach(function (c) { if (!c.removed) c.remove(); });
-    delete ld.groups[gid];
+    // Descendant group entries go with it (2026-09, #738): flatten bakes
+    // every leaf underneath into one shape, so a surviving child entry
+    // would reference strokeIds that no longer exist and keep a `parent`
+    // pointing at a group that is gone.
+    (function removeSubtree(g, depth) {
+      var meta = ld.groups[g]; if (!meta || depth > 16) return;
+      (meta.order || []).forEach(function (entry) { if (ld.groups[entry]) removeSubtree(entry, depth + 1); });
+      delete ld.groups[g];
+    })(gid, 0);
     selectedPaths = islands; state.selectedStrokeIndices = [];
     fillRegenerateLinked(layer, islands[0]);
     saveActiveLayerFrame(); updateUI();
@@ -298,9 +417,97 @@
   function renderCombinesFromChildren(layer, ld, frameIdx) {
     var suppress = [], extra = [];
     if (!ld || !ld.groups) return { suppress: suppress, extra: extra };
+    // NESTED COMBINE (2026-09, #738 — "un groupe avec merge dans un sous
+    // groupe est considéré comme un seul élément pour le merge du parent").
+    // The walk is now top-down from ROOT groups instead of a flat pass over
+    // every group id, because the two questions a nested combine asks can
+    // only be answered with the parent in hand:
+    //  - what are my operands? a child group that combines contributes ONE
+    //    operand (its own result); a child group that doesn't contributes
+    //    its leaves, exactly as if it weren't there;
+    //  - do I emit my result, or is my parent about to consume it?
+    // A child's result is therefore computed once and either handed up or
+    // drawn, never both — which is what stops the old flat pass from
+    // drawing the inner merge and the outer merge on top of each other.
+    function emit(gid, dupIndex, parentCombines, ancestors, depth, temps) {
+      var grp = ld.groups[gid];
+      if (!grp || depth > 16 || ancestors.indexOf(gid) !== -1) return [];
+      var next = ancestors.concat([gid]);
+      var mode = grp.combineMode || 'none';
+      var operands = [];
+      (grp.order || []).forEach(function (entry) {
+        if (ld.groups[entry]) {
+          operands = operands.concat(emit(entry, dupIndex, mode !== 'none', next, depth + 1, temps));
+        } else {
+          var item = findByStrokeId(layer, entry, dupIndex);
+          if (item) operands.push(item);
+        }
+      });
+      if (mode === 'none' || operands.length < 2) return operands;
+      var leaves = resolveGroupMembers(gid, ld, layer, null, 0, dupIndex);
+      // Consumed by a combining parent: hand up the UN-flattened result, so
+      // the parent sees ONE shape (holes included) — that is the whole
+      // point of #738. Emitted for real: flatten into islands, which is
+      // what the renderer's item list expects.
+      if (parentCombines) {
+        var raw;
+        try { raw = computeGroupCombineRaw(operands, mode, layer, frameIdx); }
+        catch (e2) { console.warn('[SMGroup] nested combine failed for group', gid, e2); return operands; }
+        if (!raw) return operands;
+        leaves.forEach(function (m) { if (suppress.indexOf(m) === -1) suppress.push(m); });
+        operands.forEach(function (o) { if (temps.indexOf(o) === -1 && layer && o.parent !== layer) temps.push(o); });
+        // Style is irrelevant upstream (the outermost group paints the
+        // final result from its own topmost leaf), but a fill-less operand
+        // would be mistaken for a stroke-only shape and expanded.
+        if (!raw.fillColor) raw.fillColor = '#000000';
+        raw.strokeColor = null;
+        return [raw];
+      }
+      var islands;
+      try { islands = computeGroupCombine(operands, mode, layer, frameIdx); }
+      catch (e) { console.warn('[SMGroup] combine failed for group', gid, e); return operands; }
+      leaves.forEach(function (m) { if (suppress.indexOf(m) === -1) suppress.push(m); });
+      // Operands that were themselves computed (a child's result) are
+      // scratch geometry: keep them alive until the parent's boolean has
+      // consumed them, then drop whatever the result doesn't reuse.
+      operands.forEach(function (o) { if (temps.indexOf(o) === -1 && layer && o.parent !== layer) temps.push(o); });
+      if (parentCombines) return islands;
+      var styleSource = leaves[leaves.length - 1] || operands[operands.length - 1];
+      // Vector-brush ribbon style source (2026-08 fix, feedback: "les
+      // combine gère mal stroke plus fill" for Pressure-brush shapes) —
+      // a ribbon's OWN fillColor is its ink/stroke color, never a real
+      // fill (isVectorBrush ribbons paint through fillColor — see
+      // app.js's serP comment); any real Fill the user set lives on a
+      // completely separate companion Path.
+      var srcIsVB = !!(styleSource.data && styleSource.data.isVectorBrush);
+      var isl_fill, isl_stroke;
+      if (srcIsVB) {
+        var srcCompanion = findLinkedFillCompanion(layer, styleSource);
+        isl_fill = srcCompanion ? srcCompanion.fillColor : null;
+        isl_stroke = styleSource.fillColor;
+      } else {
+        // Stroke-only style source (2026-07-29 fix, QA-confirmed live):
+        // computeGroupCombine expands a stroke-only member into its real
+        // filled ribbon geometry, so painting that geometry with ONLY a
+        // strokeColor drew just its outline.
+        isl_fill = styleSource.fillColor || styleSource.strokeColor;
+        isl_stroke = styleSource.fillColor ? styleSource.strokeColor : null;
+      }
+      islands.forEach(function (isl) {
+        isl.fillColor = isl_fill;
+        isl.strokeColor = isl_stroke;
+        isl.strokeWidth = styleSource.strokeWidth;
+        isl.opacity = styleSource.opacity;
+        extra.push({ path: isl, groupCombineOf: gid });
+      });
+      return islands;
+    }
     Object.keys(ld.groups).forEach(function (gid) {
       var grp = ld.groups[gid];
-      if (!grp || grp.combineMode === 'none') return;
+      if (!grp) return;
+      // Roots only — a child is reached through its parent's own walk, and
+      // reaching it twice is exactly the double-draw this replaces.
+      if (grp.parent && ld.groups[grp.parent]) return;
       var strokeIds = collectGroupStrokeIds(gid, ld);
       if (!strokeIds.length) return;
       // One combine per duplicator COPY (see findByStrokeId's comment) —
@@ -313,48 +520,12 @@
         if (c.data && c.data.strokeId && strokeIds.indexOf(c.data.strokeId) !== -1) dupIndices[c.data.dupIndex || 0] = true;
       });
       Object.keys(dupIndices).forEach(function (dupIndexKey) {
-        var dupIndex = Number(dupIndexKey);
-        var members = resolveGroupMembers(gid, ld, layer, null, 0, dupIndex);
-        if (members.length < 2) return;
-        members.forEach(function (m) { suppress.push(m); });
-        var styleSource = members[members.length - 1];
-        var islands;
-        try { islands = computeGroupCombine(members, grp.combineMode, layer, frameIdx); }
-        catch (e) { console.warn('[SMGroup] combine failed for group', gid, e); return; }
-        // Vector-brush ribbon style source (2026-08 fix, feedback: "les
-        // combine gère mal stroke plus fill" for Pressure-brush shapes) —
-        // a ribbon's OWN fillColor is its ink/stroke color, never a real
-        // fill (isVectorBrush ribbons paint through fillColor — see
-        // app.js's serP comment); any real Fill the user set lives on a
-        // completely separate companion Path. Reading styleSource.fillColor
-        // unconditionally as "the fill" painted the combined shape solid
-        // in the STROKE's own color with no fill at all — confirmed live.
-        // Resolve both from the ribbon's own companion, same lookup
-        // foldBooleanOp already uses to fold it into the boolean operand.
-        var srcIsVB = !!(styleSource.data && styleSource.data.isVectorBrush);
-        var isl_fill, isl_stroke;
-        if (srcIsVB) {
-          var srcCompanion = findLinkedFillCompanion(layer, styleSource);
-          isl_fill = srcCompanion ? srcCompanion.fillColor : null;
-          isl_stroke = styleSource.fillColor;
-        } else {
-          // Stroke-only style source (2026-07-29 fix, QA-confirmed live:
-          // combining two stroke-only brush strokes rendered as a thin
-          // outline tracing the merged silhouette instead of a solid merged
-          // stroke) — computeGroupCombine already expands a stroke-only
-          // member into its real filled ribbon geometry (foldBooleanOp), so
-          // painting that geometry with ONLY strokeColor (no fill) drew just
-          // its outline. Flip to filled-with-the-stroke's-own-color, same
-          // convention as eraseExpandStrokeToFill/booleanOp's identical fix.
-          isl_fill = styleSource.fillColor || styleSource.strokeColor;
-          isl_stroke = styleSource.fillColor ? styleSource.strokeColor : null;
-        }
-        islands.forEach(function (isl) {
-          isl.fillColor = isl_fill;
-          isl.strokeColor = isl_stroke;
-          isl.strokeWidth = styleSource.strokeWidth;
-          isl.opacity = styleSource.opacity;
-          extra.push({ path: isl, groupCombineOf: gid });
+        var temps = [];
+        var result = emit(gid, Number(dupIndexKey), false, [], 0, temps);
+        temps.forEach(function (t) {
+          if (t.removed || result.indexOf(t) !== -1) return;
+          if (extra.some(function (ex) { return ex.path === t; })) return;
+          t.remove();
         });
       });
     });
@@ -417,9 +588,126 @@
     // fully blank in export. Bucketing member dicts by dupIndex below and
     // suppressing only the exact dicts in each bucket fixes both at once.
     var suppressed = [], extra = [];
+    // Same top-down, parent-aware walk as renderCombinesFromChildren above
+    // (2026-09, #738) — see its comment for why a nested combine can't be
+    // resolved by a flat pass. Operands here are transient Paths built from
+    // dicts; a child group that combines hands its result Path up as ONE
+    // operand, a child that doesn't hands up its members' Paths.
+    function dictOperands(gid, dicts, dupIndex, parentCombines, ancestors, depth, temps, out) {
+      var grp = ld.groups[gid];
+      if (!grp || depth > 16 || ancestors.indexOf(gid) !== -1) return [];
+      var next = ancestors.concat([gid]);
+      var mode = grp.combineMode || 'none';
+      var operands = [];
+      (grp.order || []).forEach(function (entry) {
+        if (ld.groups[entry]) {
+          operands = operands.concat(dictOperands(entry, dicts, dupIndex, mode !== 'none', next, depth + 1, temps, out));
+        } else {
+          var sd = dicts[entry];
+          if (!sd || sd.isRaster || !sd.segments || !sd.segments.length) return;
+          operands.push(dictPathFor(sd, temps));
+        }
+      });
+      if (mode === 'none' || operands.length < 2) return operands;
+      var leafIds = collectGroupStrokeIds(gid, ld);
+      var memberDicts = leafIds.map(function (id) { return dicts[id]; }).filter(function (sd) { return sd && !sd.isRaster && sd.segments && sd.segments.length; });
+      if (memberDicts.length < 2) return operands;
+      operands.forEach(function (o) { if (temps.indexOf(o) === -1) temps.push(o); });
+      // Same single-operand rule as the live twin above (#738).
+      if (parentCombines) {
+        var raw;
+        try { raw = computeGroupCombineRaw(operands, mode, null); }
+        catch (e2) { console.warn('[SMGroup] nested combine failed for group', gid, e2); return operands; }
+        if (!raw) return operands;
+        memberDicts.forEach(function (sd) { if (suppressed.indexOf(sd) === -1) suppressed.push(sd); });
+        if (!raw.fillColor) raw.fillColor = '#000000';
+        raw.strokeColor = null;
+        return [raw];
+      }
+      var islands;
+      try { islands = computeGroupCombine(operands, mode, null); }
+      catch (e) { console.warn('[SMGroup] combine failed for group', gid, e); return operands; }
+      memberDicts.forEach(function (sd) { if (suppressed.indexOf(sd) === -1) suppressed.push(sd); });
+      // z-position of the merged result: right after the group's
+      // front-most member dict, not appended after every other stroke
+      // (feedback #735 — twin of buildSceneJson's own fix).
+      var afterIdx = -1;
+      memberDicts.forEach(function (sd) { var ix = strokes.indexOf(sd); if (ix > afterIdx) afterIdx = ix; });
+      var styleSource = memberDicts[memberDicts.length - 1];
+      var thisDi = memberDicts[0].dupIndex;
+      var combFill, combStroke;
+      if (styleSource.isVectorBrush) {
+        // Same fix as renderCombinesFromChildren's twin above, dict form: a
+        // ribbon dict's own fillColor is its ink/stroke color, never a real
+        // fill — the real Fill (if any) is a separate companion dict.
+        var styleCompanion = styleSource.linkedFillId ? strokes.filter(function (d) {
+          return d.isLinkedFillCompanion && d.linkedFillId === styleSource.linkedFillId && (d.dupIndex || 0) === (styleSource.dupIndex || 0);
+        })[0] : null;
+        combFill = styleCompanion ? styleCompanion.fillColor : null;
+        combStroke = styleSource.fillColor;
+      } else {
+        // Stroke-only style source (2026-07-29 fix) — computeGroupCombine
+        // just expanded a stroke-only member into a real filled ribbon, so
+        // the exported dict must flip to filled-with-the-stroke's-color too.
+        var srcHasRealStroke = !!styleSource.hasRealStroke;
+        combFill = styleSource.fillColor || (srcHasRealStroke ? styleSource.strokeColor : null);
+        combStroke = (styleSource.fillColor && srcHasRealStroke) ? styleSource.strokeColor : null;
+      }
+      islands.forEach(function (isl) {
+        extra.push({
+          __afterIdx: afterIdx, // consumed (and removed) by the splice at the end
+          segments: isl.segments.map(function (sg) { return { point: [sg.point.x, sg.point.y], handleIn: [sg.handleIn.x, sg.handleIn.y], handleOut: [sg.handleOut.x, sg.handleOut.y] }; }),
+          closed: isl.closed,
+          fillColor: combFill, strokeColor: combStroke, strokeWidth: styleSource.strokeWidth, opacity: styleSource.opacity,
+          // hasRealStroke (app.js desP / export.js lottieBuild) is
+          // AUTHORITATIVE, checked as !!sd.hasRealStroke — derived, not
+          // copied straight from styleSource (2026-07-29 QA-confirmed).
+          hasRealStroke: !!combStroke,
+          isGroupCombineResult: true, groupCombineOf: gid,
+          isDuplicatorCopy: memberDicts[0].isDuplicatorCopy, dupIndex: thisDi,
+        });
+      });
+      return islands;
+    }
+    // A member's transient Path, companion pre-merged and element Motion
+    // baked — extracted from the old inline loop so the recursion above can
+    // build one operand at a time.
+    function dictPathFor(sd, temps) {
+      var p = dictToPath(sd);
+      if (sd.linkedFillId) {
+        var companionDict = strokes.filter(function (d) {
+          return d.isLinkedFillCompanion && d.linkedFillId === sd.linkedFillId && (d.dupIndex || 0) === (sd.dupIndex || 0);
+        })[0];
+        if (companionDict && companionDict.segments && companionDict.segments.length) {
+          var cp = dictToPath(companionDict);
+          // Same ring-vs-boolean problem as foldBooleanOp's own pre-step
+          // (tools.js) — p.unite(cp) on a closed vector-brush ribbon (a
+          // self-touching "sliced ring" Path) can come back empty. The
+          // companion already fills the ring's own hole by construction, so
+          // recovering the ring's outer boundary alone sidesteps it.
+          var unsliced = _unsliceRingPath(p);
+          if (unsliced) {
+            var outerP = new Path({ insert: false, closed: true });
+            unsliced.exterior.forEach(function (seg) { outerP.add(seg); });
+            p.remove(); p = outerP;
+          } else {
+            try { var merged = p.unite(cp, { insert: false }); if (merged) { p.remove(); p = merged; } } catch (e) {}
+          }
+          cp.remove();
+          if (suppressed.indexOf(companionDict) === -1) suppressed.push(companionDict);
+        }
+      }
+      // After the companion merge, so the whole visible shape (ribbon + its
+      // fill) moves as one — a companion has no elementMotion entry of its
+      // own, it follows its anchor.
+      p = bakeElementMotion(p, sd);
+      temps.push(p);
+      return p;
+    }
     Object.keys(ld.groups).forEach(function (gid) {
       var grp = ld.groups[gid];
-      if (!grp || grp.combineMode === 'none') return;
+      if (!grp) return;
+      if (grp.parent && ld.groups[grp.parent]) return; // roots only
       var strokeIds = collectGroupStrokeIds(gid, ld);
       if (!strokeIds.length) return;
       var byDupIndex = {};
@@ -429,93 +717,11 @@
         (byDupIndex[di] || (byDupIndex[di] = [])).push(sd);
       });
       Object.keys(byDupIndex).forEach(function (diKey) {
-        var memberDicts = byDupIndex[diKey].filter(function (sd) { return !sd.isRaster && sd.segments && sd.segments.length; });
-        if (memberDicts.length < 2) return;
-        var thisDi = memberDicts[0].dupIndex;
-        var paths = memberDicts.map(function (sd) {
-          var p = dictToPath(sd);
-          if (sd.linkedFillId) {
-            var companionDict = strokes.filter(function (d) {
-              return d.isLinkedFillCompanion && d.linkedFillId === sd.linkedFillId && (d.dupIndex || 0) === (sd.dupIndex || 0);
-            })[0];
-            if (companionDict && companionDict.segments && companionDict.segments.length) {
-              var cp = dictToPath(companionDict);
-              // Same ring-vs-boolean problem as foldBooleanOp's own
-              // pre-step (tools.js) — p.unite(cp) on a closed vector-brush
-              // ribbon (a self-touching "sliced ring" Path, see
-              // _findRingRevisit's comment there) can come back empty. The
-              // companion already fills the ring's own hole by
-              // construction, so recovering the ring's outer boundary
-              // alone — no boolean call — sidesteps it here too.
-              var unsliced = _unsliceRingPath(p);
-              if (unsliced) {
-                var outerP = new Path({ insert: false, closed: true });
-                unsliced.exterior.forEach(function (seg) { outerP.add(seg); });
-                p.remove(); p = outerP;
-              } else {
-                try { var merged = p.unite(cp, { insert: false }); if (merged) { p.remove(); p = merged; } } catch (e) {}
-              }
-              cp.remove();
-              suppressed.push(companionDict);
-            }
-          }
-          // After the companion merge, so the whole visible shape (ribbon +
-          // its fill) moves as one — a companion has no elementMotion entry
-          // of its own, it follows its anchor.
-          return bakeElementMotion(p, sd);
-        });
-        memberDicts.forEach(function (sd) { suppressed.push(sd); });
-        // z-position of the merged result: right after the group's
-        // front-most member dict, not appended after every other stroke
-        // (feedback #735 — twin of buildSceneJson's own fix).
-        var afterIdx = -1;
-        memberDicts.forEach(function (sd) { var ix = strokes.indexOf(sd); if (ix > afterIdx) afterIdx = ix; });
-        var styleSource = memberDicts[memberDicts.length - 1];
-        var combFill, combStroke;
-        if (styleSource.isVectorBrush) {
-          // Same fix as renderCombinesFromChildren's twin above, dict
-          // form: a ribbon dict's own fillColor is its ink/stroke color,
-          // never a real fill — the real Fill (if any) is a separate
-          // companion dict, same lookup used a few lines up to merge its
-          // geometry in.
-          var styleCompanion = styleSource.linkedFillId ? strokes.filter(function (d) {
-            return d.isLinkedFillCompanion && d.linkedFillId === styleSource.linkedFillId && (d.dupIndex || 0) === (styleSource.dupIndex || 0);
-          })[0] : null;
-          combFill = styleCompanion ? styleCompanion.fillColor : null;
-          combStroke = styleSource.fillColor;
-        } else {
-          // Stroke-only style source (2026-07-29 fix, same one as
-          // renderCombinesFromChildren's twin above) — computeGroupCombine
-          // just expanded a stroke-only member into a real filled ribbon
-          // (dictToPath's new paint-carrying + foldBooleanOp's own
-          // eraseExpandStrokeToFill step), so the exported dict must flip to
-          // filled-with-the-stroke's-color too, or it round-trips as an
-          // outline-only shape (or, pre-fix, nothing visible at all).
-          var srcHasRealStroke = !!styleSource.hasRealStroke;
-          combFill = styleSource.fillColor || (srcHasRealStroke ? styleSource.strokeColor : null);
-          combStroke = (styleSource.fillColor && srcHasRealStroke) ? styleSource.strokeColor : null;
-        }
-        var islands;
-        try { islands = computeGroupCombine(paths, grp.combineMode, null); }
-        catch (e) { console.warn('[SMGroup] combine failed for group', gid, e); return; }
-        islands.forEach(function (isl) {
-          extra.push({
-            __afterIdx: afterIdx, // consumed (and removed) by the splice at the end
-            segments: isl.segments.map(function (s) { return { point: [s.point.x, s.point.y], handleIn: [s.handleIn.x, s.handleIn.y], handleOut: [s.handleOut.x, s.handleOut.y] }; }),
-            closed: isl.closed,
-            fillColor: combFill, strokeColor: combStroke, strokeWidth: styleSource.strokeWidth, opacity: styleSource.opacity,
-            // hasRealStroke (app.js desP / export.js lottieBuild) is
-            // AUTHORITATIVE, checked as !!sd.hasRealStroke — see
-            // combFill/combStroke above for why it's derived, not copied
-            // straight from styleSource anymore (2026-07-29 QA-confirmed:
-            // copying it straight resurrected a phantom white stroke
-            // whenever the topmost member was one of the strokeless
-            // members CLAUDE.md §2 documents).
-            hasRealStroke: !!combStroke,
-            isGroupCombineResult: true, groupCombineOf: gid,
-            isDuplicatorCopy: memberDicts[0].isDuplicatorCopy, dupIndex: thisDi,
-          });
-        });
+        var dicts = {};
+        byDupIndex[diKey].forEach(function (sd) { dicts[sd.strokeId] = sd; });
+        var temps = [];
+        var result = dictOperands(gid, dicts, Number(diKey), false, [], 0, temps, extra);
+        temps.forEach(function (t) { if (!t.removed && result.indexOf(t) === -1) t.remove(); });
       });
     });
     if (!extra.length) return strokes;
@@ -548,6 +754,8 @@
   window.SMGroup = {
     groupSelection: groupSelection, ungroupSelection: ungroupSelection, membersOf: membersOf,
     ensureLayerGroups: ensureLayerGroups, resolveGroupMembers: resolveGroupMembers,
+    collectGroupStrokeIds: collectGroupStrokeIds, rootGroupOf: rootGroupOf, rootGroupOfItem: rootGroupOfItem,
+    parentGroupOf: parentGroupOf, dissolveGroup: dissolveGroup,
     combineSelection: combineSelection, setGroupCombineMode: setGroupCombineMode,
     removeMemberFromGroup: removeMemberFromGroup, flattenGroup: flattenGroup, renameGroup: renameGroup,
     renderCombinesFromChildren: renderCombinesFromChildren, applyCombinesToStrokes: applyCombinesToStrokes,

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -9421,8 +9421,33 @@
   // layerElements) — the same function backs both Motion's renderElementsList
   // AND Animation 2D's forthcoming layer-row shape list, so the two can
   // never diverge in which shapes/groups exist or in what order.
+  // One group node, with its subtree. `children` is front-first (same
+  // convention as the top level below); `memberIds` is every LEAF strokeId
+  // underneath it, at any depth — consumers that need "the whole group"
+  // (select, rename, eye/solo, the timeline mirror) read that instead of
+  // re-deriving membership from the flat tag, which only ever knew about
+  // direct members.
+  function groupNode(gid, ld, byStrokeId, depth) {
+    var meta = (ld.groups && ld.groups[gid]) || null;
+    var node = { type: 'group', gid: gid, name: (meta && meta.name) || SM.t('autoNameGroup'), children: [], memberIds: [] };
+    if (!meta || depth > 16) return node;
+    (meta.order || []).forEach(function (entry) {
+      if (ld.groups && ld.groups[entry]) {
+        var child = groupNode(entry, ld, byStrokeId, depth + 1);
+        node.children.push(child);
+        node.memberIds = node.memberIds.concat(child.memberIds);
+      } else if (byStrokeId[entry]) {
+        node.children.push({ type: 'shape', strokeId: entry, sd: byStrokeId[entry].sd });
+        node.memberIds.push(entry);
+      }
+    });
+    node.children.reverse(); // front-first, like the top level
+    return node;
+  }
   function buildShapeTree(li, ld) {
     var flat = layerElements(li, ld);
+    var byStrokeId = {};
+    flat.forEach(function (e) { byStrokeId[e.strokeId] = e; });
     var out = [], emittedGroups = {};
     flat.forEach(function (entry) {
       // Feedback #143 ("toujours pas de keyframes de properties par rapport
@@ -9441,11 +9466,17 @@
       // the same treatment: skip the group-collapse, list each glyph as its
       // own expandable element row, exactly like every other ungrouped shape.
       var gid = entry.sd.isVectorText ? null : entry.sd.groupId;
-      if (gid) {
-        if (!emittedGroups[gid]) {
-          emittedGroups[gid] = true;
-          var meta = ld.groups && ld.groups[gid];
-          out.push({ type: 'group', gid: gid, name: (meta && meta.name) || SM.t('autoNameGroup') });
+      // Nested groups (2026-09, #738): a shape's own tag names its
+      // INNERMOST group, but the tree lists the OUTERMOST one — the inner
+      // ones become child nodes of it, built from ld.groups[gid].order
+      // (which has always been allowed to hold child gids, see
+      // collectGroupStrokeIds). Falls back to the tag itself when there is
+      // no ld.groups entry, i.e. exactly the old flat behaviour.
+      var root = (gid && window.SMGroup && SMGroup.rootGroupOf && ld.groups && ld.groups[gid]) ? SMGroup.rootGroupOf(gid, ld) : gid;
+      if (root) {
+        if (!emittedGroups[root]) {
+          emittedGroups[root] = true;
+          out.push(groupNode(root, ld, byStrokeId, 0));
         }
       } else {
         out.push({ type: 'shape', strokeId: entry.strokeId, sd: entry.sd });
@@ -9576,7 +9607,7 @@
         // (layerElements), not the already-collapsed tree — click-select
         // and rename both need the full membership, not just "a group
         // exists here".
-        var memberIds = layerElements(li, ld).filter(function (e) { return e.sd.groupId === node.gid; }).map(function (e) { return e.strokeId; });
+        var memberIds = node.memberIds || layerElements(li, ld).filter(function (e) { return e.sd.groupId === node.gid; }).map(function (e) { return e.strokeId; });
         function commitGroupRename(v) {
           pushUndo();
           // SMGroup.renameGroup (group-bridge.js) — creates ld.groups[gid]
@@ -12933,7 +12964,7 @@
     // Group/shape tree (2026-07-31) — mode-agnostic, reused by Animation
     // 2D's own layer-row shape list (timeline.js) so both modes' trees can
     // never diverge in content or z-order.
-    buildShapeTree: buildShapeTree,
+    buildShapeTree: buildShapeTree, groupNode: groupNode,
     selectShapesByStrokeIds: selectShapesByStrokeIds,
     elementLabel: elementLabel,
     layerElements: layerElements,

--- a/src/js/shapes-panel.js
+++ b/src/js/shapes-panel.js
@@ -321,7 +321,9 @@
       // two differ) or on any top-level row (a plain shape, or a group's
       // own header) — see performMemberReorder's 2026-09 fix.
       ? el && el.closest('#shapes-list .lrow[data-groupmember], #shapes-list .lrow[data-toplevel]')
-      : el && el.closest('#shapes-list .lrow[data-toplevel]');
+      // A group row is a valid target at ANY depth now (2026-09, #738) —
+      // dropping INTO it is how a shape or a whole group gets nested.
+      : el && el.closest('#shapes-list .lrow[data-toplevel], #shapes-list .lrow[data-gid]');
     if (row) {
       // Feedback #735 ("très difficile d'organiser") — a drop used to mean
       // only "in front of the target", with no way to land BEHIND the
@@ -330,6 +332,15 @@
       // lower half = behind it (line on its bottom edge). A paint swap has
       // no before/after — it's a swap.
       var rr = row.getBoundingClientRect();
+      // Third zone (2026-09, #738 — "drag between levels"): the MIDDLE band
+      // of a group row means "into this group", the top/bottom quarters
+      // keep their before/after meaning. Only for a whole shape or group
+      // being dragged — a member drag already has its own move-between-
+      // groups path, and a paint sub-row has no group to enter.
+      var canInto = !!row.dataset.gid && (_elDrag.kind === 'shape' || _elDrag.kind === 'group') && row.dataset.gid !== _elDrag.id;
+      var rel = (e.clientY - rr.top) / Math.max(1, rr.height);
+      _elDrag.dropInto = canInto && rel > 0.25 && rel < 0.75;
+      if (_elDrag.dropInto) { row.classList.add('drag-into'); return; }
       _elDrag.dropAfter = _elDrag.kind !== 'paint' && e.clientY > rr.top + rr.height / 2;
       row.classList.add(_elDrag.dropAfter ? 'drag-over-after' : 'drag-over');
     }
@@ -339,12 +350,12 @@
     if (_elDrag.moved) {
       window._elDragJustEnded = true;
       var list = document.getElementById('shapes-list');
-      var overRow = list && list.querySelector('.lrow.drag-over, .lrow.drag-over-after');
+      var overRow = list && list.querySelector('.lrow.drag-over, .lrow.drag-over-after, .lrow.drag-into');
       if (overRow) performReorder(overRow);
     }
     stopDragGhost();
     var list2 = document.getElementById('shapes-list');
-    if (list2) Array.prototype.forEach.call(list2.querySelectorAll('.lrow'), function (r) { r.classList.remove('dragging', 'drag-over', 'drag-over-after'); });
+    if (list2) Array.prototype.forEach.call(list2.querySelectorAll('.lrow'), function (r) { r.classList.remove('dragging', 'drag-over', 'drag-over-after', 'drag-into'); });
     _elDrag.active = false; _elDrag.moved = false;
   });
   // Fill<->Stroke swap (2026-08, "pourquoi il est pas possible de select
@@ -484,8 +495,62 @@
     if (window.renderArcs) renderArcs();
     if (window.SMEngineBridge) SMEngineBridge.renderNow();
   }
+  // "Drag between levels" (2026-09, #738): moves the dragged shape or
+  // group INTO the group whose row it was dropped on. Data-only — the
+  // z-order move right after keeps the canvas stack matching what the
+  // panel now shows.
+  function performDropInto(destGid) {
+    var c = currentLayer(); if (!c.ld || !c.ld.groups || !c.ld.groups[destGid]) return;
+    var ld = c.ld, layer = window.userLayers ? userLayers[c.li] : null;
+    if (!layer) return;
+    function isAncestorOf(a, b) { // is `a` an ancestor of `b`?
+      var cur = b, guard = 0;
+      while (cur && guard++ < 32) { var m = ld.groups[cur]; if (!m || !m.parent) return false; if (m.parent === a) return true; cur = m.parent; }
+      return false;
+    }
+    pushUndo();
+    var srcItems = [];
+    if (_elDrag.kind === 'group') {
+      var gid = _elDrag.id;
+      if (gid === destGid || isAncestorOf(gid, destGid)) return; // a group can't go inside itself
+      var oldParent = ld.groups[gid].parent;
+      if (oldParent && ld.groups[oldParent]) ld.groups[oldParent].order = (ld.groups[oldParent].order || []).filter(function (e) { return e !== gid; });
+      ld.groups[gid].parent = destGid;
+      ld.groups[destGid].order.push(gid);
+      if (oldParent && ld.groups[oldParent] && (ld.groups[oldParent].order || []).length < 2 && window.SMGroup) SMGroup.dissolveGroup(oldParent, ld, layer);
+      srcItems = window.SMGroup ? SMGroup.resolveGroupMembers(gid, ld, layer) : [];
+    } else {
+      var sid = _elDrag.id;
+      var it = window.SMMotion.liveItemByStrokeId(c.li, sid);
+      if (!it) return;
+      Object.keys(ld.groups).forEach(function (g) {
+        var o = ld.groups[g].order || []; var ix = o.indexOf(sid);
+        if (ix !== -1) o.splice(ix, 1);
+      });
+      ld.groups[destGid].order.push(sid);
+      it.data = it.data || {};
+      it.data.groupId = destGid;
+      srcItems = [it];
+    }
+    // Land just in front of the destination group's front-most member so
+    // the canvas stack agrees with the panel's new row order.
+    var destIds = window.SMGroup ? SMGroup.collectGroupStrokeIds(destGid, ld) : [];
+    var destItems = destIds.map(function (id) { return window.SMMotion.liveItemByStrokeId(c.li, id); }).filter(Boolean)
+      .filter(function (x) { return srcItems.indexOf(x) === -1; });
+    if (destItems.length && srcItems.length) {
+      destItems.sort(function (a, b) { return a.index - b.index; });
+      _placeItems(srcItems, destItems[destItems.length - 1], false);
+    }
+    expandedGroups[destGid] = true;
+    saveActiveLayerFrame();
+    renderShapesPanel();
+    if (window.renderArcs) renderArcs();
+    if (window.updateUI) updateUI();
+    if (window.SMEngineBridge) SMEngineBridge.renderNow();
+  }
   function performReorder(overRow) {
     if (_elDrag.kind === 'paint') { performPaintSwap(overRow); return; }
+    if (_elDrag.dropInto && overRow.dataset.gid) { performDropInto(overRow.dataset.gid); return; }
     if (_elDrag.kind === 'member') { performMemberReorder(overRow); return; }
     var c = currentLayer(); if (!c.ld) return;
     var destGid = overRow.dataset.gid, destStrokeId = overRow.dataset.strokeid;
@@ -701,20 +766,26 @@
       return;
     }
     var shapeIdx = 0;
-    tree.forEach(function (node) {
+    // Recursive (2026-09, #738 — nested groups): a group's children may
+    // themselves be groups, so the top level and every level below share
+    // ONE renderer. `indent` is the pixel offset buildShapeRow already
+    // took; `parentGid` is null at the top level and the enclosing group
+    // below it (used for the member-drag wiring, exactly as before).
+    function renderNode(node, indent, parentGid) {
       if (node.type === 'group') {
         // Recompute this group's own member strokeIds from the flat list
         // (layerElements), not the already-collapsed tree — same reason
         // motion.js's own renderElementsList does this (click-select,
         // rename and now expand-render all need the full membership, not
         // just "a group exists here").
-        var memberEntries = window.SMMotion.layerElements(c.li, c.ld).filter(function (e) { return e.sd.groupId === node.gid; });
-        var memberIds = memberEntries.map(function (e) { return e.strokeId; });
+        var memberIds = node.memberIds || window.SMMotion.layerElements(c.li, c.ld).filter(function (e) { return e.sd.groupId === node.gid; }).map(function (e) { return e.strokeId; });
         var expanded = !!expandedGroups[node.gid];
         var anySelected = memberIds.some(function (sid) { return isStrokeSelected(c.li, sid); });
 
         var grow = document.createElement('div'); grow.className = 'lrow motion-elem-row motion-elem-group';
-        grow.dataset.toplevel = '1'; grow.dataset.gid = node.gid;
+        if (indent) grow.style.paddingLeft = (24 + indent) + 'px';
+        if (!parentGid) grow.dataset.toplevel = '1';
+        grow.dataset.gid = node.gid;
         if (anySelected) grow.classList.add('act');
         var arrow = document.createElement('span'); arrow.className = 'lico larrow'; arrow.textContent = expanded ? '▾' : '▸';
         arrow.addEventListener('click', function (e) {
@@ -749,7 +820,7 @@
           if (window._elDragJustEnded) { window._elDragJustEnded = false; return; }
           applySelection(c.li, memberIds, e.shiftKey || e.altKey);
         });
-        grow.addEventListener('mousedown', function (e) { armDrag(e, 'group', node.gid); });
+        if (!parentGid) grow.addEventListener('mousedown', function (e) { armDrag(e, 'group', node.gid); });
         grow.addEventListener('dblclick', function (e) { e.stopPropagation(); startRename(grow, node.name, commitGroupRename); });
         grow.addEventListener('contextmenu', function (e) {
           e.preventDefault(); e.stopPropagation();
@@ -781,11 +852,13 @@
             { sep: true },
             { label: SM.t('elementsUngroup'), action: function () {
               pushUndo();
-              memberIds.forEach(function (sid) {
-                var it = window.SMMotion.liveItemByStrokeId(c.li, sid);
-                if (it && it.data) delete it.data.groupId;
-              });
-              if (c.ld.groups) delete c.ld.groups[node.gid];
+              // One level only (2026-09, #738): SMGroup.dissolveGroup
+              // promotes this group's child GROUPS to its own place instead
+              // of erasing the whole subtree — untagging every leaf, as this
+              // did before, would have destroyed the nesting below it.
+              var layer = window.userLayers ? userLayers[c.li] : null;
+              if (window.SMGroup && SMGroup.dissolveGroup) SMGroup.dissolveGroup(node.gid, c.ld, layer);
+              else { memberIds.forEach(function (sid) { var it = window.SMMotion.liveItemByStrokeId(c.li, sid); if (it && it.data) delete it.data.groupId; }); if (c.ld.groups) delete c.ld.groups[node.gid]; }
               delete expandedGroups[node.gid];
               saveActiveLayerFrame(); renderShapesPanel();
               if (window.SMEngineBridge) SMEngineBridge.renderNow();
@@ -794,18 +867,24 @@
         });
         list.appendChild(grow);
         if (expanded) {
-          // Front-most member first, same reading direction as the tree
-          // itself (buildShapeTree, feedback #735).
-          memberEntries.slice().reverse().forEach(function (me) {
-            var mIdx = tree.labelIdx && tree.labelIdx[me.strokeId] !== undefined ? tree.labelIdx[me.strokeId] : shapeIdx++;
-            buildShapeRow(list, c, { strokeId: me.strokeId, sd: me.sd }, mIdx, 20, false, node.gid);
-          });
+          // Children come from the tree itself now (front-first already,
+          // see groupNode in motion.js) instead of being re-derived from
+          // the flat groupId tag, which could only ever see DIRECT members.
+          var kids = node.children || [];
+          if (!kids.length) {
+            kids = memberIds.map(function (sid) {
+              var e = window.SMMotion.layerElements(c.li, c.ld).filter(function (x) { return x.strokeId === sid; })[0];
+              return e ? { type: 'shape', strokeId: e.strokeId, sd: e.sd } : null;
+            }).filter(Boolean).reverse();
+          }
+          kids.forEach(function (kid) { renderNode(kid, indent + 20, node.gid); });
         }
       } else {
         var sIdx = tree.labelIdx && tree.labelIdx[node.strokeId] !== undefined ? tree.labelIdx[node.strokeId] : shapeIdx++;
-        buildShapeRow(list, c, node, sIdx, 0, true);
+        buildShapeRow(list, c, node, sIdx, indent, !parentGid, parentGid || undefined);
       }
-    });
+    }
+    tree.forEach(function (node) { renderNode(node, 0, null); });
   }
   window.renderShapesPanel = renderShapesPanel;
 })();

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -5170,7 +5170,7 @@ function renderShapeTreeRowsInto(list,li,ld){
       var gswatch=document.createElement('div');gswatch.className='motion-elem-swatch';gswatch.textContent='▤';gswatch.style.background='transparent';
       var gnm=document.createElement('div');gnm.className='lnm';gnm.textContent=node.name;
       grow.appendChild(gswatch);grow.appendChild(gnm);
-      var memberIds=SMMotion.layerElements(li,ld).filter(function(e){return e.sd.groupId===node.gid;}).map(function(e){return e.strokeId;});
+      var memberIds=node.memberIds||SMMotion.layerElements(li,ld).filter(function(e){return e.sd.groupId===node.gid;}).map(function(e){return e.strokeId;});
       function commitGroupRename(v){pushUndo();if(window.SMGroup&&SMGroup.renameGroup)SMGroup.renameGroup(node.gid,ld,v,memberIds);saveActiveLayerFrame();renderLayerList();renderTimeline();}
       grow.addEventListener('click',function(){SMMotion.selectShapesByStrokeIds(li,memberIds);});
       grow.addEventListener('dblclick',function(e){e.stopPropagation();SMMotion.startShapeTreeRename(grow,node.name,commitGroupRename);});

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -6504,16 +6504,27 @@ function elementMotionBakedClone(li,p,frameIdx){
 // hard-won correctness work (vector-brush companion pre-union, hole-merging,
 // degenerate-loop cleanup) the destructive tool already has, with zero
 // duplicated boolean-op logic (CLAUDE.md §3: don't duplicate a matcher/loop).
-function computeGroupCombine(paths,mode,layer,frameIdx){
-  if(paths.length<2)return paths.slice();
+// The un-flattened result: ONE Path/CompoundPath, holes included. Needed by
+// nested combine groups (2026-09, #738) — a child group must reach its
+// parent as a SINGLE operand, and flattenBooleanResult below deliberately
+// splits a result into separate island Paths, which would hand the parent
+// several operands (measured: a union of two brush RINGS returns 3 islands
+// — outer boundary plus two hole boundaries — so the parent combined 3
+// unrelated pieces instead of one shape).
+function computeGroupCombineRaw(paths,mode,layer,frameIdx){
+  if(paths.length<2)return null;
   var li=window.userLayers?userLayers.indexOf(layer):-1;
   var motionAware=li>=0?paths.map(function(p){return elementMotionBakedClone(li,p,frameIdx);}):paths;
   var folded=foldBooleanOp(mode,motionAware,layer);
   var disposable=[];
   if(motionAware!==paths)motionAware.forEach(function(m,idx){if(m!==paths[idx])disposable.push(m);});
-  var out=flattenBooleanResult(folded.result);
   disposable.forEach(function(c){if(!c.removed)c.remove();});
-  return out;
+  return folded.result;
+}
+function computeGroupCombine(paths,mode,layer,frameIdx){
+  if(paths.length<2)return paths.slice();
+  var res=computeGroupCombineRaw(paths,mode,layer,frameIdx);
+  return flattenBooleanResult(res);
 }
 
 // ---- DYNAMIC SHAPES, phase 1 (2026-08-18) — Rectangle, independent


### PR DESCRIPTION
Ferme #738, volet 3 du feedback #735 : « si on a un groupe avec merge qui est dans un sous groupe alors celui-ci est considéré comme un seul élément pour le merge du groupe parent ».

Le modèle de données acceptait déjà des groupes enfants dans l'`order`. Ce qui manquait : une UI qui crée l'imbrication, le lien montant, et un combine qui traite l'enfant comme un tout.

## Ce qui change
- **Cmd+G** raisonne en unités : une sélection contenant tout un groupe l'imbrique entier au lieu de l'aplatir.
- **Cmd+Maj+G** pèle un niveau à la fois, les groupes enfants sont promus.
- **Clic canvas** sélectionne le groupe le plus externe (seul changement de comportement de la sélection).
- **Panneau Éléments** : vrai arbre récursif ; déposer une ligne au milieu d'une ligne de groupe la fait entrer dedans, les quarts haut et bas gardent avant/après.
- **Combine** : parcours descendant depuis les racines dans les deux jumeaux (canvas et export). Un enfant combiné remonte son résultat non aplati comme **un** opérande ; un enfant sans combine cède ses feuilles.
- **Aplatir** nettoie aussi les entrées descendantes.

Piège trouvé en route : l'union de deux rubans de pinceau renvoie 3 îlots (contour plus deux trous). Passer ces îlots au parent lui faisait combiner 3 pièces sans rapport, d'où `computeGroupCombineRaw`, qui rend le résultat non aplati.

## Vérifié en pilotant l'app
| cas | résultat |
|---|---|
| soustraction imbriquée (A∪B)−C | 2 îlots, aire 47 |
| soustraction plate A−B−C | 1 îlot, aire 12 |
| jumeau canvas contre jumeau export | aires identiques, [14,33] puis [15] |
| clic sur un membre | sélectionne les 3 formes |
| dissocier deux fois | pèle un niveau, puis l'autre |
| glisser forme puis groupe dans un groupe | GROUP(4) > GROUP(2) + 2 formes |

Mode Motion sans erreur, `npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)