### PR TITLE
Booléens et dégradés sur image tenue + fuite de l'édition vers la clé source

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -4933,14 +4933,36 @@ function saveActiveLayerFrameOrPromote(){
     if(typeof canEditActiveLayer==='function'&&!canEditActiveLayer())return;
     f.isKeyframe=true;f.isInterpolated=false;ld._justEnsuredKeyframeAt=state.currentFrame;
     saveActiveLayerFrame();
+    _reanchorMaterialized(li,f.strokes);
     syncLinkedKeyframeFolder(li,state.currentFrame);
     if(window.renderTimeline)renderTimeline();
     return;
   }
   for(var o=state.currentFrame;o>=0;o--){
-    if(ld.frames[o]&&ld.frames[o].isKeyframe){ld.frames[o].strokes=_collectLayerStrokes(li,ld);window._sceneVersion=(window._sceneVersion||0)+1;return;}
+    if(ld.frames[o]&&ld.frames[o].isKeyframe){
+      ld.frames[o].strokes=_collectLayerStrokes(li,ld);
+      _reanchorMaterialized(li,ld.frames[o].strokes);
+      window._sceneVersion=(window._sceneVersion||0)+1;return;
+    }
   }
   saveActiveLayerFrame();
+}
+// loadFrame skips rebuilding a layer whose materialised items still match
+// the strokes array it was built from (_canReuseMaterialized). On a HELD
+// frame that array IS the hold origin's — so after promoting, the live
+// items belong to the freshly written keyframe, not to the origin any
+// more. Leaving the anchor behind made the reuse test claim the edited
+// layer still represented the ORIGIN frame: measured live, a gradient
+// enabled on held frame 3 came back on keyframe 0 too, because navigating
+// there reused the edited items and the next frame change wrote them
+// back. Only bites edits that change no geometry (a geometry edit sets
+// _smGeomDirty, which already forces a rebuild) — which is exactly the
+// class the promotion helper opened up.
+function _reanchorMaterialized(li,strokes){
+  var lyr=window.userLayers&&userLayers[li];
+  if(!lyr||!strokes)return;
+  lyr._matStrokes=strokes;
+  lyr._smGeomDirty=false;
 }
 function syncLinkedKeyframeFolder(sourceLayerIdx,frameIdx){
   var srcLd=state.layers[sourceLayerIdx];

--- a/src/js/gradient-bridge.js
+++ b/src/js/gradient-bridge.js
@@ -105,7 +105,7 @@
         var prevA = (stop.color && stop.color.length === 9) ? stop.color.slice(7, 9) : 'ff';
         stop.color = this.value + prevA;
         this.dataset.hex8 = stop.color;
-        saveActiveLayerFrame(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+        saveActiveLayerFrameOrPromote(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
       });
       var offInp = document.createElement('input');
       offInp.type = 'number'; offInp.className = 'pi scrub'; offInp.min = 0; offInp.max = 100; offInp.step = 1; offInp.dataset.step = '1';
@@ -114,7 +114,7 @@
       offInp.addEventListener('change', function () {
         pushUndo(); stop.offset = Math.max(0, Math.min(100, parseFloat(this.value) || 0)) / 100;
         normalizeStops(grad);
-        saveActiveLayerFrame(); renderGradientPanel(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+        saveActiveLayerFrameOrPromote(); renderGradientPanel(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
       });
       var pct = document.createElement('span'); pct.style.cssText = 'font-size:9px;color:var(--text-dim)'; pct.textContent = '%';
       var rmBtn = document.createElement('button');
@@ -125,7 +125,7 @@
         pushUndo();
         var idx = grad.stops.indexOf(stop);
         if (idx >= 0) grad.stops.splice(idx, 1);
-        saveActiveLayerFrame(); renderGradientPanel(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+        saveActiveLayerFrameOrPromote(); renderGradientPanel(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
       });
       row.appendChild(colorInp); row.appendChild(offInp); row.appendChild(pct); row.appendChild(rmBtn);
       stopsList.appendChild(row);
@@ -133,7 +133,14 @@
   }
   window.renderGradientPanel = renderGradientPanel;
 
-  function toggleGradient(on) {
+  // Every commit in this file goes through saveActiveLayerFrameOrPromote
+// (2026-09 QA sweep, same family as #823/#824/#825/#828): a gradient is a
+// per-stroke property written on the LIVE path, and saveActiveLayerFrame()
+// does nothing on a held frame — so enabling a gradient, dragging its
+// gizmo or editing a stop on a held frame all came back undone at the next
+// scrub. The helper promotes the held frame in Animation 2D and writes
+// into the hold's own keyframe in Motion.
+function toggleGradient(on) {
     var target = singleTarget();
     if (!target) return;
     pushUndo();
@@ -143,7 +150,7 @@
     } else {
       delete target.data.fillGradient;
     }
-    saveActiveLayerFrame(); updateUI(); renderGradientPanel();
+    saveActiveLayerFrameOrPromote(); updateUI(); renderGradientPanel();
     if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
   }
   function addStop() {
@@ -163,7 +170,7 @@
     var mid = (a.offset + b.offset) / 2;
     grad.stops.push({ offset: mid, color: a.color });
     normalizeStops(grad);
-    saveActiveLayerFrame(); renderGradientPanel();
+    saveActiveLayerFrameOrPromote(); renderGradientPanel();
     if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
   }
 
@@ -283,7 +290,7 @@
     e.stopImmediatePropagation(); e.preventDefault();
     dragging = null;
     window.SMEngineBridge.resume();
-    saveActiveLayerFrame(); renderGradientPanel();
+    saveActiveLayerFrameOrPromote(); renderGradientPanel();
     window.SMEngineBridge.renderNow();
   }
 
@@ -296,7 +303,7 @@
         var target = singleTarget();
         if (!target || !target.data.fillGradient) return;
         pushUndo(); target.data.fillGradient.kind = this.value;
-        saveActiveLayerFrame(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
+        saveActiveLayerFrameOrPromote(); if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
       });
     }
     var target = document.getElementById('canvas-area') || document.getElementById('drawing-canvas');

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -6018,7 +6018,13 @@ function booleanOp(op){
   // comment) may have used one of the booleaned shapes as a wall; keep
   // re-tracing those, same as before this fix.
   fillRegenerateLinked(boolLayer,islands[0]);
-  saveActiveLayerFrame();updateUI();showToast(SM.t('toastBooleanOpApplied'));
+  // Held frame (2026-09 QA sweep, same family as #823/#824/#825/#828):
+  // saveActiveLayerFrame() does nothing on a held frame, so a Union /
+  // Subtract / Intersect applied there redrew the canvas and came back
+  // un-merged on the next scrub (measured live: the geometry changed on
+  // screen, the stored frames did not). Promotes in Animation 2D, writes
+  // into the hold's own keyframe in Motion.
+  saveActiveLayerFrameOrPromote();updateUI();showToast(SM.t('toastBooleanOpApplied'));
 }
 
 // ---- PRECISION VECTOR ERASER ----


### PR DESCRIPTION
Suite de #823 / #824 / #825 / #828.

- **Booléens** (Union / Soustraction / Intersection) sur une image tenue : le résultat revenait non fusionné au premier scrub.
- **Dégradés** (activer, glisser la poignée, éditer un arrêt) : même trou, sur toute la chaîne.
- **Fuite révélée par la promotion** : `_canReuseMaterialized` compare les objets vivants au tableau de traits qui les a produits — sur une image tenue c'est celui de la clé source. Après promotion, sans réancrage, la navigation réutilisait le calque édité pour la clé source et l'y réécrivait (mesuré : dégradé posé sur l'image 3 tenue réapparaissant sur la clé 0). Ne touchait que les éditions sans changement de géométrie.

Vérifié en direct ; `npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)