### PR TITLE
docs: add foundation remediation proposal package

### DIFF
--- a/engineering/remediation/01_CURRENT_AND_TARGET.md
+++ b/engineering/remediation/01_CURRENT_AND_TARGET.md
@@ -1,0 +1,90 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# Current architecture and target direction
+
+Status date: **2026-09-04**. Revalidate against the implementation branch before work starts.
+
+## Current
+
+Nemo is an alpha motion, animation and compositing application. Its usable core combines
+Paper.js document objects and serialized JavaScript state with Rust geometry and a vello/WebGPU
+renderer. Tauri supplies desktop filesystem, media, updater and input capabilities. The web
+application is still loaded as many ordered classic scripts, and several large modules share
+mutable globals.
+
+Existing strengths to preserve:
+
+- working vector editing and motion features;
+- Rust geometry, WebGPU rendering and worker-based vectorization;
+- Node and Cargo tests, shader checks and focused regression fixtures;
+- retained renderer resources, caches and some timing/statistics hooks;
+- browser and desktop delivery surfaces.
+
+Confirmed architectural risks:
+
+- live editor state, stored frame data, undo, components, render input and exports have
+  multiple readers/writers and explicit allowlists;
+- rendering and offscreen export can materialize or mutate live Paper state;
+- high-frequency scene data crosses a JSON boundary before Rust rendering;
+- much evaluation and scene preparation runs on the UI thread;
+- decoded media can traverse CPU RGBA buffers, which does not scale well to many UHD streams;
+- separate caches, snapshot undo and embedded media lack one resource/ownership model;
+- RGBA8 intermediates are insufficient as a universal finishing/color pipeline;
+- large global modules make concurrent feature work collision-prone.
+
+JavaScript is suitable for UI, scripting and orchestration. It is not the sole problem.
+TypeScript improves contracts, not frame throughput. Professional-scale performance requires
+retained data, immutable evaluation, bounded jobs, lower-copy media paths and explicit GPU/
+resource ownership. Rewriting the UI or translating identical data flow to Rust would not fix
+those constraints.
+
+## Target
+
+Use one modular application with:
+
+```text
+UI / SDK / MCP / tests
+        |
+versioned application API
+        |
+queries + commands + transactions + jobs
+        |
+authoritative document + stable IDs + history
+        |
+immutable revision snapshots
+        |
+dependency-aware evaluation and scheduling
+        |
+vector rendering + image composition + media + encoding
+```
+
+Recommended ownership:
+
+- Rust for reusable document/evaluation kernels where beneficial, geometry, scheduling,
+  native media, diagnostics transport and the MCP adapter.
+- TypeScript/ESM for UI, inspectors, tools and SDK bindings.
+- Paper.js as an editing/hit-test adapter during migration, not the sole render-time model.
+- Native desktop and worker/WASM browser adapters with explicit capability differences.
+
+Each migrated aggregate has exactly one writable authority. A legacy adapter may bridge old
+callers, but JavaScript and Rust must not become concurrent editable mirrors.
+
+## Performance direction
+
+Measure before moving kernels. First establish fixed workloads and p50/p95/p99 timings for
+evaluation, scene preparation, GPU completion, decode, copies, memory and export. Then:
+
+1. introduce headless evaluation from `document revision + time + quality`;
+2. replace frequent full-scene transport with retained updates and typed bulk data;
+3. move heavy ownership away from the UI thread;
+4. prototype decoded-surface-to-effect-to-preview/encode paths;
+5. coordinate RAM, VRAM, disk cache, jobs, cancellation and recovery.
+
+AE/Resolve-class breadth is a future product program. This remediation establishes a credible,
+measurable foundation; it does not itself prove performance parity.

