### PR TITLE
Footage : sélection au canvas réparée, et le lasso attrape les vidéos (#778)

### DIFF
--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -2709,6 +2709,43 @@
         // already takes (line ~2090: selectedStrokeIndices=[]).
         var spansLayers = state.activeSymbolId && selectedPaths.some(function (p) { return p.layer !== userLayers[state.activeLayerIdx]; });
         state.selectedStrokeIndices = spansLayers ? [] : selectedPaths.map(getSI).filter(function (i2) { return i2 >= 0; });
+        // Footage in a marquee (2026-09, feedback #778: "pblm de selection
+        // des footage dans le canvas"). A video layer draws no Paper item at
+        // all — getEffectiveStrokes returns [] for it (app.js) and the
+        // picture is engine-side — so the children walk above can never see
+        // one, and a rubber band drawn right around a video selected
+        // nothing while every stroke and image around it got picked up.
+        // Same priority rule the click hit-test already states: drawings sit
+        // ON TOP of footage, so a marquee that caught any stroke keeps that
+        // selection and only an otherwise-empty one falls through to the
+        // topmost video it covers. Rotation-aware through the rect's own
+        // four corners, matching the click path's own spun-back test.
+        if (!selectedPaths.length && window.SMNativeVideo && window.SMMotion) {
+          var nvMarq = -1;
+          for (var nvj = state.layers.length - 1; nvj >= 0; nvj--) {
+            var nvld = state.layers[nvj];
+            if (!nvld || !nvld.nativeVideo || !nvld.visible || nvld.locked) continue;
+            var nvr2 = SMNativeVideo.displayRect(nvj);
+            if (!nvr2) continue;
+            var ncx2 = nvr2.x + nvr2.width / 2, ncy2 = nvr2.y + nvr2.height / 2;
+            var na2 = (nvr2.rotation || 0) * Math.PI / 180, nc2 = Math.cos(na2), ns2 = Math.sin(na2);
+            var corners = [[nvr2.x, nvr2.y], [nvr2.x + nvr2.width, nvr2.y], [nvr2.x + nvr2.width, nvr2.y + nvr2.height], [nvr2.x, nvr2.y + nvr2.height]].map(function (c2) {
+              var dx2 = c2[0] - ncx2, dy2 = c2[1] - ncy2;
+              return new Point(ncx2 + dx2 * nc2 - dy2 * ns2, ncy2 + dx2 * ns2 + dy2 * nc2);
+            });
+            var quad = new Path({ segments: corners, closed: true, insert: false });
+            var hitMarq = lassoPath
+              ? (lassoPath.contains(quad.position) || lassoPath.intersects(quad))
+              : mb.intersects(quad.bounds);
+            if (hitMarq) { nvMarq = nvj; break; }
+          }
+          if (nvMarq >= 0) {
+            state.activeLayerIdx = nvMarq;
+            activateUL(nvMarq);
+            syncMotionLayerSelection(nvMarq, false);
+            window._nvSelectedLayer = nvMarq; // same gizmo the click path arms
+          }
+        }
         _marquee.rect.remove(); _marquee.rect = null;
       }
       _marquee.active = false;

--- a/src/js/tweens.js
+++ b/src/js/tweens.js
@@ -3593,6 +3593,19 @@ function splitTweenables(strokes,manualMode){
     // (generateTweens' emit loop) instead of participating in
     // autoMatch/interpStroke at all — dabs above are re-stamped fresh each
     // frame instead, a different mechanism for a different reason.
+    // An imported image/video frame (isRaster) has no `segments` at all —
+    // it goes through desR, not desP (see this file's own onion-skin
+    // branches). Letting one into `list` fed strokeFeat -> buildTPFeat a
+    // dict whose segments is undefined, and the resulting
+    // "Cannot read properties of undefined (reading 'forEach')" was thrown
+    // from renderArcs INSIDE the select tool's pointerdown/pointerup
+    // handlers — so clicking a footage layer's image on the canvas aborted
+    // the rest of the gesture (2026-09, feedback #778: "pblm de selection
+    // des footage dans le canvas"). Held, not dropped: a raster is exactly
+    // the kind of content the held path already exists for — copied
+    // unchanged into every generated inbetween instead of being morphed,
+    // which is also the only sensible reading of "tween an image".
+    if(sd.isRaster){held.push(sd);return;}
     if(manualMode&&!sd.tweenOn){held.push(sd);return;}
     list.push(sd);orig.push(i);
   });


### PR DESCRIPTION
Feedback #778 — « pblm de selection des footage dans le canvas ». Deux causes distinctes, trouvées en pilotant.

**1. Une exception à chaque clic sur une image importée.** `splitTweenables` laissait les dicts `isRaster` entrer dans le matcher de tween ; une image n'a pas de `segments`, donc `buildTPFeat` levait « Cannot read properties of undefined (reading 'forEach') ». L'appel venait de `renderArcs`, exécuté dans le pointerdown ET le pointerup de l'outil Sélection : la fin du geste était donc interrompue. Les rasters vont maintenant dans `held` (recopiés tels quels dans les inbetweens).

**2. Le lasso ignorait les vidéos.** Un calque vidéo ne dessine aucun item Paper, donc la boucle du marquee ne pouvait pas le voir. Passe footage ajoutée, avec la priorité existante : un lasso qui a attrapé un trait garde le trait, un lasso vide prend la vidéo la plus haute qu'il couvre. Rotation gérée par les quatre coins du rect.

Vérifié : clic + glissé sur une séquence, zéro erreur console (deux avant) et déplacement exact ; lasso autour d'une vidéo → sélectionnée ; loin d'elle, masquée, verrouillée → rien ; lasso contenant un trait et la vidéo → le trait seul. `npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)