### PR TITLE
Vidéo : le cache de frames et la texture suivent le calque, pas son index

### DIFF
--- a/src/js/engine-bridge.js
+++ b/src/js/engine-bridge.js
@@ -1127,7 +1127,10 @@
       // parent-chain) — this is a transient state, a plain rect at the
       // right size/position/rotation covers it without duplicating that
       // whole pipeline for something that shows for a few hundred ms.
-      if (state.layers[i].nativeVideo && window.SMEngineBridge && !registeredImageIds['nv:' + i]) {
+      // Texture id follows the LAYER (layerUid), not its index — see
+      // native-video-bridge's nvKeyFor for the reorder bug this closes.
+      var nvId = state.layers[i].nativeVideo ? ((window.SMNativeVideo && SMNativeVideo.nvImageIdFor) ? SMNativeVideo.nvImageIdFor(state.layers[i], i) : ('nv:' + i)) : null;
+      if (state.layers[i].nativeVideo && window.SMEngineBridge && !registeredImageIds[nvId]) {
         var nvPH = state.layers[i].nativeVideo;
         var inFPH = window.layerInPoint ? layerInPoint(state.layers[i]) : 0;
         var outFPH = window.layerOutPoint ? layerOutPoint(state.layers[i]) : state.totalFrames - 1;
@@ -1145,7 +1148,7 @@
           items.push(boundsRectItem(phRect.x, phRect.y, phRect.x + phRect.width, phRect.y + phRect.height, [38, 36, 42, Math.round(255 * phOp)], [110, 110, 122, Math.round(200 * phOp)], 1.5));
         }
       }
-      if (state.layers[i].nativeVideo && window.SMEngineBridge && registeredImageIds['nv:' + i]) {
+      if (state.layers[i].nativeVideo && window.SMEngineBridge && registeredImageIds[nvId]) {
         var nv = state.layers[i].nativeVideo;
         var inF = window.layerInPoint ? layerInPoint(state.layers[i]) : 0;
         var outF = window.layerOutPoint ? layerOutPoint(state.layers[i]) : state.totalFrames - 1;
@@ -1209,7 +1212,7 @@
           var nvMat = (!is3D && window.SMMotion) ? SMMotion.layerMotionAt(i, renderFrame) : null;
           var nvChain = is3D ? [] : SMMotion.parentChainMats(i, renderFrame);
           var nvProject3D = (is3D && window.SMMotion) ? SMMotion.make3DProjector(state.layers[i], nvRectBase, renderFrame, state.canvasW, state.canvasH, parent3D) : null;
-          _touchImage('nv:' + i); // one shared texture for every clone — touch once, not per clone
+          _touchImage(nvId); // one shared texture for every clone — touch once, not per clone
           for (var nvri = 0; nvri < nvRects.length; nvri++) {
             var nvRect = nvRects[nvri].rect, nvOp = nvRects[nvri].opacityFactor;
             if (nvMat) {
@@ -1219,7 +1222,7 @@
             }
             for (var nvpc = 0; nvpc < nvChain.length; nvpc++) { nvRect = SMMotion.transformImageRect(nvRect, nvChain[nvpc].pivot, nvChain[nvpc].mat); nvOp *= nvChain[nvpc].mat.op; }
             if (nvProject3D) nvRect = SMMotion.project3DImageRect(nvRect, nvProject3D);
-            var nvImgItem = { imageId: 'nv:' + i, x: nvRect.x, y: nvRect.y, width: nvRect.width, height: nvRect.height, opacity: nvOp, rotation: nvRect.rotation || 0 };
+            var nvImgItem = { imageId: nvId, x: nvRect.x, y: nvRect.y, width: nvRect.width, height: nvRect.height, opacity: nvOp, rotation: nvRect.rotation || 0 };
             // Image mesh on a VIDEO (2026-09, feedback #779). Exactly the
             // raster branch's treatment above, with the id read off the
             // LAYER (ld.videoMeshId) because a video has no Paper item to

--- a/src/js/native-video-bridge.js
+++ b/src/js/native-video-bridge.js
@@ -492,10 +492,21 @@
     // layer in a browser (loaded project) just fails its lazy re-open with
     // a console error, same as any other unreachable source.
     for (var i = 0; i < state.layers.length; i++) {
-      if (state.layers[i].nativeVideo) _layerFrameSync(i, state.layers[i], frame);
+      if (state.layers[i].nativeVideo) _layerFrameSync(nvKeyFor(state.layers[i], i), state.layers[i], frame);
     }
     _syncSymbolVideos(frame);
   }
+  // The sync state (JS frame cache, lastShown, prefetch queue) and the
+  // engine texture id used to be keyed by the layer's INDEX. Reordering two
+  // video layers then served each one the other's cached frames — confirmed
+  // live (2026-09, QA sweep): after swapping "tr" and "tr2", 'nv:3' (now
+  // "tr") kept receiving tr2's frames and 'nv:2' got tr's, the two videos
+  // literally showing each other's picture until the caches happened to
+  // roll over. Keyed by layerUid instead — stable across reorder, delete,
+  // duplicate AND undo (engine-bridge builds the scene item's imageId from
+  // the same helper, see nvImageIdFor there). Index fallback only for a
+  // layer that somehow has no uid.
+  function nvKeyFor(ld, i) { return (ld && ld.layerUid) ? ('nv:' + ld.layerUid) : i; }
   // Nested video (2026-07-30 fix — Cyril: "attaque le chantier pour les
   // vidéo dans des component"): the loop above only ever walks TOP-LEVEL
   // state.layers, by index — while editing INSIDE a Component, state.layers
@@ -835,6 +846,7 @@
   // key here is ALREADY the full 'nvsym:<symbolId>:<subLayerIndex>' string
   // _syncSymbolVideos built, so this just picks the right prefix by type.
   function _imageIdFor(key) { return typeof key === 'number' ? ('nv:' + key) : key; }
+  function nvImageIdFor(ld, i) { return _imageIdFor(nvKeyFor(ld, i)); }
 
   // ---- optimized media (the DaVinci Resolve pattern) ----
   // Long-GOP sources (H.264/HEVC/VP9…) make every seek cost a keyframe
@@ -1299,6 +1311,7 @@
     // dependency direction stays the same as every other cross-file call here.
     retryWebLinkedSessions: retryWebLinkedSessions,
     onFrameChanged: onFrameChanged,
+    nvImageIdFor: nvImageIdFor,
     displayRect: displayRect,
     transformBox: transformBox,
     stats: stats,


### PR DESCRIPTION
Trouvé en balayant la famille de bug de #798 (état indexé par position de calque).

Le cache JS de frames, `lastShown`, la file de préchargement et l'identifiant de texture `'nv:<i>'` étaient clés par l'index du calque. **Réordonner deux vidéos faisait afficher à chacune l'image de l'autre** — confirmé en pilotant : après échange, `'nv:3'` recevait `tr2#3, tr2#4, tr2#5, tr2#2` alors que le calque à l'index 3 était `tr`.

Clé par `layerUid` des deux côtés, avec une seule règle de nommage (`nvImageIdFor`) partagée par native-video-bridge et engine-bridge. Le chemin `'nvsym:'` des composants est inchangé.

Après correction, même scénario : 8 téléversements sur 8 vers la bonne vidéo. `npm test` 65/65, aucune erreur console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)