### PR TITLE
Add doctor, check, named jobs and per-run receipts (R02)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ vectorize-wasm/target/
 
 # Worktrees created by Claude Code background tasks — local scratch, never committed.
 .claude/worktrees/
+
+# Per-run receipts and logs from `npm run verify` / doctor / check (scripts/nemo). Local evidence, never committed.
+/reports/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,17 @@ npm run serve    # browser-only preview, no Tauri (python3 -m http.server on src
 Rust/wasm changes under `geometry-wasm/` need `wasm-pack build --target web`
 (see that directory) before they show up in either mode.
 
+Before opening a PR, run the named checks and keep the receipt:
+
+```bash
+npm run doctor   # read-only: toolchain, capabilities, source/build identity
+npm run check    # version sync, JSON, JS syntax, script refs, guards
+npm run verify   # doctor + check + npm test + cargo test, one receipt in reports/
+```
+
+Each job reports `pass`, `fail`, `blocked` or `not-run` with a reason; a missing tool is
+`blocked`, never a silent skip. See [scripts/nemo/README.md](scripts/nemo/README.md).
+
 ## Workflow
 
 - Branch per change (`your-topic`), PR against `main`. No direct pushes to

--- a/package.json
+++ b/package.json
@@ -7,7 +7,17 @@
     "dev": "tauri dev",
     "build": "tauri build",
     "serve": "python3 -m http.server 1420 -d src",
