### PR TITLE
Calques : le pickwhip de parentage ne réordonne plus, et un seul undo suffit (#755, #756)

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -461,7 +461,7 @@ function reorderLayersBatch(fromIndices,toIdx){
 // unlike a destination row which cannot distinguish its upper/lower edge.
 // Keeping this translation beside the actual array mutation guarantees the
 // blue insertion line and the committed order describe the same operation.
-function reorderLayersAtGap(fromIndices,gapIdx){
+function reorderLayersAtGap(fromIndices,gapIdx,skipUndo){
   var moving=fromIndices.filter(function(i){return i>=0&&i<state.layers.length;})
     .filter(function(i,p,a){return a.indexOf(i)===p;}).sort(function(a,b){return a-b;});
   if(!moving.length)return;
@@ -488,7 +488,10 @@ function reorderLayersAtGap(fromIndices,gapIdx){
   // unnecessary undo entry and full scene rebuild.
   var same=moving.every(function(orig,j){return orig===insertIdx+j;});
   if(same)return;
-  saveAllLayerFrames();pushUndoLayers(true);
+  // skipUndo: the caller already snapshotted BEFORE its own mutations (the
+  // folder un-parent in timeline.js's drop handler) — a second entry here
+  // would split one gesture across two Cmd+Z presses (feedback #755).
+  if(!skipUndo){saveAllLayerFrames();pushUndoLayers(true);}
   var nextLd=keptLd.slice(0,insertIdx).concat(movedLd,keptLd.slice(insertIdx));
   var nextUL=keptUL.slice(0,insertIdx).concat(movedUL,keptUL.slice(insertIdx));
   // Mutate the existing arrays instead of replacing them: inside a

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -7228,6 +7228,16 @@
       // above, so no duplicate drag logic needed here at all.
       function beginMotionLayerReorder(e) {
         if (e.button !== 0 || e.target.closest('.lico')) return;
+        // Anything in the row that owns its own drag must not also arm a
+        // layer reorder (2026-09, feedback #756: "le link de parentage
+        // réordonne des calques au lieu de link"). The parenting pickwhip
+        // is the reported case — its gesture is a drag ONTO another layer,
+        // which is exactly the shape of a reorder drag, so both started and
+        // the reorder won. Animation 2D's own rows never had the bug: their
+        // parent cell stops mousedown from propagating (timeline.js), which
+        // this row has no equivalent of since the drag is armed on the row
+        // itself. Fields are in the list for the same reason.
+        if (e.target.closest('.lpick, .motion-parent-pill, input, select, textarea, [contenteditable="true"]')) return;
         armLayerReorder(e, li, 'panel', row);
       }
       row.addEventListener('mousedown', beginMotionLayerReorder);

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1519,7 +1519,7 @@ window.SM={
   toggleLayerSolo:function(idx){state.layers[idx].solo=!state.layers[idx].solo;loadFrame(state.currentFrame);updateUI();},
   renameLayer:function(idx,n){state.layers[idx].name=n;updateUI();},
   reorderLayer:function(fromIdx,toIdx){reorderLayer(fromIdx,toIdx);},
-  reorderLayersAtGap:function(fromIndices,gapIdx){reorderLayersAtGap(fromIndices,gapIdx);},
+  reorderLayersAtGap:function(fromIndices,gapIdx,skipUndo){reorderLayersAtGap(fromIndices,gapIdx,skipUndo);},
   reorderLayersBatch:function(fromIndices,toIdx){reorderLayersBatch(fromIndices,toIdx);},
   // Stroke profiles (van Dijk 6.2). Acts on the current canvas selection;
   // one undo step for the whole batch, like every other selection command.
@@ -6515,10 +6515,19 @@ function finishLayerReorder(){
       // folderLayerChildMap's own comment), so this must be an explicit
       // setLayerParent(null) call; a position-only reorder would leave the
       // layer re-appearing nested under its old folder next render.
+      // ONE undo entry for ONE gesture (2026-09, feedback #755: "quand on
+      // réordonne des calques le undo ne marche pas"). setLayerParent
+      // mutates ld.parentLayerUid without snapshotting, and
+      // reorderLayersAtGap snapshots only when IT runs — so the snapshot
+      // captured a document that had ALREADY left the folder, and undo gave
+      // back the old order with the layer still un-parented. Snapshot here,
+      // before either mutation, and tell the reorder not to add a second.
+      var unparenting=moving.some(function(mi){return window.SMMotion&&folderLayerParentIdx(mi)>=0;});
+      if(unparenting){saveAllLayerFrames();pushUndoLayers(true);}
       moving.forEach(function(mi){
         if(window.SMMotion&&folderLayerParentIdx(mi)>=0)SMMotion.setLayerParent(mi,null);
       });
-      window.SM.reorderLayersAtGap(moving,_layerDrag.dropGap);
+      window.SM.reorderLayersAtGap(moving,_layerDrag.dropGap,unparenting);
     }
   }
   document.querySelectorAll('.lrow,.frow').forEach(function(r){r.classList.remove('dragging','drag-over','folder-drop-target');});


### PR DESCRIPTION
Ferme #756 et #755.

**#756** — En mode Motion, la ligne de calque arme le glisser-réordonner sur son propre mousedown et n'excluait que les icônes. Le pickwhip de parentage est lui aussi un glisser vers un autre calque, donc les deux gestes démarraient et le réordonnancement gagnait. Les lignes d'Animation 2D n'avaient pas le défaut parce que leur cellule de parent arrête la propagation. Le pickwhip, la pastille de parent et les champs sont maintenant exclus.

**#755** — Le réordonnancement simple s'annulait déjà bien : vérifié au panneau, en mode Motion, par appel direct et via le champ Order. Le cas cassé est celui qui **sort un calque de son dossier** : le détachement ne prend pas d'instantané, le réordonnancement prend le sien après, donc l'instantané décrivait un document déjà sorti du dossier. Annuler rendait l'ancien ordre avec le calque toujours dehors. L'instantané est pris avant les deux mutations.

## Vérifié en pilotant
| contrôle | résultat |
|---|---|
| mousedown + déplacement sur le pickwhip | n'arme plus le glisser, ordre inchangé |
| sortir un calque d'un dossier | une seule entrée d'annulation |
| un Cmd+Z | rétablit l'ordre **et** l'appartenance au dossier |

`npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)