--- a/engineering/remediation/02_REMEDIATION_PLAN.md
+++ b/engineering/remediation/02_REMEDIATION_PLAN.md
@@ -1,0 +1,164 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# Dependency-ordered remediation plan
+
+Status: **proposed execution plan**. R00-R22 are work-package identifiers, not existing issue
+numbers. Resolve current `main`, open work and owner assignments at kickoff.
+
+## Operating model
+
+Use three lead programs when capacity is available:
+
+| Lead | Program | Typical independent lanes |
+|---|---|---|
+| A: core/integration | sole ownership issuer, shared contracts, state-authority transitions, integration candidate | document/history, commands/evaluation, consumer audit |
+| B: editor/capabilities | UI/tool/timeline extraction and capability adoption | feature modules, UI/API parity, interaction regression |
+| C: platform/quality | test/diagnostic infrastructure, Buzz, native media/plugins, builds | fixtures/CI, OpenFX, security/runtime/benchmark review |
+
+Each lead may use bounded subagents, but every actual writer receives its own non-overlapping
+scope and worktree. One coordinator sequences shared contracts and integration. Agent count
+does not grant repository, deployment or release authority.
+
+Planning target: a first integrated foundation increment within 24 elapsed hours and the
+existing-scope remediation within 7-14 calendar days, with days 11-14 reserved for defects and
+acceptance reruns. These are planning targets. Gates are never waived to meet them.
+
+## Immediate kickoff
+
+Begin with **R00/BZ0**: collect every active developer's task, branch, head, changed/planned
+paths, contracts, agent sessions, unpushed work and next checkpoint. Name the human integration
+owner and backup. Reconcile overlaps, select the fresh base and issue the first three bounded
+packets for baseline, surface inventory and portable workflow. Do not begin broad monolith
+extraction before this shared inventory.
+
+Normalize the existing Buzz pilot through these collaboration packets:
+
+| Packet | Outcome |
+|---|---|
+| BZ0 | adopted authority, identity, scope and task-continuity contract |
+| BZ1 | authenticated desktop onboarding and self-service owner-backed agents |
+| BZ2 | one Nemo Project bound to the canonical GitHub repository and local checkout |
+| BZ3 | typed A2A grants, lifecycle, reconnect, handoff and revocation acceptance |
+| BZ4 | idempotent GitHub issue/PR/run links with GitHub canonical |
+| BZ5 | CI and Nemo product-MCP diagnostic receipts as their capabilities land |
+| BZ6 | backup/restore, offboarding, upgrades, monitoring and support ownership |
+
+Retain accepted pilot behavior, but revalidate it on the final distributed builds. Do not
+describe a source-complete packet as deployed until its runtime gate passes.
+
+## Phase sequence
+
+### F0 — current reproducible baseline
+
+**R00** Resolve current main, active PRs, dirty work, owners and supported platforms.<br>
+**R02** Add source/build identity, `doctor`, named commands and structured receipts.<br>
+**R03** Inventory actionable UI/API surfaces and their save/undo/render/export consumers;
+build deterministic fixtures and initial performance workloads.<br>
+**R04** Repair native/sidecar packaging blockers if they reproduce on the selected base.
+
+Gate: a fresh checkout runs CPU checks, reports unavailable native capabilities as blocked,
+and produces a versioned baseline without changing user projects.
+
+### F1 — portable rules and enforceable boundaries
+
+**R01** Adopt the shared handbook, short Codex/Claude entry points, task/receipt templates,
+Buzz coordination contract and GitHub Project setup.<br>
+**R05** Profile every source file; install dependency, cycle, global-state, size and exception
+checks.<br>
+**R06** Add task-isolated launcher/runtime roots, ports, browser contexts, build outputs and
+report paths.<br>
+**R07** Add real PR gates and then configure required checks after their names and behavior
+have passed on a candidate.
+
+Gate: deliberate size/import/schema violations fail; two writers cannot overwrite each
+other's source, state or artifacts; a clean clone finds the same team instructions.
+
+### F2 — contracts, first extraction and diagnostics
+
+**R08** Extract one pure animation/easing seam through a compatibility facade. Compare Node
+and Vitest using the same unit, stateful behavior and browser control; record the runner ADR.<br>
+**R09** Decide writable state ownership, stable IDs, timebase, persistence, image/color,
+platform capability and dependency direction. Generate boundary types/schemas.<br>
+**R10** Prove a disposable native OpenFX load/describe/CPU-float-render path.<br>
+**R11** Add commands, queries, transactions, gesture lifecycle, history, revision checks,
+idempotency, cancellation and per-aggregate authority transitions.<br>
+**R12** Add structured diagnostics plus deterministic fixture record/replay.
+
+Gate: one migrated aggregate has one writer, one gesture has one undo action, stale writes fail,
+replay matches an independent expectation, and a real application caller uses the extracted code.
+
+### F3 — complete slice, Rust MCP and real native effect
+
+**R13** Migrate one animated property across inspector, timeline, SDK, save/reopen, undo and
+render/export.<br>
+**R14** Add the thin Rust MCP adapter over the same application services; prove Codex and
+Claude discovery, direct-API parity, reconnect, cancellation and stale-write behavior.<br>
+**R15** Prove a geometric gesture or asynchronous export job with progress and cancellation.<br>
+**R16** Integrate one redistributable OpenFX effect through the registry, UI and MCP.<br>
+**R17** Prove color transforms, half/float image handling, EXR fixtures and an explicit OTIO
+subset/loss report.
+
+Gate: UI, SDK, direct tests and both MCP clients reach the same accepted behavior. A real
+plugin survives keying, undo, save/reload, absence, cancellation and host fault. Browser/native
+capability differences are explicit.
+
+### F4 — all shipped subsystem migrations
+
+**R18** Split into bounded issues and migrate by dependency:
+
+1. document IDs, codecs, recovery, components and history;
+2. time, tracks, easing, expressions, parenting and timeline model;
+3. render graph, masks/effects, color resources, cache and scheduler;
+4. drawing, selection, gestures, inspector, graph/timeline, text, rig and mesh;
+5. media, import/export, OpenFX/extensions and external-service adapters;
+6. preferences, shortcuts, contextual/dynamic controls, diagnostics and Labs disposition.
+
+Each child follows: claim → characterize → extract behind facade → route every consumer →
+prove UI/API/MCP/persistence/render behavior → integrate → remove the old writer.
+
+Gate per family: every shipped surface is mapped and migrated or has an owned, dated,
+maintainer-approved exception. Generated coverage cannot substitute for behavior evidence.
+
+### F5 — performance, resilience and distribution
+
+**R19** Set workload budgets from measured product fixtures; run latency, throughput, memory
+plateau, cache, export and soak regressions.<br>
+**R20** Exercise interrupted save, old/damaged files, missing assets/plugins, worker/host crash,
+device loss, stale sessions, disconnects, disk failure and recovery.<br>
+**R21** Validate generated WASM, sidecars, plugin load, media export/reimport, installed desktop
+artifacts and each supported OS.
+
+Gate: agreed budgets and recovery cases pass on identified bytes. Missing platform evidence
+blocks only the corresponding support claim, and remains visible.
+
+### F6 — close foundation remediation
+
+**R22** Reconcile the surface inventory, retire obsolete globals/adapters, validate clean-clone
+setup, rehearse a task with fresh Codex and Claude sessions, and obtain maintainer acceptance.
+
+Gate: all shipped actionable surfaces are classified; persistent data survives every required
+consumer; no unowned bypass remains; browser and packaged desktop evidence is current.
+
+## Parallel work during the program
+
+There is no repository-wide freeze. Reserve only the exact shared scaffold, contract or whole
+legacy file under active extraction. Typical reservation windows are 1-4 hours for shared
+configuration and 2-6 hours for a legacy extraction, with review at checkpoints. A timebox is
+not automatic reassignment.
+
+Continue unrelated work under four rules:
+
+- untouched legacy area: scoped feature/fix plus regression fixture, with no added global debt;
+- reserved area: coordinate with its owner or work on independent fixtures/leaves;
+- migrated area: use its public API and module/capability contract;
+- cross-cutting schema/build change: integration owner versions and sequences it.
+
+Pause bulk formatting, mass renames and competing framework/core rewrites during remediation.
+Integrate coherent packets every 2-4 hours when practical. Clear review/fix backlog before
+expanding a team's work in progress.

