### PR TITLE
Cmd+D sur une forme du panneau Éléments, et bords de barre attrapés au lasso

### DIFF
--- a/src/js/layer-inout.js
+++ b/src/js/layer-inout.js
@@ -420,6 +420,30 @@
   // the OVERLAP region's own midpoint, not the marquee rect's own bounds,
   // so a wide marquee that only grazes one edge of a narrow bar still
   // reads as a single-edge selection.
+  // Quelle(s) extrémité(s) le rectangle attrape-t-il VRAIMENT (2026-09-03) ?
+  // La règle précédente comparait le chevauchement au MILIEU de la barre : sur
+  // une barre longue de toute la timeline, un rectangle tracé quelque part
+  // dans la moitié droite sélectionnait le point de SORTIE, à des centaines de
+  // pixels de là. Cyril, capture à l'appui : « le out point du layer 1 est
+  // sélectionné alors que le rectangle est clair sur ce que je vais
+  // sélectionner ». On teste donc les POIGNÉES elles-mêmes, ce que l'œil voit,
+  // avec une petite tolérance parce qu'une poignée fait quatre pixels de large.
+  // Un rectangle qui couvre la barre sans toucher aucune poignée sélectionne
+  // la barre ENTIÈRE : il la désigne bien, il ne désigne simplement aucun bord
+  // en particulier.
+  var HANDLE_TOLERANCE_PX = 6;
+  function partForBoxHit(bar, barRect, x0, x1) {
+    var hl = bar.querySelector('.layer-inout-handle.left');
+    var hr = bar.querySelector('.layer-inout-handle.right');
+    if (!hl || !hr) return partForOverlap(barRect, Math.max(x0, barRect.left), Math.min(x1, barRect.right));
+    var rl = hl.getBoundingClientRect(), rr = hr.getBoundingClientRect();
+    var touches = function (r) { return (r.left - HANDLE_TOLERANCE_PX) <= x1 && (r.right + HANDLE_TOLERANCE_PX) >= x0; };
+    var inHit = touches(rl), outHit = touches(rr);
+    if (inHit && outHit) return 'both';
+    if (inHit) return 'in';
+    if (outHit) return 'out';
+    return 'both';
+  }
   function partForOverlap(barRect, ox0, ox1) {
     var mid = (barRect.left + barRect.right) / 2;
     var touchesLeft = ox0 <= mid, touchesRight = ox1 >= mid;
@@ -436,7 +460,7 @@
       var hit = b.left <= x1 && b.right >= x0 && b.top <= y1 && b.bottom >= y0;
       var part = null;
       if (hit) {
-        part = partForOverlap(b, Math.max(x0, b.left), Math.min(x1, b.right));
+        part = partForBoxHit(bar, b, x0, x1);
         sel.push({ li: li, part: part });
       }
       applySelClasses(bar, part);

--- a/src/js/motion.js
+++ b/src/js/motion.js
@@ -9807,6 +9807,15 @@
     if (!items.length) return;
     window.SM.setActiveLayer(li);
     selectedPaths = items;
+    // setActiveLayer lève window._layerActiveExplicit, qui veut dire « cette
+    // sélection vient d'un clic sur une LIGNE DE CALQUE de la timeline ». Ici
+    // c'est faux : on vient de sélectionner des FORMES (panneau Éléments,
+    // recherche, pickwhip). Le laisser levé faisait dupliquer le CALQUE au
+    // Cmd+D — Cyril : « je sélectionne un groupe ou une shape dans elements,
+    // je fais Cmd+D et la duplication n'apparaît pas » : elle apparaissait
+    // ailleurs, dans un calque tout neuf. Même raison pour Suppr et Cmd+G,
+    // qui lisent le même drapeau.
+    window._layerActiveExplicit = false;
     // feedback #202, "si je select une shape dans elements ça doit être les
     // properties de cette shape qui s'affiche dans layer properties" —
     // renderMotionPropsPanel's "targeted shape" branch (2026-08-30, #173)

--- a/src/js/shapes-panel.js
+++ b/src/js/shapes-panel.js
@@ -98,6 +98,9 @@
     var allIn = items.every(function (it) { return sel.indexOf(it) >= 0; });
     if (allIn) items.forEach(function (it) { var ix = sel.indexOf(it); if (ix >= 0) sel.splice(ix, 1); });
     else items.forEach(function (it) { if (sel.indexOf(it) < 0) sel.push(it); });
+    // Même raison que dans selectShapesByStrokeIds (motion.js) : une sélection
+    // ADDITIVE de formes n'est pas une sélection de calque.
+    window._layerActiveExplicit = false;
     if (window.state) state.selectedStrokeIndices = sel.map(function (it) { return typeof getSI === 'function' ? getSI(it) : -1; }).filter(function (i2) { return i2 >= 0; });
     if (window.renderArcs) renderArcs();
     if (window.updateUI) updateUI();


### PR DESCRIPTION
Deux signalements, deux causes.

**1. Cmd+D après une sélection dans Éléments ne montrait rien.** Ce n'était pas un rafraîchissement : `selectShapesByStrokeIds` appelle `setActiveLayer`, qui lève le drapeau « sélection venue d'une ligne de calque » — Cmd+D dupliquait donc le **calque**, et la copie atterrissait dans un calque neuf. Le drapeau est baissé par les deux chemins de sélection de formes. Vérifié sur les trois gestes qui le lisent : Cmd+D (+2 items, +1 ligne, 0 calque), Suppr (−2, −1, 0), Cmd+G (+1 groupe, 0 calque).

**2. Le point de sortie sélectionné loin du rectangle.** La règle comparait le chevauchement au **milieu** de la barre ; sur une barre pleine largeur, tout rectangle dans la moitié droite sélectionnait la sortie. On teste désormais les **poignées** elles-mêmes, avec 6 px de tolérance. Un rectangle qui couvre la barre sans toucher de poignée sélectionne la barre entière.

Vérifié sur quatre rectangles. `npm test` 70/70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)