### PR TITLE
Maillage d'image sur un calque vidéo (#779)

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -1211,7 +1211,26 @@
             }
             for (var nvpc = 0; nvpc < nvChain.length; nvpc++) { nvRect = SMMotion.transformImageRect(nvRect, nvChain[nvpc].pivot, nvChain[nvpc].mat); nvOp *= nvChain[nvpc].mat.op; }
             if (nvProject3D) nvRect = SMMotion.project3DImageRect(nvRect, nvProject3D);
-            items.push({ image: { imageId: 'nv:' + i, x: nvRect.x, y: nvRect.y, width: nvRect.width, height: nvRect.height, opacity: nvOp, rotation: nvRect.rotation || 0 } });
+            var nvImgItem = { imageId: 'nv:' + i, x: nvRect.x, y: nvRect.y, width: nvRect.width, height: nvRect.height, opacity: nvOp, rotation: nvRect.rotation || 0 };
+            // Image mesh on a VIDEO (2026-09, feedback #779). Exactly the
+            // raster branch's treatment above, with the id read off the
+            // LAYER (ld.videoMeshId) because a video has no Paper item to
+            // carry data.meshId. Built from nvRect, the FINAL rect, so the
+            // mesh rides the Motion/parent/3D/duplicator chain for free —
+            // and each duplicated clone gets the same deformation in its own
+            // rect, which is what the stroke path does too.
+            var nvMeshId = state.layers[i].videoMeshId;
+            if (nvMeshId && window.SMImageMesh && SMImageMesh.scenePayloadFor) {
+              var nvPose = null;
+              if (window.SMMotion && SMMotion.hasMeshVertexMotionFor && SMMotion.hasMeshVertexMotionFor(i, nvMeshId)) {
+                nvPose = (function (li2, mid2) {
+                  return function (vi) { return SMMotion.meshVertexOffsetAt(li2, mid2, vi, renderFrame); };
+                })(i, nvMeshId);
+              }
+              var nvMeshPayload = SMImageMesh.scenePayloadFor(nvMeshId, nvRect, nvPose);
+              if (nvMeshPayload) nvImgItem.mesh = nvMeshPayload;
+            }
+            items.push({ image: nvImgItem });
           }
         }
       }

--- a/src/js/image-mesh-bridge.js
+++ b/src/js/image-mesh-bridge.js
@@ -63,11 +63,52 @@
     if (typeof userLayers === 'undefined' || !p.parent || userLayers.indexOf(p.parent) < 0) return null;
     return p;
   }