--- a/engineering/remediation/03_TESTING_AND_DEBUGGING.md
+++ b/engineering/remediation/03_TESTING_AND_DEBUGGING.md
@@ -1,0 +1,124 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# Testing, regression prevention and debugging
+
+Status: **proposed quality contract**. Nemo currently has Node and Cargo tests. The expanded
+stack and commands below are not complete until implemented and accepted.
+
+## Runner decision
+
+Do not build a custom general-purpose test framework. Preserve the existing Node test runner
+and Cargo tests during migration. Trial Node and Vitest on the same extracted TypeScript module,
+stateful command/undo sequence and browser control:
+
+| Candidate | Best fit | Decision concern |
+|---|---|---|
+| Node test runner | low dependency surface and direct modules | richer TS/component/browser transforms require other tools |
+| Vitest | substantial TS/ESM/component work, watch and browser projects | transformed tests must still match shipped behavior |
+| Web Test Runner | small modules that must run in real browsers | still needs separate Node/native orchestration |
+| Jest | mature ecosystem | weaker fit for a new ESM-oriented architecture |
+| Custom runner | Nemo fixture/replay semantics only | reject custom discovery/assertions/reporting infrastructure |
+
+Select Node or Vitest in an ADR after measuring useful diagnostics, source maps, cold/warm
+speed, concurrent worktrees, reports and setup. Type checking remains an independent gate.
+
+## One command surface
+
+| Command | Required result |
+|---|---|
+| `npm run doctor` | read-only prerequisites and capability report |
+| `npm run check` | format, lint, type, architecture, module profile and schema/artifact integrity |
+| `npm test` | fast deterministic JS/TS and Rust CPU suites |
+| `npm run test:integration` | document, command/history, persistence and backend contracts |
+| `npm run test:browser` | Playwright workflows and justified visual assertions |
+| `npm run test:desktop` | actual test-build Tauri app with isolated data and native operations |
+| `npm run bench` | named workload, seed and hardware profile with structured metrics |
+| `npm run verify` | merge profile that emits one machine-readable receipt |
+
+Each job reports `pass`, `fail`, `blocked` or `not-run`, with reason. A missing required
+environment is blocked, never silently converted to success.
+
+## Test layers
+
+1. **Pure unit:** time, easing, transforms, parsing, identity and cache policy using production
+   imports and independent expected results.
+2. **Property/model:** generated identities, serialization and stateful command sequences;
+   retain minimized failing seeds.
+3. **Document contract:** old/current save, migration, unknown fields, nested components,
+   assets and undo/redo.
+4. **Backend parity:** declared Rust/native/WASM subset, numeric tolerances and independent
+   reference behavior.
+5. **Integration:** create → edit → key → undo/redo → frame change → save/reopen → render/export.
+6. **Interaction/visual:** real sliders, gestures, masks, text, alpha, mesh and playback
+   transitions at fixed font/scale/time/color settings.
+7. **Concurrency/fault:** stale revisions, retries, cancellation, disconnect, device loss,
+   missing media and interrupted save.
+8. **Performance/soak:** p95/p99 latency, missed presentations, CPU/GPU completion, memory
+   plateau, cache eviction and export throughput.
+9. **Package/client:** installed desktop artifact plus each supported MCP client and platform.
+
+Most unit tests call the application API directly. MCP has protocol and parity suites; it is
+not the route for every test. UI wiring has independent interaction tests even when command
+handlers pass.
+
+## Fixture and regression rules
+
+- Every reproduced bug gains the smallest useful failing fixture before the fix when practical.
+- Use a versioned corpus covering static/keyed/expression properties, held frames, nested
+  components, paths/groups, mask/alpha, text, mesh, media, older schemas and export.
+- Each fixture records generation, expected invariants, asset hashes, required capabilities,
+  backend, tolerance and seed.
+- Use fast-check for suitable JS/TS command models and proptest for Rust properties.
+- Preserve failing seeds and minimized command sequences.
+- Review visual baseline changes; never regenerate goldens merely to obtain green CI.
+- Apply targeted mutation/fuzz tests to critical parsers and migrated kernels, not every edit.
+- Test the combined integration candidate. Separate green branches do not prove their merge.
+
+## Built-in Diagnostics surface
+
+The Diagnostics panel, CLI, tests and MCP consume one versioned diagnostics API:
+
+- environment: source/build identity, dirty digest, application/WASM versions, platform,
+  renderer/device and current document/fixture revision;
+- event timeline: command, undo, frame, request and job IDs; JS/native/worker errors; stage
+  transitions and cancellation;
+- performance: evaluation/prepare/present p50/p95/p99, GPU completion, long tasks, cache and
+  bounded resource usage;
+- state: stable IDs, revision, dependencies and stored-model versus adapter state;
+- reproduction: load a synthetic fixture, record/replay commands with fixed clock/seed,
+  capture output and export a redacted diagnostic bundle.
+
+Use bounded ring buffers, sampling and opt-in detailed tracing. Diagnostics must not create a
+different evaluator or serialize the full project every frame. Shareable reports redact asset
+content and paths by default.
+
+Suggested application operations:
+
+```text
+getCapabilities
+getSnapshot
+loadFixture
+dispatchCommand
+evaluateFrame
+captureFrame
+getTrace
+exportBundle
+```
+
+Every operation carries request, instance, document and revision identity plus cancellation
+where applicable. Stale responses cannot update a later document.
+
+## CI design
+
+Run static architecture, fast CPU, document-contract, browser and required native/build jobs
+according to changed modules and reverse dependencies. Until global coupling is retired,
+selection stays conservative. Required aggregate checks fail if a required child fails,
+cancels or is missing. Expensive GPU/native checks use trusted runners or an explicit
+maintainer acceptance path; untrusted contributor code must not automatically execute on a
+personal privileged runner.

--- a/engineering/remediation/04_MODULARITY_POLICY.md
+++ b/engineering/remediation/04_MODULARITY_POLICY.md
@@ -1,0 +1,102 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# Modularity and file-size policy
+
+Status: **proposed initial policy**. Adopt after maintainer review, then tune from the first
+two meaningful extractions. A line budget is a warning against mixed responsibilities, not a
+substitute for a coherent API.
+
+## Logical layers
+
+```text
+bootstrap/       selects and wires concrete adapters
+features/        timeline, drawing, inspector and media UI
+application/     commands, transactions, history and use cases
+domain/          document, identity, tracks and evaluation contracts
+ports/           renderer, media, persistence and scheduler interfaces
+adapters/        Paper, WebGPU/WASM, Tauri and browser implementations
+shared/          small domain-independent values only
+```
+
+Dependency rules:
+
+- domain imports only domain/shared and has no DOM, Paper, Tauri or concrete renderer access;
+- application imports domain/ports/shared;
+- features call public application APIs and own only their UI state;
+- adapters implement ports; bootstrap composes them;
+- no private cross-module deep imports, new cycles, implicit globals or UI imports into domain;
+- a global `services`/`context` object cannot bypass boundaries;
+- typed events are for true asynchronous fan-out, not every function call;
+- every migrated module declares owner/reviewer, public API, state owner, dependencies,
+  lifecycle, fixtures and performance invariants.
+
+## Initial size profiles
+
+Count nonblank physical lines including comments after formatting, and separately report total
+physical lines.
+
+| Profile | Warn | Hard maximum |
+|---|---:|---:|
+| Domain/application JS or TS | 300 | 400 |
+| Feature UI JS or TS | 350 | 500 |
+| Platform/engine adapter | 300 | 500 |
+| Rust production module | 350 | 500 |
+| Test file | 450 | 600 |
+| Stylesheet | 250 | 350 |
+| Handwritten config/bootstrap | 150 | 250 |
+
+Function-body soft warning: 60 nonblank lines. Hard review/exception threshold: 100.
+Cyclomatic/branch complexity warns at 12 and requires explicit review above 20.
+
+Do not pass the gate by deleting useful comments, minifying, moving code into arbitrary tiny
+files or hiding branches behind meaningless helpers.
+
+## Enforcement
+
+- ESLint handles JS/TS line/function/complexity and global rules.
+- dependency-cruiser enforces imports, cycles and forbidden layer edges.
+- an AST rule inventories legacy `window.SM*` and other implicit global access.
+- rustfmt, Clippy, module visibility and Cargo metadata enforce Rust boundaries.
+- one cross-language script applies profiles and validates the exception register.
+- schemas/types are generated from one source and checked for drift.
+- dynamic loaders/plugin entry points are declared rather than omitted from the graph.
+
+Prove the checker with temporary deliberate violations: oversized module, forbidden import,
+implicit global, stale generated schema and missing capability registration. Remove the
+fixtures after verifying each failure mode.
+
+## Legacy migration
+
+1. Record an exact-path baseline for current violations. New/migrated code follows policy
+   immediately; an oversized legacy file may shrink but cannot silently exceed its ceiling.
+2. Characterize one responsibility through real behavior fixtures.
+3. Extract it behind a narrow compatibility facade with one state owner.
+4. Migrate from classic global script order toward ESM with a bootstrap that waits for required
+   modules. Do not assume changing a script tag or package type solves load order.
+5. Add JSDoc/checkJs or TypeScript incrementally at boundaries.
+6. Route every caller and consumer, validate the real app, then retire the legacy writer.
+7. Avoid broad formatting/renames while others work in the same legacy region.
+
+Suggested order: key lookup/easing → track evaluation → document codecs/identity → command/
+undo transactions → timeline UI → renderer adapters → media/export.
+
+## Exceptions
+
+Each exception names:
+
+- exact path and profile/rule;
+- current measured ceiling;
+- reason the module remains coherent;
+- accountable human owner;
+- tracking issue and review/expiry date;
+- affected contracts/tests and shrink/removal condition.
+
+CI rejects unowned, expired or increased baselines. Vendored/generated/minified/data assets
+use a separate provenance and integrity policy; do not split a shader catalog or translation
+table merely to satisfy an application-code line budget.

