### PR TITLE
Export Rive : lit le rendu réel, et grisé hors de l'app de bureau

### DIFF
--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -15,6 +15,7 @@
 (function(){
   var I18N={
     en:{
+      expAppOnly:"app only",
       hsLayerNotFound:"Layer not found",
       hsMontageEmpty:"Empty montage — snap instances against its block first",
       hsNotOnComponentOrLfs:"Not possible on a component or an existing LFS group",
@@ -1070,6 +1071,7 @@
       mgraphModeValue:'value',mgraphModeSpeed:'speed',mgraphFrozen:'frozen',mgraphExprLegend:'solid = expression, dashed = keyframes',
     },
     fr:{
+      expAppOnly:"app seulement",
       hsLayerNotFound:"Calque introuvable",
       hsMontageEmpty:"Montage vide — accrochez des instances contre son bloc d'abord",
       hsNotOnComponentOrLfs:"Impossible sur un composant ou un groupe LFS existant",
@@ -2124,6 +2126,7 @@
       mgraphModeValue:'valeur',mgraphModeSpeed:'vitesse',mgraphFrozen:'figé',mgraphExprLegend:'plein = expression, pointillés = clés',
     },
     ja:{
+      expAppOnly:"アプリのみ",
       linkedMediaBannerBtn:"アクセスを許可",
       mediaMissingFileBadge:"見つかりません",
       mediaNeedsPermissionBadge:"許可が必要",
@@ -3149,6 +3152,7 @@
       mgraphModeValue:'値',mgraphModeSpeed:'速度',mgraphFrozen:'固定',mgraphExprLegend:'実線 = 式、破線 = キーフレーム',
     },
     es:{
+      expAppOnly:"solo en la app",
       linkedMediaBannerBtn:"Permitir acceso",
       mediaMissingFileBadge:"No encontrado",
       mediaNeedsPermissionBadge:"Permiso necesario",

--- a/src/js/rive-export.js
+++ b/src/js/rive-export.js
@@ -48,6 +48,9 @@
 // 3-point stroke), but not pixel-identical to the bezier "static" shapes.
 //
 // Known gaps vs the Lottie exporter (documented, not silently dropped):
+// - (corrigé le 2026-09-03 : le duplicateur mograph et les effets de tracé
+//   manquaient, faute de lire getEffectiveStrokesRendered — voir le
+//   commentaire au point de lecture.)
 // - Blend modes: path_editor's paint schema has no blendMode field, so
 //   layer blend modes are not carried over.
 // - Symbols/components: getEffectiveStrokes() already flattens these into
@@ -567,7 +570,16 @@
       // anonymous only — exactly the old behavior, no worse.
       var laneOf0={},laneCount0=0;
       for(var f0=r.start;f0<=r.end;f0++){
-        var arr0=getEffectiveStrokes(li0,f0).filter(function(sd){return !sd.isBrushTextureCopy&&(sd.opacity!==0||sd.brushTexturePreset);});
+        // getEffectiveStrokesRendered, pas getEffectiveStrokes (2026-09-03) :
+        // pour un calque ordinaire les deux rendent le MÊME tableau, mais la
+        // variante « Rendered » est la seule qui applique le duplicateur
+        // mograph et les effets de tracé (path-fx.js). En lisant la variante
+        // nue, cet export sortait la forme source d'un duplicateur sans
+        // aucune de ses copies, et une forme sans sa déformation — sans rien
+        // signaler. C'est la famille de bug n°1 du CLAUDE.md : un mécanisme
+        // branché sur UN lecteur et pas sur les autres. export.js (PNG,
+        // vidéo, Lottie) lisait déjà la bonne variante.
+        var arr0=getEffectiveStrokesRendered(li0,f0).filter(function(sd){return !sd.isBrushTextureCopy&&(sd.opacity!==0||sd.brushTexturePreset);});
         var row0=[],anon0=0;
         for(var s0=0;s0<arr0.length;s0++){
           var sd0=arr0[s0];

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -11651,6 +11651,28 @@ window.updateCombinePanel=updateCombinePanel;
     var aeCamHint=document.getElementById('exp-ae-camera-hint');
     if(aeCamHint)aeCamHint.style.display=(v==='ae-camera')?'flex':'none';
   }
+  // L'export Rive parle à Rive Editor par MCP sur 127.0.0.1:9791. Dans un
+  // navigateur, cette requête ne peut pas aboutir (origine locale bloquée, et
+  // aucune permission de joindre un service de la machine) : sur desktop elle
+  // passe par le client HTTP de Rust, qui n'a pas cette contrainte. Plutôt que
+  // de laisser l'utilisateur choisir un format qui échouera avec un message
+  // technique, l'option est GRISÉE hors de l'app, avec la raison écrite à côté.
+  (function gateDesktopOnlyFormats(){
+    if(typeof window.__TAURI__!=='undefined')return;
+    var opt=fmtSel.querySelector('option[value="rive"]');
+    if(!opt)return;
+    opt.disabled=true;
+    if(fmtSel.value==='rive')fmtSel.value='png';
+    var base=opt.textContent.trim();
+    // Le libellé passe par SM.afterI18n : ce fichier est chargé AVANT i18n.js,
+    // donc SM.t rendrait la clé brute si on l'appelait ici — et cette liste de
+    // rappels est justement rejouée à chaque changement de langue, ce qui règle
+    // le même problème une seconde fois.
+    window.SM=window.SM||{};
+    (window.SM.afterI18n=window.SM.afterI18n||[]).push(function(){
+      opt.textContent=base+' — '+SM.t('expAppOnly');
+    });
+  })();
   fmtSel.addEventListener('change',updateScaleVisibility);
   scaleSel.addEventListener('change',function(){
     if(scaleSel.value==='custom'){wInput.value=state.canvasW;hInput.value=state.canvasH;}


### PR DESCRIPTION
Deux trouvailles d'une passe sur les exports.

**1. L'export Rive lisait la variante nue des traits.** Seule `getEffectiveStrokesRendered` applique le duplicateur mograph et les effets de tracé : cet export sortait donc la forme source d'un duplicateur **sans ses copies**, et une forme sans sa déformation, en silence. `export.js` (PNG, vidéo, Lottie) lisait déjà la bonne variante. Mesuré : 4 points contre 32 sur un rectangle avec zigzag.

**2. Rive grisé hors de l'app** (demande de Cyril). C'est structurel : l'export parle à Rive Editor sur `127.0.0.1:9791`, ce qu'un navigateur ne peut pas joindre ; sur desktop la requête passe par le client HTTP de Rust. Option désactivée, raison dans le libellé, repli sur PNG.

Le libellé passe par `SM.afterI18n` : `timeline.js` est chargé avant `i18n.js`, donc un `SM.t` direct affichait la clé brute — constaté à l'écran. Le crochet gère aussi le changement de langue à chaud.

Vérifié dans les 4 langues. `npm test` 70/70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)