### PR TITLE
Motion : les lignes Parent/Blend ne décalent plus les clés en dessous (#788)

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1365,6 +1365,12 @@ body.mode-motion #layer-list .pi.motion-val{width:28px;padding-left:2px;padding-
    the panel/grid alignment contract remains exact. */
 body.mode-motion #layer-list .motion-group-row,
 body.mode-motion #frame-grid .motion-group-row{height:22px;min-height:22px;margin-top:2px;}
+/* Parent/Blend on the grid side reuse .motion-group-row so key selection can
+   find them (motion.js's renderDiscreteKeyGridRow says why), but their panel
+   twins are plain property rows with no margin — without this the 2px above
+   pushed every row below them out of line with its own keyframe track
+   (feedback #788). */
+body.mode-motion #frame-grid .motion-discrete-row{margin-top:0;}
 .motion-snap-guide{position:absolute;top:0;bottom:0;width:1px;background:#5cb7ff;box-shadow:0 0 7px rgba(92,183,255,.8);pointer-events:none;z-index:8;}
 .motion-snap-guide::after{content:attr(data-label);position:absolute;top:43px;left:4px;padding:2px 4px;border-radius:3px;background:rgba(20,26,35,.92);color:#9fd6ff;font-size:9px;white-space:nowrap;}
 /* Both columns reserve the SAME bottom band, so #fg-wrap and #layer-list

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -10489,7 +10489,19 @@
   // trackFor (below) to resolve 'blendKeys'/'parentKeys' is the one piece
   // that makes all of it work for these rows too, unmodified.
   function renderDiscreteKeyGridRow(grid, holder, prop, label, keys, removeAt) {
-    var row = document.createElement('div'); row.className = 'frow motion-group-row';
+    // 'motion-group-row' is kept because the key-selection machinery finds
+    // this row by that class (applyMarqueeSelection and the Shift-range
+    // anchor lookup both query '.motion-track-row, .motion-group-row' —
+    // feedback #221). But this is NOT a group header: its panel twin is
+    // renderParentRow/renderBlendRow, a plain '.motion-prop-row' with no
+    // margin, while .motion-group-row carries margin-top:2px in Motion.
+    // Those 2px per row accumulated into a real misalignment — measured
+    // live: Parent +2px, Blend +4px, and every row below a layer's header
+    // stayed 4px off its own keyframe track (2026-09, feedback #788,
+    // "pblm de calage de keyframe de parentage dans motion"). The extra
+    // class zeroes just that margin, so the class stays for selection and
+    // the geometry matches the panel again — CLAUDE.md §11.
+    var row = document.createElement('div'); row.className = 'frow motion-group-row motion-discrete-row';
     row._smHolder = holder; row._smProp = prop;
     var byFrame = {};
     keys.forEach(function (k) { byFrame[k.frame] = k; });


### PR DESCRIPTION
Feedback #788 — « pblm de calage de keyframe de parentage dans motion ».

**Cause.** Côté grille, Parent et Blend utilisent `.motion-group-row` (nécessaire : la sélection de clés retrouve ces lignes par cette classe, feedback #221), mais leurs jumelles côté panneau sont de simples `.motion-prop-row`. Or `.motion-group-row` porte `margin-top:2px` en Motion : 2 px pour Parent, 2 de plus pour Blend, et tout ce qui suit se retrouvait 4 px plus bas que sa propre piste de clés.

**Correctif.** Une classe `.motion-discrete-row` en plus sur ces deux lignes de grille, qui remet la marge à zéro. `.motion-group-row` reste en place, donc la sélection de clés est intacte.

Vérifié en pilotant :

| mesure | avant | après |
|---|---|---|
| écart panneau/grille, calque déplié | Parent +2 px, Blend +4 px, suite +4 px | 0 px partout |
| avec Éléments + un élément dépliés | — | 26 lignes des deux côtés, écart max 0 |
| clé de parentage frame 10 | — | cellule 10, centre à la même hauteur que la ligne du panneau |
| clic sur la clé / lasso | — | sélectionnent toujours |

`npm test` 65/65, aucune erreur console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)