--- a/engineering/remediation/05_CAPABILITIES_MCP_AND_STANDARDS.md
+++ b/engineering/remediation/05_CAPABILITIES_MCP_AND_STANDARDS.md
@@ -1,0 +1,120 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# Shared capabilities, Rust MCP and open standards
+
+Status: **proposed product architecture**. The Nemo Rust MCP and shared capability registry are
+not current product features. They are built during remediation from application contracts,
+not as a DOM-control wrapper.
+
+## One definition, many consumers
+
+Every feature owns a namespaced capability module. Rust declarations generate transport
+schemas, TypeScript types and declarative descriptors. UI, SDK, tests and MCP call the same
+query/command/job handlers.
+
+Each descriptor defines:
+
+- stable ID, namespace, owner and schema/API version;
+- scope: document, object, component, app preference, UI session or job;
+- input/output types, defaults, bounds, units, enum values and applicability;
+- getter/query and mutation handler; static, keyed, expression or computed behavior;
+- preconditions, document revision, transaction/undo and invalidation rules;
+- UI binding plus optional presentation metadata;
+- native/browser availability, permissions and runtime/diagnostic/developer mode;
+- fixtures, invariants, diagnostics and performance-sensitive contracts.
+
+Dynamic extensions register compatible descriptors and validated handlers at runtime. Avoid
+a central switch or a new general-purpose DSL.
+
+## Complete surface inventory
+
+Maintain:
+
+```text
+surface -> capability -> handler -> UI/SDK/MCP exposure -> fixtures -> platform status
+```
+
+Inventory project lifecycle, drawing/selection/gestures, layers/components, animation,
+expressions/rigs, timeline/graph, effects/masks, media/import/export, playback, preferences,
+plugins, diagnostics and integrations. Include contextual/modal/dynamic controls and custom
+effect parameters. A button count is not coverage.
+
+States: `inventoried`, `characterized`, `legacy-adapter`, `migrated`, `validated`,
+`unavailable-with-reason`, `unmapped`. CI rejects an actionable shipped surface that is
+silently unmapped. Generated registration tests do not invent semantic or visual oracles.
+
+## Application command contract
+
+Persistent writes use one dispatcher with validation, transaction and history boundaries.
+Long work uses bounded jobs with progress and cancellation. Canvas interactions use explicit
+begin/update/commit/cancel commands so one gesture creates one undo action.
+
+Requests identify app instance, document, revision, request and optional job. Queries can use
+immutable snapshots. Writes serialize per document with optimistic revision checks.
+Byte-equivalent retries use explicit idempotency; late results cannot mutate a newer revision.
+
+## Rust MCP adapter
+
+Use the official Rust MCP SDK at a pinned released protocol version. Keep transport outside
+domain/application modules. Default to a compact tool family:
+
+```text
+discover instances and capabilities
+query snapshot/property/diagnostic resources
+dispatch a typed command or transaction
+start, observe and cancel a bounded job
+retrieve report/artifact references
+```
+
+Expose the complete schema through paginated discovery/resources and list-change notifications
+without flooding the default context with thousands of per-widget tools. Keep pixels, video
+frames and geometry arrays off ordinary JSON tool calls; exchange handles or bulk artifacts.
+
+Multiple clients may attach to an explicitly selected instance. Surface build identity,
+connection state and granted mode. A runtime app connection is not source-workspace authority.
+A browser needs a separate local companion or hosted adapter because it cannot expose native
+stdio by itself; accept desktop attachment first and name browser support separately.
+
+## Modes
+
+| Mode | Allowed capability |
+|---|---|
+| Runtime | authorized editing/query/jobs, bounded diagnostics, build identity and reports |
+| Diagnostic | opt-in trace, fixture session, capture, replay and bounded benchmark on the production path |
+| Developer workspace | issue-to-source/test/build loop in an explicitly granted isolated checkout |
+
+Never expose unrestricted remote shell/eval from release builds. A production binary does not
+patch itself; a fix becomes a reviewed build and normal update. Developer mode uses explicit
+operations and least privilege.
+
+## Open standards from the foundation
+
+| Standard | Required boundary |
+|---|---|
+| OpenFX | native effect-host port, parameter mapping, image contract, scheduler/lifecycle and fault containment |
+| OpenColorIO | working space/config identity, input/output and display transforms |
+| OpenEXR | half/float precision, alpha/channel naming and real I/O adapter |
+| OpenTimelineIO | precise time/media references and an explicit unsupported-information report |
+
+OpenFX affects images, scheduling, cache and time, not only a plugin menu. Start with a
+controlled CPU float subset and one real redistributable plugin. Map supported parameter
+descriptors into ordinary Nemo properties so UI, animation, SDK and MCP use the same handlers.
+
+Required early proof:
+
+1. discover/load/describe one real plugin and record its version/supported suites;
+2. edit and key a parameter through UI and MCP, then undo and save/reload;
+3. render known inputs against independent results;
+4. cancel work and inject a host crash without corrupting the document;
+5. preserve plugin IDs/parameters when missing;
+6. record platform, architecture, image precision and CPU/GPU path.
+
+Unmodified native OpenFX binaries do not run in browser WASM. Browser projects preserve the
+effect and report it unavailable or use an explicitly baked proxy. GPU interop and zero-copy
+claims require a measured prototype.

