### PR TITLE
Tween : les arcs de mouvement appartiennent à leur calque

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1689,7 +1689,7 @@ window.SM={
         var fA=kfs[i],fB=kfs[i+1];
         var newFA=movedFrameMap[li+':'+fA];newFA=(newFA!==undefined)?newFA:fA;
         var newFB=movedFrameMap[li+':'+fB];newFB=(newFB!==undefined)?newFB:fB;
-        rekeyTweenPairData(fA,fB,newFA,newFB);
+        rekeyTweenPairData(fA,fB,newFA,newFB,li);
         pairs.push({fA:fA,fB:fB,newFA:newFA,newFB:newFB});
       }
       retimeTweenSpans(li,pairs,capturedInbetweens[li]||{});
@@ -2499,6 +2499,34 @@ videoMeshId:l.videoMeshId,layerUid:l.layerUid,parentLayerUid:l.parentLayerUid,pa
       }
       state.tweenOverrides=migrate(state.tweenOverrides);
       state.tweenEasing=migrate(state.tweenEasing);
+      // Motion arcs (arcKey, tweens.js): the old "fA-fB-i" form carried NO
+      // layer at all. An old entry is attributed to the ONE layer that has
+      // drawn keyframes at both fA and fB; if several layers qualify the
+      // attribution would be a guess, and a mis-assigned arc bends the
+      // wrong drawing — the entry is dropped instead (an untouched arc is
+      // the default straight line, so dropping costs the curve, never the
+      // tween).
+      (function migrateArcs(){
+        var arcs=state.motionArcs;if(!arcs)return;
+        var out={};
+        Object.keys(arcs).forEach(function(k){
+          var m=/^(\d+)-(\d+)-(\d+)$/.exec(k);
+          if(!m){out[k]=arcs[k];return;}
+          var fA=parseInt(m[1],10),fB=parseInt(m[2],10);
+          var owners=[];
+          state.layers.forEach(function(ld,li){
+            var fr=ld.frames||[];
+            var a=fr[fA],b=fr[fB];
+            if(a&&a.isKeyframe&&a.strokes&&a.strokes.length&&b&&b.isKeyframe&&b.strokes&&b.strokes.length)owners.push(li);
+          });
+          if(owners.length===1){
+            var ld=state.layers[owners[0]];
+            if(!ld.layerUid)ld.layerUid='ly_'+Date.now().toString(36)+'_'+Math.floor(Math.random()*1e6);
+            out[ld.layerUid+':'+k]=arcs[k];
+          }
+        });
+        state.motionArcs=out;
+      })();
     })();
     // Migration (2026-07): the old shipped DEFAULT easing points
     // ({.42,0}/{.58,1} — CSS control values misread as on-curve knots, a

--- a/src/js/tweens.js
+++ b/src/js/tweens.js
@@ -1617,7 +1617,18 @@ function getEasingForPair(li,fA,fB){
   return getEasing();
 }
 function lerp(a,b,t){return a+(b-a)*t;}function lerpV(a,b,t){return[lerp(a[0],b[0],t),lerp(a[1],b[1],t)];}
-function arcKey(fA,fB,i){return fA+'-'+fB+'-'+i;}
+// Motion-arc key now carries the LAYER (2026-09 QA sweep): it used to be
+// "fA-fB-i" alone, so an arc bent for stroke i of the 0→10 span on one layer
+// bent stroke i of EVERY other layer with keys at 0 and 10 — confirmed live,
+// a straight horizontal tween on a fresh layer rose from y=400 to y=175
+// because of an arc that belonged to a different layer. Same uid identity
+// as tweenSpanKey; `li` defaults to the active layer, which is the only
+// layer generateTweens/renderArcs/setArcHandle ever operate on.
+function arcKey(fA,fB,i,li){
+  var ld=state.layers[li==null?state.activeLayerIdx:li];
+  var id=(ld&&ld.layerUid)?ld.layerUid:(li==null?state.activeLayerIdx:li);
+  return id+':'+fA+'-'+fB+'-'+i;
+}
 // Cubic bezier through ptA/ptB with independent OUT (leaving A) and IN
 // (arriving at B) handles — upgraded 2026-07 from a single shared quadratic
 // control point, live feedback: "le motion path de caméra a des poignées
@@ -1678,15 +1689,16 @@ function cubicBez(a,c1,c2,b,t){var u=1-t;return u*u*u*a+3*u*u*t*c1+3*u*t*t*c2+t*
 // touch) — so this MOVES the entry to the new key instead of dropping it,
 // called by moveFrames for every keyframe pair whose fA and/or fB frame
 // index changed in that move.
-function rekeyTweenPairData(fA,fB,newFA,newFB){
+function rekeyTweenPairData(fA,fB,newFA,newFB,li){
   if(fA===newFA&&fB===newFB)return;
-  var oldPrefix=fA+'-'+fB+'-';
+  var oldPrefix=arcKey(fA,fB,'',li); // "<uid>:fA-fB-"
+  var newPrefix=arcKey(newFA,newFB,'',li);
   Object.keys(state.motionArcs).forEach(function(k){
     if(k.indexOf(oldPrefix)!==0)return;
     var idx=k.slice(oldPrefix.length);
     var val=state.motionArcs[k];
     delete state.motionArcs[k];
-    state.motionArcs[newFA+'-'+newFB+'-'+idx]=val;
+    state.motionArcs[newPrefix+idx]=val;
   });
 }
 // Rotates+scales a vector (px,py) by angle ang (radians) and uniform factor


### PR DESCRIPTION
Suite de #809. La clé d'un arc de mouvement (`state.motionArcs`) était « fA-fB-i », **sans calque** : un arc posé sur un calque courbait le même trait de tout autre calque ayant des clés aux mêmes frames. Confirmé en pilotant : un tween droit sur un calque neuf montait de y=400 à y=175.

`arcKey` porte maintenant le `layerUid` (calque actif par défaut). Migration à l'import : une entrée ancienne est attribuée au seul calque qui a des keyframes aux deux frames, sinon abandonnée (un arc absent est la droite par défaut).

| test | résultat |
|---|---|
| arc sur A, tween de A | courbe, y 400 → 288 |
| tween de B, même paire de frames | droit, y 700 |
| import ancien format, deux calques éligibles | entrée abandonnée |
| import ancien format, un seul éligible | attribuée à lui |

`npm test` 65/65, aucune erreur console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)