### PR TITLE
Rectangle de survol décalé sur un groupe fusionné, et points d'entrée/sortie

### DIFF
--- a/src/js/layer-inout.js
+++ b/src/js/layer-inout.js
@@ -442,7 +442,16 @@
     if (inHit && outHit) return 'both';
     if (inHit) return 'in';
     if (outHit) return 'out';
-    return 'both';
+    // Aucune poignée dans le rectangle : on ne sélectionne AUCUN point.
+    // Cyril : « ce qu'il faudrait c'est que les in/out point qui sont
+    // SEULEMENT dans le rec de sélection soient sélectionnés ». Un premier
+    // jet renvoyait 'both' ici — donc un rectangle tracé au milieu d'une
+    // barre sélectionnait ses DEUX bords, exactement ce qu'il ne veut pas.
+    // La barre n'est pas perdue pour autant : le lasso de la grille verse
+    // alors ce calque dans la sélection de CALQUES (motion.js, endMarquee),
+    // ce qui est la lecture honnête du geste — « j'ai encadré ces lignes,
+    // sans viser de bord ».
+    return null;
   }
   function partForOverlap(barRect, ox0, ox1) {
     var mid = (barRect.left + barRect.right) / 2;
@@ -461,7 +470,7 @@
       var part = null;
       if (hit) {
         part = partForBoxHit(bar, b, x0, x1);
-        sel.push({ li: li, part: part });
+        if (part) sel.push({ li: li, part: part });
       }
       applySelClasses(bar, part);
     });

--- a/src/js/select-bridge.js
+++ b/src/js/select-bridge.js
@@ -63,6 +63,29 @@
     _hoverPathA2D = itemA2D;
     return true;
   }
+  // Le rectangle de survol annonce CE QU'UN CLIC VA SÉLECTIONNER (c'est sa
+  // raison d'être : « peu importe où on clique, si la box de hover est
+  // affichée ça doit sélectionner l'objet »). Or un clic sur un membre de
+  // groupe sélectionne TOUT le groupe, alors que la box ne montrait que le
+  // membre survolé — sur un groupe fusionné, où les membres sont masqués au
+  // profit du résultat, le rectangle tombait donc à côté du dessin visible.
+  // Mesuré sur le fichier de test de Cyril (fusion imbriquée : soustraction
+  // d'un groupe uni et d'un groupe simple) : membre survolé 790..943 en x,
+  // dessin visible 791..1259 — d'où le décalage signalé.
+  // On remonte au groupe RACINE, celui qui est réellement dessiné, comme le
+  // fait déjà la sélection.
+  function hoverBoxForGroup(item) {
+    if (!item || !item.data || !item.data.groupId || !window.SMGroup) return null;
+    var li = state.activeLayerIdx, ld = state.layers[li], layer = userLayers[li];
+    if (!ld || !ld.groups || !layer) return null;
+    var gid = SMGroup.rootGroupOfItem ? SMGroup.rootGroupOfItem(item, ld) : item.data.groupId;
+    if (!gid || !ld.groups[gid]) return null;
+    var members = SMGroup.resolveGroupMembers(gid, ld, layer) || [];
+    if (members.length < 2) return null;
+    var b = null;
+    members.forEach(function (m) { if (m && m.bounds) b = b ? b.unite(m.bounds) : m.bounds.clone(); });
+    return b ? { b: b, angle: 0, pivot: b.center } : null;
+  }
   // Oriented-box containment scan (2026-08, click-inside-the-hover-box
   // fallback — see the onDown call site's own comment for why this is a
   // fresh scan rather than trusting the last hover result). Topmost child
@@ -3564,7 +3587,9 @@
       // Oriented (rotated) box, not the raw axis-aligned strokeBounds (2026-08
       // fix — see orientedBoxForPath's own comment, tools.js): a rotated
       // shape's AABB is bigger than and doesn't match its actual outline.
-      return (_hoverPathA2D && !_hoverPathA2D.removed) ? orientedBoxForPath(_hoverPathA2D) : null;
+      var p = (_hoverPathA2D && !_hoverPathA2D.removed) ? _hoverPathA2D : null;
+      if (!p) return null;
+      return hoverBoxForGroup(p) || orientedBoxForPath(p);
     },
     // Switching tools mid-marquee-drag (2026-07-29, QA-confirmed) used to
     // leave a stuck ghost selection rectangle: onUp's own finalization


### PR DESCRIPTION
Deux retours sur le fichier de test (trois groupes imbriqués, soustraction d'un groupe uni et d'un groupe simple).

**1. Rectangle de survol décalé.** Il annonce ce qu'un clic va sélectionner, or un clic sur un membre sélectionne tout le groupe — le rectangle, lui, ne montrait que le membre survolé, et sur un groupe fusionné (membres masqués au profit du résultat) il tombait à côté du dessin. Mesuré : survol 791..1259 × **211..572**, dessin visible 791..1259 × **211..833**. Il remonte maintenant au groupe racine : 790..1259 × 211..846, qui couvre le dessin.

**2. Points d'entrée/sortie, règle stricte.** Ma passe précédente retombait sur « barre entière » quand le rectangle ne touchait aucune poignée. Désormais : aucun point sélectionné dans ce cas — seuls ceux réellement dans le rectangle le sont. Le calque entre normalement dans la sélection de calques.

Vérifié sur trois barres (milieu → aucun, entrées → 3 in, sorties → 3 out, tout → both). `npm test` 70/70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)