### PR TITLE
Rebuild the LGPL ffmpeg sidecar against current Homebrew; build:desktop --no-sign (R04)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -479,7 +479,12 @@ Checklist avant `npm run build` :
    sans ses dylibs, crash à l'export sur une machine sans Homebrew) et à exécuter **après
    chaque `npm run build`**, obligatoire de nouveau, pas optionnel. La machine qui build (pas
    celle qui reçoit l'app) doit avoir les formules Homebrew listées en tête de
-   `rebuild-ffmpeg-lgpl.sh` installées.
+   `rebuild-ffmpeg-lgpl.sh` installées — **aux versions majeures contre lesquelles le
+   sidecar committé a été lié** (R04, 2026-09-05) : le binaire référence des noms versionnés
+   (`libvpx.12.dylib`, `libSvtAv1Enc.4.dylib`, `libtheoraenc.2.dylib`…) ; un `brew upgrade`
+   qui change un majeur casse à la fois `ffmpeg -version` (dyld) et `bundle-ffmpeg-dylibs.py`
+   (« dependency not resolvable »). Diagnostic : `npm run doctor` (ligne « sidecar dylibs »,
+   liste les manquants) ; remède : relancer `rebuild-ffmpeg-lgpl.sh` et committer le binaire.
    ⚠️ **H.264/H.265 restaurés SANS libx264/libx265, via VideoToolbox** (même 2026-08-18) :
    `--enable-videotoolbox` (framework système Apple, pas une dépendance Homebrew, pas GPL)
    expose `h264_videotoolbox`/`hevc_videotoolbox`/`prores_videotoolbox` — l'encodeur matériel

--- a/scripts/nemo/lib/jobs.cjs
+++ b/scripts/nemo/lib/jobs.cjs
@@ -176,6 +176,10 @@ function jobBench() {
 }
 
 // ---- builds ------------------------------------------------------------
+// build:desktop passes --no-sign: a local verification build never has
+// TAURI_SIGNING_PRIVATE_KEY (personal secret, CLAUDE.md §9), and without the
+// flag tauri still tries to sign the updater artifact that
+// bundle.createUpdaterArtifacts requests, failing AFTER Nemo.app was built.
 function jobBuildWasm(ctx) {
   if (!which('wasm-pack')) return blocked('wasm-pack not found (release.yml installs it from rustwasm.github.io); the committed src/wasm bundle cannot be regenerated here');
   const targets = (ctx.receipt.capabilities || {}).rustTargets || [];
@@ -202,7 +206,7 @@ function jobBuildDesktop(ctx) {
   if (process.platform === 'darwin' && !which('xcode-select')) missing.push('Xcode command line tools');
   if (!which('python3')) missing.push('python3 (scripts/bundle-ffmpeg-dylibs.py)');
   if (missing.length) return blocked('missing: ' + missing.join(', '));
-  const r = run(tauri, ['build', '--target', triple, '-b', 'app'], { timeout: 2 * 60 * 60 * 1000 });
+  const r = run(tauri, ['build', '--target', triple, '-b', 'app', '--no-sign'], { timeout: 2 * 60 * 60 * 1000 });
   if (r.status !== 0) return fail(`tauri build exit ${r.status}`, { exitCode: r.status, log: logOf(r) });
   const app = path.join(ROOT, 'src-tauri', 'target', triple, 'release', 'bundle', 'macos', 'Nemo.app');
   if (process.platform !== 'darwin') return pass('tauri build ok (non-macOS: dylib bundling step not applicable)', { exitCode: 0, log: logOf(r) });

--- a/src-tauri/src/video_decode.rs
+++ b/src-tauri/src/video_decode.rs
@@ -1507,22 +1507,52 @@ mod tests {
     /// Generates a test video with the BUNDLED ffmpeg CLI binary (the
     /// exact same one this module pipes for decode AND probing — no
     /// separate "test-only" ffmpeg invocation path), cached by filename.
+    /// Fixtures are encoded with the committed LGPL sidecar, which ships no
+    /// libx264/libx265 since the 2026-08-18 rebuild (CLAUDE.md §7): H.264 and
+    /// H.265 fixtures go through Apple's VideoToolbox encoders instead — the
+    /// same encoders the app's own export uses. Both honor `-g` (verified:
+    /// 60 frames at `-g 15` yield 4 keyframes), which the seek/index tests
+    /// below depend on.
     fn gen_video(filename: &str, lavfi: &str, codec_args: &[&str]) -> std::path::PathBuf {
         let dir = std::env::temp_dir().join("nemo-video-decode-test");
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join(filename);
-        if !path.exists() {
+        // Generation is serialized and atomic. `cargo test` runs these tests
+        // on every core; without the lock, two tests sharing a fixture name
+        // raced (one decoded a half-written file, the other re-encoded over
+        // it with `-y`), and VideoToolbox refused to open yet another
+        // hardware session under that load (`err=-12903`), leaving a 0-byte
+        // file that poisoned every later run. Encode to a `.part` sibling and
+        // rename, so a fixture either exists complete or not at all.
+        static GEN_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = GEN_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let complete = path.metadata().map(|m| m.len() > 0).unwrap_or(false);
+        if !complete {
             let ffmpeg = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
                 .join("binaries/ffmpeg-aarch64-apple-darwin");
+            let part = dir.join(format!("{filename}.part"));
+            let _ = std::fs::remove_file(&part);
             let mut args: Vec<&str> = vec!["-y", "-f", "lavfi", "-i", lavfi];
             args.extend_from_slice(codec_args);
-            let out = path.to_str().unwrap().to_string();
+            let out = part.to_str().unwrap().to_string();
+            // ffmpeg picks the muxer from the output extension; `.part` has
+            // none, so name the format from the fixture's own extension.
+            let fmt = match std::path::Path::new(filename).extension().and_then(|e| e.to_str()) {
+                Some("mp4") => "mp4",
+                Some("mov") => "mov",
+                Some("webm") => "webm",
+                Some("mjpeg") => "mjpeg",
+                Some(other) => other,
+                None => "mp4",
+            };
+            args.extend_from_slice(&["-f", fmt]);
             args.push(&out);
             let status = StdCommand::new(&ffmpeg)
                 .args(&args)
                 .status()
                 .expect("bundled ffmpeg binary must exist and run");
             assert!(status.success(), "test video generation failed: {filename}");
+            std::fs::rename(&part, &path).expect("fixture rename");
         }
         path
     }
@@ -1542,7 +1572,7 @@ mod tests {
         gen_video(
             "testsrc2_60f_30fps.mp4",
             "testsrc2=size=320x240:rate=30:duration=2",
-            &["-c:v", "libx264", "-pix_fmt", "yuv420p", "-g", "15"],
+            &["-c:v", "h264_videotoolbox", "-pix_fmt", "yuv420p", "-g", "15"],
         )
     }
 
@@ -1640,7 +1670,7 @@ mod tests {
         let p = gen_video(
             "hevc_320.mp4",
             "testsrc2=size=320x240:rate=30:duration=2",
-            &["-c:v", "libx265", "-pix_fmt", "yuv420p", "-g", "15", "-tag:v", "hvc1"],
+            &["-c:v", "hevc_videotoolbox", "-pix_fmt", "yuv420p", "-g", "15", "-tag:v", "hvc1"],
         );
         assert_decodes_and_seeks(&p, 320, 240);
     }
@@ -1699,7 +1729,7 @@ mod tests {
         let p = gen_video(
             "odd_954x542.mp4",
             "testsrc2=size=954x542:rate=30:duration=1",
-            &["-c:v", "libx264", "-pix_fmt", "yuv420p", "-g", "15"],
+            &["-c:v", "h264_videotoolbox", "-pix_fmt", "yuv420p", "-g", "15"],
         );
         assert_decodes_and_seeks(&p, 954, 542);
     }
@@ -1709,7 +1739,7 @@ mod tests {
         let p = gen_video(
             "fps25_320.mp4",
             "testsrc2=size=320x240:rate=25:duration=2",
-            &["-c:v", "libx264", "-pix_fmt", "yuv420p", "-g", "12"],
+            &["-c:v", "h264_videotoolbox", "-pix_fmt", "yuv420p", "-g", "12"],
         );
         let (mut s, _, _) = open_session_core_t(p.to_str().unwrap()).unwrap();
         assert!((s.fps - 25.0).abs() < 0.01, "fps was {}", s.fps);
@@ -1727,7 +1757,7 @@ mod tests {
         let pb = gen_video(
             "iso_b_160.mp4",
             "testsrc2=size=160x120:rate=30:duration=2",
-            &["-c:v", "libx264", "-pix_fmt", "yuv420p", "-g", "15"],
+            &["-c:v", "h264_videotoolbox", "-pix_fmt", "yuv420p", "-g", "15"],
         );
         let (mut a, _, _) = open_session_core_t(pa.to_str().unwrap()).unwrap();
         let (mut b, _, _) = open_session_core_t(pb.to_str().unwrap()).unwrap();
@@ -1778,7 +1808,7 @@ mod tests {
         let p = gen_video(
             "perf_1080p.mp4",
             "testsrc2=size=1920x1080:rate=30:duration=2",
-            &["-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv420p", "-g", "15"],
+            &["-c:v", "h264_videotoolbox", "-pix_fmt", "yuv420p", "-g", "15"],
         );
         let (avg, p95) = measure_sequential_steady_state(&p, 30);
         eprintln!("[perf] 1080p sequential (steady-state): avg={avg:.1}ms p95={p95:.1}ms (budget 33.3ms)");
@@ -1790,7 +1820,7 @@ mod tests {
         let p = gen_video(
             "perf_4k.mp4",
             "testsrc2=size=3840x2160:rate=30:duration=1",
-            &["-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv420p", "-g", "15"],
+            &["-c:v", "h264_videotoolbox", "-pix_fmt", "yuv420p", "-g", "15"],
         );
         let (avg, p95) = measure_sequential_steady_state(&p, 15);
         eprintln!("[perf] 4K sequential (steady-state): avg={avg:.1}ms p95={p95:.1}ms (budget 33.3ms)");
@@ -1808,7 +1838,7 @@ mod tests {
         let p = gen_video(
             "perf_4k.mp4",
             "testsrc2=size=3840x2160:rate=30:duration=1",
-            &["-c:v", "libx264", "-preset", "ultrafast", "-pix_fmt", "yuv420p", "-g", "15"],
+            &["-c:v", "h264_videotoolbox", "-pix_fmt", "yuv420p", "-g", "15"],
         );
         let (mut s, _, _) = open_session_core_t(p.to_str().unwrap()).unwrap();
         let t0 = std::time::Instant::now();
@@ -1850,7 +1880,7 @@ mod tests {
         let p = gen_video(
             "h264_320_biggop.mp4",
             "testsrc2=size=320x240:rate=30:duration=3",
-            &["-c:v", "libx264", "-pix_fmt", "yuv420p", "-g", "60"],
+            &["-c:v", "h264_videotoolbox", "-pix_fmt", "yuv420p", "-g", "60"],
         );
         let (mut s, _frame_count, _) = open_session_core_t(p.to_str().unwrap()).unwrap();
 
@@ -1940,7 +1970,7 @@ mod tests {
     // spinning.
     #[test]
     fn readahead_backward_fill_does_not_fight_forward_playback() {
-        let p = gen_video("play_thrash.mp4", "testsrc2=size=320x240:rate=30:duration=4", &["-c:v", "libx264", "-pix_fmt", "yuv420p", "-g", "15"]);
+        let p = gen_video("play_thrash.mp4", "testsrc2=size=320x240:rate=30:duration=4", &["-c:v", "h264_videotoolbox", "-pix_fmt", "yuv420p", "-g", "15"]);
         let (s, _, _) = open_session_core_t(p.to_str().unwrap()).unwrap();
         let arc = std::sync::Arc::new(Mutex::new(s));
 
@@ -1992,7 +2022,7 @@ mod tests {
     // idle instead of spinning.
     #[test]
     fn readahead_settles_even_when_cache_cannot_hold_the_full_window() {
-        let p = gen_video("thrash_1080p.mp4", "testsrc2=size=1920x1080:rate=30:duration=3", &["-c:v", "libx264", "-pix_fmt", "yuv420p", "-g", "15"]);
+        let p = gen_video("thrash_1080p.mp4", "testsrc2=size=1920x1080:rate=30:duration=3", &["-c:v", "h264_videotoolbox", "-pix_fmt", "yuv420p", "-g", "15"]);
         let (s, _, _) = open_session_core_t(p.to_str().unwrap()).unwrap();
         let arc = std::sync::Arc::new(Mutex::new(s));
 
@@ -2173,7 +2203,7 @@ mod tests {
         let path_b = gen_video(
             "h264_320_concurrency_b.mp4",
             "testsrc2=size=320x240:rate=30:duration=3",
-            &["-c:v", "libx264", "-pix_fmt", "yuv420p", "-g", "15"],
+            &["-c:v", "h264_videotoolbox", "-pix_fmt", "yuv420p", "-g", "15"],
         );
 
         let sessions = StdArc::new(VideoSessions::default());
@@ -2220,8 +2250,8 @@ mod tests {
     #[test]
     fn three_simultaneous_sessions_playback_mostly_avoids_respawns() {
         let pa = make_test_video(); // 320x240, 60 frames
-        let pb = gen_video("play3_b.mp4", "testsrc2=size=320x240:rate=30:duration=3", &["-c:v", "libx264", "-pix_fmt", "yuv420p", "-g", "15"]);
-        let pc = gen_video("play3_c.mp4", "testsrc2=size=320x240:rate=30:duration=3", &["-c:v", "libx264", "-pix_fmt", "yuv420p", "-g", "15"]);
+        let pb = gen_video("play3_b.mp4", "testsrc2=size=320x240:rate=30:duration=3", &["-c:v", "h264_videotoolbox", "-pix_fmt", "yuv420p", "-g", "15"]);
+        let pc = gen_video("play3_c.mp4", "testsrc2=size=320x240:rate=30:duration=3", &["-c:v", "h264_videotoolbox", "-pix_fmt", "yuv420p", "-g", "15"]);
         let (sa, _, _) = open_session_core_t(pa.to_str().unwrap()).unwrap();
         let (sb, _, _) = open_session_core_t(pb.to_str().unwrap()).unwrap();
         let (sc, _, _) = open_session_core_t(pc.to_str().unwrap()).unwrap();


### PR DESCRIPTION
Closes #900. Parent #888 (F0). Depends on #932 (merged).

## What changes

- `src-tauri/binaries/ffmpeg-aarch64-apple-darwin` rebuilt with the existing `scripts/rebuild-ffmpeg-lgpl.sh`, unchanged (FFmpeg n8.1, no `--enable-gpl`, `--enable-videotoolbox`). Codec, dependency and distribution policy are untouched: the linked library set is the same 26 Homebrew dylibs; only two sonames move (`libvpx.11→12`, `libSvtAv1Enc.3→4`) and the system `Metal.framework` is now referenced. `THIRD_PARTY_NOTICES.md` needs no change.
- `scripts/nemo/lib/jobs.cjs`: `build:desktop` passes `--no-sign`. Without it tauri builds `Nemo.app` and then fails signing the updater artifact for lack of the personal `TAURI_SIGNING_PRIVATE_KEY`, which a local verification build never has.
- `CLAUDE.md` §7 step 3: the sidecar is bound to the Homebrew *major* versions it was linked against; how to diagnose (`npm run doctor`) and repair (rerun the rebuild script).

## Reproduction (before repair)

Recorded on #900. On base `f529907` the sidecar failed on `libtheoraenc.2.dylib` (theora 1.1.1 installed); after `brew upgrade theora` (1.2.0, which also bumped libvpx and svt-av1) on base `e1d2ea7` it failed on `libvpx.11.dylib` and `libSvtAv1Enc.3.dylib`, and `bundle-ffmpeg-dylibs.py` exited with "dependency not resolvable".

## Validation (macOS 15 / Darwin 25.6.0 arm64, M3 Ultra, node 24.18, cargo 1.91.1, Homebrew theora 1.2.0 / libvpx 1.17.0 / svt-av1 4.2.0)

| Check | Result |
|---|---|
| Rebuilt sidecar `-version` | runs; `License: LGPL version 2.1 or later`; `--enable-gpl` absent from configuration |
| `otool -L` external dylibs | 26/26 resolve on this machine (`npm run doctor`: 0 missing) |
| Encoders present | `h264_videotoolbox`, `hevc_videotoolbox`, `prores_videotoolbox`, `prores_ks`, `libvpx`/`libvpx-vp9`, `libaom-av1`, `libsvtav1`, `libtheora` |
| `npm run build:desktop` | **pass**, receipt `20260905T111827Z-e1d2ea7-dirty` (tauri build + dylib bundling, 32.9 s warm) |
| Packaged `Nemo.app/Contents/MacOS/ffmpeg` | 37 dylibs in `Contents/Frameworks`, 0 `/opt/homebrew` references left, runs |
| Encode with the app's own export arguments (12 PNG frames) | `h264_videotoolbox -pix_fmt yuv420p -q:v 65 -profile:v high` → 6.6 KB MP4, probed `h264 (High) yuv420p 320x240 12 fps`; `prores_ks -profile:v 4 -pix_fmt yuva444p10le` → 360 KB MOV; `libvpx-vp9` → 6.2 KB WebM |
| Packaged app launch | `open -n Nemo.app`, process alive after 6 s, quits cleanly via AppleScript |
| Rebuild script smoke test | libvpx-vp9 encode inside the script passed (script exit 0) |

Initial validation limitation (resolved below on 2026-09-05): the first pass drove the packaged sidecar directly. The later packaged UI export and native playback now pass. The artifact remains an unsigned, un-notarized local build; the release pipeline was not exercised. Browser export uses MediaRecorder and is unaffected by this sidecar change.


## Additional reproduction evidence (CI) and residual risk

Release pipeline, same failure class, before any repair: `release.yml` runs [33754441195](https://github.com/mysteropodes/nemo/actions/runs/33754441195) (v0.7.0-alpha.3) and [33755502939](https://github.com/mysteropodes/nemo/actions/runs/33755502939) (v0.7.0-alpha.4) both failed on 2026-09-03 in "Make the .app self-contained" with `dependency not resolvable: /opt/homebrew/opt/svt-av1/lib/libSvtAv1Enc.3.dylib`. The runner does `brew install … svt-av1 …` at release time and therefore always gets the *current* Homebrew major (4.x = `.4`), while the committed sidecar was linked against 3.x. (Evidence surfaced by the R03 session.)

So the blocker is Homebrew soname drift between the machine that linked the committed sidecar and the machine that bundles it. The rebuild in #934 links against today's majors (theora 1.2 / libvpx 1.17 / svt-av1 4.2), which is what the runner installs now, so the next release run is expected to pass; but a committed binary will drift again at the next major bump of any linked formula.

**Not done here (policy change, outside R04's "repair only confirmed blockers while preserving codec, dependency and distribution policy")**: making the sidecar drift-proof, either by building it in `release.yml` from `scripts/rebuild-ffmpeg-lgpl.sh` on the same runner that bundles it, or by linking the Homebrew libraries statically. Proposed as a follow-up task under Platform; `npm run doctor` (sidecar dylibs line) is the early-warning signal until then.


---

## Update 2026-09-05 — second commit (VideoToolbox fixtures) and rebuild verification

### Commit 2 `7bd1f88` — `src-tauri tests: encode fixtures with VideoToolbox, serialized and atomic`

The `test:rust-tauri` suite generates its fixtures by spawning the committed sidecar, so it surfaced two problems that the sidecar repair alone did not:

1. **libx264/libx265 gone.** The suite encoded H.264/H.265 fixtures with `libx264`/`libx265`, which the LGPL rebuild of 2026-08-18 removed on purpose. Rewritten to use `h264_videotoolbox`/`hevc_videotoolbox` — the same encoders `export.js` uses. Both honor `-g`, so the seek/index tests still get their keyframe cadence (60 frames at `-g 15` → 4 keyframes).
2. **Non-atomic fixture generation.** Concurrent/duplicate fixture writes could race. Generation is now serialized and writes atomically, so a partially written fixture can no longer be read by a test.

Result: `node scripts/nemo/job.cjs test:rust-tauri` → **37 passed / 0 failed** at `7bd1f88` (reviewer rerun, receipt `20260905T121932Z-7bd1f88-dirty`; on base `e1d2ea7` the same suite fails 30/37 because the committed sidecar did not run).

### Rebuild verification at HEAD `7bd1f88`

`npm run build:desktop` re-run on this commit — receipt `20260905T153432Z-7bd1f88-dirty`, **pass** (tauri build + `bundle-ffmpeg-dylibs.py`, 33.6 s warm). Packaged `Nemo.app`:

| Check | Result |
|---|---|
| Homebrew (`/opt/homebrew`) references in app | **0** across the main binary, sidecar and all bundled dylibs |
| Bundled dylibs in `Contents/Frameworks` | 37 |
| Committed sidecar SHA-256 (`src-tauri/binaries/ffmpeg-aarch64-apple-darwin`) | `8fbf0afc…a367eeb7` (matches review); bundled copy differs only because `install_name_tool` rewrites the load paths, which is why 0 Homebrew refs remain |
| Encoders in the bundled sidecar | `h264_videotoolbox`, `hevc_videotoolbox`, `prores_videotoolbox`, `prores_ks` present |

### Packaged desktop acceptance completed — 2026-09-05 21:59 UTC

Codexitron independently drove the existing packaged Nemo UI, loaded the committed `export-12f-320x240.json` fixture, selected Export → MP4 (H.264), Work area, scale 1x, and saved the movie through the native dialog. No source edits or rebuild occurred during this check. The package matches build receipt `20260905T153432Z-7bd1f88-dirty` at the unchanged PR head `7bd1f88c9816873cbb2f1a4996a135d40fdc636a`.

| Evidence | Observed result |
|---|---|
| Packaged launch / project load / UI export | Pass |
| Output probe | H.264 High, yuv420p, 320×240, 12 fps, 12 decoded frames, 1.000000 seconds; encoder `h264_videotoolbox` |
| Decoded frame content | 12/12 pass: red rectangle moves 20 px per frame, first bounds `[0,100,39,139]`, last `[220,100,259,139]`; red center and white background within 8/255 RGB tolerance |
| QuickTime playback | Opened the exported MP4, Play advanced the timeline, reached one second and stopped without an error |
| Source preservation | Only the pre-existing generated capabilities schema and node_modules worktree entries remain; no validation source changes |

Artifact identities (SHA-256):

- Packaged main executable: `e70fba22739216eaa043df23caa7c331e8e68ad8abc9d3f73562e0770b216928`
- Packaged ffmpeg: `91566ff440e785f3f8e7799eb2d5f346c8b3e62ba8c3290f57d8edbf1fbb98e1`
- Input fixture: `f79902af620add3209314154c6dcfca5f6ce4f8f44bbb4e37b666abbbceab684`, from [committed R03 fixture](https://github.com/mysteropodes/nemo/blob/93d6d2ae76ffea04fcbd8e2fbe849f14469c6092/tests/fixtures/projects/export-12f-320x240.json)
- Output MP4: `5ef19dba86a909c21be8e94aa5150b147c4ce3c3e5386c8086fe3f17e286e94d`, 1470 bytes

Probe and frame checks used `ffprobe -count_frames -show_streams -show_format` and decoding all frames to RGB24 with ffmpeg, followed by center/background/bounds assertions. The exact output, probe JSON and per-frame receipt are retained locally with the validation evidence. A CUA connection interruption after Save was reconciled against the existing output and reconnected app before continuing; the export was not repeated.

R04's remaining packaged desktop acceptance is satisfied. Browser behavior was not used as a substitute. Signing, notarization, release-pipeline verification and future Homebrew major-version drift remain separate from this bounded repair acceptance.
