### PR TITLE
Motion : un raccourci de propriété passe devant le filtre, et l'icône montre son état (#758)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -994,6 +994,11 @@ body.mode-motion #btn-tween-curves{display:none;}
 .motion-filter-btn{display:flex;align-items:center;justify-content:center;width:16px;height:16px;border-radius:3px;cursor:pointer;color:var(--text-dark);flex-shrink:0;}
 .motion-filter-btn:hover{background:var(--panel3);color:var(--text);}
 .motion-filter-btn.on{color:var(--accent);}
+/* The icon has to READ as a state, not just change colour (2026-09,
+   feedback #758: "faudrait pivoter cette icône si fermé") — colour alone
+   left "filtering" and "not filtering" looking like the same control. */
+.motion-filter-btn svg{transition:transform .12s ease;}
+.motion-filter-btn.on svg{transform:rotate(-90deg);}
 .motion-prop-row{padding-left:24px;gap:6px;}
 .motion-prop-row:hover{background:rgba(255,255,255,.03);}
 .motion-prop-select-target{cursor:pointer;border-radius:3px;}

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -689,6 +689,14 @@
     }
     window._motionRevealedLayers = targets;
     window._motionExpandedLayer = null; // the reveal set replaces the single-row accordion
+    // "Hide unanimated" would hide the very row this just revealed (2026-09,
+    // feedback #758: "les raccourcis de transform ne marchent pas si le menu
+    // de transform d'un calque dans motion est fermé"). What reads as a
+    // CLOSED Transform menu is that filter being ON — its blue funnel sits
+    // right in the header — and P on a layer with no Position keys then did
+    // nothing at all, since the row it reveals has no content to survive the
+    // filter. Asking for a property explicitly outranks a standing filter.
+    _hideUnanimated = false;
     if (shiftKey) {
       if (!_propFilter) _propFilter = PROPS.slice(); // shift on a fresh/all-shown state starts from "all", then removes
       var i = _propFilter.indexOf(prop);


### PR DESCRIPTION
Ferme #758.

Le triangle bleu de la capture n'est pas un chevron de repli : c'est le filtre « masquer les propriétés non animées », dans l'en-tête Transform. Actif, il fait disparaître toutes les propriétés sans clé, ce qui se lit comme un menu Transform fermé, et P sur un calque sans clé de position ne montrait rien puisque la ligne révélée n'a aucun contenu qui survive au filtre.

- Demander une propriété explicitement passe maintenant devant le filtre.
- L'icône pivote de 90° quand le filtre est actif, la couleur seule ne distinguant pas les deux états.

## Vérifié en pilotant
| état | résultat |
|---|---|
| filtre actif | les six lignes de transform disparaissent, icône tournée |
| P avec filtre actif | Position apparaît (avant : rien) |
| panneau / grille | alignés |

`npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)