### PR TITLE
Rename STROKEMOTION_FEEDBACK_TOKEN to NEMO_FEEDBACK_TOKEN

### DIFF
--- a/.github/workflows/deploy-feedback-worker.yml
+++ b/.github/workflows/deploy-feedback-worker.yml
@@ -1,19 +1,23 @@
 name: Deploy feedback Worker to Cloudflare
 
 # Separate from deploy-web.yml on purpose: this Worker holds a GitHub write
-# token scoped to mysteropodes/strokemotion-feedback (Issues + Contents),
-# the editor's static-site Worker holds none — no reason to redeploy one
-# whenever the other's files change.
+# token scoped to mysteropodes/nemo (Issues) + mysteropodes/strokemotion-
+# feedback (Contents, for attachments) — see index.js's ISSUE_REPO /
+# ATTACHMENT_REPO — the editor's static-site Worker holds none, so there's
+# no reason to redeploy one whenever the other's files change.
 #
 # One-time setup this workflow depends on (can't be done from a workflow
 # file):
 #   1. The Worker needs its OWN Cloudflare-side secret — NOT a GitHub
 #      Actions secret, set once via the CLI directly against the account:
 #        npx wrangler secret put GITHUB_FEEDBACK_TOKEN --name nemo-feedback
-#      (run locally, with a fine-grained GitHub PAT scoped ONLY to
-#      mysteropodes/strokemotion-feedback, Issues:write + Contents:write —
-#      the same scope src-tauri's NEMO_FEEDBACK_TOKEN already uses;
-#      can be the same token value or a fresh one).
+#      (run locally, with a fine-grained GitHub PAT scoped to BOTH
+#      mysteropodes/nemo and mysteropodes/strokemotion-feedback,
+#      Issues:write + Contents:write on each — the same scope src-tauri's
+#      NEMO_FEEDBACK_TOKEN already uses; can be the same token value or a
+#      fresh one. Note this grants Contents:write on nemo itself too, since
+#      a fine-grained PAT applies one permission set to every repo it
+#      covers — see CLAUDE.md's feedback section for the trade-off).
 #   2. CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID (GitHub Actions repo
 #      secrets) — already added for deploy-web.yml, reused here.
 # ALLOWED_ORIGINS (the editor's real origin(s)) and feedback-bridge.js's

--- a/.github/workflows/deploy-feedback-worker.yml
+++ b/.github/workflows/deploy-feedback-worker.yml
@@ -12,7 +12,7 @@ name: Deploy feedback Worker to Cloudflare
 #        npx wrangler secret put GITHUB_FEEDBACK_TOKEN --name nemo-feedback
 #      (run locally, with a fine-grained GitHub PAT scoped ONLY to
 #      mysteropodes/strokemotion-feedback, Issues:write + Contents:write —
