### PR TITLE
Fix release build: patch ffmpeg dylibs before bundling, not after publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,30 @@ jobs:
 
       - run: npm ci || npm install
 
+      # Two-phase build. Tauri has no post-app/pre-dmg hook (only
+      # beforeBuildCommand and beforeBundleCommand, both of which fire
+      # before the .app is even scaffolded — too early to patch its
+      # Contents/), so the .app has to be built and patched in its own
+      # pass BEFORE tauri-action's normal build+bundle+publish call gets
+      # anywhere near it.
+      #
+      # Bug this replaces (2026-09): the previous single-pass workflow ran
+      # tauri-action first (building AND publishing the dmg/tar.gz in one
+      # shot), then tried to patch the .app afterward — patching a file
+      # nobody would ever look at again, since the already-published dmg
+      # was built from the unpatched .app. On top of that, the patch step
+      # itself silently failed on every build (missing its one required
+      # argument, swallowed by `|| echo "::warning::..."`), so this had
+      # never actually worked even for the file it was patching. Net
+      # effect: every past release's ffmpeg sidecar still pointed at
+      # /opt/homebrew/opt/... paths that only exist on the CI runner — the
+      # app would crash on Export on any real user's Mac.
+      - name: Build the .app (no bundling yet)
+        run: npx tauri build --target ${{ matrix.target }} -b app
+
+      - name: Make the .app self-contained
+        run: python3 scripts/bundle-ffmpeg-dylibs.py "src-tauri/target/${{ matrix.target }}/release/bundle/macos/Nemo.app"
+
       - name: Build and publish the release
         uses: tauri-apps/tauri-action@v0
         env:
@@ -123,10 +147,14 @@ jobs:
           # GitHub — so the prerelease label would only be cosmetic here,
           # at the cost of breaking auto-update for every future version.
           prerelease: false
+          # Cargo has nothing left to compile at this point (the previous
+          # step already built this exact target) — this call's own
+          # `tauri build` re-invocation is effectively just "assemble the
+          # dmg/updater-tar.gz around the .app that's already on disk and
+          # publish them", it should not touch Contents/Frameworks (added
+          # by the dylib patch above) since Tauri's bundler only manages
+          # the paths it knows about (binary, resources, sidecars, Info.plist).
           args: --target ${{ matrix.target }}
           # Writes latest.json next to the artifacts, which is what
           # tauri.conf.json's updater endpoint now reads.
           includeUpdaterJson: true
-
-      - name: Make the .app self-contained
-        run: python3 scripts/bundle-ffmpeg-dylibs.py || echo "::warning::dylib bundling skipped"


### PR DESCRIPTION
## Summary
- `bundle-ffmpeg-dylibs.py` requires the `.app` path as an argument; the workflow called it with none, and the failure was swallowed by `|| echo "::warning::..."` — it has been a silent no-op on every past release.
- Even fixed in place, it ran AFTER `tauri-action` had already built, signed, and published the dmg/tar.gz — patching a copy nobody would look at again.
- Net effect: every past release's bundled ffmpeg still links against `/opt/homebrew/opt/...` paths that only exist on the CI runner (confirmed via `otool -L` on a downloaded build) — Export would crash on any real user's Mac.

## Fix
Split into two passes: `tauri build -b app` (just the `.app`, no bundling) → dylib patch → `tauri-action`'s normal build+bundle+publish call finishes the job. Cargo has nothing left to recompile, and Tauri's bundler doesn't manage `Contents/Frameworks/`.

## Test plan
- [ ] Tag a new alpha, trigger the release build, download the resulting `.app`, and confirm via `otool -L` on `Contents/MacOS/ffmpeg` that it now references `@rpath/...` instead of `/opt/homebrew/...`, and that `Contents/Frameworks/` contains the copied dylibs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)