-    "test": "node --test tests/*.test.cjs"
+    "doctor": "node scripts/nemo/doctor.cjs",
+    "check": "node scripts/nemo/check.cjs",
+    "test": "node --test tests/*.test.cjs",
+    "test:rust": "node scripts/nemo/job.cjs test:rust",
+    "test:integration": "node scripts/nemo/job.cjs test:integration",
+    "test:browser": "node scripts/nemo/job.cjs test:browser",
+    "test:desktop": "node scripts/nemo/job.cjs test:desktop",
+    "bench": "node scripts/nemo/job.cjs bench",
+    "build:wasm": "node scripts/nemo/job.cjs build:wasm",
+    "build:desktop": "node scripts/nemo/job.cjs build:desktop",
+    "verify": "node scripts/nemo/verify.cjs"
   },
   "keywords": [
     "motion-design",

--- a/scripts/nemo/README.md
+++ b/scripts/nemo/README.md
@@ -1,0 +1,59 @@
+# `scripts/nemo` — doctor, check, named jobs and receipts
+
+The one command surface proposed in
+[engineering/remediation/03_TESTING_AND_DEBUGGING.md](../../engineering/remediation/03_TESTING_AND_DEBUGGING.md),
+implemented with Node only (no new dependencies). Work package R02.
+
+| Command | What it does | Exit |
+|---|---|---|
+| `npm run doctor` | Read-only: source identity (HEAD, branch, dirty digest), build identity (versions, wasm/sidecar hashes), platform, tool prerequisites, capabilities. Never installs or writes outside `reports/`. | always 0 |
+| `npm run check` | Static integrity: version strings in sync (package.json, tauri.conf.json, index.html fallback), JSON validity, `src/js` syntax (ES modules checked as such), `index.html` script references resolve, private-labs guard, committed artifacts present. | 0 pass / 1 fail / 2 blocked |
+| `npm test` | Existing Node unit tests (`tests/*.test.cjs`). Unchanged. | node |
+| `npm run test:rust` | `cargo test` for `geometry-wasm` (CPU, native host). | 0/1/2 |
+| `npm run test:integration` | `tests/integration` when it exists; `not-run` until R12/R13 define it. | 0/1/2 |
+| `npm run test:browser` | Playwright specs under `tests/browser`; `blocked` while `@playwright/test` is absent. | 0/1/2 |
+| `npm run test:desktop` | Packaged-app harness under `tests/desktop`; `blocked` without a built `Nemo.app`. | 0/1/2 |
+| `npm run bench` | `tests/bench` workloads; `not-run` until R03/R19 define them. | 0/1/2 |
+| `npm run build:wasm` | `wasm-pack build` into the run directory and compare with the committed `src/wasm`; `blocked` without wasm-pack. | 0/1/2 |
+| `npm run build:desktop` | `tauri build -b app` for the host triple, then `scripts/bundle-ffmpeg-dylibs.py`. Local, unsigned. | 0/1/2 |
+| `npm run verify` | Runs a profile (`--profile quick` default: doctor, check, test:unit, test:rust; `--profile full` adds the rest) or `--jobs a,b,c`, and emits **one receipt**. | 0 pass / 1 any fail / 2 required job blocked |
+
+Any job can be run alone: `node scripts/nemo/job.cjs test:rust,build:wasm`. Add `--json` to
+print the receipt instead of the summary.
+
+## Result vocabulary
+
+| Status | Meaning |
+|---|---|
+| `pass` | the job ran and its own success criterion held |
+| `fail` | the job ran and it did not |
+| `blocked` | a tool, target, suite or artifact the job needs is absent. Named precisely. **Never** downgraded to a skip: a required blocked job fails `verify` with exit 2 |
+| `not-run` | intentionally not attempted, with the work package that will define it |
+
+## Receipts
+
+Every run writes `reports/<runId>/receipt.json` (schema `nemo.receipt/1`), a
+`receipt.md` rendering, and one `<job>.log` per job that produced output. `reports/` is
+git-ignored; paste `receipt.md` into the issue or PR as the verification table. `runId` is
+`<UTC stamp>-<short SHA>[-dirty]`. Set `NEMO_REPORT_DIR` to write elsewhere (per-worktree
+isolation for concurrent runs).
+
+A receipt records, in this order: source (`head`, `branch`, `describe`, `dirty`,
+`dirtyDigest` = SHA-256 of `git diff HEAD --binary` plus the porcelain list, changed paths),
+build (four version strings, crate versions, host triple, SHA-256 of the committed
+`geometry_wasm_bg.wasm`, `vectorize_wasm_bg.wasm` and host ffmpeg sidecar), platform (OS,
+arch, CPU, memory, node; no hostname or user), tools and capabilities (from `doctor`), then
+`jobs[]` with `status`, `reason`, `exitCode`, `durationMs`, `artifacts[]` (path, bytes,
+sha256), `limitations[]`, `details`, and `summary` (`overall`, `exitCode`, `counts`).
+
+## Rules the code enforces
+
+- `doctor` only runs `--version`-style commands, reads files and, on macOS, `system_profiler`
+  and `otool -L` on the committed sidecar. It never installs, upgrades or writes to the
+  workstation or a user project.
+- Missing environment is `blocked` with the missing thing named. Nothing converts it to
+  `pass`.
+- Builds write into the run directory (`build:wasm`) or the worktree's own `src-tauri/target`
+  (`build:desktop`); they never overwrite the committed `src/wasm` bundle.
+- Historical counts are never treated as current proof: every receipt is bound to the SHA
+  and dirty digest it was measured on.

--- a/scripts/nemo/check.cjs
+++ b/scripts/nemo/check.cjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+'use strict';
+// npm run check — static integrity: version sync, JSON validity, JS syntax,
+// index.html script references, private-labs guard, committed artifacts.
+const { parseArgs, runJobs } = require('./lib/cli.cjs');
+const args = parseArgs(process.argv.slice(2));
+const { receipt } = runJobs('check', ['check'], { json: args.json, quiet: args.quiet });
+if (!args.json && !args.quiet) {
+  const j = receipt.jobs.find((x) => x.name === 'check');
+  console.log('');
+  for (const [k, v] of Object.entries(j.details || {})) console.log(`  ${v.status.toUpperCase().padEnd(8)} ${k.padEnd(20)} ${v.reason}`);
+  console.log('');
+}
+process.exit(receipt.summary.exitCode);

--- a/scripts/nemo/doctor.cjs
+++ b/scripts/nemo/doctor.cjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+'use strict';
+// npm run doctor — read-only report of source/build identity, platform,
+// tool prerequisites and capabilities. Exit 0 always unless the report
+// itself cannot be produced: absence of a tool is information here, it is
+// the jobs that need the tool which report `blocked`.
+const { parseArgs, runJobs } = require('./lib/cli.cjs');
+const args = parseArgs(process.argv.slice(2));
+const { receipt } = runJobs('doctor', ['doctor'], { json: args.json, quiet: true });
+if (!args.json) {
+  const s = receipt.source, b = receipt.build, p = receipt.platform, t = receipt.tools, c = receipt.capabilities;
+  const yes = (v) => (v ? 'ok     ' : 'MISSING');
+  const line = (k, v) => console.log(`  ${k.padEnd(22)} ${v}`);
+  console.log('\nNemo doctor  (read-only)\n');
+  console.log('Source');
+  line('HEAD', `${s.head} (${s.branch}, ${s.describe})`);
+  line('commit', `${s.commitDate}  ${s.subject}`);
+  line('worktree', s.worktree);
+  line('state', s.dirty ? `DIRTY — ${s.modifiedTracked} modified, ${s.untracked} untracked, digest ${s.dirtyDigest.slice(0, 12)}` : 'clean');
+  console.log('Build');
+  line('package.json', b.packageVersion);
+  line('tauri.conf.json', b.tauriVersion);
+  line('index.html fallback', `${b.indexHtmlTitleVersion} (title) / ${b.indexHtmlStatusVersion} (status bar)`);
+  line('crates', Object.entries(b.crates).map(([k, v]) => `${k}@${v || '?'}`).join('  '));
+  line('geometry_wasm', b.artifacts.geometryWasm.present ? `${b.artifacts.geometryWasm.bytes} B  ${b.artifacts.geometryWasm.sha256.slice(0, 12)}` : 'MISSING');
+  line('vectorize_wasm', b.artifacts.vectorizeWasm.present ? `${b.artifacts.vectorizeWasm.bytes} B  ${b.artifacts.vectorizeWasm.sha256.slice(0, 12)}` : 'MISSING');
+  line('ffmpeg sidecar', b.artifacts.ffmpegSidecar.present ? `${b.artifacts.ffmpegSidecar.path}  ${b.artifacts.ffmpegSidecar.bytes} B  ${b.artifacts.ffmpegSidecar.sha256.slice(0, 12)}` : `MISSING (${b.artifacts.ffmpegSidecar.path || b.artifacts.ffmpegSidecar.note})`);
+  console.log('Platform');
+  line('os', `${p.os} ${p.osRelease} ${p.arch}  (${p.osVersion || ''})`);
+  line('cpu / memory', `${p.cpuModel} ×${p.cpuCount}, ${(p.memoryBytes / 2 ** 30).toFixed(0)} GiB`);
+  line('node', p.node);
+  line('rust host', b.hostTriple || 'unknown');
+  console.log('Tools');
+  for (const [k, v] of Object.entries(t)) line(k, `${yes(v.present)} ${v.version || v.note || ''}`);
+  console.log('Capabilities');
+  line('rust targets', c.rustTargets.join(' ') || 'none');
+  line('wasm32 target', yes(c.wasm32Target));
+  line('host target', yes(c.hostTargetInstalled));
+  line('node_modules', yes(c.nodeModulesInstalled));
+  const sc = c.ffmpegSidecar;
+  line('sidecar runs', sc.present ? `${yes(sc.runs)} ${sc.runs ? sc.versionLine : sc.failure}` : 'n/a');
+  if (sc.present && sc.licenseLine) line('sidecar license', `${sc.licenseLine.trim()}  gpl=${sc.enableGpl} videotoolbox=${sc.enableVideotoolbox}`);
+  if (sc.dynamicLibs) line('sidecar dylibs', `${sc.dynamicLibs.external.length} external, ${sc.externalDylibsMissing} missing on this machine`);
+  if (sc.dynamicLibs) for (const e of sc.dynamicLibs.external.filter((x) => !x.present)) line('', `MISSING ${e.path}`);
+  line('gpu', c.gpu.status === 'ok' ? c.gpu.gpus.map((g) => `${g.model || '?'} ${g.metal ? '(' + g.metal + ')' : ''}`).join('; ') : `unknown — ${c.gpu.reason || ''}`);
+  line('webgpu', 'unknown outside a browser');
+  line('browser suite', `runner ${yes(c.browserSuite.runnerPresent)} specs ${yes(c.browserSuite.defined)}`);
+  line('desktop suite', `harness ${yes(c.desktopSuite.defined)} app ${c.desktopSuite.appBundle || 'none built'}`);
+  line('integration suite', yes(c.integrationSuite.defined));
+  line('bench workloads', yes(c.benchWorkloads.defined));
+  console.log(`\nreceipt reports/${receipt.runId}/receipt.json\n`);
+}
+process.exit(0);

--- a/scripts/nemo/job.cjs
+++ b/scripts/nemo/job.cjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+'use strict';
+// node scripts/nemo/job.cjs <job>[,<job>...] — run named jobs and emit a receipt.
+const { parseArgs, runJobs } = require('./lib/cli.cjs');
+const { JOBS } = require('./lib/jobs.cjs');
+const args = parseArgs(process.argv.slice(2));
+const names = args._.join(',').split(',').filter(Boolean);
+if (!names.length) { console.error('usage: job.cjs <job>[,<job>...]\njobs: ' + Object.keys(JOBS).join(', ')); process.exit(64); }
+for (const n of names) if (!JOBS[n]) { console.error(`unknown job "${n}". jobs: ${Object.keys(JOBS).join(', ')}`); process.exit(64); }
+const { receipt } = runJobs(names.join(','), names, { json: args.json, quiet: args.quiet });
+process.exit(receipt.summary.exitCode);

--- a/scripts/nemo/lib/capabilities.cjs
+++ b/scripts/nemo/lib/capabilities.cjs
@@ -1,0 +1,130 @@
+'use strict';
+// Read-only prerequisite and capability probes. Each probe only runs
+// `--version`-style commands or reads files; none installs, writes or
+// mutates workstation state. "unknown" is a legitimate answer: a capability
+// that can only be established inside a browser or a packaged app says so
+// instead of guessing.
+const path = require('node:path');
+const fs = require('node:fs');
+const { ROOT, run, which, probeTool, exists } = require('./util.cjs');
+
+function localBin(name) {
+  const p = path.join(ROOT, 'node_modules', '.bin', name);
+  return exists(p) ? p : null;
+}
+
+function resolvable(mod) {
+  try { return require.resolve(mod, { paths: [ROOT] }); } catch { return null; }
+}
+
+function rustTargets() {
+  const r = run('rustup', ['target', 'list', '--installed'], { timeout: 15000 });
+  return r.status === 0 ? r.stdout.trim().split(/\r?\n/).filter(Boolean) : [];
+}
+
+function sidecarProbe(build) {
+  const info = build.artifacts.ffmpegSidecar;
+  if (!info || !info.present) return { present: false, path: info ? info.path : null };
+  const abs = path.join(ROOT, info.path);
+  const out = { present: true, path: info.path, bytes: info.bytes, sha256: info.sha256 };
+  const v = run(abs, ['-version'], { timeout: 20000 });
+  out.runs = v.status === 0;
+  out.exitCode = v.status;
+  out.error = v.error;
+  if (!out.runs) out.failure = (v.stderr || v.stdout || '').trim().split(/\r?\n/).filter(Boolean).slice(0, 4).join(' | ') || `exit ${v.status}${v.signal ? ' signal ' + v.signal : ''}`;
+  if (v.stdout) {
+    const lines = v.stdout.split(/\r?\n/);
+    out.versionLine = lines[0] || null;
+    out.licenseLine = lines.find((l) => /license/i.test(l)) || null;
+    const cfg = lines.find((l) => /configuration:/.test(l)) || '';
+    out.enableGpl = /--enable-gpl/.test(cfg);
+    out.enableVideotoolbox = /--enable-videotoolbox/.test(cfg);
+  }
+  if (process.platform === 'darwin' && which('otool')) {
+    const o = run('otool', ['-L', abs], { timeout: 20000 });
+    if (o.status === 0) {
+      const libs = o.stdout.split(/\r?\n/).slice(1).map((l) => l.trim().split(' ')[0]).filter(Boolean);
+      const external = libs.filter((l) => !l.startsWith('/usr/lib/') && !l.startsWith('/System/') && !l.startsWith('@'));
+      out.dynamicLibs = { total: libs.length, external: external.map((l) => ({ path: l, present: exists(l) })) };
+      out.externalDylibsMissing = out.dynamicLibs.external.filter((e) => !e.present).length;
+    }
+  }
+  return out;
+}
+
+function gpuProbe() {
+  if (process.platform !== 'darwin' || !which('system_profiler')) {
+    return { status: 'unknown', reason: 'no read-only GPU probe on this platform yet' };
+  }
+  const r = run('system_profiler', ['SPDisplaysDataType', '-json'], { timeout: 30000 });
+  if (r.status !== 0) return { status: 'unknown', reason: 'system_profiler failed: ' + (r.error || r.stderr.trim()) };
+  try {
+    const d = JSON.parse(r.stdout);
+    const gpus = (d.SPDisplaysDataType || []).map((g) => ({
+      model: g.sppci_model || g._name || null,
+      vendor: g.spdisplays_vendor || null,
+      metal: g.spdisplays_mtlgpufamilysupport || g.spdisplays_metal || null,
+      cores: g.sppci_cores || null,
+      vram: g.spdisplays_vram || g.spdisplays_vram_shared || null,
+    }));
+    return { status: gpus.length ? 'ok' : 'unknown', gpus, webgpu: 'unknown outside a browser; see test:browser' };
+  } catch (e) {
+    return { status: 'unknown', reason: 'could not parse system_profiler output' };
+  }
+}
+
+function collect(build) {
+  const tools = {
+    node: { present: true, path: process.execPath, version: process.version },
+    npm: probeTool('npm'),
+    git: probeTool('git'),
+    rustc: probeTool('rustc'),
+    cargo: probeTool('cargo'),
+    rustup: probeTool('rustup'),
+    'wasm-pack': probeTool('wasm-pack'),
+    'wasm-bindgen': probeTool('wasm-bindgen'),
+    'tauri-cli': localBin('tauri') ? probeTool('tauri', ['--version'], { path: localBin('tauri') }) : { present: false, path: null, version: null, note: 'node_modules/.bin/tauri missing — run npm ci' },
+    ffmpeg: probeTool('ffmpeg', ['-version']),
+    ffprobe: probeTool('ffprobe', ['-version']),
+    python3: probeTool('python3'),
+    playwright: (function () {
+      const m = resolvable('@playwright/test') || resolvable('playwright');
+      if (!m) return { present: false, path: null, version: null, note: 'neither @playwright/test nor playwright resolvable from the repo root' };
+      return probeTool('playwright', ['--version'], { path: localBin('playwright') || m });
+    })(),
+    xcodeSelect: process.platform === 'darwin' ? probeTool('xcode-select', ['-p']) : { present: false, path: null, version: null, note: 'darwin only' },
+    otool: process.platform === 'darwin' ? probeTool('otool', ['--version']) : { present: false, path: null, version: null, note: 'darwin only' },
+    brew: probeTool('brew'),
+  };
+  const targets = rustTargets();
+  const caps = {
+    rustTargets: targets,
+    wasm32Target: targets.includes('wasm32-unknown-unknown'),
+    hostTargetInstalled: build.hostTriple ? targets.includes(build.hostTriple) : false,
+    nodeModulesInstalled: exists(path.join(ROOT, 'node_modules', '.package-lock.json')),
+    committedWasmPresent: !!(build.artifacts.geometryWasm.present && build.artifacts.vectorizeWasm.present),
+    ffmpegSidecar: sidecarProbe(build),
+    gpu: gpuProbe(),
+    browserSuite: { defined: exists(path.join(ROOT, 'tests', 'browser')), runnerPresent: !!(resolvable('@playwright/test') || resolvable('playwright')) },
+    desktopSuite: { defined: exists(path.join(ROOT, 'tests', 'desktop')), appBundle: findBuiltApp() },
+    integrationSuite: { defined: exists(path.join(ROOT, 'tests', 'integration')) },
+    benchWorkloads: { defined: exists(path.join(ROOT, 'tests', 'bench')) },
+  };
+  return { tools, capabilities: caps };
+}
+
+function findBuiltApp() {
+  if (process.env.NEMO_DESKTOP_APP && exists(process.env.NEMO_DESKTOP_APP)) return process.env.NEMO_DESKTOP_APP;
+  const base = path.join(ROOT, 'src-tauri', 'target');
+  if (!exists(base)) return null;
+  const candidates = [];
+  for (const sub of fs.readdirSync(base)) {
+    for (const rel of [['release', 'bundle', 'macos', 'Nemo.app'], ['bundle', 'macos', 'Nemo.app']]) {
+      const p = path.join(base, sub, ...rel);
+      if (exists(p)) candidates.push(p);
+    }
+  }
+  return candidates[0] || null;
+}
+
+module.exports = { collect, findBuiltApp, resolvable, localBin };

--- a/scripts/nemo/lib/cli.cjs
+++ b/scripts/nemo/lib/cli.cjs
@@ -1,0 +1,43 @@
+'use strict';
+// Common runner: build a receipt, execute the requested jobs in order, write
+// the receipt under reports/<runId>/ and exit with the overall status code
+// (0 pass, 1 fail, 2 blocked). Every entry point goes through here so a
+// single job run and a full verify produce the same receipt shape.
+const receipt = require('./receipt.cjs');
+const jobs = require('./jobs.cjs');
+
+function parseArgs(argv) {
+  const out = { _: [], json: false, quiet: false, profile: null, jobs: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') out.json = true;
+    else if (a === '--quiet') out.quiet = true;
+    else if (a === '--profile') out.profile = argv[++i];
+    else if (a.startsWith('--profile=')) out.profile = a.slice(10);
+    else if (a === '--jobs') out.jobs = argv[++i].split(',');
+    else if (a.startsWith('--jobs=')) out.jobs = a.slice(7).split(',');
+    else out._.push(a);
+  }
+  return out;
+}
+
+function runJobs(command, names, opts = {}) {
+  const r = receipt.create(command, { profile: opts.profile || null });
+  const ctx = { receipt: r, reportDir: receipt.reportDir(r) };
+  // doctor first when present so later jobs can read capabilities
+  const ordered = names.includes('doctor') ? ['doctor'].concat(names.filter((n) => n !== 'doctor')) : names;
+  for (const n of ordered) {
+    if (!opts.quiet && !opts.json) process.stdout.write(`… ${n}\n`);
+    jobs.execute(n, ctx);
+  }
+  receipt.finalize(r);
+  const written = receipt.write(r);
+  if (opts.json) {
+    process.stdout.write(require('node:fs').readFileSync(written.jsonPath, 'utf8'));
+  } else if (!opts.quiet) {
+    receipt.printSummary(r, written);
+  }
+  return { receipt: r, written };
+}
+
+module.exports = { parseArgs, runJobs };

--- a/scripts/nemo/lib/identity.cjs
+++ b/scripts/nemo/lib/identity.cjs
@@ -1,0 +1,101 @@
+'use strict';
+// Source, build and platform identity. Every receipt carries all three so a
+// result can never be quoted without the bytes it was measured on.
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+const { ROOT, run, readJson, exists, fileInfo, sha256Text } = require('./util.cjs');
+
+function git(args) {
+  const r = run('git', args, { timeout: 30000 });
+  return r.status === 0 ? r.stdout.trim() : null;
+}
+
+function sourceIdentity() {
+  const head = git(['rev-parse', 'HEAD']);
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+  const describe = git(['describe', '--tags', '--always', '--dirty']);
+  const porcelain = git(['status', '--porcelain', '--untracked-files=all']) || '';
+  const originUrl = git(['config', '--get', 'remote.origin.url']);
+  const upstream = git(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}']);
+  const worktree = git(['rev-parse', '--show-toplevel']);
+  const commitDate = git(['log', '-1', '--format=%cI']);
+  const subject = git(['log', '-1', '--format=%s']);
+  const entries = porcelain ? porcelain.split(/\r?\n/).filter(Boolean) : [];
+  const tracked = entries.filter((l) => !l.startsWith('??'));
+  const untracked = entries.filter((l) => l.startsWith('??'));
+  let dirtyDigest = null;
+  if (entries.length) {
+    const diff = run('git', ['diff', 'HEAD', '--binary'], { timeout: 60000 }).stdout;
+    dirtyDigest = sha256Text(diff + '\n' + entries.join('\n'));
+  }
+  return {
+    head, branch, describe, commitDate, subject, originUrl, upstream, worktree,
+    dirty: entries.length > 0,
+    modifiedTracked: tracked.length,
+    untracked: untracked.length,
+    dirtyDigest,
+    changedPaths: entries.slice(0, 200),
+  };
+}
+
+function readVersionFromCargo(file) {
+  if (!exists(file)) return null;
+  const m = fs.readFileSync(file, 'utf8').match(/^\s*version\s*=\s*"([^"]+)"/m);
+  return m ? m[1] : null;
+}
+
+function hostTriple() {
+  const r = run('rustc', ['-vV'], { timeout: 15000 });
+  if (r.status !== 0) return null;
+  const m = r.stdout.match(/^host:\s*(\S+)/m);
+  return m ? m[1] : null;
+}
+
+function buildIdentity() {
+  const pkg = readJson(path.join(ROOT, 'package.json'));
+  const tauriConf = readJson(path.join(ROOT, 'src-tauri', 'tauri.conf.json'));
+  const indexHtml = fs.readFileSync(path.join(ROOT, 'src', 'index.html'), 'utf8');
+  const titleM = indexHtml.match(/<title>\s*Nemo v([^<\s]+)\s*<\/title>/);
+  const statusM = indexHtml.match(/id="status-text">\s*Nemo v([^<\s]+)\s*</);
+  const triple = hostTriple();
+  const sidecarPath = triple ? path.join(ROOT, 'src-tauri', 'binaries', 'ffmpeg-' + triple) : null;
+  return {
+    packageVersion: pkg.version,
+    tauriVersion: tauriConf.version,
+    indexHtmlTitleVersion: titleM ? titleM[1] : null,
+    indexHtmlStatusVersion: statusM ? statusM[1] : null,
+    productName: tauriConf.productName || null,
+    identifier: tauriConf.identifier || null,
+    tauriCliRange: (pkg.devDependencies || {})['@tauri-apps/cli'] || null,
+    crates: {
+      'geometry-wasm': readVersionFromCargo(path.join(ROOT, 'geometry-wasm', 'Cargo.toml')),
+      'vectorize-wasm': readVersionFromCargo(path.join(ROOT, 'vectorize-wasm', 'Cargo.toml')),
+      'src-tauri': readVersionFromCargo(path.join(ROOT, 'src-tauri', 'Cargo.toml')),
+    },
+    hostTriple: triple,
+    artifacts: {
+      geometryWasm: fileInfo(path.join(ROOT, 'src', 'wasm', 'geometry_wasm_bg.wasm')),
+      vectorizeWasm: fileInfo(path.join(ROOT, 'src', 'wasm-vectorize', 'vectorize_wasm_bg.wasm')),
+      ffmpegSidecar: sidecarPath ? fileInfo(sidecarPath) : { present: false, path: null, note: 'host triple unknown (rustc missing)' },
+    },
+  };
+}
+
+function platformIdentity() {
+  const cpus = os.cpus();
+  return {
+    os: process.platform,
+    osRelease: os.release(),
+    osVersion: typeof os.version === 'function' ? os.version() : null,
+    arch: process.arch,
+    hostname: null, // deliberately not recorded: receipts are shareable
+    cpuModel: cpus.length ? cpus[0].model : null,
+    cpuCount: cpus.length,
+    memoryBytes: os.totalmem(),
+    node: process.version,
+    user: null, // deliberately not recorded
+  };
+}
+
+module.exports = { sourceIdentity, buildIdentity, platformIdentity, hostTriple };

