### PR TITLE
Timeline : les petits traits se raréfient aussi quand on dézoome

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1661,7 +1661,7 @@ body.mode-motion .layer-inout-bar .layer-inout-handle{width:4px;border-radius:2p
    the text for the taller round-3 tick marks instead of the two visually
    colliding at this row's old, tighter height. */
 .fhc{width:var(--fc);min-width:var(--fc);font-size:9px;color:var(--text-dark);display:flex;align-items:flex-start;justify-content:center;padding-top:3px;box-sizing:border-box;position:relative;}
-.fhc:nth-child(5n){color:var(--text-dim);}
+.fhc.tickMaj{color:var(--text-dim);}
 /* Real tick marks (round 1 finding: the ruler previously had NO physical
    graduation at all, only a text-color change every 5th cell). Three
    tiers, tallest/brightest wins on a coincidence (CSS specificity alone
@@ -1675,8 +1675,8 @@ body.mode-motion .layer-inout-bar .layer-inout-handle{width:4px;border-radius:2p
      - every 5th:    6px/.32 — the mid-level landmark.
      - each second:  tallest/brightest (::before below) — the label
        ("1s"/"2s") already gets the same priority treatment. */
-.fhc::before{content:'';position:absolute;left:0;bottom:0;width:1px;height:4px;background:rgba(255,255,255,.16);}
-.fhc:nth-child(5n)::before{height:6px;background:rgba(255,255,255,.32);}
+.fhc.tick::before{content:'';position:absolute;left:0;bottom:0;width:1px;height:4px;background:rgba(255,255,255,.16);}
+.fhc.tickMaj::before{height:6px;background:rgba(255,255,255,.32);}
 .fhc.cur{color:var(--accent);font-weight:700;}
 .fhc.sec{color:var(--accent);font-weight:700;font-size:8.5px;}
 .fhc.sec::before{content:'';position:absolute;left:0;top:0;bottom:-2px;width:1px;background:rgba(255,255,255,.3);}

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -4066,6 +4066,21 @@ function renderTimeline(){
   // quand même se coller à l'autre (mesuré : « 120 » collé à « 5s », 4 px).
   // Un numéro d'image n'est donc écrit que s'il est assez loin de la seconde
   // étiquetée la plus proche.
+  // Les petits traits suivent la même logique que les chiffres : en dessous
+  // de 7 px d'écart ils ne se lisent plus comme des graduations mais comme
+  // une trame grise (Cyril : « enlever les petits traits de frames quand ça
+  // devient illisible, simplifier au fur et à mesure »). Le pas est calé sur
+  // un diviseur du fps pour que la seconde reste un repère juste ; s'il faut
+  // aller jusqu'à la seconde entière, les traits d'image disparaissent et
+  // seules les secondes graduent la règle.
+  var _tickStep=0;
+  for(var _t=Math.max(1,Math.ceil(7/_fcpx));_t<fps;_t++){ if(fps%_t===0){_tickStep=_t;break;} }
+  // Un trait toutes les demi-secondes ou moins n'apprend plus rien à côté des
+  // lignes de seconde : à ce stade on ne garde que les secondes.
+  if(_tickStep>=fps/2)_tickStep=0;
+  // Et quand la seconde elle-même est trop étroite, seules les secondes
+  // ÉTIQUETÉES gardent leur trait — sinon la trame revient, en plus haut.
+  var _secTickAlways=fps*_fcpx>=7;
   var _secPeriod=_secStep*fps;
   function _farFromSec(i){
     var m=i%_secPeriod;
@@ -4089,8 +4104,13 @@ function renderTimeline(){
     //
     // The plain every-5 tick keeps showing the 1-based frame NUMBER (i+1),
     // which is what the rest of the UI displays — that part was never wrong.
-    if(i>0&&i%fps===0){c.classList.add('sec');if(Math.round(i/fps)%_secStep===0)c.textContent=Math.round(i/fps)+'s';}
-    else if(_showFrameNums&&(i+1)%_frameStep===0&&_farFromSec(i))c.textContent=i+1;
+    if(i>0&&i%fps===0){
+      var _lab=Math.round(i/fps)%_secStep===0;
+      if(_lab||_secTickAlways)c.classList.add('sec');
+      if(_lab)c.textContent=Math.round(i/fps)+'s';
+    }
+    else if(_showFrameNums&&(i+1)%_frameStep===0&&_farFromSec(i)){c.textContent=i+1;c.classList.add('tick','tickMaj');}
+    else if(_tickStep&&i%_tickStep===0)c.classList.add('tick');
     hdr.appendChild(c);
   }
   // Bug found 2026-07 ("pourquoi visuellement y a cette séparation du noir


### PR DESCRIPTION
Suite de #880. Cyril : « c'est mieux mais je pense que au fur et à mesure on peut changer plus, enlever les petits traits de frames quand ça devient illisible, simplifier au fur et à mesure ».

## Cause
Seuls les CHIFFRES étaient adaptatifs. Les graduations, elles, étaient dessinées sur **toutes** les cellules (`.fhc::before`), avec un trait plus haut tous les 5 en dur dans le CSS (`nth-child(5n)`) — sans aucun rapport avec le zoom. À 1,6 px par image ça ne se lit plus comme des graduations mais comme une trame grise pleine largeur.

## Correctif
Les traits passent par le même calcul que les chiffres, en trois paliers de simplification :
- **petits traits** : pas calé sur un diviseur du fps qui laisse au moins 7 px ;
- **demi-seconde ou plus** : ils disparaissent, les lignes de seconde suffisent ;
- **seconde trop étroite** : seules les secondes *étiquetées* gardent leur trait, sinon la trame revient en plus haut.

Le trait haut n'est plus « tous les 5 » mais celui qui porte un chiffre (`.tickMaj`), donc les deux hiérarchies visuelles restent d'accord à tous les zooms.

## Vérification
Timeline de 1200 images, 9 combinaisons zoom × fps (0,8 → 30 px/image, 12/24/30 fps) : écart minimal entre deux marques de 6 à 19 px (contre 1 à 2 px avant), et à 0,8 px/image **zéro petit trait** — seules les secondes, à 19 px. `npm test` : 70 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)