### PR TITLE
Dupliquer ou couper un calque vidéo garde la vidéo ; un décodeur par session, en file

### DIFF
--- a/src/js/native-video-bridge.js
+++ b/src/js/native-video-bridge.js
@@ -293,7 +293,25 @@
   // both backends. tauri::ipc::Response arrives as an ArrayBuffer (one
   // structured-clone copy across the IPC boundary, no JSON/base64); the
   // web backend produces the same shape via _decodeWebFrame/getImageData.
-  async function frameBytes(sessionId, frameIndex) {
+  // One decode at a time PER SESSION (2026-09 QA sweep). A session can have
+  // several readers: a duplicated video layer shares its source's session
+  // (duplicateLayer, timeline.js), and a video inside a Component is read
+  // both as its own layer ('nv:') and as an instance ('nvsym:'). The
+  // per-LAYER busy/pending coalescing in _layerFrameSync never knew about
+  // each other, so two layers could drive one WebCodecs decoder at once —
+  // measured right after sharing sessions: the original layer's sync died
+  // with "décodeur WebCodecs muet (aucune image en 4s)" while its copy
+  // decoded fine, because the second request's flush starved the first.
+  // A promise chain per session queues them; the desktop (ffmpeg) backend
+  // gets the same ordering for free.
+  var _sessionChain = {};
+  function frameBytes(sessionId, frameIndex) {
+    var prev = _sessionChain[sessionId] || Promise.resolve();
+    var run = prev.then(function () { return _frameBytesNow(sessionId, frameIndex); });
+    _sessionChain[sessionId] = run.then(function () {}, function () {}); // a failed decode must not jam the queue
+    return run;
+  }
+  async function _frameBytesNow(sessionId, frameIndex) {
     if (String(sessionId).indexOf('web-') === 0) {
       var ws = webSessions[sessionId];
       if (!ws) throw new Error('unknown web session ' + sessionId);

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -1216,6 +1216,11 @@ window.SM={
     if(ld.effects)dst.effects=JSON.parse(JSON.stringify(ld.effects));
     if(ld.markers)dst.markers=JSON.parse(JSON.stringify(ld.markers));
     if(ld.symbolId){dst.symbolId=ld.symbolId;dst.symPlayMode=ld.symPlayMode;dst.symSpeed=ld.symSpeed;dst.symPlacedAt=ld.symPlacedAt;dst.symSingleFrame=ld.symSingleFrame;dst.symMatrix=ld.symMatrix;dst.locked=ld.locked;}
+    // Same gap as duplicateLayer's (see its nativeVideo comment): cutting a
+    // video layer at the playhead left the second half blank.
+    if(ld.nativeVideo){dst.nativeVideo=JSON.parse(JSON.stringify(ld.nativeVideo));if(ld._nvSessionId)dst._nvSessionId=ld._nvSessionId;}
+    if(ld.footage)dst.footage=JSON.parse(JSON.stringify(ld.footage));
+    if(ld.timeRemap)dst.timeRemap=JSON.parse(JSON.stringify(ld.timeRemap));
     dst.inPoint=f;dst.outPoint=outF;
     ld.outPoint=f-1;
     // Splitting materialises hard in/out values on both halves, which a
@@ -1257,6 +1262,17 @@ window.SM={
     if(src.matteMode)state.layers[ni].matteMode=src.matteMode;
     if(src.matteSourceLayerUid)state.layers[ni].matteSourceLayerUid=src.matteSourceLayerUid;
     if(src.mattesMore&&src.mattesMore.length)state.layers[ni].mattesMore=src.mattesMore.map(function(m){return{uid:m.uid,mode:m.mode};});
+    // Video/footage (2026-09 QA sweep): a video layer keeps NOTHING in its
+    // frames (getEffectiveStrokes returns [] for nativeVideo, app.js), so
+    // the frames clone above produced an empty copy — "Dupliquer" on a
+    // video gave a blank layer, measured: "tr copy" with no nativeVideo and
+    // no session. The record is deep-copied (its own offsetFrames/time
+    // settings from here on); the decode SESSION is shared by id — it is a
+    // read-only decoder, and frames are cached per layerUid since #808, so
+    // two layers reading one session cannot cross their pictures. Same for
+    // the descriptive footage tag.
+    if(src.nativeVideo){state.layers[ni].nativeVideo=JSON.parse(JSON.stringify(src.nativeVideo));if(src._nvSessionId)state.layers[ni]._nvSessionId=src._nvSessionId;}
+    if(src.footage)state.layers[ni].footage=JSON.parse(JSON.stringify(src.footage));
     // elementMotion is keyed by strokeId, and duplicateLayer's frames clone
     // above (JSON.stringify) preserves each stroke's strokeId unchanged —
     // so the duplicate's strokes carry the SAME ids the original's element


### PR DESCRIPTION
Trouvé en balayant les opérations de calque sur un footage.

**Dupliquer / couper.** Un calque vidéo ne garde rien dans ses frames, donc le clone de `duplicateLayer` donnait un calque blanc (mesuré : « tr copy » sans `nativeVideo`). Même trou dans la coupe au playhead. L'enregistrement est copié, la session de décodage partagée par id (frames en cache par `layerUid` depuis #808).

**File par session.** Partager la session a révélé que deux calques pouvaient piloter un même décodeur WebCodecs en même temps — la synchro de l'original mourait avec « décodeur WebCodecs muet ». C'était déjà possible avec une vidéo dans un composant (lue par deux chemins). `frameBytes` met les décodages en file par session.

| test | résultat |
|---|---|
| dupliquer une vidéo | copie avec `nativeVideo`, objet distinct, session partagée |
| décalage sur la copie | original inchangé |
| scrub 0→8 à deux calques | original 1..8, copie 1..5, zéro erreur |
| couper au playhead | « tr (2) » garde la vidéo, inPoint 8 |

`npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)