### PR TITLE
Fix release build: wire STROKEMOTION_FEEDBACK_TOKEN into release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,8 @@ name: Release
 # updater manifest included.
 #
 # It produces the public binaries and, via includeUpdaterJson, the latest.json
-# the auto-updater will read. Pointing the app AT it is a deliberate follow-up:
-# that means editing src-tauri/src/lib.rs, which PR #710 is already rewriting,
-# and stacking both edits on one file would only create a conflict. Until that
-# lands the app still reads the old endpoint, so this workflow's value today is
-# the public builds, not the update path.
+# the auto-updater reads (tauri.conf.json points at this repo's own
+# releases/latest/download/latest.json — no token needed, it's public).
 #
 # This supersedes scripts/publish-update.sh, which pushed the .app.tar.gz into
 # the private strokemotion-updates repo and served it through the Contents
@@ -107,6 +104,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Baked into the binary at compile time via env! (src-tauri/src/lib.rs) —
+          # fine-grained PAT scoped to ONLY mysteropodes/strokemotion-feedback,
+          # Issues:write + Contents:write. Without it the build fails outright
+          # (env! is a hard compile error, not a runtime default).
+          STROKEMOTION_FEEDBACK_TOKEN: ${{ secrets.STROKEMOTION_FEEDBACK_TOKEN }}
         with:
           tagName: ${{ github.event.inputs.tag || github.ref_name }}
           releaseName: 'Nemo __VERSION__'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           # fine-grained PAT scoped to ONLY mysteropodes/strokemotion-feedback,
           # Issues:write + Contents:write. Without it the build fails outright
           # (env! is a hard compile error, not a runtime default).
-          STROKEMOTION_FEEDBACK_TOKEN: ${{ secrets.STROKEMOTION_FEEDBACK_TOKEN }}
+          NEMO_FEEDBACK_TOKEN: ${{ secrets.NEMO_FEEDBACK_TOKEN }}
         with:
           tagName: ${{ github.event.inputs.tag || github.ref_name }}
           releaseName: 'Nemo __VERSION__'


### PR DESCRIPTION
## Summary
- The v0.7.0-alpha.1 release build failed outright: `STROKEMOTION_FEEDBACK_TOKEN` is read via `env!()` at compile time (no runtime fallback), and `release.yml` never passed it in
- Wires the secret into the build step's env, alongside the Tauri signing keys
- Drops a stale comment block referencing PR #710's updater rewrite, which already landed

## Still needed before the next build
This repo has no `STROKEMOTION_FEEDBACK_TOKEN` secret yet — someone with repo admin access needs to:
1. Mint a fine-grained PAT at https://github.com/settings/tokens?type=beta scoped to **only** `mysteropodes/strokemotion-feedback`, with `Issues: write` + `Contents: write`
2. `gh secret set STROKEMOTION_FEEDBACK_TOKEN --repo mysteropodes/nemo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)