-  function targetMesh() {
+  // The selected NATIVE VIDEO layer, when that is what the canvas selection
+  // is (2026-09, feedback #779: "le mesh sur une video ne persiste pas a la
+  // lecture ou scrub"). A video draws no Paper item at all, so singleRaster
+  // can structurally never see one and the whole mesh feature was silently
+  // image-only. select-bridge arms window._nvSelectedLayer for exactly this
+  // selection, and it is the same flag the transform gizmo reads.
+  function singleVideoLayer() {
+    if (state.tool !== 'select' && state.tool !== 'subselect') return -1;
+    if (window.selectedPaths && selectedPaths.length) return -1; // a stroke selection wins, same priority as the click hit-test
+    var li = window._nvSelectedLayer;
+    if (li == null) return -1;
+    var ld = state.layers[li];
+    if (!ld || !ld.nativeVideo || ld.locked || !ld.visible) return -1;
+    return li;
+  }
+  // ONE target shape for both kinds, so everything downstream (panel,
+  // overlay, drag) is written once. `raster` is null for a video; `li` is
+  // the layer either way.
+  function currentTarget() {
     var r = singleRaster();
-    if (!r || !r.data || !r.data.meshId || !window.SMImageMesh) return null;
-    var mesh = SMImageMesh.get(r.data.meshId);
-    return mesh ? { raster: r, mesh: mesh, meshId: r.data.meshId } : null;
+    if (r) return { kind: 'raster', raster: r, li: state.activeLayerIdx };
+    var vli = singleVideoLayer();
+    if (vli >= 0) return { kind: 'video', raster: null, li: vli };
+    return null;
+  }
+  function meshIdOfTarget(t) {
+    if (!t) return null;
+    if (t.kind === 'video') return state.layers[t.li] && state.layers[t.li].videoMeshId || null;
+    return (t.raster && t.raster.data && t.raster.data.meshId) || null;
+  }
+  // The rect the mesh is normalized against. For an image that is the
+  // raster's own display rect and the layer's Motion still has to be applied
+  // on top (motionMap below); for a video, displayRect ALREADY composes
+  // Motion and the whole parent chain, so applying it again would double
+  // every transform.
+  function rectOfTarget(t) {
+    if (!t) return null;
+    if (t.kind === 'video') return window.SMNativeVideo ? SMNativeVideo.displayRect(t.li) : null;
+    return (window.SMEngineBridge && SMEngineBridge.rasterImageRect) ? SMEngineBridge.rasterImageRect(t.raster) : null;
+  }
+  function targetMesh() {
+    var t = currentTarget();
+    var id = meshIdOfTarget(t);
+    if (!t || !id || !window.SMImageMesh) return null;
+    var mesh = SMImageMesh.get(id);
+    return mesh ? { raster: t.raster, kind: t.kind, li: t.li, mesh: mesh, meshId: id } : null;
   }
 
   // Vertex positions in RENDERED space. Two mappings are involved and both
@@ -77,10 +118,15 @@
   // what buildNodeHandleItems does for path handles, and for the same
   // reason: without it the handles sit at the shape's pre-transform position
   // while the picture is somewhere else).
-  function motionMap() {
+  function motionMap(t) {
     if (!window.SMMotion) return null;
-    var m = SMMotion.layerMotionPointMap ? SMMotion.layerMotionPointMap(state.activeLayerIdx) : null;
-    if (!m && SMMotion.layerMotion3DPointMap) m = SMMotion.layerMotion3DPointMap(state.activeLayerIdx);
+    // A video's rect comes out of displayRect with Motion already folded in
+    // (see rectOfTarget) — mapping again would move the handles off the
+    // picture by exactly one extra transform.
+    if (t && t.kind === 'video') return null;
+    var li = t ? t.li : state.activeLayerIdx;
+    var m = SMMotion.layerMotionPointMap ? SMMotion.layerMotionPointMap(li) : null;
+    if (!m && SMMotion.layerMotion3DPointMap) m = SMMotion.layerMotion3DPointMap(li);
     return m;
   }
   // The animated pose for this mesh at the current frame, or null when it
@@ -90,16 +136,16 @@
   // showing the rest sculpt while the image renders its animated pose.
   function poseAtFor(t) {
     if (!window.SMMotion || !SMMotion.hasMeshVertexMotionFor) return null;
-    var li = state.activeLayerIdx;
+    var li = t.li != null ? t.li : state.activeLayerIdx;
     if (!SMMotion.hasMeshVertexMotionFor(li, t.meshId)) return null;
     return function (vi) { return SMMotion.meshVertexOffsetAt(li, t.meshId, vi, state.currentFrame); };
   }
   function renderedVerts(t) {
-    if (!window.SMEngineBridge || !SMEngineBridge.rasterImageRect) return null;
-    var rect = SMEngineBridge.rasterImageRect(t.raster);
+    var rect = rectOfTarget(t);
+    if (!rect) return null;
     var pts = SMImageMesh.worldVerts(t.mesh, rect, poseAtFor(t));
     if (!pts) return null;
-    var mm = motionMap();
+    var mm = motionMap(t);
     if (mm) pts = pts.map(function (p) { return mm.fwd(p[0], p[1]); });
     return { pts: pts, rect: rect, mm: mm };
   }
@@ -188,12 +234,13 @@
     var t = targetMesh();
     if (!t) { dragIdx = -1; return; }
     e.stopImmediatePropagation(); e.preventDefault();
-    var rect = SMEngineBridge.rasterImageRect(t.raster);
+    var rect = rectOfTarget(t);
+    if (!rect) { dragIdx = -1; return; }
     var w = SMEngineBridge.screenToWorld(e.clientX, e.clientY);
     // Back through the layer's Motion transform first, into the raw space
     // the rect itself lives in, then into the rect's normalized space —
     // the exact reverse of renderedVerts' forward chain.
-    var mm = motionMap();
+    var mm = motionMap(t);
     if (mm && mm.inv) { var iv = mm.inv(w[0], w[1]); w = [iv[0], iv[1]]; }
     var uv = SMImageMesh.normalizedOf(rect, w[0], w[1]);
     var rest = t.mesh.verts[dragIdx];
@@ -202,7 +249,7 @@
     // override) on its vtxN track, an un-animated one edits the mesh's own
     // rest sculpt. The track value is a deviation ON TOP of the sculpt, so
     // it is measured from rest+sculpt rather than from rest.
-    var li = state.activeLayerIdx;
+    var li = t.li != null ? t.li : state.activeLayerIdx;
     if (window.SMMotion && SMMotion.isMeshVertexAnimated && SMMotion.isMeshVertexAnimated(li, t.meshId, dragIdx)) {
       var sculpt = (t.mesh.offsets && t.mesh.offsets[dragIdx]) || [0, 0];
       SMMotion.setMeshVertexOffset(li, t.meshId, dragIdx, uv[0] - rest[0] - sculpt[0], uv[1] - rest[1] - sculpt[1]);
@@ -225,7 +272,7 @@
     // would repaint it until the next unrelated UI event.
     var tUp = targetMesh();
     if (dragMoved && tUp && window.SMMotion && SMMotion.isMeshVertexAnimated
-        && SMMotion.isMeshVertexAnimated(state.activeLayerIdx, tUp.meshId, dragIdx)
+        && SMMotion.isMeshVertexAnimated(tUp.li != null ? tUp.li : state.activeLayerIdx, tUp.meshId, dragIdx)
         && typeof updateUI === 'function') updateUI();
     dragIdx = -1;
     SMEngineBridge.resume();
@@ -244,7 +291,7 @@
   function renderImageMeshPanel() {
     var sec = el('p-imagemesh-sec');
     if (!sec) return;
-    var r = singleRaster();
+    var tgt = currentTarget();
     // NOT `editing = false` here. This runs from updateUI, which fires on
     // every frame change — and loadFrame rebuilds the Paper items, so
     // singleRaster() is transiently null in the middle of an ordinary
@@ -254,9 +301,10 @@
     // is a sticky preference; with no valid target the overlay returns []
     // and the pointer handlers bail on their own, so leaving it on costs
     // nothing. It is cleared only when the mesh is genuinely gone (below).
-    if (!r) { sec.style.display = 'none'; return; }
+    if (!tgt) { sec.style.display = 'none'; return; }
     sec.style.display = '';
-    var has = !!(r.data && r.data.meshId && SMImageMesh.get(r.data.meshId));
+    var curId = meshIdOfTarget(tgt);
+    var has = !!(curId && SMImageMesh.get(curId));
     if (!has) editing = false;
     var onCb = el('p-imagemesh-on');
     if (onCb) onCb.checked = has;
@@ -265,7 +313,7 @@
     var body = el('p-imagemesh-body');
     if (body) body.style.display = has ? '' : 'none';
     if (has) {
-      var mesh = SMImageMesh.get(r.data.meshId);
+      var mesh = SMImageMesh.get(curId);
       var cols = el('p-imagemesh-cols'), rows = el('p-imagemesh-rows');
       if (cols) cols.value = mesh.cols;
       if (rows) rows.value = mesh.rows;
@@ -276,8 +324,8 @@
   window.renderImageMeshPanel = renderImageMeshPanel;
 
   function toggleMesh(on) {
-    var r = singleRaster();
-    if (!r) return;
+    var tgt = currentTarget();
+    if (!tgt) return;
     pushUndo();
     // attach/detach write BOTH the live Raster's data.meshId and every
     // frame's stored dict (SMImageMesh.propagate), so there is nothing left
@@ -286,8 +334,14 @@
     // the removed Raster, so the very next click on this panel found no
     // valid target and silently did nothing while the checkbox had already
     // flipped. Found live, toggling the real checkbox twice in a row.
-    if (on) SMImageMesh.attach(r, { cols: 4, rows: 4 });
-    else { SMImageMesh.detach(r); editing = false; }
+    // A video keeps its id on the LAYER — there is no Raster to tag and no
+    // per-frame dict to propagate into, which is also why it cannot go out
+    // of step with the frames (#779).
+    if (tgt.kind === 'video') {
+      if (on) SMImageMesh.attachToVideoLayer(tgt.li, { cols: 4, rows: 4 });
+      else { SMImageMesh.detachFromVideoLayer(tgt.li); editing = false; }
+    } else if (on) SMImageMesh.attach(tgt.raster, { cols: 4, rows: 4 });
+    else { SMImageMesh.detach(tgt.raster); editing = false; }
     renderImageMeshPanel();
     if (window.SMEngineBridge) SMEngineBridge.renderNow();
   }
@@ -441,15 +495,14 @@
   }
 
   window.SMImageMeshUI = {
-    canMesh: function () { return !!singleRaster(); },
-    hasMesh: function () { var r = singleRaster(); return !!(r && r.data && r.data.meshId); },
-    toggleMesh: function () { var r = singleRaster(); if (r) toggleMesh(!(r.data && r.data.meshId)); },
+    canMesh: function () { return !!currentTarget(); },
+    hasMesh: function () { return !!meshIdOfTarget(currentTarget()); },
+    toggleMesh: function () { var t = currentTarget(); if (t) toggleMesh(!meshIdOfTarget(t)); },
     isEditing: function () { return editing; },
     canMaskWithShape: function () { return !!maskPair(); },
     maskImageWithShape: maskImageWithShape,
     toggleEditing: function () {
-      var r = singleRaster();
-      if (!r || !(r.data && r.data.meshId)) return;
+      if (!meshIdOfTarget(currentTarget())) return;
       editing = !editing;
       renderImageMeshPanel();
       if (window.SMEngineBridge) SMEngineBridge.renderNow();

--- a/src/js/image-mesh.js
+++ b/src/js/image-mesh.js
@@ -343,6 +343,12 @@
     for (var s = 0; s < sets.length; s++) {
       var layers = sets[s];
       for (var l = 0; l < layers.length; l++) {
+        // A VIDEO layer holds its mesh id on the layer itself, not in a
+        // stroke dict — it has no stroke dicts at all (getEffectiveStrokes
+        // short-circuits to [] for nativeVideo, app.js). Without this the
+        // refcount below would read "unreferenced" and drop a mesh that is
+        // on screen (2026-09, feedback #779).
+        if (layers[l] && layers[l].videoMeshId === meshId) return true;
         var frames = layers[l] && layers[l].frames;
         if (!frames) continue;
         for (var f = 0; f < frames.length; f++) {
@@ -446,7 +452,15 @@
   // offsets. PR3 (Motion vertex keyframes) supplies it; PR1 passes nothing.
   function scenePayload(raster, rect, poseAt) {
     var meshId = raster && raster.data && raster.data.meshId;
-    if (!meshId) return null;
+    return scenePayloadFor(meshId, rect, poseAt);
+  }
+  // Same payload, addressed by mesh id instead of by the Raster carrying it
+  // — a native video layer has no Paper item to hang the id on, so it keeps
+  // it on the layer (ld.videoMeshId). ONE body for both callers on purpose
+  // (CLAUDE.md §3): a second copy of this mapping is exactly the kind of
+  // twin that drifts silently, and a drift here moves pixels.
+  function scenePayloadFor(meshId, rect, poseAt) {
+    if (!meshId || !rect) return null;
     var mesh = get(meshId);
     if (!mesh || !mesh.tris || !mesh.tris.length) return null;
     var rad = (rect.rotation || 0) * Math.PI / 180;
@@ -540,6 +554,30 @@
   NS.setOutline = setOutline;
   NS.rebuild = function (meshId) { var m = get(meshId); return m ? rebuild(m) : null; };
   NS.scenePayload = scenePayload;
+  NS.scenePayloadFor = scenePayloadFor;
+  // Video layers (2026-09, feedback #779: "le mesh sur une video ne persiste
+  // pas a la lecture ou scrub"). A video's picture is engine-side, so there
+  // is no Raster to tag and no per-frame dict to propagate into — the id
+  // lives on the layer, which is also why it cannot fall out of step with
+  // the frames the way a per-frame tag can (the failure mode §12 documents
+  // for images). Everything else — the store, undo, persistence of the mesh
+  // itself, the engine payload — is shared with the image path unchanged.
+  NS.attachToVideoLayer = function (li, opts) {
+    var ld = state.layers[li];
+    if (!ld || !ld.nativeVideo) return null;
+    var id = newId();
+    store()[id] = createMesh(opts);
+    ld.videoMeshId = id;
+    return id;
+  };
+  NS.detachFromVideoLayer = function (li) {
+    var ld = state.layers[li];
+    if (!ld || !ld.videoMeshId) return false;
+    var id = ld.videoMeshId;
+    delete ld.videoMeshId;
+    releaseIfUnused(id);
+    return true;
+  };
   NS.worldVerts = worldVerts;
   NS.normalizedOf = normalizedOf;
   NS.serialize = serialize;

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1277,6 +1277,14 @@ window.SM={
           st.meshId=map[st.meshId];
         });
       });
+      // A VIDEO layer's mesh id sits on the layer, not in a stroke dict
+      // (#779) — same "must not be shared with the copy" rule as above,
+      // just a different place to read it from.
+      var vmId=state.layers[ni].videoMeshId;
+      if(vmId){
+        if(!map[vmId]){var vnid=SMImageMesh.duplicate(vmId);if(vnid)map[vmId]=vnid;}
+        if(map[vmId])state.layers[ni].videoMeshId=map[vmId];
+      }
       var em=state.layers[ni].elementMotion;
       if(em)Object.keys(map).forEach(function(oldId){
         if(em[oldId]){em[map[oldId]]=em[oldId];delete em[oldId];}
@@ -2004,7 +2012,7 @@ window.SM={
         // be just as useless. Note isNullLayer above was already persisted,
         // and its own tooltip calls a null layer a "pivot/parent pour d'autres
         // calques" — the pivot came back, everything hung off it did not.
-layerUid:l.layerUid,parentLayerUid:l.parentLayerUid,parentKeys:l.parentKeys,parentLayerUidB:l.parentLayerUidB,parentsMore:l.parentsMore,followPath:l.followPath,markers:l.markers,shy:l.shy,keyLock:l.keyLock,timeRemap:l.timeRemap,motionBlur:l.motionBlur,effectsFrom:l.effectsFrom,timeLink:l.timeLink,
+videoMeshId:l.videoMeshId,layerUid:l.layerUid,parentLayerUid:l.parentLayerUid,parentKeys:l.parentKeys,parentLayerUidB:l.parentLayerUidB,parentsMore:l.parentsMore,followPath:l.followPath,markers:l.markers,shy:l.shy,keyLock:l.keyLock,timeRemap:l.timeRemap,motionBlur:l.motionBlur,effectsFrom:l.effectsFrom,timeLink:l.timeLink,
         // Expression controls (2026-08-30) — the DECLARATIONS only
         // ({key,name,type,default}). Their keyframes are ordinary tracks and
         // already ride along inside `motion`/`motionStatic` above, keyed by
@@ -2377,6 +2385,13 @@ layerUid:l.layerUid,parentLayerUid:l.parentLayerUid,parentKeys:l.parentKeys,pare
       // (_nvSessionId) — native-video-bridge reopens it lazily from
       // nativeVideo.path on the first frame sync after this load.
       if(ld.nativeVideo)state.layers[idx].nativeVideo=ld.nativeVideo;
+      // Image mesh on a video (2026-09, #779) — the id lives on the LAYER
+      // because a video has no stroke dict to carry it; the mesh itself
+      // rides in state.imageMeshes like every other one. Guarded on the
+      // layer really being a video, same shape check the widget/matte
+      // fields use, so a corrupted nemo-auto can't leave a dangling id on
+      // an ordinary layer.
+      if(ld.videoMeshId&&ld.nativeVideo)state.layers[idx].videoMeshId=ld.videoMeshId;
       if(ld.montageId)state.layers[idx].montageId=ld.montageId;
       // Footage tag (2026-07-27) — descriptive only (it changes no
       // stroke), but exportJSON persists it, so the import side has to


### PR DESCRIPTION
Feedback #779 — « le mesh sur une vidéo ne persiste pas à la lecture ou scrub dans la timeline ».

Diagnostic : le maillage n'a jamais existé sur une vidéo. Il se déclenche sur un Raster sélectionné, et une vidéo ne dessine aucun item Paper (image côté moteur), donc le panneau ne pouvait pas apparaître et rien ne pouvait persister.

L'id vit maintenant sur le calque (`ld.videoMeshId`) au lieu d'un dict de frame — une vidéo n'en a pas, et cela évite le décalage frame-par-frame décrit en CLAUDE.md §12. Le store, l'undo, la persistance et le payload moteur sont partagés tels quels avec le chemin image.

Vérifié en pilotant (moteur actif, vidéo de 24 images) :

| test | résultat |
|---|---|
| panneau sur vidéo sélectionnée | visible |
| glissé d'un sommet (300×220 px sur 1440×1080) | offset 0.208 / 0.204, exact |
| déformation en pixels, frames 4 et 30 | −9 300 px sombres, identique aux deux |
| export → import JSON | id et offsets identiques |
| case décochée | store vidé, image de nouveau plate |
| chemin image (raster) | inchangé |

`npm test` 65/65. Limite v1 : pas de lignes de sommets animables en Motion pour une vidéo, le sculpt statique et le masque oui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)