### PR TITLE
Grouper/dissoudre un dossier de calques devient annulable

### DIFF
--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -5596,6 +5596,11 @@ function groupSelectionIntoFolder(){
   var sorted=_layerSel.slice().sort(function(a,b){return a-b;});
   for(var k=1;k<sorted.length;k++)if(sorted[k]!==sorted[k-1]+1){showToast(SM.t('toastLayersMustBeConsecutive'));return;}
   if(sorted.some(function(i){return state.layers[i].folderId;})){showToast(SM.t('toastSelectedLayerAlreadyInFolder'));return;}
+  // No undo entry at all until now (2026-09 QA sweep, measured: 0 entries
+  // pushed, Cmd+Z gave back the previous action instead) — every other
+  // structural layer action snapshots. All the guards above run first so a
+  // refused grouping still costs nothing.
+  saveAllLayerFrames();pushUndoLayers(true);
   var fid='folder-'+Date.now()+'-'+Math.floor(Math.random()*1000);
   state.layerFolders[fid]={name:SM.t('layerKindFolder'),collapsed:false};
   sorted.forEach(function(i){state.layers[i].folderId=fid;});
@@ -5607,6 +5612,9 @@ function folderMemberIndices(fid){
   return idxs;
 }
 function ungroupFolder(fid){
+  // Same missing snapshot as groupSelectionIntoFolder above — dissolving a
+  // folder was equally un-undoable.
+  saveAllLayerFrames();pushUndoLayers(true);
   state.layers.forEach(function(ld){if(ld.folderId===fid)delete ld.folderId;});
   delete state.layerFolders[fid];
   renderLayerList();renderTimeline();

--- a/src/js/tweens.js
+++ b/src/js/tweens.js
@@ -4839,6 +4839,14 @@ function layersSnapshotNow(){return{type:'layers',layers:_cloneLayersForUndo(sta
   // through the module so `tris` comes back as a real Array rather than the
   // typed array Delaunator hands out — see SMImageMesh.serialize's comment.
   imageMeshes:(window.SMImageMesh?SMImageMesh.serialize():JSON.parse(JSON.stringify(state.imageMeshes||{}))),
+  // Folder + link-group METADATA (2026-09 QA sweep) — same blind spot as
+  // cameraKeys/imageMeshes above: a layer's membership lives on the layer
+  // (ld.folderId), but the folder's own name and collapsed state live in
+  // these two maps, which _cloneLayersForUndo cannot see. Without them an
+  // undo brought the layers back out of the folder and left its now-empty
+  // entry behind (renamed folders came back with the new name, too).
+  layerFolders:JSON.parse(JSON.stringify(state.layerFolders||{})),
+  layerLinkGroups:JSON.parse(JSON.stringify(state.layerLinkGroups||{})),
   symbolId:state.activeSymbolId||null,montageViewId:state.activeMontageViewId||null};}
 // Human-readable "where this undo entry belongs", for the cross-context
 // guard in undo()/redo() below. Falls back to '?' for a symbol/montage
@@ -4893,6 +4901,10 @@ function restoreLayersSnapshot(s){
   if(state.waOut>=s.totalFrames)state.waOut=s.totalFrames-1;window._waOut=state.waOut;
   if(state.currentFrame>=s.totalFrames)state.currentFrame=s.totalFrames-1;
   state.activeLayerIdx=Math.max(0,Math.min(s.active,state.layers.length-1));
+  // Folder/link-group metadata (see layersSnapshotNow) — undefined in any
+  // snapshot taken before this existed, left untouched in that case.
+  if(s.layerFolders)state.layerFolders=JSON.parse(JSON.stringify(s.layerFolders));
+  if(s.layerLinkGroups)state.layerLinkGroups=JSON.parse(JSON.stringify(s.layerLinkGroups));
   // The `state.layers=[]` above replaces the array, which breaks the alias
   // enterSymbol set up (state.layers === state.symbols[id].layers). Re-point
   // it immediately so anything reading the SYMBOL rather than `state` mid-


### PR DESCRIPTION
Mesuré : `groupSelectionIntoFolder` poussait **0 entrée d'annulation** (Cmd+Z rejouait l'action précédente), `ungroupFolder` non plus. Toutes les autres actions structurelles snapshotent.

Corrigé aussi le trou correspondant dans l'instantané : `layerFolders` / `layerLinkGroups` n'en faisaient pas partie, donc un undo laissait derrière l'entrée de dossier vide et un dossier renommé revenait avec le nouveau nom (même famille que `cameraKeys` et `imageMeshes`, déjà ajoutés).

Vérifié en direct (grouper → undo → redo → dissoudre → undo) ; `npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)