--- a/scripts/nemo/lib/jobs.cjs
+++ b/scripts/nemo/lib/jobs.cjs
@@ -1,0 +1,251 @@
+'use strict';
+// Named jobs. Each returns { status, reason, exitCode?, artifacts?, limitations?, details?, log? }.
+// A job that needs a tool, target, suite or artifact that is absent returns
+// `blocked` with the exact missing thing. A job with nothing defined to run
+// yet returns `not-run` and names the work package that will define it.
+const fs = require('node:fs');
+const path = require('node:path');
+const { ROOT, run, which, exists, readJson, fileInfo } = require('./util.cjs');
+const { STATUS } = require('./receipt.cjs');
+const caps = require('./capabilities.cjs');
+
+function pass(reason, extra) { return Object.assign({ status: STATUS.PASS, reason }, extra); }
+function fail(reason, extra) { return Object.assign({ status: STATUS.FAIL, reason }, extra); }
+function blocked(reason, extra) { return Object.assign({ status: STATUS.BLOCKED, reason }, extra); }
+function notRun(reason, extra) { return Object.assign({ status: STATUS.NOT_RUN, reason }, extra); }
+
+function logOf(r) { return `$ ${r.cmd}\n(exit ${r.status}${r.signal ? ' signal ' + r.signal : ''}${r.error ? ' error ' + r.error : ''}, ${r.durationMs} ms)\n--- stdout ---\n${r.stdout}\n--- stderr ---\n${r.stderr}\n`; }
+
+// ---- doctor ------------------------------------------------------------
+function jobDoctor(ctx) {
+  const c = caps.collect(ctx.receipt.build);
+  ctx.receipt.tools = c.tools;
+  ctx.receipt.capabilities = c.capabilities;
+  const missing = Object.entries(c.tools).filter(([, t]) => !t.present).map(([k]) => k);
+  return pass(`probed ${Object.keys(c.tools).length} tools, ${missing.length} absent (${missing.join(', ') || 'none'})`, {
+    details: { absentTools: missing, gpu: c.capabilities.gpu.status, sidecar: c.capabilities.ffmpegSidecar.present ? (c.capabilities.ffmpegSidecar.runs ? 'runs' : 'present but does not run') : 'absent' },
+    limitations: ['WebGPU availability is only observable inside a browser or the packaged app (test:browser / test:desktop)'],
+  });
+}
+
+// ---- check -------------------------------------------------------------
+function checkVersionSync(b) {
+  const problems = [];
+  if (b.packageVersion !== b.tauriVersion) problems.push(`package.json ${b.packageVersion} != src-tauri/tauri.conf.json ${b.tauriVersion}`);
+  if (b.indexHtmlTitleVersion !== b.packageVersion) problems.push(`src/index.html <title> fallback ${b.indexHtmlTitleVersion} != ${b.packageVersion} (CLAUDE.md §7 step 2)`);
+  if (b.indexHtmlStatusVersion !== b.packageVersion) problems.push(`src/index.html #status-text fallback ${b.indexHtmlStatusVersion} != ${b.packageVersion} (CLAUDE.md §7 step 2)`);
+  return problems.length ? fail(problems.join('; ')) : pass(`all four version strings say ${b.packageVersion}`);
+}
+
+function checkJsonValid() {
+  const files = ['package.json', 'package-lock.json', 'src-tauri/tauri.conf.json', 'src/wasm/package.json', 'src/wasm-vectorize/package.json']
+    .concat(exists(path.join(ROOT, 'src-tauri', 'capabilities')) ? fs.readdirSync(path.join(ROOT, 'src-tauri', 'capabilities')).filter((f) => f.endsWith('.json')).map((f) => 'src-tauri/capabilities/' + f) : []);
+  const bad = [];
+  for (const f of files) {
+    const p = path.join(ROOT, f);
+    if (!exists(p)) { bad.push(`${f}: missing`); continue; }
+    try { readJson(p); } catch (e) { bad.push(`${f}: ${e.message}`); }
+  }
+  return bad.length ? fail(bad.join('; ')) : pass(`${files.length} JSON files parse`);
+}
+
+function checkJsSyntax(ctx) {
+  const dir = path.join(ROOT, 'src', 'js');
+  const files = [];
+  (function walk(d) { for (const e of fs.readdirSync(d, { withFileTypes: true })) { const p = path.join(d, e.name); if (e.isDirectory()) walk(p); else if (e.name.endsWith('.js')) files.push(p); } })(dir);
+  // ES modules (module scripts and module workers) fail `node --check` as
+  // CommonJS on `import.meta` / top-level import. They are checked from a
+  // .mjs copy inside the run's report directory, never in place.
+  const isModule = (src) => /^\s*(import|export)\s/m.test(src) || /import\.meta/.test(src);
+  const scratch = path.join(ctx.reportDir, 'check-modules');
+  const bad = [];
+  let modules = 0;
+  for (const f of files) {
+    const src = fs.readFileSync(f, 'utf8');
+    let target = f;
+    if (isModule(src)) {
+      modules++;
+      fs.mkdirSync(scratch, { recursive: true });
+      target = path.join(scratch, path.basename(f, '.js') + '.mjs');
+      fs.writeFileSync(target, src);
+    }
+    const r = run(process.execPath, ['--check', target], { timeout: 60000 });
+    if (r.status !== 0) bad.push(`${path.relative(ROOT, f)}: ${(r.stderr.split(/\r?\n/).find((l) => /SyntaxError/.test(l)) || r.stderr.trim().split(/\r?\n/)[0] || 'exit ' + r.status)}`);
+  }
+  return bad.length ? fail(bad.join('; ')) : pass(`${files.length} scripts under src/js parse (${modules} as ES modules)`);
+}
+
+function checkScriptRefs() {
+  const html = fs.readFileSync(path.join(ROOT, 'src', 'index.html'), 'utf8');
+  const refs = [];
+  const re = /<script[^>]*\ssrc="([^"]+)"/g;
+  let m; while ((m = re.exec(html))) if (!/^https?:/.test(m[1])) refs.push(m[1]);
+  const missing = refs.filter((r) => !exists(path.join(ROOT, 'src', r.split('?')[0])));
+  return missing.length ? fail('index.html references missing scripts: ' + missing.join(', ')) : pass(`${refs.length} <script src> references in index.html resolve`);
+}
+
+function checkPrivateLabs() {
+  if (!which('python3')) return blocked('python3 not found; scripts/assert-no-private-labs.py cannot run');
+  const r = run('python3', ['scripts/assert-no-private-labs.py'], { timeout: 60000 });
+  return r.status === 0 ? pass('no private-labs leakage under src/') : fail((r.stdout + r.stderr).trim().split(/\r?\n/).slice(-1)[0] || 'assert-no-private-labs.py exit ' + r.status);
+}
+
+function checkArtifacts(b) {
+  const missing = [];
+  if (!b.artifacts.geometryWasm.present) missing.push('src/wasm/geometry_wasm_bg.wasm');
+  if (!b.artifacts.vectorizeWasm.present) missing.push('src/wasm-vectorize/vectorize_wasm_bg.wasm');
+  if (!b.hostTriple) return blocked('rustc missing, cannot name the host sidecar', { limitations: missing.map((m) => 'also missing: ' + m) });
+  if (!b.artifacts.ffmpegSidecar.present) missing.push(b.artifacts.ffmpegSidecar.path || 'src-tauri/binaries/ffmpeg-' + b.hostTriple);
+  return missing.length ? fail('committed build artifacts missing: ' + missing.join(', ')) : pass('committed wasm bundles and host ffmpeg sidecar present');
+}
+
+function jobCheck(ctx) {
+  const b = ctx.receipt.build;
+  const sub = {
+    'version-sync': checkVersionSync(b),
+    'json-valid': checkJsonValid(),
+    'js-syntax': checkJsSyntax(ctx),
+    'script-refs': checkScriptRefs(),
+    'private-labs-guard': checkPrivateLabs(),
+    'artifacts-present': checkArtifacts(b),
+  };
+  const failed = Object.entries(sub).filter(([, r]) => r.status === STATUS.FAIL);
+  const blockedOnes = Object.entries(sub).filter(([, r]) => r.status === STATUS.BLOCKED);
+  const log = Object.entries(sub).map(([k, r]) => `${r.status.toUpperCase().padEnd(8)} ${k}: ${r.reason}`).join('\n') + '\n';
+  const details = Object.fromEntries(Object.entries(sub).map(([k, r]) => [k, { status: r.status, reason: r.reason }]));
+  if (failed.length) return fail(failed.map(([k, r]) => `${k}: ${r.reason}`).join(' | '), { details, log });
+  if (blockedOnes.length) return blocked(blockedOnes.map(([k, r]) => `${k}: ${r.reason}`).join(' | '), { details, log });
+  return pass(`${Object.keys(sub).length} checks pass`, { details, log });
+}
+
+// ---- tests -------------------------------------------------------------
+function jobTestUnit() {
+  const files = fs.readdirSync(path.join(ROOT, 'tests')).filter((f) => f.endsWith('.test.cjs'));
+  if (!files.length) return notRun('no tests/*.test.cjs files');
+  const r = run(process.execPath, ['--test'].concat(files.map((f) => 'tests/' + f)), { timeout: 10 * 60 * 1000 });
+  const m = r.stdout.match(/^ℹ pass (\d+)/m), mf = r.stdout.match(/^ℹ fail (\d+)/m), mt = r.stdout.match(/^ℹ tests (\d+)/m);
+  const summary = mt ? `${mt[1]} tests, ${m ? m[1] : '?'} pass, ${mf ? mf[1] : '?'} fail` : `exit ${r.status}`;
+  return (r.status === 0 ? pass : fail)(`node --test: ${summary}`, { exitCode: r.status, log: logOf(r), details: { files } });
+}
+
+function jobTestRust(ctx, crateDir, label) {
+  if (!which('cargo')) return blocked('cargo not found');
+  const manifest = path.join(ROOT, crateDir, 'Cargo.toml');
+  if (!exists(manifest)) return blocked(`${crateDir}/Cargo.toml missing`);
+  const r = run('cargo', ['test', '--manifest-path', manifest], { timeout: 60 * 60 * 1000 });
+  const results = [...r.stdout.matchAll(/^test result: (\w+)\. (\d+) passed; (\d+) failed/gm)];
+  const passed = results.reduce((a, m) => a + Number(m[2]), 0), failed = results.reduce((a, m) => a + Number(m[3]), 0);
+  const summary = results.length ? `${results.length} binaries, ${passed} passed, ${failed} failed` : `exit ${r.status}`;
+  return (r.status === 0 ? pass : fail)(`cargo test ${label}: ${summary}`, { exitCode: r.status, log: logOf(r) });
+}
+
+function jobTestIntegration() {
+  const dir = path.join(ROOT, 'tests', 'integration');
+  if (!exists(dir)) return notRun('no tests/integration suite defined yet (R12/R13 add document, command/history and persistence contracts)');
+  const files = fs.readdirSync(dir).filter((f) => /\.test\.(c?js|mjs)$/.test(f));
+  if (!files.length) return notRun('tests/integration exists but holds no *.test.* files');
+  const r = run(process.execPath, ['--test'].concat(files.map((f) => 'tests/integration/' + f)), { timeout: 30 * 60 * 1000 });
+  return (r.status === 0 ? pass : fail)(`node --test tests/integration: exit ${r.status}`, { exitCode: r.status, log: logOf(r) });
+}
+
+function jobTestBrowser() {
+  const runner = caps.resolvable('@playwright/test');
+  if (!runner) return blocked('@playwright/test is not installed (not in devDependencies); browser workflows cannot run', { limitations: ['install is a dependency change owned by R07/R03, not done implicitly here'] });
+  const dir = path.join(ROOT, 'tests', 'browser');
+  if (!exists(dir) || !fs.readdirSync(dir).some((f) => /\.spec\.(c?js|mjs|ts)$/.test(f))) return notRun('runner present but no tests/browser/*.spec.* defined yet (R03 fixtures / R07 gates)');
+  const bin = caps.localBin('playwright');
+  const r = run(bin || process.execPath, bin ? ['test', 'tests/browser'] : [runner, 'test', 'tests/browser'], { timeout: 60 * 60 * 1000 });
+  return (r.status === 0 ? pass : fail)(`playwright test tests/browser: exit ${r.status}`, { exitCode: r.status, log: logOf(r) });
+}
+
+function jobTestDesktop() {
+  const app = caps.findBuiltApp();
+  const harness = exists(path.join(ROOT, 'tests', 'desktop'));
+  const missing = [];
+  if (!app) missing.push('no packaged app found (src-tauri/target/*/release/bundle/macos/Nemo.app or NEMO_DESKTOP_APP)');
+  if (!harness) missing.push('no tests/desktop harness defined yet (R06 isolated data roots, R21 installed-artifact validation)');
+  if (!app) return blocked(missing.join('; '));
+  if (!harness) return notRun(missing.join('; '), { artifacts: [{ path: path.relative(ROOT, app) }] });
+  return notRun('tests/desktop exists but no runner is wired for it yet');
+}
+
+function jobBench() {
+  const dir = path.join(ROOT, 'tests', 'bench');
+  if (!exists(dir)) return notRun('no tests/bench workloads defined yet (R03 initial workloads, R19 budgets)');
+  return notRun('tests/bench exists but no runner is wired for it yet');
+}
+
+// ---- builds ------------------------------------------------------------
+function jobBuildWasm(ctx) {
+  if (!which('wasm-pack')) return blocked('wasm-pack not found (release.yml installs it from rustwasm.github.io); the committed src/wasm bundle cannot be regenerated here');
+  const targets = (ctx.receipt.capabilities || {}).rustTargets || [];
+  if (targets.length && !targets.includes('wasm32-unknown-unknown')) return blocked('rust target wasm32-unknown-unknown not installed');
+  const out = path.join(ctx.reportDir, 'build-wasm');
+  const r = run('wasm-pack', ['build', '--target', 'web', '--out-dir', out], { cwd: path.join(ROOT, 'geometry-wasm'), timeout: 60 * 60 * 1000 });
+  if (r.status !== 0) return fail(`wasm-pack build exit ${r.status}`, { exitCode: r.status, log: logOf(r) });
+  const built = fileInfo(path.join(out, 'geometry_wasm_bg.wasm'));
+  const committed = ctx.receipt.build.artifacts.geometryWasm;
+  const same = built.sha256 === committed.sha256;
+  return pass(`wasm-pack build ok; ${same ? 'byte-identical to' : 'differs from'} committed src/wasm bundle`, {
+    exitCode: 0, log: logOf(r), artifacts: [built],
+    limitations: same ? [] : ['built bundle differs from the committed one — wasm-pack output is not guaranteed reproducible across toolchains; treat as information, not failure'],
+  });
+}
+
+function jobBuildDesktop(ctx) {
+  const tauri = caps.localBin('tauri');
+  const missing = [];
+  if (!tauri) missing.push('node_modules/.bin/tauri (run npm ci)');
+  if (!which('cargo')) missing.push('cargo');
+  const triple = ctx.receipt.build.hostTriple;
+  if (!triple) missing.push('rustc host triple');
+  if (process.platform === 'darwin' && !which('xcode-select')) missing.push('Xcode command line tools');
+  if (!which('python3')) missing.push('python3 (scripts/bundle-ffmpeg-dylibs.py)');
+  if (missing.length) return blocked('missing: ' + missing.join(', '));
+  const r = run(tauri, ['build', '--target', triple, '-b', 'app'], { timeout: 2 * 60 * 60 * 1000 });
+  if (r.status !== 0) return fail(`tauri build exit ${r.status}`, { exitCode: r.status, log: logOf(r) });
+  const app = path.join(ROOT, 'src-tauri', 'target', triple, 'release', 'bundle', 'macos', 'Nemo.app');
+  if (process.platform !== 'darwin') return pass('tauri build ok (non-macOS: dylib bundling step not applicable)', { exitCode: 0, log: logOf(r) });
+  if (!exists(app)) return fail('tauri build reported success but Nemo.app not found at ' + path.relative(ROOT, app), { log: logOf(r) });
+  const d = run('python3', ['scripts/bundle-ffmpeg-dylibs.py', app], { timeout: 10 * 60 * 1000 });
+  const log = logOf(r) + '\n' + logOf(d);
+  if (d.status !== 0) return fail(`bundle-ffmpeg-dylibs.py exit ${d.status}`, { exitCode: d.status, log });
+  const mainBin = fileInfo(path.join(app, 'Contents', 'MacOS', 'Nemo'));
+  const sidecar = fileInfo(path.join(app, 'Contents', 'MacOS', 'ffmpeg'));
+  return pass('tauri build + ffmpeg dylib bundling ok', { exitCode: 0, log, artifacts: [{ path: path.relative(ROOT, app) }, mainBin, sidecar],
+    limitations: ['unsigned, un-notarized local build; not the release pipeline artifact'] });
+}
+
+// ---- registry ----------------------------------------------------------
+const JOBS = {
+  doctor: { run: jobDoctor, required: true },
+  check: { run: jobCheck, required: true },
+  'test:unit': { run: jobTestUnit, required: true },
+  'test:rust': { run: (ctx) => jobTestRust(ctx, 'geometry-wasm', 'geometry-wasm'), required: true },
+  'test:rust-tauri': { run: (ctx) => jobTestRust(ctx, 'src-tauri', 'src-tauri'), required: false },
+  'test:integration': { run: jobTestIntegration, required: false },
+  'test:browser': { run: jobTestBrowser, required: false },
+  'test:desktop': { run: jobTestDesktop, required: false },
+  bench: { run: jobBench, required: false },
+  'build:wasm': { run: jobBuildWasm, required: false },
+  'build:desktop': { run: jobBuildDesktop, required: false },
+};
+
+const PROFILES = {
+  quick: ['doctor', 'check', 'test:unit', 'test:rust'],
+  full: ['doctor', 'check', 'test:unit', 'test:rust', 'test:rust-tauri', 'test:integration', 'build:wasm', 'test:browser', 'bench', 'build:desktop', 'test:desktop'],
+};
+
+function execute(name, ctx) {
+  const def = JOBS[name];
+  if (!def) throw new Error('unknown job ' + name);
+  const t0 = Date.now();
+  let res;
+  try { res = def.run(ctx) || fail('job returned nothing'); }
+  catch (e) { res = fail('exception: ' + (e && e.stack || e)); }
+  const job = Object.assign({ name, required: !!def.required, exitCode: null, artifacts: [], limitations: [], details: null, log: null }, res, { durationMs: Date.now() - t0 });
+  ctx.receipt.jobs.push(job);
+  return job;
+}
+
+module.exports = { JOBS, PROFILES, execute };

