### PR TITLE
Tween : easing et appariements forcés suivent leur calque, plus son index

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -2475,6 +2475,31 @@ videoMeshId:l.videoMeshId,layerUid:l.layerUid,parentLayerUid:l.parentLayerUid,pa
     }
     state.layerFolders=d.layerFolders||{};state.layerLinkGroups=d.layerLinkGroups||{};
     state.motionArcs=d.motionArcs||{};state.tweenOverrides=d.tweenOverrides||{};state.tweenEasing=d.tweenEasing||{};
+    // Migration (2026-09): tween span keys used to start with the layer's
+    // INDEX ("5:0-10"); they now start with its layerUid (tweenSpanKey,
+    // tweens.js). At load time the indices are still consistent with the
+    // file, which is the only moment this rewrite is unambiguous.
+    (function migrateTweenSpanKeys(){
+      function migrate(map){
+        if(!map)return map;
+        var out={};
+        Object.keys(map).forEach(function(k){
+          var m=/^(\d+):(.*)$/.exec(k);
+          if(m){
+            var ld=state.layers[parseInt(m[1],10)];
+            if(ld){
+              if(!ld.layerUid)ld.layerUid='ly_'+Date.now().toString(36)+'_'+Math.floor(Math.random()*1e6);
+              out[ld.layerUid+':'+m[2]]=map[k];
+              return;
+            }
+          }
+          out[k]=map[k];
+        });
+        return out;
+      }
+      state.tweenOverrides=migrate(state.tweenOverrides);
+      state.tweenEasing=migrate(state.tweenEasing);
+    })();
     // Migration (2026-07): the old shipped DEFAULT easing points
     // ({.42,0}/{.58,1} — CSS control values misread as on-curve knots, a
     // park/teleport/park cliff, see app.js's easingCurve comment) were
