### PR TITLE
Ouvrir un shot Kitsu n'échoue plus juste après le chargement

### DIFF
--- a/src/js/kitsu.js
+++ b/src/js/kitsu.js
@@ -385,7 +385,7 @@
     list.innerHTML = '<div style="font-size:10px;color:var(--text-dim)">Ouverture du shot…</div>';
     try {
       var res = await window.SMKitsu.openShot(window.SMKitsu.getSession(), project, sequence, shot);
-      hideModal(); hideStartScreen(); ensureInitialTab();
+      hideModal(); if(window.SMProject&&SMProject.enterEditor)SMProject.enterEditor();
       updateKitsuShotUI();
       var previewNote = res.previews && res.previews.length ? (' — ' + res.previews.length + ' référence(s) publiée(s) visibles dans l\'historique Kitsu') : '';
       showToast('Shot ouvert : ' + shot.name + ' (' + res.meta.w + '×' + res.meta.h + ', ' + res.meta.fps + 'fps, ' + res.meta.frameCount + ' frames)' + previewNote);

--- a/src/js/project.js
+++ b/src/js/project.js
@@ -396,7 +396,16 @@
     return report;
   }
 
-  window.SMProject={save:save,saveAs:saveAs,open:openDialog,openPath:openPath,newProject:function(cfg){newProject(cfg);hideStartScreen();ensureInitialTab();},pushVersionSnapshot:pushVersionSnapshot,listVersionHistory:listVersionHistory,restoreVersion:restoreVersion,autosaveWrite:autosaveWrite,
+  window.SMProject={save:save,saveAs:saveAs,open:openDialog,openPath:openPath,newProject:function(cfg){newProject(cfg);hideStartScreen();ensureInitialTab();},
+    // "A project is now open, show the editor" — hideStartScreen +
+    // ensureInitialTab, the pair newProject above already runs. Exported
+    // (2026-09 QA sweep) because kitsu.js called those two by their bare
+    // names, which live only in this closure: opening a shot from Kitsu
+    // threw ReferenceError right after the shot had loaded, so the start
+    // screen stayed up, no tab was created, and the user got
+    // "hideStartScreen is not defined" in the shot list instead of the
+    // success toast.
+    enterEditor:function(){hideStartScreen();ensureInitialTab();},pushVersionSnapshot:pushVersionSnapshot,listVersionHistory:listVersionHistory,restoreVersion:restoreVersion,autosaveWrite:autosaveWrite,
     getSyncFolder:getSyncFolder,chooseSyncFolder:chooseSyncFolder,disableSync:disableSync,publishToShared:publishToShared,checkSharedUpdates:checkSharedUpdates,pullAndMerge:pullAndMerge,
     // Stable per-project filesystem-safe identifier — same slug/hash
     // feedback-bridge.js's local + shared feedback storage keys off, so a


### PR DESCRIPTION
Même famille que #839 : `kitsu.js` appelait `hideStartScreen()` / `ensureInitialTab()` par leur nom nu, alors qu'elles vivent dans la fermeture de `project.js`. Le shot se chargeait puis ReferenceError : écran de démarrage toujours là, aucun onglet, message d'erreur cryptique à la place du toast.

`SMProject.enterEditor()` exporté, appelé avec garde depuis Kitsu.

Vérifié en direct (appel OK, ancien appel nu confirmé en ReferenceError) ; `npm test` 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)