### PR TITLE
Rotate the updater signing key

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -47,7 +47,7 @@
       "endpoints": [
         "https://api.github.com/repos/mysteropodes/strokemotion-updates/contents/latest.json"
       ],
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDVCNkU3Q0E3RThENTVEQ0QKUldUTlhkWG9wM3h1VzlqN1lsKzlvb3dMeFVjZGhFME8rM3A0M0F2ZkxNblV1clUrY3hWekFORlIK"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDFFNzBENUE3MjlDNzI4OUMKUldTY0tNY3BwOVZ3SHZGSWpBVk5ncisvWS9RNzVjR1dQcUc4YmpsbzdYVVVNTk9qTFhMKzQ3S2EK"
     }
   }
 }


### PR DESCRIPTION
Replaces the embedded updater pubkey: `5B6E7CA7E8D55DCD` → `1E70D5A729C7289C`.

No public release has ever shipped with the old pubkey (`gh release list` returns none), so this breaks no existing installs — the trust chain simply starts fresh with the new keypair.

The matching private key is not in this repo (gitignored, as always) and is set as the `TAURI_SIGNING_PRIVATE_KEY` GitHub secret separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)