@@ -4247,7 +4272,7 @@ window.renderTweenCurveStrips=renderTweenCurveStrips;
 // inline and via the popup (right-click a cell → "Éditer la courbe de ce
 // tween…", still available when the toggle is off) always agree.
 function buildTweenCurveSVG(li,fA,fB,svgW,svgH){
-  var key=li+':'+fA+'-'+fB;
+  var key=tweenSpanKey(li,fA,fB);
   if(!state.tweenEasing)state.tweenEasing={};
   var seg=state.tweenEasing[key]=state.tweenEasing[key]||{};
   if(!seg.points||!seg.points.length){
@@ -4389,7 +4414,7 @@ function openTweenCurveInset(li,fA,fB){
   closeTweenCurveInset();
   var row=findLayerRow(li);
   if(!row)return;
-  var key=li+':'+fA+'-'+fB;
+  var key=tweenSpanKey(li,fA,fB);
   var rowRect=row.getBoundingClientRect();
   var HDR=20,pad=10;
   var W=Math.max(140,(fB-fA)*FC);
@@ -4452,7 +4477,7 @@ function editTweenSegForCell(li,fi,fr0){
   openPropsSection('tween-sec');openPropsSection('easing-sec');
   var pair=tweenPairForCell(li,fi);
   if(!pair||!window._curveEditor||!window._curveEditor.editTweenPair)return;
-  var key=li+':'+pair.a+'-'+pair.b;
+  var key=tweenSpanKey(li,pair.a,pair.b);
   if(!state.tweenEasing)state.tweenEasing={};
   var seg=state.tweenEasing[key]=state.tweenEasing[key]||{};
   // Captured BEFORE onTweenPairCurveChanged's own selClear/selAdd dance
@@ -4470,12 +4495,12 @@ function editTweenSegForCell(li,fi,fr0){
 // frames landing in the same span only regenerate it once. Falls back to
 // the single-pair path unchanged when nothing else is selected.
 function applyTweenCurveToSelection(li,pair,seg,selSnapshot){
-  var seen={};seen[li+':'+pair.a+'-'+pair.b]=true;
+  var seen={};seen[tweenSpanKey(li,pair.a,pair.b)]=true;
   var touched=[{li:li,fA:pair.a}];
   (selSnapshot||[]).forEach(function(s){
     var p2=tweenPairForCell(s.layer,s.frame);
     if(!p2)return;
-    var k2=s.layer+':'+p2.a+'-'+p2.b;
+    var k2=tweenSpanKey(s.layer,p2.a,p2.b);
     if(seen[k2])return;
     seen[k2]=true;
     if(!state.tweenEasing)state.tweenEasing={};

--- a/src/js/tweens.js
+++ b/src/js/tweens.js
@@ -1593,8 +1593,22 @@ function getEasing(){if(window._curveEditor)return window._curveEditor.evalCurve
 // pure evaluator (ui.js) — independent of whatever the curve widget
 // happens to be showing right now, unlike evalCurve/activePoints which
 // only reflect the currently-open view.
+// The key every per-span tween setting is stored under (state.tweenEasing,
+// state.tweenOverrides). It used to start with the layer's INDEX, so any
+// reorder/delete/duplicate silently handed a span's easing curve and forced
+// pairings to whichever layer slid into that index — confirmed live (2026-09
+// QA sweep): easing set on layer 5, layer moved to index 6, the entry stayed
+// at "5:0-10". Keyed by layerUid now, the same stable identity parenting and
+// mattes already rely on; importJSON migrates files saved with index keys.
+// Index fallback only for a layer without a uid (should not exist).
+function tweenSpanKey(li,fA,fB){
+  var ld=state.layers[li];
+  var id=(ld&&ld.layerUid)?ld.layerUid:li;
+  return id+':'+fA+'-'+fB;
+}
+window.tweenSpanKey=tweenSpanKey;
 function getEasingForPair(li,fA,fB){
-  var key=li+':'+fA+'-'+fB;
+  var key=tweenSpanKey(li,fA,fB);
   var custom=state.tweenEasing&&state.tweenEasing[key];
   if(custom&&custom.points&&custom.points.length&&window._curveEditor&&window._curveEditor.evalPointsCurve){
     var pts=custom.points;
@@ -3801,7 +3815,7 @@ function generateTweens(explicitRestrictTo){
     // A stroke removed since the override was made just makes that one
     // override silently inert (falls through to auto-matching again),
     // rather than erroring the whole tween generation.
-    var ovKey=li+':'+fA+'-'+fB;
+    var ovKey=tweenSpanKey(li,fA,fB);
     var overrides=(state.tweenOverrides&&state.tweenOverrides[ovKey])||[];
     var forcedAIdx={},forcedBIdx={},forcedPairs=[];
     overrides.forEach(function(ov){
@@ -4432,7 +4446,7 @@ function computeArcMatchBase(){
   // time, so dragging it has zero effect on the actual tween. Found live
   // 2026-07: dragged both handles of a forced pair substantially, motionArcs
   // held real offsets, but the in-between frame's content never moved.
-  var ovKey=li+':'+fA+'-'+fB;
+  var ovKey=tweenSpanKey(li,fA,fB);
   var overrides=(state.tweenOverrides&&state.tweenOverrides[ovKey])||[];
   var forcedAIdx={},forcedBIdx={},forcedPairs=[];
   overrides.forEach(function(ov){
@@ -5006,7 +5020,7 @@ function reassignHandleClick(pt){
   }
   // step 2
   saveActiveLayerFrame();
-  var key=li+':'+_reassign.frameA+'-'+_reassign.frameB;
+  var key=tweenSpanKey(li,_reassign.frameA,_reassign.frameB);
   var list=state.tweenOverrides[key]=state.tweenOverrides[key]||[];
   // replace any earlier override touching either side of this pair — one
   // strokeId can't sensibly be forced into two different correspondences
@@ -5117,7 +5131,7 @@ function updateReassignBadge(cached){
       var sid=ensureStrokeId(target);
       saveActiveLayerFrame();
       var li=_reassign.layer;
-      var key=li+':'+_reassign.frameA+'-'+_reassign.frameB;
+      var key=tweenSpanKey(li,_reassign.frameA,_reassign.frameB);
       var list=state.tweenOverrides[key]=state.tweenOverrides[key]||[];
       state.tweenOverrides[key]=list.filter(function(ov){
         var ovA=ov.aIds||[ov.aId];


### PR DESCRIPTION
Même famille que #807 et #808. `state.tweenEasing` et `state.tweenOverrides` étaient clés par l'**index** du calque (« 5:0-10ﾻ) : réordonner, supprimer ou dupliquer un calque cédait ses réglages de tween au calque qui prenait sa place — et le fichier gardait la mauvaise attribution.

Confirmé en pilotant : easing sur l'index 5, calque déplacé à l'index 6, entrée toujours « 5:0-10 ».

Une seule fabrique de clé, `tweenSpanKey`, par `layerUid`, utilisée par les onze sites des deux fichiers ; `importJSON` migre l'ancien format.

| test | résultat |
|---|---|
| clé à l'écriture | `<uid>:0-10` |
| calque réordonné | clé toujours résolue pour lui, pas pour son voisin |
| import d'un fichier à clés « 3:0-10 » | easing et appariements retrouvés par uid, plus de clé numérique |
| export | clés par uid conservées |

`npm test` 65/65, aucune erreur console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)