### PR TITLE
Arcs de mouvement et courbes d'ease : annulables, en un seul Cmd+Z

### DIFF
--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -1017,6 +1017,12 @@
     var ah = hitTestArc(pt);
     if (ah) {
       mode = 'arc';
+      // One undo entry per arc-handle GESTURE (2026-09 QA sweep): dragging
+      // a motion-arc handle rewrote state.motionArcs with no snapshot at
+      // all, so Cmd+Z jumped straight past it to the previous action and
+      // the bent trajectory stayed bent. Pushed at grab time, before the
+      // first setArcHandle, like every other drag in this file.
+      if (typeof pushUndo === 'function') pushUndo();
       draggingArc = ah;
       // Perf fix 2026-07: compute the (expensive, O(n³) autoMatch) stroke
       // pairing ONCE here instead of on every pointermove — only the
@@ -2547,7 +2553,7 @@
     if (mode === 'arc') {
       draggingArc = null;
       arcDragCache = null;
-      generateTweens();
+      generateTweens(undefined,true);
     } else if (mode === 'xform-scale' || mode === 'xform-rotate' || mode === 'xform-skew') {
       // Motion mode: geometry was never touched during this gesture (see
       // onMove's early-return) — none of the fork/regenerate/save-frame

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -4469,6 +4469,13 @@ function buildTweenCurveSVG(li,fA,fB,svgW,svgH){
         // entirely. `svg` itself is never destroyed by redraw() (only its
         // children are), so capturing there instead survives every redraw.
         svg.setPointerCapture(e.pointerId);
+        // One undo entry per curve-point GESTURE (2026-09 QA sweep):
+        // state.tweenEasing was written straight through with no snapshot,
+        // so Cmd+Z after re-shaping an ease jumped to the previous action
+        // and left the new curve in place. The snapshot now carries
+        // tweenEasing (layersSnapshotNow, tweens.js), so one push here is
+        // all this needs.
+        if(typeof pushUndo==='function')pushUndo();
         function move(ev){
           var r=svg.getBoundingClientRect();
           var nx=fromSX(ev.clientX-r.left),ny=fromSY(ev.clientY-r.top);

--- a/src/js/tools.js
+++ b/src/js/tools.js
@@ -7365,7 +7365,7 @@ function onMouseDown(event){
     // unrelated action happened to trigger the next render tick.
     if(window.SMEngineBridge&&window.SMEngineBridge.renderNow)window.SMEngineBridge.renderNow();
   }else if(state.tool==='select'){
-    for(var i=0;i<arcHandles.length;i++){var ah=arcHandles[i];if(event.point.getDistance(ah.handle.position)<14/view.zoom){draggingArc=ah;arcDragCache=computeArcMatchState();return;}}draggingArc=null;
+    for(var i=0;i<arcHandles.length;i++){var ah=arcHandles[i];if(event.point.getDistance(ah.handle.position)<14/view.zoom){pushUndo();draggingArc=ah;arcDragCache=computeArcMatchState();return;}}draggingArc=null;
     var bestXh=null,bestXd=9/view.zoom;
     // Ring band check first (2026-07): a 'rotate' entry now stores
     // {center,radius} instead of a single pos — anywhere within ~7px of
@@ -8102,7 +8102,7 @@ function onMouseUp(event){
       }
       _marquee.active=false;renderArcs();updateUI();
     }
-    else if(draggingArc){draggingArc=null;arcDragCache=null;generateTweens();}else if(selectedPaths.length>0){
+    else if(draggingArc){draggingArc=null;arcDragCache=null;generateTweens(undefined,true);}else if(selectedPaths.length>0){
       _moveDragStarted=false;
       var mLd2=state.layers[state.activeLayerIdx];
       if(mLd2&&mLd2.symbolId){

--- a/src/js/tweens.js
+++ b/src/js/tweens.js
@@ -3769,7 +3769,7 @@ function _dedupeFrameStrokeIds(strokes,frameIdx){
     else seen[sd.strokeId]=1;
   }
 }
-function generateTweens(explicitRestrictTo){
+function generateTweens(explicitRestrictTo,skipUndo){
   saveAllLayerFrames();var li=state.activeLayerIdx;var ld=state.layers[li];
   var keys=[];for(var i=0;i<state.totalFrames;i++){if(ld.frames[i].isKeyframe&&ld.frames[i].strokes.length>0)keys.push(i);}
   if(keys.length<2){showToast(SM.t('toastNeedAtLeast2DrawnKeyframes'));return;}
@@ -3789,7 +3789,12 @@ function generateTweens(explicitRestrictTo){
     restrictTo={};
     selOnLayer.forEach(function(fi0){for(var pi=fi0;pi>=0;pi--){if(ld.frames[pi].isKeyframe){restrictTo[pi]=true;break;}}});
   }
-  pushUndoLayers();
+  // skipUndo: the caller already snapshotted BEFORE its own mutation (the
+  // motion-arc handle drag, which changes state.motionArcs at grab time) —
+  // a second entry here would split one gesture across two Cmd+Z presses,
+  // the same "one gesture, one undo" rule feedback #755 established for
+  // the layer reorder.
+  if(!skipUndo)pushUndoLayers();
   var resN=state.resamplePts;var step=state.tweenStep;var total=0;
   for(var ki=0;ki<keys.length-1;ki++){
     var fA=keys[ki],fB=keys[ki+1];
@@ -4847,6 +4852,13 @@ function layersSnapshotNow(){return{type:'layers',layers:_cloneLayersForUndo(sta
   // entry behind (renamed folders came back with the new name, too).
   layerFolders:JSON.parse(JSON.stringify(state.layerFolders||{})),
   layerLinkGroups:JSON.parse(JSON.stringify(state.layerLinkGroups||{})),
+  // Tween-side state (2026-09 QA sweep) — same blind spot again: a motion
+  // ARC handle and an ease CURVE point are real edits to the animation,
+  // but they live in these maps, not in any frame's strokes, so undo left
+  // them exactly as the (now undone) gesture had set them.
+  motionArcs:JSON.parse(JSON.stringify(state.motionArcs||{})),
+  tweenEasing:JSON.parse(JSON.stringify(state.tweenEasing||{})),
+  tweenOverrides:JSON.parse(JSON.stringify(state.tweenOverrides||{})),
   symbolId:state.activeSymbolId||null,montageViewId:state.activeMontageViewId||null};}
 // Human-readable "where this undo entry belongs", for the cross-context
 // guard in undo()/redo() below. Falls back to '?' for a symbol/montage
@@ -4905,6 +4917,9 @@ function restoreLayersSnapshot(s){
   // snapshot taken before this existed, left untouched in that case.
   if(s.layerFolders)state.layerFolders=JSON.parse(JSON.stringify(s.layerFolders));
   if(s.layerLinkGroups)state.layerLinkGroups=JSON.parse(JSON.stringify(s.layerLinkGroups));
+  if(s.motionArcs)state.motionArcs=JSON.parse(JSON.stringify(s.motionArcs));
+  if(s.tweenEasing)state.tweenEasing=JSON.parse(JSON.stringify(s.tweenEasing));
+  if(s.tweenOverrides)state.tweenOverrides=JSON.parse(JSON.stringify(s.tweenOverrides));
   // The `state.layers=[]` above replaces the array, which breaks the alias
   // enterSymbol set up (state.layers === state.symbols[id].layers). Re-point
   // it immediately so anything reading the SYMBOL rather than `state` mid-


### PR DESCRIPTION
Suite de #834.

- `motionArcs`, `tweenEasing`, `tweenOverrides` absents de l'instantané d'annulation.
- Aucun des deux gestes (poignée d'arc, point de courbe) ne poussait d'entrée : Cmd+Z sautait à l'action précédente.
- Le drag d'arc en poussait une seconde à la fin via `generateTweens` → deux Cmd+Z pour un geste. `generateTweens` accepte maintenant `skipUndo` (même mécanique que #755).

Vérifié en direct : 1 entrée, 1 undo, arc rétabli. `npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)