--- a/engineering/remediation/06_BUZZ_A2A_AND_ENROLLMENT.md
+++ b/engineering/remediation/06_BUZZ_A2A_AND_ENROLLMENT.md
@@ -1,0 +1,175 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# Buzz collaboration, A2A and enrollment
+
+Protocol: **NEMO-A2A-1**<br>
+Expected canonical skill path after adoption: `.agents/skills/nemo-a2a/SKILL.md`
+
+## Status boundary
+
+Current pilot behavior includes authenticated desktop chat, distinct human and managed-agent
+identities, self-service owner-backed agent admission, normal inline replies, a Nemo Project
+bound to the canonical GitHub repository and a narrow issue/PR/run link bridge. GitHub remains
+canonical.
+
+Automatic immutable project-instruction preloading, the complete typed A2A grant/settings
+surface, hardened execution lifecycle and team-distributable cross-platform builds must pass
+fresh final-build acceptance before being called generally deployed. Nemo's product Rust MCP
+is a separate future product surface.
+
+## Roles and permissions
+
+Keep these independent:
+
+1. GitHub repository/Project permission;
+2. Buzz community membership;
+3. Project/channel membership;
+4. managed-agent response policy and provider login;
+5. local checkout capability/path/branch/worktree grant;
+6. publication, merge, deployment and release authority.
+
+Membership or an agent persona does not imply source authority. Each agent has one accountable
+human sponsor, a distinct public identity and least-privilege channel/grant scope.
+
+## Enroll a human developer
+
+1. Operator verifies current project-collaborator eligibility and agrees the initial role and
+   channels.
+2. Developer creates/imports their own Buzz identity and verifies an encrypted local backup.
+3. Developer sends only their public identity (`npub`) over an authenticated path and confirms
+   its short fingerprint out of band.
+4. Operator admits the exact public identity with ordinary `member` role unless the person has
+   a named operational need for `admin`.
+5. Developer joins using the team relay URL obtained from the operator and selects their local
+   profile name.
+6. Operator adds only the required Project/channel access.
+7. Verify signed connection, message/reply, relaunch history and denial of an ungranted channel.
+
+An invitation link is a convenience for connection details. It never replaces collaborator
+verification or admission. Private keys, recovery passwords and provider credentials are never
+sent to the operator or chat.
+
+## Create and authorize a developer-owned agent
+
+Agent creation is self-service after human enrollment:
+
+1. Confirm the local Codex/Claude runtime is installed and authenticated on that developer's
+   machine.
+2. In Buzz Desktop choose **Agents → New agent**, select runtime/model/effort/instructions and
+   use owner-only or an explicit operator allowlist.
+3. Buzz creates a unique agent key and an owner-signed attestation. Keep both human and agent
+   secrets in the local protected store.
+4. Start the agent. The relay grants virtual membership only while the attestation and direct
+   human membership are valid. The agent is not inserted as a direct human member.
+5. Add the required Project/channel, then create a separate worktree and an exact local
+   checkout grant for capability, path prefixes, base SHA, branch and worktree ID.
+6. Verify process, signed admission, directed request/reply, negative scope tests, reconnect
+   and no duplicate execution.
+
+Each developer's agents use that machine's own Codex/Claude provider login unless deliberately
+configured otherwise. Buzz identity does not select or share an AI-provider billing account.
+
+## Attach Nemo as a Buzz Project
+
+1. Configure the local repositories root to the parent of the developer's Nemo checkout.
+2. Create/open one Project named Nemo with:
+   - clone URL `https://github.com/mysteropodes/nemo.git`;
+   - web URL `https://github.com/mysteropodes/nemo`;
+   - one Project home channel.
+3. Resolve the existing checkout only when its canonical path stays under the configured root
+   and Git `origin` matches the announcement.
+4. Add admitted humans/agents to the Project channel.
+5. Give each writer an isolated worktree and scoped checkout grant.
+6. Keep Buzz tasks out of the canonical backlog. The GitHub bridge posts only signed,
+   idempotent links/status for allowed issue, PR and workflow-run events.
+
+## Workspace and agent settings
+
+The operator configures one workspace Project binding per relay:
+
+- Project address and home-channel ID;
+- canonical repository/display name;
+- exact immutable instruction revision;
+- allowed peers and A2A capabilities;
+- per-agent repository-relative path prefixes;
+- exact base SHA, branch and logical worktree ID;
+- owner-only or explicit response allowlist.
+
+Machine-local checkout roots stay in local protected settings and never enter signed A2A events
+or model prompts. Changing the immutable instruction revision or Project binding requires new
+provider sessions; missing or ambiguous policy fails before work starts.
+
+## Typed A2A tools
+
+Managed agents use:
+
+| Intent | Tool |
+|---|---|
+| Reply in the current human conversation | `buzz_chat_send` |
+| Delegate one bounded job | `buzz_a2a_dispatch` |
+| Discover addressed work | `buzz_a2a_inbox` |
+| Follow one exact request | `buzz_a2a_status` |
+| Request cancellation | `buzz_a2a_cancel` |
+| Release/transfer owned execution | `buzz_a2a_handoff` |
+
+Do not use shell commands, the unrestricted human CLI, raw relay events or reconstructed
+credentials as substitutes. One-shot job sessions cannot send arbitrary chat, browse unrelated
+inbox work or dispatch unrelated jobs; they may use native local subagents within their packet.
+
+## Dispatch contract
+
+Before dispatch:
+
+1. inspect the active task queue and existing A2A status;
+2. choose disjoint repository-relative paths, worktree and acceptance checks;
+3. select an already authorized recipient and exact Project/repository grant;
+4. create a fresh operation UUID and stable non-secret idempotency key;
+5. include base SHA, branch, logical worktree, expiry and inert contract references;
+6. keep credentials, machine-local paths and executable shell strings out of the envelope.
+
+Save the returned `request_event_id`. Relay acknowledgement means only that an event was stored.
+Work is owned only after the exact recipient publishes both:
+
+- `processed`: durable validation;
+- `accepted`: atomic ownership claim before side effects.
+
+Neither means completed, reviewed, merged or released.
+
+## Lifecycle, cancellation and handoff
+
+The normal path is:
+
+```text
+request -> processed -> accepted -> progress* -> completed
+                                      \-> failed or indeterminate
+                                      \-> cancelled/release/handoff
+```
+
+Cancellation after a claim is two-stage: requester publishes `cancel_requested`; worker
+quiesces and publishes `cancelled`. Silence is not cancellation.
+
+A handoff releases the current worker but does not assign its successor. The coordinator
+dispatches the same operation to the authorized successor with the next coordinator epoch and
+the handoff event as superseded. The successor must publish new `processed` and `accepted`
+claims.
+
+Byte-equivalent retries reuse the original key and signed bytes. Changed semantics require a
+new idempotency key. An accepted operation that crashes without a terminal receipt becomes
+`indeterminate` and requires reconciliation; it is never automatically rerun.
+
+Fail closed on missing tools/grants, ambiguous Project binding, origin/branch/HEAD drift,
+expired authority, path escape, signature/lifecycle mismatch or unreachable relay state.
+
+## Revocation
+
+Freeze and reconcile active grants first. Stop the agent, remove its channels, revoke/ban its
+exact identity and delete its local secret/provider configuration. For a departing human,
+revoke every sponsored agent before removing the human's direct membership and repository/
+infrastructure permissions. Verify fresh WebSocket, protected HTTP/media and job authorization
+all fail. Preserve work/evidence; elapsed time or disconnection never authorizes takeover.