--- a/scripts/nemo/lib/receipt.cjs
+++ b/scripts/nemo/lib/receipt.cjs
@@ -1,0 +1,126 @@
+'use strict';
+// One receipt per run. Schema `nemo.receipt/1`:
+//   { schema, runId, command, profile, startedAt, finishedAt, durationMs,
+//     source, build, platform, tools?, capabilities?, jobs: [Job], summary }
+//   Job: { name, required, status: pass|fail|blocked|not-run, reason,
+//          exitCode, durationMs, command, artifacts: [{path, sha256?, bytes?}],
+//          limitations: [string], details?, log? }
+// Status semantics (03_TESTING_AND_DEBUGGING.md):
+//   pass     the job ran and its own success criterion held
+//   fail     the job ran and it did not
+//   blocked  a required environment/tool/artifact is missing; NEVER a skip
+//   not-run  intentionally not attempted (no suite defined, not in profile)
+const fs = require('node:fs');
+const path = require('node:path');
+const { ROOT, nowIso, compactStamp } = require('./util.cjs');
+const identity = require('./identity.cjs');
+
+const SCHEMA = 'nemo.receipt/1';
+const STATUS = { PASS: 'pass', FAIL: 'fail', BLOCKED: 'blocked', NOT_RUN: 'not-run' };
+const EXIT = { pass: 0, fail: 1, blocked: 2, 'not-run': 0 };
+
+function create(command, opts = {}) {
+  const source = identity.sourceIdentity();
+  const build = identity.buildIdentity();
+  const platform = identity.platformIdentity();
+  const started = new Date();
+  const runId = compactStamp(started) + '-' + (source.head ? source.head.slice(0, 7) : 'nogit') + (source.dirty ? '-dirty' : '');
+  return {
+    schema: SCHEMA,
+    runId,
+    command,
+    profile: opts.profile || null,
+    startedAt: started.toISOString(),
+    finishedAt: null,
+    durationMs: null,
+    source, build, platform,
+    tools: null,
+    capabilities: null,
+    jobs: [],
+    limitations: [],
+    summary: null,
+  };
+}
+
+function reportDir(receipt) {
+  return path.join(process.env.NEMO_REPORT_DIR || path.join(ROOT, 'reports'), receipt.runId);
+}
+
+function finalize(receipt) {
+  const counts = { pass: 0, fail: 0, blocked: 0, 'not-run': 0 };
+  for (const j of receipt.jobs) counts[j.status] = (counts[j.status] || 0) + 1;
+  let overall = STATUS.PASS;
+  if (receipt.jobs.some((j) => j.status === STATUS.FAIL)) overall = STATUS.FAIL;
+  else if (receipt.jobs.some((j) => j.status === STATUS.BLOCKED && j.required)) overall = STATUS.BLOCKED;
+  else if (receipt.jobs.length && receipt.jobs.every((j) => j.status === STATUS.NOT_RUN)) overall = STATUS.NOT_RUN;
+  receipt.finishedAt = nowIso();
+  receipt.durationMs = new Date(receipt.finishedAt) - new Date(receipt.startedAt);
+  receipt.summary = { overall, exitCode: EXIT[overall], counts };
+  return receipt;
+}
+
+function write(receipt) {
+  const dir = reportDir(receipt);
+  fs.mkdirSync(dir, { recursive: true });
+  const stripped = JSON.parse(JSON.stringify(receipt));
+  for (const j of stripped.jobs) {
+    if (j.log != null) {
+      const logFile = path.join(dir, j.name.replace(/[^a-z0-9_-]+/gi, '_') + '.log');
+      fs.writeFileSync(logFile, j.log);
+      j.logPath = path.relative(ROOT, logFile);
+      delete j.log;
+    }
+  }
+  const jsonPath = path.join(dir, 'receipt.json');
+  fs.writeFileSync(jsonPath, JSON.stringify(stripped, null, 2) + '\n');
+  const mdPath = path.join(dir, 'receipt.md');
+  fs.writeFileSync(mdPath, renderMarkdown(stripped));
+  return { dir, jsonPath, mdPath };
+}
+
+function shortSha(s) { return s ? s.slice(0, 12) : 'n/a'; }
+
+function renderMarkdown(r) {
+  const s = r.source, b = r.build, p = r.platform;
+  const lines = [];
+  lines.push(`# Nemo receipt \`${r.runId}\``);
+  lines.push('');
+  lines.push(`- Command: \`${r.command}\`${r.profile ? ` (profile \`${r.profile}\`)` : ''}`);
+  lines.push(`- Overall: **${r.summary ? r.summary.overall : 'incomplete'}** (exit ${r.summary ? r.summary.exitCode : '?'}) — ${r.summary ? Object.entries(r.summary.counts).map(([k, v]) => `${k} ${v}`).join(', ') : ''}`);
+  lines.push(`- Started: ${r.startedAt}; finished: ${r.finishedAt}; ${r.durationMs} ms`);
+  lines.push(`- Source: \`${shortSha(s.head)}\` on \`${s.branch}\` (${s.describe})${s.dirty ? ` — **dirty**, ${s.modifiedTracked} modified, ${s.untracked} untracked, digest \`${shortSha(s.dirtyDigest)}\`` : ' — clean'}`);
+  lines.push(`- Build: package \`${b.packageVersion}\`, tauri.conf \`${b.tauriVersion}\`, index.html fallback \`${b.indexHtmlTitleVersion}\`/\`${b.indexHtmlStatusVersion}\`; geometry_wasm \`${shortSha(b.artifacts.geometryWasm.sha256)}\`, sidecar ${b.artifacts.ffmpegSidecar.present ? '`' + shortSha(b.artifacts.ffmpegSidecar.sha256) + '`' : 'absent'}`);
+  lines.push(`- Platform: ${p.os} ${p.osRelease} ${p.arch}, ${p.cpuModel} ×${p.cpuCount}, ${(p.memoryBytes / 2 ** 30).toFixed(0)} GiB, node ${p.node}`);
+  lines.push('');
+  lines.push('| Job | Required | Result | Reason / evidence | Limitation |');
+  lines.push('|---|---|---|---|---|');
+  for (const j of r.jobs) {
+    const ev = [j.reason, j.logPath ? `log \`${j.logPath}\`` : null].concat((j.artifacts || []).map((a) => `\`${a.path}\`${a.sha256 ? ' ' + shortSha(a.sha256) : ''}`)).filter(Boolean).join('; ');
+    lines.push(`| \`${j.name}\` | ${j.required ? 'yes' : 'no'} | **${j.status}** | ${ev.replace(/\|/g, '\\|')} | ${(j.limitations || []).join('; ').replace(/\|/g, '\\|')} |`);
+  }
+  if (r.limitations && r.limitations.length) {
+    lines.push('');
+    lines.push('Run limitations:');
+    for (const l of r.limitations) lines.push(`- ${l}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+function printSummary(receipt, written) {
+  const r = receipt;
+  const pad = (s, n) => String(s).padEnd(n);
+  console.log('');
+  console.log(`nemo ${r.command}${r.profile ? ' --profile ' + r.profile : ''}  run ${r.runId}`);
+  console.log(`source ${shortSha(r.source.head)} ${r.source.branch}${r.source.dirty ? ' (dirty ' + shortSha(r.source.dirtyDigest) + ')' : ' (clean)'}  build ${r.build.packageVersion}  ${r.platform.os}/${r.platform.arch}`);
+  console.log('');
+  for (const j of r.jobs) {
+    console.log(`  ${pad(j.status.toUpperCase(), 8)} ${pad(j.name, 18)} ${((j.durationMs || 0) / 1000).toFixed(1).padStart(7)}s  ${j.reason || ''}`);
+    for (const l of j.limitations || []) console.log(`           ${pad('', 18)}          ! ${l}`);
+  }
+  console.log('');
+  console.log(`overall ${r.summary.overall.toUpperCase()} (exit ${r.summary.exitCode})  pass ${r.summary.counts.pass}  fail ${r.summary.counts.fail}  blocked ${r.summary.counts.blocked}  not-run ${r.summary.counts['not-run']}`);
+  if (written) console.log(`receipt ${path.relative(ROOT, written.jsonPath)}`);
+}
+
+module.exports = { SCHEMA, STATUS, EXIT, create, finalize, write, renderMarkdown, printSummary, reportDir };

--- a/scripts/nemo/lib/util.cjs
+++ b/scripts/nemo/lib/util.cjs
@@ -1,0 +1,78 @@
+'use strict';
+// Shared helpers for the Nemo command surface (R02). Read-only by design:
+// nothing in here writes outside the run's own report directory.
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function run(cmd, args, opts = {}) {
+  const t0 = Date.now();
+  const r = spawnSync(cmd, args, {
+    encoding: 'utf8',
+    cwd: opts.cwd || ROOT,
+    env: Object.assign({}, process.env, opts.env || {}),
+    timeout: opts.timeout || 0,
+    maxBuffer: 256 * 1024 * 1024,
+    shell: false,
+    stdio: opts.inherit ? ['ignore', 'inherit', 'inherit'] : ['ignore', 'pipe', 'pipe'],
+  });
+  return {
+    cmd: [cmd].concat(args).join(' '),
+    status: r.status,
+    signal: r.signal || null,
+    error: r.error ? String(r.error.code || r.error.message) : null,
+    stdout: r.stdout || '',
+    stderr: r.stderr || '',
+    durationMs: Date.now() - t0,
+  };
+}
+
+function which(bin) {
+  const r = run(process.platform === 'win32' ? 'where' : 'which', [bin], { timeout: 5000 });
+  return r.status === 0 ? r.stdout.trim().split(/\r?\n/)[0] : null;
+}
+
+// First line of `<bin> --version` (or custom args). Never throws.
+function probeTool(bin, args, opts = {}) {
+  const p = opts.path || which(bin);
+  if (!p) return { present: false, path: null, version: null };
+  const r = run(p, args || ['--version'], { timeout: opts.timeout || 20000, cwd: opts.cwd });
+  const out = (r.stdout + '\n' + r.stderr).trim();
+  const line = out.split(/\r?\n/).find((l) => l.trim()) || '';
+  return { present: true, path: p, version: line.trim(), exitCode: r.status, error: r.error };
+}
+
+function sha256File(file) {
+  const h = crypto.createHash('sha256');
+  h.update(fs.readFileSync(file));
+  return h.digest('hex');
+}
+
+function sha256Text(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+function exists(p) {
+  try { fs.accessSync(p); return true; } catch { return false; }
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function nowIso() { return new Date().toISOString(); }
+
+function compactStamp(d) {
+  return (d || new Date()).toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
+}
+
+function fileInfo(p) {
+  if (!exists(p)) return { path: path.relative(ROOT, p), present: false };
+  const st = fs.statSync(p);
+  return { path: path.relative(ROOT, p), present: true, bytes: st.size, sha256: st.isFile() ? sha256File(p) : null };
+}
+
+module.exports = { ROOT, run, which, probeTool, sha256File, sha256Text, exists, readJson, nowIso, compactStamp, fileInfo };

--- a/scripts/nemo/verify.cjs
+++ b/scripts/nemo/verify.cjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+'use strict';
+// npm run verify [-- --profile quick|full | --jobs a,b,c] — the merge
+// profile: runs the selected jobs and emits ONE machine-readable receipt.
+// Exit: 0 pass, 1 any job failed, 2 a required job is blocked.
+const { parseArgs, runJobs } = require('./lib/cli.cjs');
+const { JOBS, PROFILES } = require('./lib/jobs.cjs');
+const args = parseArgs(process.argv.slice(2));
+let names;
+if (args.jobs) names = args.jobs;
+else names = PROFILES[args.profile || 'quick'];
+if (!names) { console.error(`unknown profile "${args.profile}". profiles: ${Object.keys(PROFILES).join(', ')}`); process.exit(64); }
+for (const n of names) if (!JOBS[n]) { console.error(`unknown job "${n}". jobs: ${Object.keys(JOBS).join(', ')}`); process.exit(64); }
+const { receipt } = runJobs('verify', names, { profile: args.jobs ? 'custom' : (args.profile || 'quick'), json: args.json, quiet: args.quiet });
+process.exit(receipt.summary.exitCode);


### PR DESCRIPTION
Closes #898. Parent #888 (F0).

## What changes

One command surface under `scripts/nemo/`, Node only, no new dependencies. See [`scripts/nemo/README.md`](https://github.com/mysteropodes/nemo/blob/claude/r02-doctor-receipts/scripts/nemo/README.md).

| Command | Behavior |
|---|---|
| `npm run doctor` | Read-only. Source identity (HEAD, branch, dirty digest), build identity (4 version strings, crate versions, SHA-256 of committed wasm bundles and host ffmpeg sidecar), platform, 16 tool probes, capabilities (rust targets, sidecar `-version` + `otool -L` with per-dylib presence, GPU via `system_profiler`, which suites exist). Exit 0 always. |
| `npm run check` | version sync, JSON validity, `src/js` syntax (ES modules checked as `.mjs` copies in the run dir), `index.html` script refs, private-labs guard, committed artifacts present. |
| `test:rust`, `test:integration`, `test:browser`, `test:desktop`, `bench`, `build:wasm`, `build:desktop` | Named jobs. Missing tool/target/suite/artifact → `blocked` naming it. Undefined suite → `not-run` naming the work package. Neither becomes a pass. |
| `npm run verify` | Profile `quick` (doctor, check, test:unit, test:rust) or `full`, or `--jobs a,b`. One receipt `reports/<runId>/receipt.json` + `.md` + per-job logs. Exit 0 pass / 1 fail / 2 required job blocked. |

`npm test` is unchanged. No application source touched. `reports/` is git-ignored.

## Acceptance (issue #898)

- **Doctor reports prerequisites and capabilities without mutating the workstation or project.** Only `--version`-style commands, file reads, `system_profiler`, `otool -L`. Verified: `git status` identical before/after; only `reports/` written.
- **Commands record source, build, platform, fixture, pass/fail/blocked/not-run, artifacts, and limitations.** Receipt schema `nemo.receipt/1`, fields listed in the README. Fixture identity is a field on job `details` for suites that have one (none yet).
- **A missing native or GPU environment remains blocked and cannot be converted to a passing skip.** `build:wasm` → `blocked: wasm-pack not found`; `test:browser` → `blocked: @playwright/test is not installed`; `test:desktop` → `blocked: no packaged app found`. WebGPU is reported `unknown outside a browser`, never assumed.

## Validation on this branch (macOS 15 / M3 Ultra, node 24.18, cargo 1.91.1)

| Job | Result | Evidence |
|---|---|---|
| `doctor` | pass | 16 tools probed, 2 absent (wasm-pack, playwright) |
| `check` | **fail** (correct) | `version-sync`: `src/index.html` fallback says `0.7.0-alpha.1`, package says `0.7.0-alpha.4` (CLAUDE.md §7). Other 5 checks pass: 6 JSON, 143 scripts (3 ES modules), 131 script refs, private-labs, artifacts |
| `test:unit` | pass | 70/70 |
| `test:rust` | pass | geometry-wasm, 4 binaries, 15 tests |

Two real findings surfaced by `doctor`, both outside this PR's scope:
1. The stale index.html fallback above → separate one-line PR.
2. **The committed ffmpeg sidecar does not run on this workstation**: `dyld: Library not loaded: /opt/homebrew/opt/theora/lib/libtheoraenc.2.dylib`. It was linked against theora 1.2 (split `libtheoraenc`/`libtheoradec`); this machine has Homebrew theora 1.1.1 (single `libtheora.0.dylib`). `scripts/bundle-ffmpeg-dylibs.py` exits with "dependency not resolvable" in that state, so a packaged build cannot be produced here as-is. This is R04's blocker (#900), reproduced on base `f529907`.

A `--profile full` run (adds `test:rust-tauri`, `build:wasm`, `test:browser`, `bench`, `build:desktop`, `test:desktop`) is in progress on commit 1ea8d34 and will be attached as a comment with its receipt.