### PR TITLE
Coller un élément sur une frame tenue ne le perd plus (#752)

### DIFF
--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -1631,13 +1631,43 @@ function cutSelection(){
 function pasteSelection(){
   if(!_canvasClip||!_canvasClip.snaps.length){showToast(SM.t('toastNothingToPaste'));return;}
   pushUndo();
+  // A HELD frame is neither a keyframe nor an interpolated one, and
+  // saveActiveLayerFrame() returns early on exactly that — so the pasted
+  // shapes appeared on canvas and were stored NOWHERE, vanishing at the
+  // next frame change (2026-09, feedback #752: "j'ai copié-collé un élément
+  // dans un autre calque mais celui-ci disparaît quand je scrubbe la
+  // timeline après" — measured: 1 item on canvas, 0 stored). Every other
+  // content-writing gesture already handles this; paste was the one that
+  // didn't. Two different right answers, one per mode:
+  //  - Animation 2D promotes the held frame, the convention drawing on a
+  //    held frame already follows (ensureKeyframe, select-bridge's move).
+  //  - Motion holds ONE drawing across a span and animates its transform;
+  //    promoting there would make the pasted shape appear only from the
+  //    playhead on, which reads as "it disappeared" again the moment you
+  //    scrub back. It writes into the keyframe the held frame inherits
+  //    from instead, so the shape belongs to the whole hold — which is
+  //    what Cyril's own report asks for ("il disparaît quand je scrubbe").
+  var _pasteHeldOrigin=-1;
+  var _pasteLd=state.layers[state.activeLayerIdx];
+  var _pasteF=_pasteLd&&_pasteLd.frames[state.currentFrame];
+  if(_pasteF&&!_pasteF.isKeyframe&&!_pasteF.isInterpolated){
+    if(state.appMode!=='motion'){ if(typeof ensureKeyframe==='function')ensureKeyframe(); }
+    else { for(var _oi=state.currentFrame;_oi>=0;_oi--){ if(_pasteLd.frames[_oi]&&_pasteLd.frames[_oi].isKeyframe){_pasteHeldOrigin=_oi;break;} } }
+  }
   var layer=userLayers[state.activeLayerIdx];
   var samePlace=(_canvasClip.layerIdx===state.activeLayerIdx&&_canvasClip.frameIdx===state.currentFrame);
   var clones=_materializeClones(_canvasClip.snaps,layer,samePlace?12:0);
   clearSel();
   selectedPaths=clones.filter(isSelectablePathChild);
   state.selectedStrokeIndices=selectedPaths.map(getSI).filter(function(i2){return i2>=0;});
-  saveActiveLayerFrame();renderArcs();updateUI();
+  if(_pasteHeldOrigin>=0&&typeof _collectLayerStrokes==='function'){
+    // Motion, held frame: write the layer's live content into the hold's
+    // OWN keyframe (see the comment above). saveActiveLayerFrame would
+    // return early here, which is the whole bug.
+    _pasteLd.frames[_pasteHeldOrigin].strokes=_collectLayerStrokes(state.activeLayerIdx,_pasteLd);
+    window._sceneVersion++;
+  } else saveActiveLayerFrame();
+  renderArcs();updateUI();
   if(window.SMEngineBridge)SMEngineBridge.renderNow();
   showToast(SM.t('toastPasted')+clones.filter(isSelectablePathChild).length+')');
 }


### PR DESCRIPTION
Ferme #752 : « j'ai copié-collé un élément dans un autre calque mais celui-ci disparaît quand je scrubbe la timeline après » (dans Motion, précisé par Cyril).

Une frame tenue n'est ni une keyframe ni une interpolée, et l'enregistrement du calque sort par le haut dans ce cas précis. Les formes collées apparaissaient sur le canvas et n'étaient enregistrées nulle part : mesuré, **1 objet sur le canvas, 0 stocké**.

Deux bonnes réponses, une par mode.

- **Animation 2D** promeut la frame tenue, comme le fait déjà le dessin sur une frame tenue.
- **Motion** tient un dessin sur toute une portée. Y promouvoir une keyframe ferait apparaître la forme seulement à partir de la tête de lecture, ce qui se relit comme « elle a disparu » dès qu'on scrubbe en arrière. Le collage écrit donc dans la keyframe dont la frame tenue hérite.

## Vérifié en pilotant
| mode | résultat |
|---|---|
| Motion, collage à la frame 5 d'une tenue | stocké dans la keyframe 1, pas de keyframe créée à 5, 2 objets présents aux frames 1, 5 et 10 |
| Animation 2D, collage à la frame 8 | la frame est promue, 3 traits stockés, retrouvés après aller-retour |

`npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)