--- a/engineering/remediation/07_GITHUB_PROJECT_AND_PARALLEL_WORK.md
+++ b/engineering/remediation/07_GITHUB_PROJECT_AND_PARALLEL_WORK.md
@@ -1,0 +1,142 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# GitHub Project and parallel-development contract
+
+Status: **proposed team workflow**. The board, fields and automation are not active until a
+Project owner creates/adopts them. GitHub issues, PRs, CI and review remain canonical even
+when Buzz carries the coordination messages.
+
+## Project
+
+Create one Project named **Nemo Development**, owned where the repository maintainers can
+administer it, and link it to the Nemo repository.
+
+Recommended fields:
+
+| Field | Values |
+|---|---|
+| Status | Inbox → Ready → In progress → Review → Validate → Done; Blocked is a side state |
+| Assignee | one accountable human |
+| Priority | P0 / P1 / P2 |
+| Area | Document / Animation / UI / Renderer / Media / Platform / DevEx |
+| Goal | Reliable alpha / Modular core / Measured performance / Reproducible desktop |
+| Size | S / M / L; split L before concurrent implementation |
+| Milestone/iteration | real release or checkpoint |
+
+Useful views: triage inbox, Ready by priority, active work by owner/area, review/validation,
+blocked/dependencies, goal roadmap and performance investigations.
+
+Task bodies and receipts carry detailed base SHA, worktree, paths, contracts, agent sessions,
+risks and evidence. Do not create a custom field for every packet detail or assign fictional
+agent accounts in place of the accountable human.
+
+## State semantics
+
+- **Ready:** outcome, owner, dependencies, scope and observable acceptance are complete.
+- **In progress:** one acknowledged writer owns the scope.
+- **Review:** concrete diff and evidence exist.
+- **Validate:** integrated/runtime/platform acceptance is still required.
+- **Done:** specified behavior is accepted on an identified integrated commit/artifact.
+- **Blocked:** exact dependency, owner and next action are recorded.
+
+A merged PR is not automatically Done when desktop, export or visual acceptance remains.
+Use issue-closing keywords only when the full issue acceptance is satisfied by merge/CI.
+Do not mass-close old issues based on a `resolved` label; triage each against evidence.
+
+## Minimal automation
+
+- Auto-add only intentionally triaged items, for example those with a `tracked` label.
+- Link PRs, issues and CI receipts.
+- Move merged work to Validate when runtime evidence remains.
+- Use one coordinator for milestone/status updates.
+- Keep credentialed Project writes separate from untrusted pull-request execution.
+- Add a stable required aggregate check only after the workflow exists, passes and reports
+  required missing/cancelled jobs as failures.
+
+## Claim and assignment
+
+Every task uses [the task packet](templates/TASK_PACKET.md). One coordinator issues scope.
+A claim identifies issue, human owner, unique agent session, base, branch/worktree, allowed
+paths, contracts, dependencies, resource slots, checkpoint and acceptance.
+
+Buzz/Project status is not an atomic file lock. Before editing, the writer acknowledges the
+exact grant. Scope expiry starts reconciliation; it never permits a second writer to overwrite
+an unreachable owner's work.
+
+Reserve whole legacy files during extraction. Line ranges are too fragile for shared monoliths.
+Shared manifests, lockfiles, bootstrap, schemas, workflows and policy documents have one active
+writer. When a task needs another owner's path, request a scope change or pass a bounded patch
+to that owner.
+
+## Isolation
+
+| Resource | Rule |
+|---|---|
+| source/index | separate branch and worktree per writer |
+| browser state | separate profile/context and origin |
+| Tauri data/autosave | task-specific configured data root |
+| ports/processes | atomic reservation and source handshake; stop only owned processes |
+| media/temp/cache | unique run roots |
+| build output | per-worktree mutable outputs |
+| reports/artifacts | run IDs and unique paths |
+| desktop input | serialize when sharing a physical UI |
+| GPU benchmarks | exclusive reference-machine slot |
+| shared docs/lockfiles | one writer, then consolidation |
+
+A separate worktree does not isolate browser storage, app data, GPU load or desktop input.
+
+## Commit hygiene
+
+1. Fetch and inspect main, relevant branches/PRs and current claims before diagnosis.
+2. Confirm the grant covers every changed path and semantic scope.
+3. Stage explicit files/hunks and inspect the staged diff.
+4. Keep one coherent extraction, fix or contract change with its tests/docs per commit.
+5. Separate broad formatting, renames and dependency churn from behavior.
+6. Do not hand-edit generated output; regenerate from its source.
+7. Check for secrets, local profiles, private fixtures and accidental large artifacts.
+8. Follow the repository's authorship, sign-off and signing policy; never invent identities.
+9. Do not push directly to `main`. Open a scoped PR.
+10. Do not reset/rebase/push another agent's checkout or rewrite a shared branch without an
+    explicit coordinated decision.
+
+Nemo contributions are GPL-3.0-or-later and the current contributor guide uses no CLA. Review
+third-party notices before changing bundled/native dependencies. If a target repository
+enforces DCO, include the verified contributor's matching `Signed-off-by`; authorship,
+co-authorship, DCO sign-off and cryptographic signing are separate claims.
+
+Commit and PR descriptions lead with changed behavior or responsibility, state preserved
+invariants, link the canonical task and summarize validation plus limitations.
+
+## Review and integration
+
+The reviewer receives the actual diff, task contract, fixtures/results and limits. Different
+models are not independent evidence by themselves; reproduce behavior against an independent
+expectation.
+
+One integration owner:
+
+1. refreshes main, active claims and dependent PRs;
+2. resolves semantic as well as textual conflicts with affected owners;
+3. builds the combined candidate and reruns affected plus reverse-dependency checks;
+4. records exact base, candidate and artifact identity;
+5. integrates only with current authority and required human review;
+6. verifies the landed SHA/runtime and updates the canonical receipt.
+
+If main changes during validation, reassess and refresh evidence. Roll back the smallest coherent
+change without enabling two state authorities or discarding newer/unknown document data.
+
+## Pause, handoff and urgent regressions
+
+On pause, checkpoint branch/dirty state, fixtures, failures and one exact next action. Keep the
+scope held until an explicit release/transfer. A new session rereads history, base and current
+grant.
+
+For an urgent regression in a reserved area: reproduce it, pause/checkpoint the extraction,
+agree a handoff, land the smallest fix through normal review, then reconcile every affected
+worktree and forward-port the regression fixture.