-#      the same scope src-tauri's STROKEMOTION_FEEDBACK_TOKEN already uses;
+#      the same scope src-tauri's NEMO_FEEDBACK_TOKEN already uses;
 #      can be the same token value or a fresh one).
 #   2. CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID (GitHub Actions repo
 #      secrets) — already added for deploy-web.yml, reused here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,8 +409,7 @@ automatiquement, même si le remote dit `'approved'` — seule l'approbation loc
 [`mysteropodes/strokemotion-feedback`](https://github.com/mysteropodes/strokemotion-feedback)
 (aucun code de l'app dedans) — une Issue GitHub par feedback, créée depuis Rust
 (`submit_feedback_issue` dans `src-tauri/src/lib.rs`, **jamais** depuis JS) avec un token
-compilé à la build via `env!("STROKEMOTION_FEEDBACK_TOKEN")` (même pattern que
-`STROKEMOTION_UPDATER_TOKEN`) — fine-grained PAT scopé À CE SEUL REPO, permissions
+compilé à la build via `env!("NEMO_FEEDBACK_TOKEN")` — fine-grained PAT scopé À CE SEUL REPO, permissions
 "Issues: write" + "Contents: write" (élargi en 2026-07 pour les captures d'écran jointes,
 voir ci-dessous — décision utilisateur explicite, toujours zéro exposition de code) : un
 token extrait du binaire peut au pire spammer des issues ou écrire n'importe quel fichier
@@ -624,12 +623,11 @@ mutuellement. Règles à suivre **sans qu'on ait besoin de le redemander** :
   copie du repo GitHub ailleurs. Ne jamais partager ce dossier OneDrive directement avec un
   collaborateur pour du travail simultané (sync cloud + git en parallèle sur le même dossier
   risque de corrompre l'historique).
-- Secrets (`TAURI_SIGNING_PRIVATE_KEY`, `STROKEMOTION_PUBLISH_TOKEN`,
-  `STROKEMOTION_UPDATER_TOKEN`, `STROKEMOTION_FEEDBACK_TOKEN`) restent strictement
-  personnels à Cyril — jamais committés (déjà couvert par `.gitignore` pour les clés de
-  signature), jamais partagés même avec un collaborateur de confiance. Pour du dev normal,
-  des valeurs placeholder (`STROKEMOTION_FEEDBACK_TOKEN=dev-placeholder
-  STROKEMOTION_UPDATER_TOKEN=dev-placeholder`) suffisent à compiler et lancer `npm run dev`.
+- Secrets (`TAURI_SIGNING_PRIVATE_KEY(_PASSWORD)`, `NEMO_FEEDBACK_TOKEN`) restent
+  strictement personnels à Cyril — jamais committés (déjà couvert par `.gitignore` pour
+  les clés de signature), jamais partagés même avec un collaborateur de confiance. Pour
+  du dev normal, une valeur placeholder (`NEMO_FEEDBACK_TOKEN=dev-placeholder`) suffit à
+  compiler et lancer `npm run dev`.
 - **Avant de partir en investigation sur un bug rapporté (surtout Motion/canvas), vérifier
   les branches sœurs AVANT de diagnostiquer soi-même** — quand plusieurs sessions Claude
   travaillent en parallèle dans des worktrees séparés (ex. `nemo` sur `claude/web-public-beta`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,16 +405,23 @@ Transport multi-poste : réutilise le dossier de Sync équipe déjà existant
 profils et importe leurs entrées en LOCAL avec `status:'pending'` (jamais approuvées
 automatiquement, même si le remote dit `'approved'` — seule l'approbation locale compte).
 
-**Transport beta-testeurs (2026-07)** : repo public dédié
+**Transport beta-testeurs (2026-07, repos scindés depuis)** : une Issue GitHub par
+feedback, créée depuis Rust (`submit_feedback_issue` dans `src-tauri/src/lib.rs`,
+**jamais** depuis JS) directement dans **`mysteropodes/nemo`** (à côté de toutes les
+autres issues du projet, plus de silo séparé) ; les captures d'écran jointes restent
+dans le repo dédié sans code
 [`mysteropodes/strokemotion-feedback`](https://github.com/mysteropodes/strokemotion-feedback)
-(aucun code de l'app dedans) — une Issue GitHub par feedback, créée depuis Rust
-(`submit_feedback_issue` dans `src-tauri/src/lib.rs`, **jamais** depuis JS) avec un token
-compilé à la build via `env!("NEMO_FEEDBACK_TOKEN")` — fine-grained PAT scopé À CE SEUL REPO, permissions
-"Issues: write" + "Contents: write" (élargi en 2026-07 pour les captures d'écran jointes,
-voir ci-dessous — décision utilisateur explicite, toujours zéro exposition de code) : un
-token extrait du binaire peut au pire spammer des issues ou écrire n'importe quel fichier
-dans CE repo précis, jamais toucher au code de l'app. Le label `pending` est posé
-automatiquement à la création.
+(`upload_feedback_attachment`) — même répartition que `worker-feedback/src/index.js`
+côté web (`ISSUE_REPO`/`ATTACHMENT_REPO`). Un seul token compilé à la build via
+`env!("NEMO_FEEDBACK_TOKEN")`, fine-grained PAT scopé aux DEUX repos, permissions
+"Issues: write" + "Contents: write" sur chacun. ⚠️ Un fine-grained PAT applique le
+même jeu de permissions à tous les repos sélectionnés — ce token a donc aussi
+"Contents: write" sur `nemo` lui-même, pas seulement sur le repo sans code : un token
+extrait du binaire pourrait au pire écrire des fichiers dans le vrai code de l'app,
+pas juste spammer des issues. Compromis accepté (même que le Worker web utilise déjà
+en prod), à revisiter si ça devient gênant — un token séparé par repo serait plus
+strict mais demande un second `env!()`. Le label `pending` est posé automatiquement
+à la création.
 
 **Capture d'écran jointe (2026-07)** : l'outil Commentaire a une zone de drop
 (`#comment-shot-drop`) — glisser-déposer, clic-pour-parcourir, ou Cmd+V. Gardée en data URL

--- a/scripts/dev_server.py
+++ b/scripts/dev_server.py
@@ -25,7 +25,7 @@ from pathlib import Path
 # `.feedback` directory so ordinary development never touches app data.
 FEEDBACK_ROOT = Path(
     os.environ.get(
-        "STROKEMOTION_FEEDBACK_ROOT",
+        "NEMO_FEEDBACK_ROOT",
         str(Path(__file__).resolve().parent.parent / ".feedback"),
     )
 ).expanduser()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,7 +44,7 @@ async fn run_ffmpeg(app: tauri::AppHandle, window: tauri::Window, args: Vec<Stri
 
 // Beta-tester feedback → public GitHub repo (mysteropodes/strokemotion-feedback),
 // one Issue per feedback entry. The write token is baked in at compile time
-// via env! — export STROKEMOTION_FEEDBACK_TOKEN before `tauri build` —
+// via env! — export NEMO_FEEDBACK_TOKEN before `tauri build` —
 // scoped as a
 // fine-grained PAT to ONLY this one repo, ONLY "Issues: write" — nothing
 // else, so an extracted token can at worst spam issues in a repo that
@@ -54,7 +54,7 @@ async fn run_ffmpeg(app: tauri::AppHandle, window: tauri::Window, args: Vec<Stri
 // this command exists instead of a plain JS fetch.
 #[tauri::command]
 async fn submit_feedback_issue(title: String, body: String, labels: Vec<String>) -> Result<(), String> {
-    let token = env!("STROKEMOTION_FEEDBACK_TOKEN");
+    let token = env!("NEMO_FEEDBACK_TOKEN");
     let client = reqwest::Client::new();
     let payload = serde_json::json!({ "title": title, "body": body, "labels": labels });
     let resp = client
@@ -88,7 +88,7 @@ async fn submit_feedback_issue(title: String, body: String, labels: Vec<String>)
 // `content` field IS base64 already, no decode/re-encode needed here.
 #[tauri::command]
 async fn upload_feedback_attachment(filename: String, content_base64: String) -> Result<String, String> {
-    let token = env!("STROKEMOTION_FEEDBACK_TOKEN");
+    let token = env!("NEMO_FEEDBACK_TOKEN");
     let client = reqwest::Client::new();
     let path = format!("attachments/{}", filename);
     let payload = serde_json::json!({

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,26 +42,37 @@ async fn run_ffmpeg(app: tauri::AppHandle, window: tauri::Window, args: Vec<Stri
     }
 }
 
-// Beta-tester feedback → public GitHub repo (mysteropodes/strokemotion-feedback),
-// one Issue per feedback entry. The write token is baked in at compile time
-// via env! — export NEMO_FEEDBACK_TOKEN before `tauri build` —
-// scoped as a
-// fine-grained PAT to ONLY this one repo, ONLY "Issues: write" — nothing
-// else, so an extracted token can at worst spam issues in a repo that
-// contains no app source. The POST happens entirely in Rust (never in JS)
-// so the token never touches the webview's network inspector or any
-// devtools-visible fetch() call — see feedback-bridge.js's comment for why
-// this command exists instead of a plain JS fetch.
+// Beta-tester feedback. Issues land in the public `nemo` repo itself
+// (mysteropodes/nemo) so they show up next to every other issue instead of
+// a separate silo; attachments still go to the code-free
+// mysteropodes/strokemotion-feedback (see upload_feedback_attachment) —
+// mirrors the split worker-feedback/src/index.js already uses on the web
+// path (ISSUE_REPO / ATTACHMENT_REPO there). The write token is baked in
+// at compile time via env! — export NEMO_FEEDBACK_TOKEN before
+// `tauri build` — a fine-grained PAT covering BOTH repos with
+// "Issues: write" + "Contents: write" (same token the web Worker's
+// GITHUB_FEEDBACK_TOKEN uses). Note this is broader than the old
+// single-repo design: because a fine-grained PAT applies one permission
+// set to every repo it's scoped to, giving it Issues+Contents on `nemo`
+// too means a leaked token could also write files into the real app
+// source, not just spam issues/attachments in the code-free repo. The POST
+// happens entirely in Rust (never in JS) so the token never touches the
+// webview's network inspector or any devtools-visible fetch() call — see
+// feedback-bridge.js's comment for why this command exists instead of a
+// plain JS fetch.
+const FEEDBACK_ISSUE_REPO: &str = "mysteropodes/nemo";
+const FEEDBACK_ATTACHMENT_REPO: &str = "mysteropodes/strokemotion-feedback";
+
 #[tauri::command]
 async fn submit_feedback_issue(title: String, body: String, labels: Vec<String>) -> Result<(), String> {
     let token = env!("NEMO_FEEDBACK_TOKEN");
     let client = reqwest::Client::new();
     let payload = serde_json::json!({ "title": title, "body": body, "labels": labels });
     let resp = client
-        .post("https://api.github.com/repos/mysteropodes/strokemotion-feedback/issues")
+        .post(format!("https://api.github.com/repos/{}/issues", FEEDBACK_ISSUE_REPO))
         .header("Authorization", format!("Bearer {}", token))
         .header("Accept", "application/vnd.github+json")
-        .header("User-Agent", "strokemotion-app")
+        .header("User-Agent", "nemo-app")
         .json(&payload)
         .send()
         .await
@@ -76,15 +87,11 @@ async fn submit_feedback_issue(title: String, body: String, labels: Vec<String>)
 }
 
 // Feedback screenshot attachments — committed via the GitHub Contents API
-// into strokemotion-feedback's attachments/ folder, then linked from the
+// into strokemotion-feedback's attachments/ folder (kept separate from the
+// issue itself, see FEEDBACK_ATTACHMENT_REPO above), then linked from the
 // issue body via raw.githubusercontent.com (GFM doesn't render data:
-// URIs, so the image has to actually be a file in the repo to show up
-// inline). Needs "Contents: Read and write" on top of submit_feedback_
-// issue's "Issues" permission — a deliberate scope increase on the same
-// embedded, repo-scoped token (see CLAUDE.md's feedback section for the
-// trade-off): a leaked token can now write arbitrary files into this one
-// code-free repo, not just spam issues, but still can't touch anything
-// else. content_base64 is passed straight through — the Contents API's
+// URIs, so the image has to actually be a file in a repo to show up
+// inline). content_base64 is passed straight through — the Contents API's
 // `content` field IS base64 already, no decode/re-encode needed here.
 #[tauri::command]
 async fn upload_feedback_attachment(filename: String, content_base64: String) -> Result<String, String> {
@@ -97,20 +104,20 @@ async fn upload_feedback_attachment(filename: String, content_base64: String) ->
     });
     let resp = client
         .put(format!(
-            "https://api.github.com/repos/mysteropodes/strokemotion-feedback/contents/{}",
-            path
+            "https://api.github.com/repos/{}/contents/{}",
+            FEEDBACK_ATTACHMENT_REPO, path
         ))
         .header("Authorization", format!("Bearer {}", token))
         .header("Accept", "application/vnd.github+json")
-        .header("User-Agent", "strokemotion-app")
+        .header("User-Agent", "nemo-app")
         .json(&payload)
         .send()
         .await
         .map_err(|e| e.to_string())?;
     if resp.status().is_success() {
         Ok(format!(
-            "https://raw.githubusercontent.com/mysteropodes/strokemotion-feedback/main/{}",
-            path
+            "https://raw.githubusercontent.com/{}/main/{}",
+            FEEDBACK_ATTACHMENT_REPO, path
         ))
     } else {
         let status = resp.status();

--- a/worker-feedback/README.md
+++ b/worker-feedback/README.md
@@ -33,7 +33,7 @@ Both POST-only, JSON in and out:
    ```
    Use a fine-grained GitHub PAT scoped ONLY to
    `mysteropodes/strokemotion-feedback`, `Issues: write` + `Contents: write`
-   — the exact same scope `STROKEMOTION_FEEDBACK_TOKEN` already uses for the
+   — the exact same scope `NEMO_FEEDBACK_TOKEN` already uses for the
    desktop build. Can be that same token value, or a fresh one.
 2. `ALLOWED_ORIGINS` is set in `wrangler.jsonc`'s `vars` (currently
    `https://nemo-editor.mysteropodes-auth.workers.dev`, comma-separated if

--- a/worker-feedback/README.md
+++ b/worker-feedback/README.md
@@ -2,12 +2,14 @@
 
 Browser-only transport for the beta-tester feedback pipeline. On desktop
 (Tauri), `submit_feedback_issue`/`upload_feedback_attachment`
-(`src-tauri/src/lib.rs`) create GitHub Issues in
-[`mysteropodes/strokemotion-feedback`](https://github.com/mysteropodes/strokemotion-feedback)
-directly from Rust, keeping the write-scoped token out of the webview. A
-browser has no Rust backend to hide that token behind — this Worker is the
-same trust boundary, just running on Cloudflare instead of on the user's
-machine.
+(`src-tauri/src/lib.rs`) create GitHub Issues directly in
+[`mysteropodes/nemo`](https://github.com/mysteropodes/nemo) from Rust (screenshots
+still go to the code-free
+[`mysteropodes/strokemotion-feedback`](https://github.com/mysteropodes/strokemotion-feedback)),
+keeping the write-scoped token out of the webview. A browser has no Rust backend to
+hide that token behind — this Worker is the same trust boundary, just running on
+Cloudflare instead of on the user's machine, and splits the same way
+(`ISSUE_REPO`/`ATTACHMENT_REPO` below).
 
 2026-08: added after the web beta shipped without it — a tester's feedback
 looked "saved" (it *was*, in `localStorage`) but silently never reached
@@ -31,10 +33,13 @@ Both POST-only, JSON in and out:
    cd worker-feedback
    npx wrangler secret put GITHUB_FEEDBACK_TOKEN --name nemo-feedback
    ```
-   Use a fine-grained GitHub PAT scoped ONLY to
+   Use a fine-grained GitHub PAT scoped to BOTH `mysteropodes/nemo` and
    `mysteropodes/strokemotion-feedback`, `Issues: write` + `Contents: write`
-   — the exact same scope `NEMO_FEEDBACK_TOKEN` already uses for the
-   desktop build. Can be that same token value, or a fresh one.
+   on each — the exact same scope `NEMO_FEEDBACK_TOKEN` already uses for the
+   desktop build (note this also grants `Contents: write` on `nemo` itself,
+   since a fine-grained PAT applies one permission set to every repo it
+   covers — see CLAUDE.md's feedback section). Can be that same token
+   value, or a fresh one.
 2. `ALLOWED_ORIGINS` is set in `wrangler.jsonc`'s `vars` (currently
    `https://nemo-editor.mysteropodes-auth.workers.dev`, comma-separated if
    more origins are added later — e.g. a custom domain). Update it there


### PR DESCRIPTION
## Summary
- Renames the compile-time env var/secret from `STROKEMOTION_FEEDBACK_TOKEN` to `NEMO_FEEDBACK_TOKEN` everywhere (lib.rs, docs, worker-feedback README, deploy workflow comment) — leftover naming from the StrokeMotion → Nemo rebrand
- Also renames the local dev-only `STROKEMOTION_FEEDBACK_ROOT` path override to `NEMO_FEEDBACK_ROOT`
- **Bigger fix found along the way**: desktop feedback (`submit_feedback_issue`) was still posting issues into the old `strokemotion-feedback` silo repo — the web path (`worker-feedback/src/index.js`) was already split (issues → `nemo`, attachments → `strokemotion-feedback`) and live, but the Rust side never got updated to match. Fixed to mirror the same split, with named constants.
- Docs (CLAUDE.md, deploy-feedback-worker.yml, worker-feedback/README.md) updated to describe the resulting token scope accurately: `NEMO_FEEDBACK_TOKEN` needs `Issues: write` + `Contents: write` on **both** `mysteropodes/nemo` and `mysteropodes/strokemotion-feedback` — which also means `Contents: write` on `nemo` itself, since a fine-grained PAT applies one permission set to every repo it covers. Flagged explicitly as a real scope increase from the original single-repo design.

## Depends on
#872 (adds the secret to release.yml) — merge that one first or alongside this one, both reference the same new name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)