### PR TITLE
Bump version to 0.7.0-alpha.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nemo",
-  "version": "0.7.0-alpha.3",
+  "version": "0.7.0-alpha.4",
   "description": "Open-source motion design and 2D animation in one app — a keyframe motion editor alongside frame-by-frame drawing with automatic inbetweening",
   "scripts": {
     "tauri": "tauri",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Nemo",
-  "version": "0.7.0-alpha.3",
+  "version": "0.7.0-alpha.4",
   "identifier": "com.strokemotion.app",
   "build": {
     "frontendDist": "../src",


### PR DESCRIPTION
Tests the app-only-step signing key fix (#881).

🤖 Generated with [Claude Code](https://claude.com/claude-code)