### PR TITLE
Bump version to 0.7.0-alpha.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo",
-  "version": "0.7.0-alpha.1",
+  "version": "0.7.0-alpha.2",
   "description": "Open-source motion design and 2D animation in one app — a keyframe motion editor alongside frame-by-frame drawing with automatic inbetweening",
   "scripts": {
     "tauri": "tauri",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Nemo",
-  "version": "0.7.0-alpha.1",
+  "version": "0.7.0-alpha.2",
   "identifier": "com.strokemotion.app",
   "build": {
     "frontendDist": "../src",


### PR DESCRIPTION
## Summary
- v0.7.0-alpha.1's tag pointed at a pre-#874 commit that fails to build (missing `STROKEMOTION_FEEDBACK_TOKEN`, since removed entirely). No release was ever published from it.
- Bumps `package.json` and `src-tauri/tauri.conf.json` to `0.7.0-alpha.2` rather than force-moving the existing tag.

## Test plan
- [ ] Tag `v0.7.0-alpha.2` on this commit once merged, trigger `release.yml`, confirm it builds and produces a .dmg

🤖 Generated with [Claude Code](https://claude.com/claude-code)