### PR TITLE
Desktop feedback goes through the Worker, not a token in the binary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,22 +405,31 @@ Transport multi-poste : réutilise le dossier de Sync équipe déjà existant
 profils et importe leurs entrées en LOCAL avec `status:'pending'` (jamais approuvées
 automatiquement, même si le remote dit `'approved'` — seule l'approbation locale compte).
 
-**Transport beta-testeurs (2026-07)** : repo public dédié
+**Transport beta-testeurs — desktop ET web passent par le même Worker Cloudflare
+(2026-09).** `worker-feedback/` (racine du repo) est l'UNIQUE frontière de confiance : il
+détient le seul token GitHub write-scoped (secret Cloudflare `GITHUB_FEEDBACK_TOKEN`, posé
+une fois via `wrangler secret put`, **jamais** un secret GitHub Actions — voir
+`worker-feedback/README.md`). Aucun build (ni desktop ni web) n'embarque plus son propre
+token. `/issue` crée une Issue dans [`mysteropodes/nemo`](https://github.com/mysteropodes/nemo)
+(les retours vivent avec le code) ; `/attachment` committe les captures d'écran dans
 [`mysteropodes/strokemotion-feedback`](https://github.com/mysteropodes/strokemotion-feedback)
-(aucun code de l'app dedans) — une Issue GitHub par feedback, créée depuis Rust
-(`submit_feedback_issue` dans `src-tauri/src/lib.rs`, **jamais** depuis JS) avec un token
-compilé à la build via `env!("STROKEMOTION_FEEDBACK_TOKEN")` (même pattern que
-`STROKEMOTION_UPDATER_TOKEN`) — fine-grained PAT scopé À CE SEUL REPO, permissions
-"Issues: write" + "Contents: write" (élargi en 2026-07 pour les captures d'écran jointes,
-voir ci-dessous — décision utilisateur explicite, toujours zéro exposition de code) : un
-token extrait du binaire peut au pire spammer des issues ou écrire n'importe quel fichier
-dans CE repo précis, jamais toucher au code de l'app. Le label `pending` est posé
-automatiquement à la création.
+(repo séparé, sans code, pour ne pas gonfler l'historique git du repo principal avec des
+PNG). Le Worker filtre aussi le spam (`looksLikeSpam` dans `worker-feedback/src/index.js`).
+
+Historique : avant 2026-09, desktop postait directement depuis Rust
+(`submit_feedback_issue`/`upload_feedback_attachment` dans `src-tauri/src/lib.rs`) avec un
+token `env!()`-compilé — ça marchait, mais dupliquait le token (un par build desktop) ET
+contournait le filtre anti-spam du Worker. Supprimé : `feedback-bridge.js` appelle
+maintenant le Worker depuis desktop aussi, via `window.__TAURI__.http.fetch` (plugin
+`tauri_plugin_http`) plutôt que `window.fetch` — un `fetch()` classique serait bloqué à la
+fois par le `connect-src` de la CSP (qui ne liste pas le Worker) et par la CORS allowlist du
+Worker (qui liste les origines web, pas `tauri://localhost`) ; passer par Rust via le plugin
+contourne les deux sans avoir à élargir ni l'un ni l'autre.
 
 **Capture d'écran jointe (2026-07)** : l'outil Commentaire a une zone de drop
 (`#comment-shot-drop`) — glisser-déposer, clic-pour-parcourir, ou Cmd+V. Gardée en data URL
-localement (`entry.screenshotDataUrl`) ; à la publication GitHub, `uploadScreenshotIfAny()`
-(feedback-bridge.js) l'envoie à `upload_feedback_attachment` (Rust) qui la committe dans
+localement (`entry.screenshotDataUrl`) ; à la publication GitHub, `uploadScreenshotsIfAny()`
+(feedback-bridge.js) l'envoie au Worker (`/attachment`), qui la committe dans
 `attachments/<id>.<ext>` via l'API Contents, puis référence l'URL
 `raw.githubusercontent.com` résultante en Markdown dans le corps de l'issue — GFM ne rend
 PAS les data URIs, le fichier doit réellement exister dans le repo pour s'afficher inline.
@@ -432,18 +441,10 @@ uniquement — jamais embarqué dans le build distribué. Une copie de l'app liv
 beta-testeur a ce même panneau de triage dans le code, mais il est inutilisable sans le
 token perso de Cyril.
 
-**Build web (2026-08) : la publication GitHub passe par un Worker, pas par Rust.**
-Sur desktop, `submit_feedback_issue`/`upload_feedback_attachment` tournent en Rust — un
-navigateur n'a pas ce backend pour cacher le token. `worker-feedback/` (racine du repo) est
-un Worker Cloudflare séparé (secret `GITHUB_FEEDBACK_TOKEN` propre, jamais dans le Worker du
-site statique `nemo-editor`) qui joue exactement le même rôle de frontière de confiance.
-`feedback-bridge.js` branche sur `tauriOk()` : Tauri → `invoke()`, sinon → `fetch()` vers ce
-Worker (`FEEDBACK_WORKER_URL`, à mettre à jour après le premier déploiement). **Piège déjà
-tombé une fois** : le premier jet du build web gardait le vieux garde-fou `if (tauriOk())`
-autour de tout l'appel de publication — le feedback s'enregistrait bien en local
-(`localStorage`) et semblait "envoyé", mais ne partait jamais vers GitHub, silencieusement.
-Voir `worker-feedback/README.md` pour le setup (secret Worker à poser une fois via
-`wrangler secret put`, PAS un secret GitHub Actions).
+**Piège déjà tombé une fois** : le premier jet du build web gardait le vieux garde-fou
+`if (tauriOk())` autour de tout l'appel de publication — le feedback s'enregistrait bien en
+local (`localStorage`) et semblait "envoyé", mais ne partait jamais vers GitHub,
+silencieusement.
 
 ## 7. Avant chaque build : synchroniser le numéro de version partout
 
@@ -624,12 +625,13 @@ mutuellement. Règles à suivre **sans qu'on ait besoin de le redemander** :
   copie du repo GitHub ailleurs. Ne jamais partager ce dossier OneDrive directement avec un
   collaborateur pour du travail simultané (sync cloud + git en parallèle sur le même dossier
   risque de corrompre l'historique).
-- Secrets (`TAURI_SIGNING_PRIVATE_KEY`, `STROKEMOTION_PUBLISH_TOKEN`,
-  `STROKEMOTION_UPDATER_TOKEN`, `STROKEMOTION_FEEDBACK_TOKEN`) restent strictement
-  personnels à Cyril — jamais committés (déjà couvert par `.gitignore` pour les clés de
-  signature), jamais partagés même avec un collaborateur de confiance. Pour du dev normal,
-  des valeurs placeholder (`STROKEMOTION_FEEDBACK_TOKEN=dev-placeholder
-  STROKEMOTION_UPDATER_TOKEN=dev-placeholder`) suffisent à compiler et lancer `npm run dev`.
+- Secrets (`TAURI_SIGNING_PRIVATE_KEY`) restent strictement personnels à Cyril — jamais
+  committés (déjà couvert par `.gitignore` pour les clés de signature), jamais partagés même
+  avec un collaborateur de confiance. Depuis 2026-09, ni l'updater (releases GitHub
+  publiques, voir §7) ni le feedback (Worker Cloudflare, voir §6) n'ont besoin d'un token
+  compilé dans le binaire — le seul token GitHub feedback restant vit côté Cloudflare
+  (`GITHUB_FEEDBACK_TOKEN`, posé via `wrangler secret put`, voir `worker-feedback/README.md`),
+  pas dans ce repo ni dans les secrets GitHub Actions.
 - **Avant de partir en investigation sur un bug rapporté (surtout Motion/canvas), vérifier
   les branches sœurs AVANT de diagnostiquer soi-même** — quand plusieurs sessions Claude
   travaillent en parallèle dans des worktrees séparés (ex. `nemo` sur `claude/web-public-beta`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,82 +42,20 @@ async fn run_ffmpeg(app: tauri::AppHandle, window: tauri::Window, args: Vec<Stri
     }
 }
 
-// Beta-tester feedback → public GitHub repo (mysteropodes/strokemotion-feedback),
-// one Issue per feedback entry. The write token is baked in at compile time
-// via env! — export STROKEMOTION_FEEDBACK_TOKEN before `tauri build` —
-// scoped as a
-// fine-grained PAT to ONLY this one repo, ONLY "Issues: write" — nothing
-// else, so an extracted token can at worst spam issues in a repo that
-// contains no app source. The POST happens entirely in Rust (never in JS)
-// so the token never touches the webview's network inspector or any
-// devtools-visible fetch() call — see feedback-bridge.js's comment for why
-// this command exists instead of a plain JS fetch.
-#[tauri::command]
-async fn submit_feedback_issue(title: String, body: String, labels: Vec<String>) -> Result<(), String> {
-    let token = env!("STROKEMOTION_FEEDBACK_TOKEN");
-    let client = reqwest::Client::new();
-    let payload = serde_json::json!({ "title": title, "body": body, "labels": labels });
-    let resp = client
-        .post("https://api.github.com/repos/mysteropodes/strokemotion-feedback/issues")
-        .header("Authorization", format!("Bearer {}", token))
-        .header("Accept", "application/vnd.github+json")
-        .header("User-Agent", "strokemotion-app")
-        .json(&payload)
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-    if resp.status().is_success() {
-        Ok(())
-    } else {
-        let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
-        Err(format!("GitHub API error {}: {}", status, text))
-    }
-}
-
-// Feedback screenshot attachments — committed via the GitHub Contents API
-// into strokemotion-feedback's attachments/ folder, then linked from the
-// issue body via raw.githubusercontent.com (GFM doesn't render data:
-// URIs, so the image has to actually be a file in the repo to show up
-// inline). Needs "Contents: Read and write" on top of submit_feedback_
-// issue's "Issues" permission — a deliberate scope increase on the same
-// embedded, repo-scoped token (see CLAUDE.md's feedback section for the
-// trade-off): a leaked token can now write arbitrary files into this one
-// code-free repo, not just spam issues, but still can't touch anything
-// else. content_base64 is passed straight through — the Contents API's
-// `content` field IS base64 already, no decode/re-encode needed here.
-#[tauri::command]
-async fn upload_feedback_attachment(filename: String, content_base64: String) -> Result<String, String> {
-    let token = env!("STROKEMOTION_FEEDBACK_TOKEN");
-    let client = reqwest::Client::new();
-    let path = format!("attachments/{}", filename);
-    let payload = serde_json::json!({
-        "message": format!("Feedback attachment: {}", filename),
-        "content": content_base64,
-    });
-    let resp = client
-        .put(format!(
-            "https://api.github.com/repos/mysteropodes/strokemotion-feedback/contents/{}",
-            path
-        ))
-        .header("Authorization", format!("Bearer {}", token))
-        .header("Accept", "application/vnd.github+json")
-        .header("User-Agent", "strokemotion-app")
-        .json(&payload)
-        .send()
-        .await
-        .map_err(|e| e.to_string())?;
-    if resp.status().is_success() {
-        Ok(format!(
-            "https://raw.githubusercontent.com/mysteropodes/strokemotion-feedback/main/{}",
-            path
-        ))
-    } else {
-        let status = resp.status();
-        let text = resp.text().await.unwrap_or_default();
-        Err(format!("GitHub upload error {}: {}", status, text))
-    }
-}
+// Beta-tester feedback (issues + screenshot attachments) used to POST
+// straight to GitHub from here, with a write-scoped token baked in via
+// env!() at compile time. That token had to be embedded in every
+// distributed binary, and — since this bypassed the nemo-feedback Worker
+// entirely — it also skipped the Worker's spam filter (worker-feedback/
+// src/index.js's looksLikeSpam), the same protection the web build already
+// gets. Removed 2026-09: feedback-bridge.js now posts through that Worker
+// on desktop too, using tauri_plugin_http's fetch (window.__TAURI__.http.
+// fetch) instead of `window.fetch` — a plain fetch() would be blocked by
+// both the CSP's connect-src (which doesn't list the Worker) and the
+// Worker's own CORS allowlist (which only lists the web origins, not
+// tauri://localhost); routing the request through Rust via the plugin
+// sidesteps both without having to widen either guard. See
+// worker-feedback/README.md for the Worker side.
 
 // Live Google Fonts (2026-08-28, feedback: "peux t'on avoir d'autre typo
 // sans probleme de droit genre les google fonts ?" then "un vrai catalogue
@@ -258,8 +196,6 @@ pub fn run() {
         .manage(video_decode::VideoSessions::default())
         .invoke_handler(tauri::generate_handler![
             run_ffmpeg,
-            submit_feedback_issue,
-            upload_feedback_attachment,
             fetch_google_font,
             video_decode::open_video_session,
             video_decode::decode_video_frame,

--- a/src/js/feedback-bridge.js
+++ b/src/js/feedback-bridge.js
@@ -22,12 +22,24 @@
   function tauriOk() { return typeof window.__TAURI__ !== 'undefined'; }
   function projectKey() { return (window.SMProject && window.SMProject.getProjectKey()) || 'untitled-autosave'; }
 
-  // Browser-only transport for the two GitHub calls Tauri does via Rust
-  // (submit_feedback_issue/upload_feedback_attachment) — see worker-feedback/
-  // (repo root).
+  // Transport for both GitHub calls (issue + attachment) — see
+  // worker-feedback/ (repo root). Both desktop and web post through this
+  // same Worker, so they share its spam filter (looksLikeSpam) and neither
+  // ever holds the write-scoped GitHub token itself.
+  //
+  // On Tauri, use tauri_plugin_http's fetch (window.__TAURI__.http.fetch)
+  // instead of plain window.fetch: the app's CSP connect-src doesn't list
+  // this Worker, and the Worker's own CORS allowlist holds the web origins,
+  // not tauri://localhost — a plain fetch() would be blocked twice over.
+  // The plugin issues the request from Rust, so neither guard applies and
+  // neither has to be widened just for this one call.
   var FEEDBACK_WORKER_URL = 'https://nemo-feedback.mysteropodes-auth.workers.dev';
+  function workerFetch() {
+    var t = window.__TAURI__;
+    return (t && t.http && t.http.fetch) ? t.http.fetch : fetch;
+  }
   async function workerPost(path, payload) {
-    var resp = await fetch(FEEDBACK_WORKER_URL + path, {
+    var resp = await workerFetch()(FEEDBACK_WORKER_URL + path, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
@@ -315,16 +327,13 @@
     }
     // Best-effort: beta testers have no shared Sync folder (that's a local/
     // network-drive mechanism for Cyril's own machines) — this is THEIR
-    // transport instead: one GitHub Issue per feedback entry, in the public
-    // mysteropodes/strokemotion-feedback repo. On Tauri the write-scoped
-    // token lives entirely in Rust (submit_feedback_issue, src-tauri/src/
-    // lib.rs) so it never appears in this file or a devtools-visible
-    // fetch(); on the web build there IS no Rust backend to hide it behind,
-    // so the same call instead goes to the nemo-feedback Worker (see
-    // githubIssue()/githubAttachment() below), which holds the token
-    // server-side the same way. 2026-08: this used to be Tauri-only and
-    // silently no-op on web — a tester's feedback looked "saved" but never
-    // reached anyone, see worker-feedback/README for the fix.
+    // transport instead: one GitHub Issue per feedback entry, in
+    // mysteropodes/nemo, posted through the nemo-feedback Worker (see
+    // workerPost above and worker-feedback/README.md) — desktop and web
+    // both go through it, so neither needs its own copy of the write token.
+    // 2026-08: this used to be Tauri-only and silently no-op on web — a
+    // tester's feedback looked "saved" but never reached anyone, see
+    // worker-feedback/README for the fix.
     try {
       await publishToGitHubIssue(entry);
     } catch (e) { console.warn('[feedback] GitHub publish failed', e); }
@@ -335,21 +344,20 @@
     return { bug: 'bug', perf: 'perf', idee: 'idée', polish: 'polish' }[tag] || tag;
   }
   // Commits each screenshot into strokemotion-feedback's attachments/
-  // folder via the GitHub Contents API (Rust command upload_feedback_
-  // attachment — same reasoning as submit_feedback_issue for keeping the
-  // token out of JS/devtools) and returns an array of raw.githubusercontent.com
+  // folder via the Worker's /attachment endpoint (GitHub Contents API
+  // under the hood) and returns an array of raw.githubusercontent.com
   // URLs that render inline in the issue body via normal Markdown image
   // syntax — GFM does NOT render data: URIs, so each file has to actually
   // land in the repo, not just be inlined as base64 in the issue text.
   //
   // feedback #208: was one screenshot per entry (uploadScreenshotIfAny,
   // singular) — now uploads however many were attached, sequentially (not
-  // Promise.all: the Rust command and the Worker both write via the GitHub
-  // Contents API, which 409s on two concurrent commits to the same repo —
-  // a real risk once this is more than one file per submission). filename
-  // includes an index (entry.id + '-' + i) so multiple images from the
-  // SAME entry never collide on the single-screenshot naming the old code
-  // used unconditionally. Compat: an older stored entry may only have the
+  // Promise.all: the Worker writes via the GitHub Contents API, which
+  // 409s on two concurrent commits to the same repo — a real risk once
+  // this is more than one file per submission). filename includes an
+  // index (entry.id + '-' + i) so multiple images from the SAME entry
+  // never collide on the single-screenshot naming the old code used
+  // unconditionally. Compat: an older stored entry may only have the
   // singular screenshotDataUrl field.
   async function uploadScreenshotsIfAny(entry) {
     var dataUrls = entry.screenshotDataUrls && entry.screenshotDataUrls.length ? entry.screenshotDataUrls
@@ -360,15 +368,8 @@
       if (!m) continue;
       var ext = m[1] === 'jpeg' ? 'jpg' : m[1];
       var filename = entry.id + (dataUrls.length > 1 ? '-' + (i + 1) : '') + '.' + ext;
-      var url = null;
-      if (tauriOk()) {
-        var t = window.__TAURI__;
-        url = await t.core.invoke('upload_feedback_attachment', { filename: filename, contentBase64: m[2] });
-      } else {
-        var data = await workerPost('/attachment', { filename: filename, contentBase64: m[2] });
-        url = data && data.url;
-      }
-      if (url) urls.push(url);
+      var data = await workerPost('/attachment', { filename: filename, contentBase64: m[2] });
+      if (data && data.url) urls.push(data.url);
     }
     return urls;
   }
@@ -417,11 +418,6 @@
       '',
       '<!-- sm-feedback-id: ' + entry.id + ' -->',
     ].join('\n');
-    if (tauriOk()) {
-      var t = window.__TAURI__;
-      await t.core.invoke('submit_feedback_issue', { title: title, body: body, labels: labels });
-      return;
-    }
     await workerPost('/issue', { title: title, body: body, labels: labels });
   }
 

--- a/worker-feedback/README.md
+++ b/worker-feedback/README.md
@@ -1,19 +1,27 @@
 # nemo-feedback — Cloudflare Worker
 
-Browser-only transport for the beta-tester feedback pipeline. On desktop
-(Tauri), `submit_feedback_issue`/`upload_feedback_attachment`
-(`src-tauri/src/lib.rs`) create GitHub Issues in
-[`mysteropodes/strokemotion-feedback`](https://github.com/mysteropodes/strokemotion-feedback)
-directly from Rust, keeping the write-scoped token out of the webview. A
-browser has no Rust backend to hide that token behind — this Worker is the
-same trust boundary, just running on Cloudflare instead of on the user's
-machine.
+Transport for the beta-tester feedback pipeline, for BOTH desktop (Tauri)
+and web. This Worker is the sole trust boundary holding the write-scoped
+GitHub token — neither build embeds one. On desktop, `feedback-bridge.js`
+calls it through `tauri_plugin_http`'s fetch (`window.__TAURI__.http.fetch`)
+instead of `window.fetch`, so the request is issued from Rust and isn't
+subject to the webview's CSP `connect-src` or this Worker's own CORS
+allowlist (neither lists `tauri://localhost`).
 
 2026-08: added after the web beta shipped without it — a tester's feedback
 looked "saved" (it *was*, in `localStorage`) but silently never reached
 GitHub, because `feedback-bridge.js` used to gate the whole publish step on
 `tauriOk()`. See `src/js/feedback-bridge.js`'s `workerPost`/`FEEDBACK_WORKER_URL`
 for the client side of this.
+
+2026-09: desktop stopped embedding its own token (`submit_feedback_issue`/
+`upload_feedback_attachment` in `src-tauri/src/lib.rs` are gone) and now
+posts through this same Worker — the only reason that Rust-side path ever
+existed was "a browser can't hide a token, Rust can," but `tauri_plugin_http`
+means Rust doesn't need to hide one at all here, it just relays the request.
+This also means desktop submissions are now covered by this Worker's spam
+filter (`looksLikeSpam` in `src/index.js`), which the old direct-from-Rust
+path bypassed entirely.
 
 ## Endpoints
 
@@ -31,10 +39,11 @@ Both POST-only, JSON in and out:
    cd worker-feedback
    npx wrangler secret put GITHUB_FEEDBACK_TOKEN --name nemo-feedback
    ```
-   Use a fine-grained GitHub PAT scoped ONLY to
-   `mysteropodes/strokemotion-feedback`, `Issues: write` + `Contents: write`
-   — the exact same scope `STROKEMOTION_FEEDBACK_TOKEN` already uses for the
-   desktop build. Can be that same token value, or a fresh one.
+   Use a fine-grained GitHub PAT covering both repos: `mysteropodes/nemo`
+   with `Issues: write` (reports live with the code) and
+   `mysteropodes/strokemotion-feedback` with `Contents: write` (screenshots
+   stay there so no token needs write access to the source tree). This is
+   now the ONLY feedback token anywhere — neither build embeds its own.
 2. `ALLOWED_ORIGINS` is set in `wrangler.jsonc`'s `vars` (currently
    `https://nemo-editor.mysteropodes-auth.workers.dev`, comma-separated if
    more origins are added later — e.g. a custom domain). Update it there


### PR DESCRIPTION
## Summary
- Redoes PR #710's idea (which had gone 185 commits stale and was `CONFLICTING`) fresh on top of current `main`.
- Removes `submit_feedback_issue`/`upload_feedback_attachment` from `src-tauri/src/lib.rs` — desktop no longer compiles in its own GitHub write token via `env!()`.
- `feedback-bridge.js` now posts through the same `nemo-feedback` Worker the web build already uses, via `window.__TAURI__.http.fetch` (`tauri_plugin_http`) instead of a plain `fetch()` — the app's CSP `connect-src` doesn't list the Worker, and the Worker's CORS allowlist holds web origins, not `tauri://localhost`; routing through Rust via the plugin sidesteps both.
- Bonus: desktop feedback now goes through the Worker's spam filter (`looksLikeSpam`), which the old direct-from-Rust path bypassed entirely.
- Updates `worker-feedback/README.md` and `CLAUDE.md` §6/§9 to describe the new architecture and drop references to the now-nonexistent `STROKEMOTION_FEEDBACK_TOKEN`/`STROKEMOTION_UPDATER_TOKEN`/`STROKEMOTION_PUBLISH_TOKEN`.

This supersedes PR #710 (stale/conflicting, closing separately), #872 (secret wiring for a token that no longer needs to exist), and #873 (rename of a token whose backing functions this PR deletes).

## Test plan
- [x] `cargo check` passes with no new errors (only pre-existing unrelated `objc` macro warnings)
- [x] `node -c src/js/feedback-bridge.js` — syntax OK
- [ ] Manual: `npm run dev` (or a real desktop build), submit a test feedback entry with a screenshot, confirm it lands as an Issue in `mysteropodes/nemo` and the attachment lands in `mysteropodes/strokemotion-feedback`, via the Worker (check Worker logs / `wrangler tail`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)