### PR TITLE
Pass the signing key to the app-only build step too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,13 @@ jobs:
       # /opt/homebrew/opt/... paths that only exist on the CI runner — the
       # app would crash on Export on any real user's Mac.
       - name: Build the .app (no bundling yet)
+        # Even with `-b app`, Tauri still produces and signs the updater
+        # .tar.gz right away (the updater plugin is active), so it needs
+        # the signing key here too — not just in the later tauri-action
+        # step. That second pass will just re-sign the same archive.
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npx tauri build --target ${{ matrix.target }} -b app
 
       - name: Make the .app self-contained


### PR DESCRIPTION
## Summary
- Follow-up to #878: \`tauri build -b app\` alone still tries to produce+sign the updater \`.tar.gz\` immediately, since the updater plugin is active regardless of which bundle targets were requested. That step didn't have \`TAURI_SIGNING_PRIVATE_KEY\`, causing v0.7.0-alpha.3's build to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)