### PR TITLE
Duplicateur mode Objets : l'action plantait au milieu (fonction non définie)

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1862,7 +1862,14 @@ function convertSelectionToObjectDuplicator(indices){
   pool.forEach(function(l){l.visible=false;});
   if(typeof activateUL==='function')activateUL(hostIdx);
   loadFrame(state.currentFrame);
-  invalidateSymbolUnionBounds(); // same cache-staleness fix toggleLayerDuplicator applies
+  // Bare call → ReferenceError (2026-09 QA sweep): this function lives in
+  // motion.js's closure and is only reachable as SMMotion.
+  // invalidateSymbolUnionBounds — every other caller (undo/redo, dupRefresh,
+  // saveActiveLayerFrame) goes through the namespace. Creating an object
+  // duplicator therefore threw here, AFTER the host layer had been created
+  // and the pool hidden: the action half-completed, no toast, no panel, and
+  // the exception took the rest of the click handler with it.
+  if(window.SMMotion&&SMMotion.invalidateSymbolUnionBounds)SMMotion.invalidateSymbolUnionBounds(); // same cache-staleness fix toggleLayerDuplicator applies
   if(window.SMEngineBridge)SMEngineBridge.renderNow();
   renderLayerList();renderTimeline();
   if(window.updateDuplicatorPanel)updateDuplicatorPanel();


### PR DESCRIPTION
`convertSelectionToObjectDuplicator` appelait `invalidateSymbolUnionBounds()` sans le préfixe `SMMotion.` — ReferenceError **après** la création du calque hôte et le masquage du pool : action à moitié faite, sans toast ni panneau, et l'exception emportait la suite du gestionnaire de clic. Introduit avec le mode Objets (#693).

Vérifié en direct : création complète, grille 3×3 → 9 items, radial 6 → 6, champs du panneau annulables. `npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)