--- a/engineering/remediation/08_ACCEPTANCE_AND_MAINTENANCE.md
+++ b/engineering/remediation/08_ACCEPTANCE_AND_MAINTENANCE.md
@@ -1,0 +1,102 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# Acceptance, evidence and maintenance
+
+## Evidence vocabulary
+
+- **Observed:** directly reproduced on the named source/runtime with retained evidence.
+- **Implemented:** source contains the behavior; end-to-end acceptance may still be missing.
+- **Historical:** earlier documentation/receipt says it worked; revalidate before relying on it.
+- **Proposed:** design or plan that has not been adopted or delivered.
+- **Blocked:** required validation could not run for an exact reason.
+- **Unknown/not-run:** not checked; no inference from another surface.
+- **Accepted:** designated maintainer accepts the required behavior on identified bytes.
+
+Every health claim identifies source/base/candidate SHA, environment/platform, command or
+interaction, fixture/version/seed, result, date and limitations.
+
+## Per-packet acceptance
+
+Use [the handoff receipt](templates/HANDOFF_RECEIPT.md). Minimum gates:
+
+1. Intended behavior and forbidden regression are explicit.
+2. Changed paths stay inside the acknowledged grant.
+3. Module/API/schema and state-authority changes are declared.
+4. Fast static and behavior checks run on the candidate.
+5. Persistent changes cover create/edit/key/undo/redo/save/reload and every relevant consumer.
+6. UI/API/SDK/MCP parity is checked where the surface exists.
+7. Browser and packaged desktop are treated as separate acceptance surfaces.
+8. Native media/plugin/export claims use the actual packaged artifact.
+9. Performance changes preserve output and compare controlled workloads.
+10. Limitations, blocked/not-run scope, reviewer and rollback are visible.
+
+## Foundation close gate
+
+Remediation is complete only when:
+
+- every actionable shipped surface is mapped to a capability and handler or has an explicit
+  unavailable/owned exception;
+- each migrated aggregate has one writable authority and no undocumented bypass;
+- module dependencies, profiles and exception expiry are enforced;
+- supported documents preserve IDs, fields, assets and unknown-data policy across migrations;
+- the direct application API, UI, SDK and MCP agree for declared shared behavior;
+- real browser, desktop, media/export and supported-platform evidence is current;
+- representative performance, soak, cancellation, crash and recovery gates pass;
+- a real OpenFX subset and color/precision boundaries are fixture-backed;
+- clean-clone Codex and Claude sessions find the same adopted instructions and can complete
+  one bounded task through NEMO-A2A-1;
+- handbook, ADRs, support matrix and release path match the integrated source;
+- the maintainer accepts the identified candidate/artifacts.
+
+A line-count reduction, generated schema, passing unit suite, merged PR, relay acknowledgement
+or agent completion message alone is not this gate.
+
+## Required maintenance cadence
+
+| Trigger | Update |
+|---|---|
+| task start | fetch/read current main, issues/PRs/claims and relevant policies |
+| branch/worktree/base change | re-evaluate scope, contract versions and prior evidence |
+| new feature/type/field/dependency | update architecture, capability inventory, fixtures and affected consumers |
+| bug reproduction/test result | retain exact evidence and failure scope |
+| accepted decision | add/update ADR and supersede old guidance explicitly |
+| policy/protocol change | version all affected instructions, schemas and client adapters together |
+| before handoff | receipt with state, results, uncertainty and exact next action |
+| before integration | validate the combined candidate against current main |
+| before release | validate built bytes, support matrix, native/media/plugin paths and recovery |
+| periodic active review | triage stale claims/exceptions, dependencies, CI flakes, docs drift and benchmark baselines |
+
+Do not schedule activity merely to generate reports. Review when the project is active and
+when evidence can affect a decision.
+
+## Document ownership and updates
+
+- One writer owns a shared policy/manifest in each integration window.
+- Other agents submit per-task receipts; the owner reconciles rather than overwriting.
+- Normative rules are concise. Detailed logs/traces live in approved artifacts and are linked.
+- Architecture or behavior changes update the relevant document in the same PR.
+- Mark old facts superseded; do not delete the only failure evidence.
+- Keep current source facts separate from proposals and future product scope.
+- Revalidate public links and package-local links after moves/renames.
+- Increment the package version for contract changes and record migration notes.
+- Validate clean-clone Codex and Claude loading whenever instruction topology changes.
+
+## Metrics for active review
+
+Track measures that drive decisions:
+
+- delivery: review wait, blocked age, integration conflicts, reopened regressions;
+- validation: time to first useful failure, gate time, flake/blocked rate;
+- architecture: cycles, forbidden edges, new globals, oversized debt and exception expiry;
+- product performance: p95/p99 evaluation/presentation, dropped frames, GPU/decode/upload,
+  memory plateau and export throughput;
+- agent operations: duplicate investigations, abandoned claims, rework after handoff and
+  cost per accepted outcome where available.
+
+Do not rank people by lines of code, generated commits or agent completion messages.

--- a/engineering/remediation/MANIFEST.md
+++ b/engineering/remediation/MANIFEST.md
@@ -1,0 +1,50 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# Nemo foundation remediation package
+
+Status: **proposal for maintainer review**<br>
+Prepared: **2026-09-04**<br>
+Package version: **0.1.0**
+Repository: <https://github.com/mysteropodes/nemo>
+
+This package is the portable starting point for Nemo's foundation remediation. It contains
+architecture, execution, quality, collaboration and maintenance guidance that can be reviewed
+and tracked with the source. It contains no credentials, private relay address, machine-specific
+checkout path, private evidence, or deployment procedure.
+
+## Reading order
+
+| File | Purpose |
+|---|---|
+| [README.md](README.md) | How to adopt the package and interpret status labels |
+| [01_CURRENT_AND_TARGET.md](01_CURRENT_AND_TARGET.md) | Current architecture, confirmed constraints and target direction |
+| [02_REMEDIATION_PLAN.md](02_REMEDIATION_PLAN.md) | Dependency-ordered R00-R22 implementation plan |
+| [03_TESTING_AND_DEBUGGING.md](03_TESTING_AND_DEBUGGING.md) | Test-runner decision, fixture stack and built-in diagnostics |
+| [04_MODULARITY_POLICY.md](04_MODULARITY_POLICY.md) | Layer rules, file/function budgets, exceptions and migration method |
+| [05_CAPABILITIES_MCP_AND_STANDARDS.md](05_CAPABILITIES_MCP_AND_STANDARDS.md) | Shared capability registry, Rust MCP and OpenFX/OCIO/EXR/OTIO boundaries |
+| [06_BUZZ_A2A_AND_ENROLLMENT.md](06_BUZZ_A2A_AND_ENROLLMENT.md) | Human/agent enrollment and the NEMO-A2A-1 operating contract |
+| [07_GITHUB_PROJECT_AND_PARALLEL_WORK.md](07_GITHUB_PROJECT_AND_PARALLEL_WORK.md) | Project fields, ownership, worktrees, commits and integration |
+| [08_ACCEPTANCE_AND_MAINTENANCE.md](08_ACCEPTANCE_AND_MAINTENANCE.md) | Phase gates, evidence vocabulary and update rules |
+| [templates/TASK_PACKET.md](templates/TASK_PACKET.md) | Ready-work and scope-grant template |
+| [templates/HANDOFF_RECEIPT.md](templates/HANDOFF_RECEIPT.md) | Review, handoff and completion evidence template |
+
+## Authority
+
+These documents become team policy only after maintainer review and adoption. Source, tests,
+accepted ADRs and observed runtime behavior settle implementation facts. GitHub remains
+canonical for code, issues, pull requests, CI and review. Buzz carries authenticated
+coordination and A2A lifecycle events; it is not the product backlog or source of merge
+authority.
+
+The package deliberately separates:
+
+- **Current:** present in Nemo source or directly accepted collaboration behavior.
+- **Proposed:** designed but not yet implemented or adopted.
+- **Gate:** evidence required before a proposal can be called delivered.
+- **Future:** product breadth beyond foundation remediation.

