### PR TITLE
Motion : le lasso n'écrase plus la sélection des points d'entrée/sortie (#856)

### DIFF
--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -12738,7 +12738,18 @@
         if (window.SM && SM.setActiveLayer) SM.setActiveLayer(sweptLayers[0]);
         _layerSel = sweptLayers.slice();
         _layerSelAnchor = sweptLayers[0];
-        syncBarSelToLayerSel();
+        // #856 — NE PAS resynchroniser les barres depuis la sélection de
+        // calques quand ce même geste vient d'en sélectionner : le sync force
+        // chaque barre balayée à `part:'both'`, ce qui EFFACE la distinction
+        // entrée/sortie que le lasso avait établie (balayer les moitiés
+        // gauches de trois barres sélectionnait bien trois points d'entrée,
+        // puis le sync les remplaçait par trois barres entières — donc « on
+        // ne peut plus sélectionner les in/out séparément »). Le sync n'a de
+        // sens que dans l'autre cas : un lasso qui n'a attrapé QUE des clés,
+        // où les barres doivent suivre les calques plutôt que rester sur une
+        // sélection périmée.
+        var sweptBars = (window.SMLayerInOut && SMLayerInOut.getBarSelection) ? SMLayerInOut.getBarSelection() : [];
+        if (!sweptBars.length) syncBarSelToLayerSel();
         renderLayerList(); renderTimeline();
         if (window.SMEngineBridge) window.SMEngineBridge.renderNow();
       }


### PR DESCRIPTION
Le lasso de la grille attrape les clés, les points d'entrée/sortie, et depuis #769 reflète aussi les lignes balayées dans la sélection de calques. Ce dernier point écrasait le deuxième : au relâchement, `syncBarSelToLayerSel` réécrivait chaque barre balayée en `part:'both'` — un balayage des moitiés gauches sélectionnait bien trois points d'entrée avant de les remplacer par trois barres entières.

Le sync est désormais conditionné à une sélection de barres vide, cas où il garde tout son sens (un lasso qui n'a attrapé que des clés).

⚠️ **Vérification partielle** : raisonnement sur le chemin de code, l'écrasement étant inconditionnel. Le geste complet n'a pas pu être piloté dans le navigateur de test (le panneau se masque entre deux appels et gèle les minuteurs). À confirmer en usage réel.

`npm test` 70/70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)