### PR TITLE
Panneau d'animation de typo : visible même hors de la plage du calque (#797)

### DIFF
--- a/src/js/text-animator-panel.js
+++ b/src/js/text-animator-panel.js
@@ -27,11 +27,35 @@
   // re-renders from updateUI on every frame change, and loadFrame rebuilds
   // items — the same transient-null trap image-mesh-bridge.js documents
   // (§12bis piège #2) would otherwise blink the section away mid-scrub.
+  // The strokes this layer's text lives in — the CURRENT frame first, and
+  // failing that any stored frame of the layer.
+  //
+  // The fallback is the fix for 2026-09 feedback #797 ("le panel d'animation
+  // de typo ne s'affiche pas quand je select un calque text dans motion"):
+  // getEffectiveStrokes returns [] whenever the playhead sits outside the
+  // layer's in/out range (and on any frame with no stored content), so
+  // selecting a perfectly ordinary text layer with the playhead parked past
+  // its out point hid this whole section. Reproduced live: same layer, same
+  // selection, panel shown at frame 5 and gone at frame 38 with outPoint 10.
+  // Animators live on the LAYER (ld.textAnimators), not in a frame, so the
+  // panel has no reason to depend on what is drawn right now.
+  function textStrokesOf(li, ld) {
+    if (typeof getEffectiveStrokes !== 'function') return null;
+    var strokes = getEffectiveStrokes(li, state.currentFrame);
+    if (strokes && strokes.length) return strokes;
+    var frames = ld && ld.frames;
+    if (!frames) return null;
+    for (var f = 0; f < frames.length; f++) {
+      var st = frames[f] && frames[f].strokes;
+      if (st && st.length) return st;
+    }
+    return null;
+  }
   function activeTextLayer() {
     if (!window.state || !state.layers) return null;
     var li = state.activeLayerIdx, ld = state.layers[li];
     if (!ld) return null;
-    var strokes = (typeof getEffectiveStrokes === 'function') ? getEffectiveStrokes(li, state.currentFrame) : null;
+    var strokes = textStrokesOf(li, ld);
     if (!strokes || !strokes.length) return null;
     for (var i = 0; i < strokes.length; i++) {
       if (strokes[i] && strokes[i].charIndex != null) return { li: li, ld: ld };
@@ -49,7 +73,7 @@
     if (!window.state || !state.layers) return null;
     var li = state.activeLayerIdx, ld = state.layers[li];
     if (!ld) return null;
-    var strokes = (typeof getEffectiveStrokes === 'function') ? getEffectiveStrokes(li, state.currentFrame) : null;
+    var strokes = textStrokesOf(li, ld); // same off-frame fallback as above (#797)
     if (!strokes || strokes.length !== 1) return null;
     var s = strokes[0];
     return (s && s.isRaster && s.isText && !s.isTextChar) ? { li: li, ld: ld } : null;


### PR DESCRIPTION
Feedback #797 — « le panel d'animation de typo ne s'affiche pas quand je select un calque text dans motion ».

**Rien n'a disparu du code** : la section `#p-textanim-sec` et `text-animator-panel.js` sont intacts (derniers commits #719/#717/#686, aucun des miens ne les touche). C'est la condition d'affichage qui était trop étroite : elle passait par `getEffectiveStrokes(li, frame courante)`, qui renvoie `[]` dès que la tête de lecture sort de la plage in/out du calque, ou sur une frame sans contenu stocké.

Reproduit en pilotant : même calque texte, même sélection, panneau affiché à la frame 5 et disparu à la frame 38 avec `outPoint` 10.

Les animateurs vivent sur le calque (`ld.textAnimators`), pas dans une frame : `textStrokesOf` essaie la frame courante puis retombe sur la première frame stockée.

Vérifié après correction : panneau visible et ligne « ajouter » active à la frame 38 avec 0 trait rendu ; ajout d'un animateur depuis cet état (1 animateur, 16 lignes) ; un calque non texte reste sans panneau. `npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)