### PR TITLE
Suppr sur un calque sélectionné dans la timeline supprime le calque

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -9820,7 +9820,14 @@ function onKeyDown(event){
         }
       }
     }
-    else if(state.tool==='select'&&selectedPaths.length>0)window.SM.deleteSelStrokes();
+    // Same rule as Cmd+D (feedback #803, see that branch): a timeline row
+    // click auto-selects the layer's whole content, so this branch fired
+    // for a LAYER selection too and Delete emptied the drawing instead of
+    // removing the layer — while the next branch, added for feedback #107
+    // ("la touche supprimer ne marche pas pour supprimer un calque dans la
+    // timeline"), only ever saw the case where the layer happened to be
+    // empty. window._layerActiveExplicit tells the two apart.
+    else if(state.tool==='select'&&selectedPaths.length>0&&!window._layerActiveExplicit)window.SM.deleteSelStrokes();
     // Delete key on the Select tool with nothing on canvas selected — but a
     // layer row IS (feedback #107: "la touche supprimer ne marche pas pour
     // supprimer un calque dans la timeline"). Every branch above only ever


### PR DESCRIPTION
Symétrique de #803 / PR #829 : un clic sur une ligne de timeline auto-sélectionne le contenu du calque, donc **Suppr** vidait le dessin au lieu de retirer le calque (la branche « supprimer le calque » du feedback #107 ne se déclenchait que sur un calque déjà vide). Même signal que Cmd+D pour distinguer les deux gestes.

Vérifié en direct : ligne + Suppr → calque supprimé, undo OK ; forme sélectionnée au canvas + Suppr → seule la forme part. `npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)