--- a/engineering/remediation/README.md
+++ b/engineering/remediation/README.md
@@ -1,0 +1,48 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# Using this package
+
+Start with [the manifest](MANIFEST.md), then read the current/target architecture and the
+remediation plan. A developer or agent working on one packet reads only the relevant policy,
+task packet and module documentation in addition to the repository's contributor guidance.
+
+## Adoption checklist
+
+1. Reconcile every current-state statement with the selected `main` commit.
+2. Review and accept, amend or reject the proposed ADR-level decisions.
+3. Choose the tracked destination, for example `engineering/remediation/`, and move this
+   directory as one unit so its internal links remain valid.
+4. Point the repository's Codex and Claude entry files at the adopted documents. Keep those
+   entry files short.
+5. During adoption, install or retain `.agents/skills/nemo-a2a/` as the canonical A2A skill;
+   this proposal package does not include that runtime skill. Test clean-clone discovery in
+   both clients.
+6. Create the GitHub Project fields/views and real CI workflow before making their checks
+   required.
+7. Open R00-R22 as parent/child issues only after current owners, dependencies and acceptance
+   are reconciled.
+8. Validate one small multi-agent fixture before opening broad concurrent extraction.
+
+## Working interpretation
+
+A proposal does not grant file, GitHub, relay, deployment, merge or release authority.
+Every writable task needs a human owner, exact base, branch/worktree, allowed paths,
+dependencies, observable acceptance and a reviewer. New requests are queued without
+silently abandoning the active task.
+
+Implementation status belongs in the corresponding issue and handoff receipt. Do not turn
+this package into a shared mutable task ledger. Update a policy document in the same pull
+request that changes its contract, and retain dated evidence outside normative prose.
+
+## Safe customization
+
+Replace placeholders such as `<base-sha>` and `<worktree-id>` when creating a task. Keep
+secrets and machine-local paths in approved local configuration. Repository-relative paths,
+public issue/PR links, commit IDs and sanitized artifact hashes are suitable for shared
+receipts.

--- a/engineering/remediation/templates/HANDOFF_RECEIPT.md
+++ b/engineering/remediation/templates/HANDOFF_RECEIPT.md
@@ -1,0 +1,49 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# Handoff / review / completion receipt
+
+- Issue/task:
+- Human owner:
+- Agent/session:
+- Disposition: review-ready / blocked / paused / handoff / completed
+- Base SHA:
+- Candidate SHA and dirty digest:
+- Branch/worktree ID:
+- Changed repository-relative paths:
+- Intended behavior and preserved invariants:
+- Contract/schema/state-authority changes:
+- Generated artifacts and hashes:
+- Fixture/version/seed:
+- Platform/runtime/backend:
+
+## Verification
+
+| Command or interaction | Result: pass/fail/blocked/not-run | Evidence/artifact | Limitation |
+|---|---|---|---|
+|  |  |  |  |
+
+## Review and risk
+
+- Independent reviewer:
+- Review result:
+- Known failures/untested scope:
+- Data/compatibility/rollback considerations:
+- Visual baseline decision:
+- Required downstream revalidation:
+
+## Ownership
+
+- Working state preserved at:
+- Grant disposition requested:
+- Handoff recipient, if any:
+- Exact next action:
+- Product acceptance owner/result:
+
+An agent-complete state, green branch or merged PR does not imply product acceptance. Tie
+acceptance to the declared behavior and identified integrated bytes.

--- a/engineering/remediation/templates/TASK_PACKET.md
+++ b/engineering/remediation/templates/TASK_PACKET.md
@@ -1,0 +1,44 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# Task packet
+
+- Issue/Project item:
+- Human owner:
+- Coordinator:
+- Agent/session:
+- Status: Ready
+- Priority/area/goal:
+- Intended user-visible outcome:
+- Forbidden regression:
+- Explicit non-goals:
+- Base SHA:
+- Branch:
+- Worktree ID:
+- Repository-relative writable paths:
+- Read-only context paths:
+- Public contract/schema versions:
+- State authority before/after:
+- Dependencies and required predecessor receipts:
+- Runtime resources/isolated data/ports:
+- Required platforms/capabilities:
+- Acceptance fixtures and checks:
+- Reviewer:
+- Checkpoint/expiry:
+- Publication/PR/merge/release authority:
+- Expected result format:
+
+## Acknowledgement
+
+- Exact grant received:
+- Current root/origin/branch/HEAD verified:
+- Conflicting claims/PRs inspected:
+- Work started at:
+
+This packet records scope and authority already granted by the appropriate human/coordinator.
+It does not grant new account, deployment, merge or release permission.


### PR DESCRIPTION
Add the 12-document foundation remediation proposal under `engineering/remediation/` so maintainers can review the architecture, R00–R22 execution plan, testing and modularity policies, shared capabilities and Rust MCP direction, collaboration workflow, acceptance gates, and task/handoff templates alongside the source.

The package remains a proposal for maintainer review and adoption. This documentation-only PR preserves the reviewed package as one unit and does not implement its proposed application or infrastructure changes.

Validation: all 12 files match the reviewed source package byte for byte; all 14 relative links resolve; symlink and private-data marker checks passed; `git diff --check` passed; the diff is confined to `engineering/remediation/`. The published commit is `2ec97e2440708fae783babc4d9c9e777b520fb04` and includes a DCO sign-off.
