### PR TITLE
Motion : les keyframes de dessin s'affichent aussi hors du in/out (#754)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1616,6 +1616,10 @@ body.mode-motion .layer-inout-bar .layer-inout-handle{width:4px;border-radius:2p
    frame away instantly revealed the tick was there all along. */
 .layer-inout-bar .layer-inout-key{position:absolute;top:0;bottom:0;width:3px;margin-left:-1.5px;background:#fff;opacity:.85;cursor:ew-resize;z-index:6;border-radius:1px;}
 .layer-inout-bar .layer-inout-key:hover{opacity:1;background:var(--accent);width:4px;margin-left:-2px;}
+/* Drawing keyframes sitting OUTSIDE the layer's in/out range (2026-09,
+   feedback #754) — darker and inert: they say "there is a drawing here"
+   without pretending to be a handle. */
+.layer-inout-bar .layer-inout-key.outside{background:#6c7484;opacity:.5;pointer-events:none;width:2px;margin-left:-1px;}
 /* Blank-keyframe gaps inside the bar (layer-inout.js renderContentGaps,
    2026-07) — dims a genuinely empty stretch instead of letting it read as
    solid content, pointer-events:none so the bar underneath stays

--- a/src/js/layer-inout.js
+++ b/src/js/layer-inout.js
@@ -299,16 +299,25 @@
     var old = bar.querySelectorAll('.layer-inout-key');
     for (var o = 0; o < old.length; o++) old[o].remove();
     if (!ld.frames) return;
-    for (var f = inF; f <= outF; f++) {
+    // Outside the in/out range too (2026-09, feedback #754: "les keyframes
+    // d'animation 2D dans motion devraient aussi être avant et après le out
+    // point mais dans une couleur plus foncée"). A trimmed bar used to hide
+    // the fact that the layer still HAS drawings on either side — you had to
+    // go back to Animation 2D to find out. They render darker and are not
+    // draggable: a tick outside the range is information about the drawing,
+    // not a handle (the retime drag clamps into [inF,outF], which would yank
+    // such a keyframe into the visible range on the smallest movement).
+    for (var f = 0; f < ld.frames.length; f++) {
       var fr = ld.frames[f];
       if (!fr || !fr.isKeyframe || !fr.strokes || !fr.strokes.length) continue;
       (function (frameIdx) {
+        var outside = frameIdx < inF || frameIdx > outF;
         var tick = document.createElement('div');
-        tick.className = 'layer-inout-key';
+        tick.className = 'layer-inout-key' + (outside ? ' outside' : '');
         tick.style.left = ((frameIdx - inF) * FC) + 'px';
         tick.title = window.SM.t('layerInoutKeyTitle').replace('{n}', frameIdx + 1);
         bar.appendChild(tick);
-        tick.addEventListener('mousedown', function (e) { onKeyDown(li, row, bar, tick, frameIdx, e); });
+        if (!outside) tick.addEventListener('mousedown', function (e) { onKeyDown(li, row, bar, tick, frameIdx, e); });
       })(f);
     }
   }


### PR DESCRIPTION
Ferme #754 : « les keyframes d'animation 2D dans motion devraient aussi être avant et après le out point mais dans une couleur plus foncée ».

Les repères sur la barre de calque ne parcouraient que la plage in/out, donc une barre rognée cachait le fait que le calque a encore des dessins de part et d'autre. Ils couvrent maintenant toute la timeline.

Les repères hors plage sont plus sombres, plus fins et inertes : ils renseignent sur le dessin sans prétendre être une poignée, le glisser de retiming bornant de toute façon à la plage visible.

## Vérifié en pilotant
Dessins aux frames 1, 6, 11 et 16, calque rogné à 5-12.

| repère | rendu |
|---|---|
| frames 6 et 11 (dans la plage) | blanc, 3 px, déplaçable |
| frames 1 et 16 (hors plage) | gris à 50 %, 2 px, inerte |

`npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)