### PR TITLE
Sync the index.html version fallback with 0.7.0-alpha.4

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Nemo v0.7.0-alpha.1</title>
+<title>Nemo v0.7.0-alpha.4</title>
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png">
 <link rel="icon" type="image/png" sizes="64x64" href="favicon-64.png">
 <script src="js/gpu-gate.js"></script>
@@ -2277,7 +2277,7 @@
 
 <div id="statusbar">
   <span id="statusbar-help" data-i18n-title="statusbarHelpTitle" title="Aide contextuelle — change selon l'outil actif ou l'élément sélectionné"><span class="sc">F5</span><span data-i18n="scFrame">Frame</span> <span class="sc">F6</span><span data-i18n="scKey">Key</span> <span class="sc">F7</span><span data-i18n="scBlank">Blank</span> <span class="sc">T</span><span data-i18n="scTween">Tween</span> <span class="sc">D</span><span data-i18n="scDupli">Dupli</span> <span class="sc">F</span><span data-i18n="scFlip">Flip</span> <span class="sc">X</span><span data-i18n="scMirror">Mirror</span> <span class="sc">Enter</span><span data-i18n="scPlay">Play</span></span>
-  <span id="status-text">Nemo v0.7.0-alpha.1</span>
+  <span id="status-text">Nemo v0.7.0-alpha.4</span>
 </div>
 </div>
 <div id="toast"></div>


### PR DESCRIPTION
The static `<title>` and `#status-text` fallback in `src/index.html` said `0.7.0-alpha.1` while `package.json` and `src-tauri/tauri.conf.json` are at `0.7.0-alpha.4` (CLAUDE.md §7 step 2). Shown for an instant at launch and permanently in the browser preview.

Found by the `version-sync` check in #932. With both merged, `npm run check` passes on main.

Validation: `grep -n 'Nemo v' src/index.html` shows both strings at `0.7.0-alpha.4`; no other change.