### PR TITLE
Miroir, aligner, distribuer, dupliquer et lisser persistent sur image tenue

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4916,6 +4916,32 @@ function layerIsEffectivelyVisible(i){var ld=state.layers[i];if(!ld)return false
 // a consistent key/held state (distinct from the existing
 // state.layers[i].lfsGroup/symbol-based system, whose 3 channels are each
 // their own independent mini-timeline with NO shared timing at all).
+// saveActiveLayerFrame() deliberately does nothing on a HELD frame (a scrub
+// must never mint keyframes) — but a real edit made on one has to land
+// somewhere, or it snaps back on the next scrub (feedback #752, then #823/
+// #824/#825, 2026-09 QA sweep: flip, align, distribute, duplicate, smooth
+// all had the same hole). Same two answers as pasteSelection: Animation 2D
+// promotes the held frame — here AFTER the fact, from the live content
+// (which loadFrame materialised from the hold and the gesture just edited)
+// by flagging it a keyframe and letting the ordinary save path store it;
+// Motion writes into the keyframe the hold inherits from. On a keyframe or
+// an inbetween this is exactly saveActiveLayerFrame().
+function saveActiveLayerFrameOrPromote(){
+  var li=state.activeLayerIdx,ld=state.layers[li],f=ld&&ld.frames[state.currentFrame];
+  if(!f||f.isKeyframe||f.isInterpolated){saveActiveLayerFrame();return;}
+  if(state.appMode!=='motion'){
+    if(typeof canEditActiveLayer==='function'&&!canEditActiveLayer())return;
+    f.isKeyframe=true;f.isInterpolated=false;ld._justEnsuredKeyframeAt=state.currentFrame;
+    saveActiveLayerFrame();
+    syncLinkedKeyframeFolder(li,state.currentFrame);
+    if(window.renderTimeline)renderTimeline();
+    return;
+  }
+  for(var o=state.currentFrame;o>=0;o--){
+    if(ld.frames[o]&&ld.frames[o].isKeyframe){ld.frames[o].strokes=_collectLayerStrokes(li,ld);window._sceneVersion=(window._sceneVersion||0)+1;return;}
+  }
+  saveActiveLayerFrame();
+}
 function syncLinkedKeyframeFolder(sourceLayerIdx,frameIdx){
   var srcLd=state.layers[sourceLayerIdx];
   var gid=srcLd&&srcLd.linkGroupId;

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -780,7 +780,7 @@ window.SM={
       regenerateBrushTexture(p,userLayers[state.activeLayerIdx]);
     });
     fillRegenerateLinked(userLayers[state.activeLayerIdx],null);
-    saveActiveLayerFrame();updateUI();
+    saveActiveLayerFrameOrPromote();updateUI();
   },
   setVectorBrush:function(v){state.vectorBrush=v;},setTaperEnds:function(v){state.taperEnds=v;},setShadowMode:function(v){state.shadowMode=v;},
   setMaskMode:function(v){state.maskMode=v;},setMaskModeType:function(v){state.maskModeType=v;},
@@ -2011,7 +2011,7 @@ window.SM={
         s.point=[2*cx-s.point[0],s.point[1]];s.handleIn=[-s.handleIn[0],s.handleIn[1]];s.handleOut=[-s.handleOut[0],s.handleOut[1]];
       });}
     });
-    saveActiveLayerFrame();updateUI();showToast('Flip horizontal');
+    saveActiveLayerFrameOrPromote();updateUI();showToast('Flip horizontal');
   },
   flipVertical:function(){
     if(state.tool!=='select'||!selectedPaths.length){showToast(SM.t('toastSelectStrokes'));return;}
@@ -2022,7 +2022,7 @@ window.SM={
         s.point=[s.point[0],2*cy-s.point[1]];s.handleIn=[s.handleIn[0],-s.handleIn[1]];s.handleOut=[s.handleOut[0],-s.handleOut[1]];
       });}
     });
-    saveActiveLayerFrame();updateUI();showToast('Flip vertical');
+    saveActiveLayerFrameOrPromote();updateUI();showToast('Flip vertical');
   },
   exportJSON:function(){
     // Never exits an open component: the 30s autosave calls this, and the

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -1318,7 +1318,7 @@ function alignSelection(mode){
   });
   if(!moved){state.undoStack.pop();return;}
   fillRegenerateLinked(userLayers[state.activeLayerIdx],null);
-  saveActiveLayerFrame();renderArcs();updateUI();
+  saveActiveLayerFrameOrPromote();renderArcs();updateUI();
   if(window.SMEngineBridge)SMEngineBridge.renderNow();
 }
 // Distribute (2026-09 — alignSelection's own comment already named this
@@ -1362,7 +1362,7 @@ function distributeSelection(mode){
   });
   if(!moved){state.undoStack.pop();return;}
   fillRegenerateLinked(userLayers[state.activeLayerIdx],null);
-  saveActiveLayerFrame();renderArcs();updateUI();
+  saveActiveLayerFrameOrPromote();renderArcs();updateUI();
   if(window.SMEngineBridge)SMEngineBridge.renderNow();
 }
 // Rotation/scale pivot picker (redesign 2026-07-09, AE-style 9-dot anchor
@@ -1642,7 +1642,7 @@ function duplicateSelection(){
   clearSel();
   selectedPaths=clones.filter(isSelectablePathChild);
   state.selectedStrokeIndices=selectedPaths.map(getSI).filter(function(i2){return i2>=0;});
-  saveActiveLayerFrame();renderArcs();updateUI();
+  saveActiveLayerFrameOrPromote();renderArcs();updateUI();
   if(window.SMEngineBridge)SMEngineBridge.renderNow();
 }
 // ---- CANVAS ELEMENT COPY / CUT / PASTE (2026-07) ----


### PR DESCRIPTION
Suite de #823 / #824 / #825. Balayage des 118 appelants de `saveActiveLayerFrame()` : six gestes de plus éditaient une **image tenue** et repartaient au premier scrub — Miroir H/V, Aligner, Distribuer, Dupliquer la sélection, Lisser.

Un helper unique `saveActiveLayerFrameOrPromote()` porte la règle : image-clé ou interpolée → comportement inchangé ; image tenue → promotion en Animation 2D, écriture dans la clé d'origine en Motion.

Vérifié en direct dans les deux modes ; `npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)