### PR TITLE
R05: add validated module-boundary checker and scoped exceptions

### DIFF
--- a/engineering/boundaries/README.md
+++ b/engineering/boundaries/README.md
@@ -47,8 +47,11 @@ Unknown flags, missing option values and extra positional arguments also exit 2.
 - **Lexical JS scanning, not AST or binding analysis.** Literal `require` calls (including
   optional calls), static imports/re-exports and dynamic `import()` accept whitespace and
   comments between tokens. Quoted/no-substitution template targets and ordinary string
-  escapes are decoded. Comments, string text and ordinary regex literals are opaque;
-  template substitutions are scanned. Nonliteral loads fail with `unsupported-import`.
+  escapes are decoded. Object method declarations named `require` with their body opener on
+  the closing-parameter line are not loader calls; separating that brace remains outside this
+  lexical subset because automatic semicolon insertion can make the same tokens a real call
+  followed by a block. Comments, string text and ordinary regex literals are opaque; template
+  substitutions are scanned. Nonliteral loads fail with `unsupported-import`.
 - **Deliberately unsupported lexical ambiguity fails the run (exit 2).** A slash after `)`
   or `}` requires statement/expression context to distinguish regex from division; escaped
   identifiers and legacy numeric string escapes also require a fuller parser. This can
@@ -85,8 +88,9 @@ ceiling still fails. Other rules cannot carry a size ceiling. All expired entrie
 when the associated source has no current violation; expired exceptions never suppress rules.
 
 An active exception for private imports, layer edges or globals applies only to its exact
-file/rule. A cycle exception applies only to a cycle with an import edge originating in its
-exact file. Applied exceptions are recorded in the report. Unsupported-source diagnostics
+file/rule. A cycle exception removes only dependency contributions originating in its exact
+file; another file contributing the same module edge remains in the prohibited graph. Applied
+exceptions are recorded in the report. Unsupported-source diagnostics
 cannot be waived by an exception. This validation does not compare policy changes against an
 older Git baseline; preventing an authorized ceiling from being raised in a later revision
 still requires the R01/R03 baseline/CI adoption work.

--- a/engineering/boundaries/README.md
+++ b/engineering/boundaries/README.md
@@ -7,7 +7,8 @@ application. Code lives in [`scripts/nemo/lib/boundaries.cjs`](../../scripts/nem
 (the checker, pure functions, no I/O beyond reading the files a profile names) and
 [`scripts/nemo/boundaries.cjs`](../../scripts/nemo/boundaries.cjs) (a standalone CLI). Behavioral
 tests are in [`scripts/nemo/boundaries.test.cjs`](../../scripts/nemo/boundaries.test.cjs)
-(`node --test scripts/nemo/boundaries.test.cjs`).
+(`node --test scripts/nemo/boundaries.test.cjs`). The library validates the profile before
+reading its sources; the CLI uses the same validation and exits 2 on malformed policy.
 
 This is **not wired into `npm run check`/`verify`, `scripts/nemo/lib/jobs.cjs` or
 `package.json`** in this packet — see "What's pending" below.
@@ -24,6 +25,7 @@ file every declared module lists:
 | `layer-violation` | An import crosses into a layer the importer's declared `layerRules` does not allow. |
 | `global-state` | `window.SM*` is accessed from a layer other than `adapters`/`bootstrap`. |
 | `size` | A file's nonblank physical line count exceeds its `sizeProfile`'s `hardMax`, and no non-expired exception raises the ceiling far enough. |
+| `unsupported-import` / `unsupported-global` | A dynamic load or computed `window` member cannot be determined from literal tokens. |
 | `expired-exception` | An exception's `expires` date is on/before the check's clock; it stops shielding its rule (which is then re-evaluated and may itself fail) and is reported by itself too. |
 
 Intra-module imports (a file importing another file of the *same* module) are never flagged —
@@ -37,22 +39,57 @@ node scripts/nemo/boundaries.cjs <profile.json> [--root <dir>] [--json]
 ```
 
 Exit 0 = no violations, 1 = one or more, 2 = bad usage or a profile that could not run (e.g.
-an unknown `sizeProfile` key, or a listed file missing on disk).
+an unknown `sizeProfile` key, malformed exception, missing file, or unsupported lexical syntax).
+Unknown flags, missing option values and extra positional arguments also exit 2.
 
 ## Limitations (v1, deliberate scope cut)
 
-- **Regex-based import extraction**, not a real parser. A specifier that only *looks* like
-  `require('x')` inside a comment or string would be misread. Acceptable for a small,
-  hand-reviewed profile; not for scanning arbitrary source at scale.
+- **Lexical JS scanning, not AST or binding analysis.** Literal `require` calls (including
+  optional calls), static imports/re-exports and dynamic `import()` accept whitespace and
+  comments between tokens. Quoted/no-substitution template targets and ordinary string
+  escapes are decoded. Comments, string text and ordinary regex literals are opaque;
+  template substitutions are scanned. Nonliteral loads fail with `unsupported-import`.
+- **Deliberately unsupported lexical ambiguity fails the run (exit 2).** A slash after `)`
+  or `}` requires statement/expression context to distinguish regex from division; escaped
+  identifiers and legacy numeric string escapes also require a fuller parser. This can
+  reject otherwise valid JS. Use a parsed R03 inventory before broader adoption.
+- **Global rule covers direct `window.SM*` access**, including whitespace, optional chaining
+  and literal bracket properties. Nonliteral computed `window` access fails explicitly.
+  Binding aliases, destructuring, `globalThis`/`self`, indirect loaders such as `module.require`
+  or `eval`, and function-local shadowing are not resolved. Hand-review these in the bounded
+  profile; this checker does not certify the absence of every implicit global or dependency.
 - **No filesystem walking.** A module's `files` list is authoritative; a file that exists on
   disk but isn't listed is invisible to the checker. This is intentional for this increment —
   see the inventory contract below for where that changes.
 - **Bare (non-relative) specifiers are external and unchecked** — no alias resolution,
-  `node:`/npm packages are always ignored for cycle/private/layer purposes.
+  `node:`/npm packages are always ignored for cycle/private/layer purposes. Unresolved
+  relative references (including URL query/hash suffixes) are also outside this graph;
+  extension inference is limited to `.cjs`, `.js`, `.mjs` and their directory indexes.
+  Review unresolved/indirect edges before using any profile as an adoption gate.
 - **A layer with no `layerRules` entry is permissive** — declare every layer whose outbound
   imports you want enforced.
 - `size` is measured **per file**, not summed per module, matching the policy's per-file line
   budgets.
+
+## Profile and exception validation
+
+The schema describes the input shape; the library additionally checks relationships that
+JSON Schema cannot directly express here: unique module IDs and file ownership, normalized
+relative paths, nonempty module/file sets, known size profiles, public API subsets and
+`warn <= hardMax`. Unknown fields, invalid numbers and malformed policy never become a pass.
+
+Every exception must name a declared exact file, supported rule, nonblank owner/issue/reason
+and a real `YYYY-MM-DD` expiry. Duplicate file/rule exceptions are rejected. Size exceptions
+require a finite integer ceiling at least as high as the base hard maximum; exceeding that
+ceiling still fails. Other rules cannot carry a size ceiling. All expired entries fail even
+when the associated source has no current violation; expired exceptions never suppress rules.
+
+An active exception for private imports, layer edges or globals applies only to its exact
+file/rule. A cycle exception applies only to a cycle with an import edge originating in its
+exact file. Applied exceptions are recorded in the report. Unsupported-source diagnostics
+cannot be waived by an exception. This validation does not compare policy changes against an
+older Git baseline; preventing an authorized ceiling from being raised in a later revision
+still requires the R01/R03 baseline/CI adoption work.
 
 ## Integration contract for R01/R03 (pending)
 

--- a/engineering/boundaries/README.md
+++ b/engineering/boundaries/README.md
@@ -1,0 +1,98 @@
+# Boundaries checker — R05 first increment
+
+Implements the enforcement half of
+[`engineering/remediation/04_MODULARITY_POLICY.md`](../remediation/04_MODULARITY_POLICY.md)
+for a **bounded, explicitly declared set of modules** — a *profile* — not the whole
+application. Code lives in [`scripts/nemo/lib/boundaries.cjs`](../../scripts/nemo/lib/boundaries.cjs)
+(the checker, pure functions, no I/O beyond reading the files a profile names) and
+[`scripts/nemo/boundaries.cjs`](../../scripts/nemo/boundaries.cjs) (a standalone CLI). Behavioral
+tests are in [`scripts/nemo/boundaries.test.cjs`](../../scripts/nemo/boundaries.test.cjs)
+(`node --test scripts/nemo/boundaries.test.cjs`).
+
+This is **not wired into `npm run check`/`verify`, `scripts/nemo/lib/jobs.cjs` or
+`package.json`** in this packet — see "What's pending" below.
+
+## What it checks
+
+Given a profile (JSON, shape in [`profile.schema.json`](./profile.schema.json)), for every
+file every declared module lists:
+
+| Rule | Fires when |
+|---|---|
+| `cycle` | Two or more declared modules import each other, directly or transitively. |
+| `private-import` | An import resolves into another module's file that is not in that module's `publicApi`. |
+| `layer-violation` | An import crosses into a layer the importer's declared `layerRules` does not allow. |
+| `global-state` | `window.SM*` is accessed from a layer other than `adapters`/`bootstrap`. |
+| `size` | A file's nonblank physical line count exceeds its `sizeProfile`'s `hardMax`, and no non-expired exception raises the ceiling far enough. |
+| `expired-exception` | An exception's `expires` date is on/before the check's clock; it stops shielding its rule (which is then re-evaluated and may itself fail) and is reported by itself too. |
+
+Intra-module imports (a file importing another file of the *same* module) are never flagged —
+only cross-module edges are checked, matching the policy's "no private cross-module deep
+imports, new cycles, ... or UI imports into domain."
+
+## Usage
+
+```bash
+node scripts/nemo/boundaries.cjs <profile.json> [--root <dir>] [--json]
+```
+
+Exit 0 = no violations, 1 = one or more, 2 = bad usage or a profile that could not run (e.g.
+an unknown `sizeProfile` key, or a listed file missing on disk).
+
+## Limitations (v1, deliberate scope cut)
+
+- **Regex-based import extraction**, not a real parser. A specifier that only *looks* like
+  `require('x')` inside a comment or string would be misread. Acceptable for a small,
+  hand-reviewed profile; not for scanning arbitrary source at scale.
+- **No filesystem walking.** A module's `files` list is authoritative; a file that exists on
+  disk but isn't listed is invisible to the checker. This is intentional for this increment —
+  see the inventory contract below for where that changes.
+- **Bare (non-relative) specifiers are external and unchecked** — no alias resolution,
+  `node:`/npm packages are always ignored for cycle/private/layer purposes.
+- **A layer with no `layerRules` entry is permissive** — declare every layer whose outbound
+  imports you want enforced.
+- `size` is measured **per file**, not summed per module, matching the policy's per-file line
+  budgets.
+
+## Integration contract for R01/R03 (pending)
+
+R05's acceptance is explicit that full adoption is **blocked on R01** (current/target
+inventory) and **R03** (`scripts/nemo/inventory.cjs`, owned by a separate work package —
+`engineering/inventory/**`, `tests/fixtures/**`, `tests/bench/**` are out of scope for this
+packet). This checker is written so that once either lands, its output can be mapped to
+[`profile.schema.json`](./profile.schema.json) without changing `checkProfile`'s public
+contract:
+
+- **R03 inventory → `modules[]`.** Whatever the inventory scan groups a directory/file set
+  into as a "module" should be emitted with the same four required fields this schema already
+  needs: `id`, `layer`, `dir`, `files`. If the inventory already knows a module's declared
+  public surface (e.g. an `index.cjs`/barrel file, or JSDoc-tagged exports), that becomes
+  `publicApi`; if it doesn't yet, the safe default is `publicApi: []` (everything private,
+  every cross-module reach flagged) rather than guessing.
+- **R01 current/target layers → `layerRules`.** The "Logical layers" table and dependency
+  rules in `04_MODULARITY_POLICY.md` are the source of truth; R01's classification of
+  existing/legacy files into a target layer should produce exactly the `layer` value each
+  module needs and the `layerRules.<layer>.allowedLayers` list.
+- **`04_MODULARITY_POLICY.md`'s "Initial size profiles" table → `sizeProfiles`.** Copy the
+  Warn/Hard maximum columns verbatim per row name (e.g. `"Domain/application JS or TS"`) once
+  a profile is meant to represent real, not synthetic, ceilings.
+- **`04_MODULARITY_POLICY.md`'s "Exceptions" section → `exceptions[]`.** Every field the
+  policy already requires per exception (exact path, rule/profile, ceiling, owner, tracking
+  issue, review/expiry date) maps 1:1 onto this schema's `exception` definition — nothing new
+  to invent there.
+- Once real `modules[]`/`layerRules`/`sizeProfiles` exist for a meaningful slice of the app,
+  wiring `scripts/nemo/boundaries.cjs` into `scripts/nemo/lib/jobs.cjs` as a named job (and
+  from there into `npm run check`/`verify`) is a small, mechanical follow-up — not part of
+  this packet, which is scoped to proving the checker itself works.
+
+## What's pending after this increment
+
+- No `package.json` script, no `scripts/nemo/lib/jobs.cjs` job registration (explicitly out of
+  scope for this packet).
+- No real, reviewed profile for any part of the actual `src/js` tree — only the illustrative
+  fixtures inside `boundaries.test.cjs`. Producing one is R01/R03's job, not this checker's;
+  fabricating a "reviewed" profile here would misrepresent unreviewed code as audited.
+- `layer-violation` was implemented alongside the five rules the R05 acceptance criteria name
+  (cycle, private-import, global-state, size, expired-exception) because it falls out of the
+  same module graph at near-zero extra cost, and the policy explicitly calls out forbidden
+  layer edges; it is exercised by one additional test but isn't a required category.

--- a/engineering/boundaries/profile.schema.json
+++ b/engineering/boundaries/profile.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "nemo.boundaries.profile/1",
+  "title": "Nemo boundaries profile (R05 first increment, candidate)",
+  "description": "Input shape for scripts/nemo/lib/boundaries.cjs#checkProfile. Describes a BOUNDED set of modules under review, not the whole application — see README.md for the integration contract with the future R01/R03 inventory, which is expected to generate this shape rather than have it hand-authored long-term.",
+  "type": "object",
+  "required": ["modules", "sizeProfiles"],
+  "additionalProperties": false,
+  "properties": {
+    "modules": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/module" }
+    },
+    "layerRules": {
+      "type": "object",
+      "description": "Keyed by layer name (engineering/remediation/04_MODULARITY_POLICY.md's 'Logical layers'). A layer with no entry is treated permissively (no layer-violation is ever raised for imports it makes) — declare every layer you want enforced.",
+      "additionalProperties": { "$ref": "#/definitions/layerRule" }
+    },
+    "sizeProfiles": {
+      "type": "object",
+      "description": "Keyed by the sizeProfile name modules reference. Real usage should copy the 'Initial size profiles' table from 04_MODULARITY_POLICY.md; tests may use smaller synthetic values.",
+      "additionalProperties": { "$ref": "#/definitions/sizeProfile" }
+    },
+    "exceptions": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/exception" }
+    }
+  },
+  "definitions": {
+    "module": {
+      "type": "object",
+      "required": ["id", "layer", "dir", "files", "publicApi", "sizeProfile"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string", "description": "Unique, stable module id, e.g. \"domain.track\". Used in violation reports and as the cycle-graph node." },
+        "layer": { "type": "string", "description": "One of the logical layers from 04_MODULARITY_POLICY.md (domain, application, features, ports, adapters, bootstrap, shared) or a project-specific extension." },
+        "dir": { "type": "string", "description": "Path to the module's directory, relative to the profile run's --root (normally the repo root)." },
+        "files": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Every file belonging to this module, relative to `dir`. Files not listed here are invisible to the checker even if they exist on disk (v1 does not walk the filesystem — see README limitations)."
+        },
+        "publicApi": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Subset of `files` other modules may import. Reaching any file in `files` that is not also in `publicApi` from outside the module is a private-import violation."
+        },
+        "sizeProfile": { "type": "string", "description": "Key into the top-level `sizeProfiles` map. Applied per-file, not summed across the module." }
+      }
+    },
+    "layerRule": {
+      "type": "object",
+      "required": ["allowedLayers"],
+      "additionalProperties": false,
+      "properties": {
+        "allowedLayers": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Layers this layer's modules may import from. \"*\" disables the check entirely for this layer (use for bootstrap, which composes everything)."
+        }
+      }
+    },
+    "sizeProfile": {
+      "type": "object",
+      "required": ["warn", "hardMax"],
+      "additionalProperties": false,
+      "properties": {
+        "warn": { "type": "integer", "minimum": 0 },
+        "hardMax": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "exception": {
+      "type": "object",
+      "required": ["path", "rule", "owner", "issue", "expires", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "path": { "type": "string", "description": "Repo/root-relative file path, exactly as `dir`/file join produces it (posix separators)." },
+        "rule": { "type": "string", "enum": ["size", "private-import", "layer-violation", "global-state", "cycle"] },
+        "ceiling": { "type": "integer", "description": "Only meaningful for rule \"size\": the raised hard maximum this exception grants. Exceeding the ceiling itself still fails." },
+        "owner": { "type": "string", "description": "Accountable human owner, per 04_MODULARITY_POLICY.md's Exceptions section." },
+        "issue": { "type": "string", "description": "Tracking issue number/id." },
+        "expires": { "type": "string", "format": "date", "description": "ISO date. On/after this date the exception stops shielding its rule and is itself reported as an expired-exception violation." },
+        "reason": { "type": "string" }
+      }
+    }
+  }
+}

--- a/engineering/boundaries/profile.schema.json
+++ b/engineering/boundaries/profile.schema.json
@@ -2,13 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "nemo.boundaries.profile/1",
   "title": "Nemo boundaries profile (R05 first increment, candidate)",
-  "description": "Input shape for scripts/nemo/lib/boundaries.cjs#checkProfile. Describes a BOUNDED set of modules under review, not the whole application — see README.md for the integration contract with the future R01/R03 inventory, which is expected to generate this shape rather than have it hand-authored long-term.",
+  "description": "Input shape for scripts/nemo/lib/boundaries.cjs#checkProfile. Describes a BOUNDED set of modules under review, not the whole application — see README.md for the integration contract with the future R01/R03 inventory, which is expected to generate this shape rather than have it hand-authored long-term. Runtime validation additionally checks unique module/file ownership, publicApi subsets, known size profiles, threshold order, real dates and declared exception paths.",
   "type": "object",
   "required": ["modules", "sizeProfiles"],
   "additionalProperties": false,
   "properties": {
     "modules": {
       "type": "array",
+      "minItems": 1,
       "items": { "$ref": "#/definitions/module" }
     },
     "layerRules": {
@@ -32,20 +33,23 @@
       "required": ["id", "layer", "dir", "files", "publicApi", "sizeProfile"],
       "additionalProperties": false,
       "properties": {
-        "id": { "type": "string", "description": "Unique, stable module id, e.g. \"domain.track\". Used in violation reports and as the cycle-graph node." },
-        "layer": { "type": "string", "description": "One of the logical layers from 04_MODULARITY_POLICY.md (domain, application, features, ports, adapters, bootstrap, shared) or a project-specific extension." },
-        "dir": { "type": "string", "description": "Path to the module's directory, relative to the profile run's --root (normally the repo root)." },
+        "id": { "type": "string", "minLength": 1, "pattern": "\\S", "description": "Unique, stable module id, e.g. \"domain.track\". Used in violation reports and as the cycle-graph node." },
+        "layer": { "type": "string", "minLength": 1, "pattern": "\\S", "description": "One of the logical layers from 04_MODULARITY_POLICY.md (domain, application, features, ports, adapters, bootstrap, shared) or a project-specific extension." },
+        "dir": { "type": "string", "minLength": 1, "pattern": "\\S", "description": "Path to the module's directory, relative to the profile run's --root (normally the repo root)." },
         "files": {
           "type": "array",
-          "items": { "type": "string" },
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1, "pattern": "\\S" },
           "description": "Every file belonging to this module, relative to `dir`. Files not listed here are invisible to the checker even if they exist on disk (v1 does not walk the filesystem — see README limitations)."
         },
         "publicApi": {
           "type": "array",
-          "items": { "type": "string" },
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1, "pattern": "\\S" },
           "description": "Subset of `files` other modules may import. Reaching any file in `files` that is not also in `publicApi` from outside the module is a private-import violation."
         },
-        "sizeProfile": { "type": "string", "description": "Key into the top-level `sizeProfiles` map. Applied per-file, not summed across the module." }
+        "sizeProfile": { "type": "string", "minLength": 1, "pattern": "\\S", "description": "Key into the top-level `sizeProfiles` map. Applied per-file, not summed across the module." }
       }
     },
     "layerRule": {
@@ -55,7 +59,8 @@
       "properties": {
         "allowedLayers": {
           "type": "array",
-          "items": { "type": "string" },
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1, "pattern": "\\S" },
           "description": "Layers this layer's modules may import from. \"*\" disables the check entirely for this layer (use for bootstrap, which composes everything)."
         }
       }
@@ -72,15 +77,16 @@
     "exception": {
       "type": "object",
       "required": ["path", "rule", "owner", "issue", "expires", "reason"],
+      "allOf": [{ "if": { "properties": { "rule": { "const": "size" } } }, "then": { "required": ["ceiling"] }, "else": { "not": { "required": ["ceiling"] } } }],
       "additionalProperties": false,
       "properties": {
-        "path": { "type": "string", "description": "Repo/root-relative file path, exactly as `dir`/file join produces it (posix separators)." },
+        "path": { "type": "string", "minLength": 1, "pattern": "\\S", "description": "Repo/root-relative file path, exactly as `dir`/file join produces it (posix separators). Must name a declared file; a cycle exception requires an edge originating in this exact file." },
         "rule": { "type": "string", "enum": ["size", "private-import", "layer-violation", "global-state", "cycle"] },
-        "ceiling": { "type": "integer", "description": "Only meaningful for rule \"size\": the raised hard maximum this exception grants. Exceeding the ceiling itself still fails." },
-        "owner": { "type": "string", "description": "Accountable human owner, per 04_MODULARITY_POLICY.md's Exceptions section." },
-        "issue": { "type": "string", "description": "Tracking issue number/id." },
-        "expires": { "type": "string", "format": "date", "description": "ISO date. On/after this date the exception stops shielding its rule and is itself reported as an expired-exception violation." },
-        "reason": { "type": "string" }
+        "ceiling": { "type": "integer", "minimum": 0, "description": "Only meaningful for rule \"size\": the raised hard maximum this exception grants. Exceeding the ceiling itself still fails." },
+        "owner": { "type": "string", "minLength": 1, "pattern": "\\S", "description": "Accountable human owner, per 04_MODULARITY_POLICY.md's Exceptions section." },
+        "issue": { "type": "string", "minLength": 1, "pattern": "\\S", "description": "Tracking issue number/id." },
+        "expires": { "type": "string", "format": "date", "pattern": "^\\d{4}-\\d{2}-\\d{2}$", "description": "ISO date. On/after this date the exception stops shielding its rule and is itself reported as an expired-exception violation." },
+        "reason": { "type": "string", "minLength": 1, "pattern": "\\S" }
       }
     }
   }

--- a/scripts/nemo/boundaries.cjs
+++ b/scripts/nemo/boundaries.cjs
@@ -21,14 +21,24 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--json') out.json = true;
-    else if (a === '--root') out.root = argv[++i];
+    else if (a === '--root') {
+      if (!argv[i + 1] || argv[i + 1].startsWith('--')) throw new Error('--root requires a directory');
+      out.root = argv[++i];
+    } else if (a.startsWith('-')) throw new Error(`unknown option: ${a}`);
     else if (!out.profilePath) out.profilePath = a;
+    else throw new Error(`unexpected argument: ${a}`);
   }
   return out;
 }
 
 function main() {
-  const args = parseArgs(process.argv.slice(2));
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(`bad usage: ${err.message}`);
+    process.exit(2);
+  }
   if (!args.profilePath) {
     console.error('usage: node scripts/nemo/boundaries.cjs <profile.json> [--root <dir>] [--json]');
     process.exit(2);

--- a/scripts/nemo/boundaries.cjs
+++ b/scripts/nemo/boundaries.cjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+'use strict';
+// Standalone CLI for the R05 module-profile/dependency rule checker
+// (scripts/nemo/lib/boundaries.cjs). Not wired into `npm run check`/`verify`
+// or scripts/nemo/lib/jobs.cjs yet — see engineering/boundaries/README.md for
+// why (R01/R03 need to land first) and the integration contract for when
+// they do.
+//
+// Usage:
+//   node scripts/nemo/boundaries.cjs <profile.json> [--root <dir>] [--json]
+//
+// Exit codes: 0 = no violations, 1 = one or more violations, 2 = bad usage or
+// a profile that could not be loaded/run (unknown sizeProfile, missing file).
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { checkProfile } = require('./lib/boundaries.cjs');
+
+function parseArgs(argv) {
+  const out = { profilePath: null, root: process.cwd(), json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') out.json = true;
+    else if (a === '--root') out.root = argv[++i];
+    else if (!out.profilePath) out.profilePath = a;
+  }
+  return out;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.profilePath) {
+    console.error('usage: node scripts/nemo/boundaries.cjs <profile.json> [--root <dir>] [--json]');
+    process.exit(2);
+  }
+
+  let profile;
+  try {
+    profile = JSON.parse(fs.readFileSync(path.resolve(args.profilePath), 'utf8'));
+  } catch (err) {
+    console.error(`could not read/parse profile "${args.profilePath}": ${err.message}`);
+    process.exit(2);
+  }
+
+  let report;
+  try {
+    report = checkProfile(profile, { root: path.resolve(args.root) });
+  } catch (err) {
+    console.error(`boundaries check could not run: ${err.message}`);
+    process.exit(2);
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(`boundaries: ${report.moduleCount} module(s), ${report.violations.length} violation(s), ${report.warnings.length} warning(s)`);
+    for (const v of report.violations) {
+      console.log(`  FAIL  ${v.rule.padEnd(18)} ${v.file || v.module}${v.line ? `:${v.line}` : ''} — ${v.message}`);
+    }
+    for (const w of report.warnings) {
+      console.log(`  WARN  ${w.rule.padEnd(18)} ${w.file || w.module}${w.line ? `:${w.line}` : ''} — ${w.message}`);
+    }
+  }
+  process.exit(report.ok ? 0 : 1);
+}
+
+main();

--- a/scripts/nemo/boundaries.test.cjs
+++ b/scripts/nemo/boundaries.test.cjs
@@ -326,6 +326,21 @@ test('cycle edges survive whitespace and export syntax; a cycle exception has ex
   assert.equal(report.ok, true); assert.equal(report.exceptionsApplied[0].rule, 'cycle');
 });
 
+test('a cycle exception removes only the matching source file contribution', () => {
+  const root = makeRoot(), p = fixtureProfile();
+  p.modules[0].files.push('a2.cjs'); p.modules[0].publicApi.push('a2.cjs');
+  p.modules.push({ ...p.modules[0], id: 'b', dir: 'other', files: ['b.cjs'], publicApi: ['b.cjs'] });
+  p.exceptions = [{ ...sizeException(), rule: 'cycle' }]; delete p.exceptions[0].ceiling;
+  write(root, 'domain/a.cjs', "require('../other/b.cjs');");
+  write(root, 'domain/a2.cjs', "require('../other/b.cjs');");
+  write(root, 'other/b.cjs', "require('../domain/a2.cjs');");
+
+  const report = checkProfile(p, { root });
+  assert.equal(report.ok, false);
+  assert.ok(report.violations.some((v) => v.rule === 'cycle'));
+  assert.deepEqual(report.exceptionsApplied.map((e) => e.path), ['domain/a.cjs']);
+});
+
 test('global access variants cannot bypass the domain rule', async (t) => {
   for (const source of ['window . SMProject.run();', "window['SMProject'].run();", 'window?.SMProject.run();', "window?.['SMProject'].run();", 'window[`SMProject`].run();']) await t.test(source, () => {
     const root = makeRoot(); write(root, 'domain/a.cjs', source);
@@ -343,6 +358,15 @@ test('comments, strings, template text and ordinary regex literals do not invent
     'const r = /window.SMProject/;',
   ].join('\n'));
   assert.equal(checkProfile(fixtureProfile(), { root }).ok, true);
+});
+
+test('object method declarations named require are clean while loader calls still fail', () => {
+  const root = makeRoot();
+  write(root, 'domain/a.cjs', 'const obj = { require(value) { return value; } };');
+  assert.equal(checkProfile(fixtureProfile(), { root }).ok, true);
+
+  write(root, 'domain/a.cjs', 'const obj = { require(value) { return value; } }; require(value);');
+  assert.equal(checkProfile(fixtureProfile(), { root }).violations[0].rule, 'unsupported-import');
 });
 
 test('nonliteral imports fail explicitly instead of silently leaving the graph', () => {

--- a/scripts/nemo/boundaries.test.cjs
+++ b/scripts/nemo/boundaries.test.cjs
@@ -10,10 +10,14 @@ const test = require('node:test');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { checkProfile, extractImports, countNonBlankLines } = require('./lib/boundaries.cjs');
+const { checkProfile, extractImports, countNonBlankLines, validateProfile } = require('./lib/boundaries.cjs');
 
+const roots = new Set();
+test.afterEach(() => { for (const root of roots) fs.rmSync(root, { recursive: true, force: true }); roots.clear(); });
 function makeRoot() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-boundaries-'));
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-boundaries-'));
+  roots.add(root);
+  return root;
 }
 
 function write(root, relPath, content) {
@@ -218,4 +222,156 @@ test('extractImports finds require/import/dynamic-import/export-from specifiers'
 test('countNonBlankLines ignores whitespace-only lines and a trailing newline', () => {
   assert.equal(countNonBlankLines('a\n\nb\n   \nc\n'), 3);
   assert.equal(countNonBlankLines('a\nb'), 2);
+});
+
+
+function fixtureProfile() {
+  return {
+    modules: [{ id: 'a', layer: 'domain', dir: 'domain', files: ['a.cjs'], publicApi: ['a.cjs'], sizeProfile: 'small' }],
+    sizeProfiles: SIZE_PROFILES,
+    layerRules: LAYER_RULES,
+  };
+}
+function sizeException() {
+  return { path: 'domain/a.cjs', rule: 'size', ceiling: 20, owner: 'test-owner', issue: '901', expires: '2999-01-01', reason: 'bounded fixture' };
+}
+
+test('invalid profiles fail before checking source or granting an exception', async (t) => {
+  const cases = {
+    'missing warn/hardMax': (p) => { p.sizeProfiles = { small: {} }; },
+    'nonfinite hardMax': (p) => { p.sizeProfiles = { small: { warn: 5, hardMax: Infinity } }; },
+    'inverted thresholds': (p) => { p.sizeProfiles = { small: { warn: 11, hardMax: 10 } }; },
+    'empty module list': (p) => { p.modules = []; },
+    'duplicate module id': (p) => { p.modules.push({ ...p.modules[0], dir: 'other' }); },
+    'overlapping file ownership': (p) => { p.modules.push({ ...p.modules[0], id: 'b' }); },
+    'unlisted public API': (p) => { p.modules[0].publicApi.push('hidden.cjs'); },
+    'escaped file path': (p) => { p.modules[0].files = ['../a.cjs']; },
+    'missing layer rule list': (p) => { p.layerRules = { domain: {} }; },
+    'missing size ceiling': (p) => { delete p.exceptions[0].ceiling; },
+    'nonfinite size ceiling': (p) => { p.exceptions[0].ceiling = NaN; },
+    'blank owner': (p) => { p.exceptions[0].owner = ' '; },
+    'missing issue': (p) => { delete p.exceptions[0].issue; },
+    'missing reason': (p) => { delete p.exceptions[0].reason; },
+    'invalid date': (p) => { p.exceptions[0].expires = 'not-a-date'; },
+    'impossible calendar date': (p) => { p.exceptions[0].expires = '2026-02-30'; },
+    'orphan exception': (p) => { p.exceptions[0].path = 'domain/other.cjs'; },
+    'duplicate exception': (p) => { p.exceptions.push({ ...p.exceptions[0] }); },
+    'unknown profile field': (p) => { p.ignoredPolicy = true; },
+  };
+  for (const [name, mutate] of Object.entries(cases)) await t.test(name, () => {
+    const p = structuredClone(fixtureProfile()); p.exceptions = [sizeException()]; mutate(p);
+    assert.throws(() => validateProfile(p), /invalid profile/);
+  });
+});
+
+test('valid size exception cannot hide growth beyond its finite ceiling', () => {
+  const root = makeRoot(), p = fixtureProfile();
+  p.exceptions = [sizeException()];
+  write(root, 'domain/a.cjs', Array.from({ length: 21 }, (_, i) => `const x${i} = ${i};`).join('\n'));
+  const report = checkProfile(p, { root });
+  assert.equal(report.ok, false);
+  assert.equal(report.violations[0].rule, 'size');
+  assert.equal(report.violations[0].detail.ceiling, 20);
+});
+
+test('exception expiry is checked for every supported rule, even without a current violation', async (t) => {
+  for (const rule of ['size', 'global-state', 'private-import', 'layer-violation', 'cycle']) await t.test(rule, () => {
+    const root = makeRoot(), p = fixtureProfile(), exception = { ...sizeException(), rule, expires: '2026-09-05' };
+    if (rule !== 'size') delete exception.ceiling;
+    p.exceptions = [exception]; write(root, 'domain/a.cjs', 'module.exports = 1;');
+    const report = checkProfile(p, { root, now: new Date('2026-09-05') });
+    assert.deepEqual(report.violations.map((v) => v.rule), ['expired-exception']);
+    assert.equal(report.exceptionsApplied.length, 0);
+  });
+});
+
+test('non-size exceptions apply only to their exact rule and file', () => {
+  const root = makeRoot(), p = fixtureProfile();
+  p.exceptions = [{ ...sizeException(), rule: 'global-state' }]; delete p.exceptions[0].ceiling;
+  p.modules[0].files.push('b.cjs');
+  write(root, 'domain/a.cjs', 'window . SMProject.getProjectKey();');
+  write(root, 'domain/b.cjs', "window['SMProject'].getProjectKey();");
+  const report = checkProfile(p, { root });
+  assert.equal(report.exceptionsApplied.length, 1);
+  assert.deepEqual(report.violations.map((v) => v.file), ['domain/b.cjs']);
+});
+
+test('legal JS spelling variants enforce the same private import and layer edge', async (t) => {
+  const variants = [
+    "require ('../adapter/private.cjs');", "require /* comment */ ('../adapter/private.cjs');", "require?.('../adapter/private.cjs');",
+    "const marker = '.'\nrequire('../adapter/private.cjs');",
+    "import ('../adapter/private.cjs');", "import/*comment*/('../adapter/private.cjs');",
+    "import{default as x}from '../adapter/private.cjs';", "export{default}from '../adapter/private.cjs';",
+    "import '../adapter/private.cjs';", "require(`../adapter/private.cjs`);",
+    "const s = `value ${require ('../adapter/private.cjs')}`;",
+    "import('../adapter/private.cjs', { with: { type: 'json' } });",
+  ];
+  for (const source of variants) await t.test(source, () => {
+    const root = makeRoot(), p = fixtureProfile();
+    p.modules.push({ id: 'b', layer: 'adapters', dir: 'adapter', files: ['private.cjs'], publicApi: [], sizeProfile: 'small' });
+    write(root, 'domain/a.cjs', source); write(root, 'adapter/private.cjs', 'module.exports = 1;');
+    const report = checkProfile(p, { root });
+    assert.deepEqual(report.violations.map((v) => v.rule), ['private-import', 'layer-violation']);
+  });
+});
+
+test('cycle edges survive whitespace and export syntax; a cycle exception has exact edge provenance', () => {
+  const root = makeRoot(), p = fixtureProfile();
+  p.modules.push({ ...p.modules[0], id: 'b', dir: 'other' });
+  write(root, 'domain/a.cjs', "require ('../other/a.cjs');");
+  write(root, 'other/a.cjs', "export{default}from '../domain/a.cjs';");
+  assert.ok(checkProfile(p, { root }).violations.some((v) => v.rule === 'cycle'));
+  p.exceptions = [{ ...sizeException(), rule: 'cycle' }]; delete p.exceptions[0].ceiling;
+  const report = checkProfile(p, { root });
+  assert.equal(report.ok, true); assert.equal(report.exceptionsApplied[0].rule, 'cycle');
+});
+
+test('global access variants cannot bypass the domain rule', async (t) => {
+  for (const source of ['window . SMProject.run();', "window['SMProject'].run();", 'window?.SMProject.run();', "window?.['SMProject'].run();", 'window[`SMProject`].run();']) await t.test(source, () => {
+    const root = makeRoot(); write(root, 'domain/a.cjs', source);
+    assert.equal(checkProfile(fixtureProfile(), { root }).violations[0].rule, 'global-state');
+  });
+});
+
+test('comments, strings, template text and ordinary regex literals do not invent dependencies/globals', () => {
+  const root = makeRoot();
+  write(root, 'domain/a.cjs', [
+    "// require('../other/a.cjs'); window.SMProject.run();",
+    "/* import '../other/a.cjs'; window.SMProject.run(); */",
+    'const s = "require(\'../other/a.cjs\'); window.SMProject.run();";',
+    "const t = `window.SMProject.run(); require('../other/a.cjs')`;",
+    'const r = /window.SMProject/;',
+  ].join('\n'));
+  assert.equal(checkProfile(fixtureProfile(), { root }).ok, true);
+});
+
+test('nonliteral imports fail explicitly instead of silently leaving the graph', () => {
+  for (const source of ["require('../other/' + name);", 'import(target);', 'import(`../other/${name}.cjs`);']) {
+    const root = makeRoot(); write(root, 'domain/a.cjs', source);
+    assert.equal(checkProfile(fixtureProfile(), { root }).violations[0].rule, 'unsupported-import');
+  }
+});
+
+test('CLI rejects malformed profiles and unknown/trailing/missing arguments with exit 2', () => {
+  const { spawnSync } = require('node:child_process');
+  const root = makeRoot(), profilePath = path.join(root, 'profile.json');
+  write(root, 'domain/a.cjs', 'module.exports = 1;'); fs.writeFileSync(profilePath, JSON.stringify(fixtureProfile()));
+  const cli = path.join(__dirname, 'boundaries.cjs');
+  const run = (extra) => spawnSync(process.execPath, [cli, profilePath, '--root', root, '--json', ...extra], { encoding: 'utf8' });
+  assert.equal(run([]).status, 0);
+  for (const args of [['--unknown'], ['extra.json'], ['--root'], ['--root', '--json']]) assert.equal(run(args).status, 2);
+  const invalid = fixtureProfile(); invalid.sizeProfiles = { small: {} };
+  fs.writeFileSync(profilePath, JSON.stringify(invalid));
+  assert.equal(run([]).status, 2);
+});
+
+
+test('ambiguous lexical forms fail closed and computed globals are explicit', () => {
+  const root = makeRoot(), p = fixtureProfile();
+  write(root, 'domain/a.cjs', 'if (ok) /pattern/.test(value);');
+  assert.throws(() => checkProfile(p, { root }), /ambiguous slash/);
+  write(root, 'domain/a.cjs', 'window[member].run();');
+  assert.equal(checkProfile(p, { root }).violations[0].rule, 'unsupported-global');
+  write(root, 'domain/a.cjs', "require('\\056/hidden.cjs');");
+  assert.throws(() => checkProfile(p, { root }), /numeric string escapes/);
 });

--- a/scripts/nemo/boundaries.test.cjs
+++ b/scripts/nemo/boundaries.test.cjs
@@ -1,0 +1,221 @@
+// Behavioral tests for scripts/nemo/lib/boundaries.cjs (R05 first increment).
+// Each violation category gets a deliberately broken fixture (proving the
+// checker rejects it) and there is one fixture per category that is valid
+// (proving the checker does not cry wolf on a clean module). Fixtures are
+// written to a throwaway temp dir per test — real files on disk, not mocks,
+// so `resolveSpecifier`'s fs.statSync calls exercise the same path a real
+// profile run would.
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { checkProfile, extractImports, countNonBlankLines } = require('./lib/boundaries.cjs');
+
+function makeRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-boundaries-'));
+}
+
+function write(root, relPath, content) {
+  const abs = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+
+const SIZE_PROFILES = { small: { warn: 5, hardMax: 10 } };
+const LAYER_RULES = {
+  domain: { allowedLayers: ['domain', 'shared'] },
+  application: { allowedLayers: ['domain', 'application', 'shared'] },
+};
+
+test('a clean two-module profile passes with no violations', () => {
+  const root = makeRoot();
+  write(root, 'domain/track/index.cjs', "module.exports = { evaluate: () => 1 };\n");
+  write(root, 'application/use-case.cjs', "const track = require('../domain/track/index.cjs');\nmodule.exports = () => track.evaluate();\n");
+
+  const profile = {
+    modules: [
+      { id: 'domain.track', layer: 'domain', dir: 'domain/track', files: ['index.cjs'], publicApi: ['index.cjs'], sizeProfile: 'small' },
+      { id: 'application.useCase', layer: 'application', dir: 'application', files: ['use-case.cjs'], publicApi: ['use-case.cjs'], sizeProfile: 'small' },
+    ],
+    layerRules: LAYER_RULES,
+    sizeProfiles: SIZE_PROFILES,
+  };
+
+  const report = checkProfile(profile, { root });
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.violations, []);
+});
+
+test('an import cycle between two modules is rejected', () => {
+  const root = makeRoot();
+  write(root, 'domain/a/index.cjs', "const b = require('../b/index.cjs');\nmodule.exports = { b };\n");
+  write(root, 'domain/b/index.cjs', "const a = require('../a/index.cjs');\nmodule.exports = { a };\n");
+
+  const profile = {
+    modules: [
+      { id: 'domain.a', layer: 'domain', dir: 'domain/a', files: ['index.cjs'], publicApi: ['index.cjs'], sizeProfile: 'small' },
+      { id: 'domain.b', layer: 'domain', dir: 'domain/b', files: ['index.cjs'], publicApi: ['index.cjs'], sizeProfile: 'small' },
+    ],
+    layerRules: LAYER_RULES,
+    sizeProfiles: SIZE_PROFILES,
+  };
+
+  const report = checkProfile(profile, { root });
+  assert.equal(report.ok, false);
+  const cycle = report.violations.find((v) => v.rule === 'cycle');
+  assert.ok(cycle, 'expected a cycle violation');
+  assert.ok(cycle.detail.path.includes('domain.a') && cycle.detail.path.includes('domain.b'));
+});
+
+test('reaching a non-public file of another module is a private-import violation', () => {
+  const root = makeRoot();
+  write(root, 'domain/track/index.cjs', "module.exports = { evaluate: () => 1 };\n");
+  write(root, 'domain/track/internal.cjs', "module.exports = { secret: () => 2 };\n");
+  write(root, 'application/use-case.cjs', "const internal = require('../domain/track/internal.cjs');\nmodule.exports = () => internal.secret();\n");
+
+  const profile = {
+    modules: [
+      { id: 'domain.track', layer: 'domain', dir: 'domain/track', files: ['index.cjs', 'internal.cjs'], publicApi: ['index.cjs'], sizeProfile: 'small' },
+      { id: 'application.useCase', layer: 'application', dir: 'application', files: ['use-case.cjs'], publicApi: ['use-case.cjs'], sizeProfile: 'small' },
+    ],
+    layerRules: LAYER_RULES,
+    sizeProfiles: SIZE_PROFILES,
+  };
+
+  const report = checkProfile(profile, { root });
+  assert.equal(report.ok, false);
+  const v = report.violations.find((x) => x.rule === 'private-import');
+  assert.ok(v, 'expected a private-import violation');
+  assert.equal(v.detail.targetModule, 'domain.track');
+  assert.equal(v.detail.targetFile, 'domain/track/internal.cjs');
+});
+
+test('an import that crosses into a disallowed layer is a layer-violation', () => {
+  const root = makeRoot();
+  write(root, 'adapters/paper-adapter.cjs', "module.exports = { draw: () => {} };\n");
+  write(root, 'domain/track/index.cjs', "const adapter = require('../../adapters/paper-adapter.cjs');\nmodule.exports = { adapter };\n");
+
+  const profile = {
+    modules: [
+      { id: 'domain.track', layer: 'domain', dir: 'domain/track', files: ['index.cjs'], publicApi: ['index.cjs'], sizeProfile: 'small' },
+      { id: 'adapters.paper', layer: 'adapters', dir: 'adapters', files: ['paper-adapter.cjs'], publicApi: ['paper-adapter.cjs'], sizeProfile: 'small' },
+    ],
+    layerRules: LAYER_RULES, // domain may only depend on domain/shared
+    sizeProfiles: SIZE_PROFILES,
+  };
+
+  const report = checkProfile(profile, { root });
+  assert.equal(report.ok, false);
+  const v = report.violations.find((x) => x.rule === 'layer-violation');
+  assert.ok(v, 'expected a layer-violation');
+  assert.equal(v.detail.fromLayer, 'domain');
+  assert.equal(v.detail.toLayer, 'adapters');
+});
+
+test('window.SM* access outside adapters/bootstrap is a global-state violation', () => {
+  const root = makeRoot();
+  write(root, 'application/use-case.cjs', "function run() {\n  return window.SMProject.getProjectKey();\n}\nmodule.exports = { run };\n");
+
+  const profile = {
+    modules: [
+      { id: 'application.useCase', layer: 'application', dir: 'application', files: ['use-case.cjs'], publicApi: ['use-case.cjs'], sizeProfile: 'small' },
+    ],
+    layerRules: LAYER_RULES,
+    sizeProfiles: SIZE_PROFILES,
+  };
+
+  const report = checkProfile(profile, { root });
+  assert.equal(report.ok, false);
+  const v = report.violations.find((x) => x.rule === 'global-state');
+  assert.ok(v, 'expected a global-state violation');
+  assert.equal(v.detail.global, 'window.SMProject');
+});
+
+test('window.SM* access from an adapters module is allowed', () => {
+  const root = makeRoot();
+  write(root, 'adapters/bridge.cjs', "function sync() {\n  return window.SMProject.getProjectKey();\n}\nmodule.exports = { sync };\n");
+
+  const profile = {
+    modules: [
+      { id: 'adapters.bridge', layer: 'adapters', dir: 'adapters', files: ['bridge.cjs'], publicApi: ['bridge.cjs'], sizeProfile: 'small' },
+    ],
+    layerRules: LAYER_RULES,
+    sizeProfiles: SIZE_PROFILES,
+  };
+
+  const report = checkProfile(profile, { root });
+  assert.equal(report.ok, true);
+});
+
+test('a file over its size profile hard maximum fails, at/under it passes', () => {
+  const root = makeRoot();
+  const longBody = Array.from({ length: 11 }, (_, i) => `const x${i} = ${i};`).join('\n');
+  write(root, 'domain/big.cjs', `${longBody}\nmodule.exports = {};\n`);
+  write(root, 'domain/ok.cjs', "const a = 1;\nconst b = 2;\nmodule.exports = { a, b };\n");
+
+  const profile = {
+    modules: [
+      { id: 'domain.big', layer: 'domain', dir: 'domain', files: ['big.cjs'], publicApi: ['big.cjs'], sizeProfile: 'small' },
+    ],
+    layerRules: LAYER_RULES,
+    sizeProfiles: SIZE_PROFILES,
+  };
+  const bigReport = checkProfile(profile, { root });
+  assert.equal(bigReport.ok, false);
+  const sizeViolation = bigReport.violations.find((v) => v.rule === 'size');
+  assert.ok(sizeViolation);
+  assert.equal(sizeViolation.detail.hardMax, 10);
+
+  const okProfile = {
+    modules: [{ id: 'domain.ok', layer: 'domain', dir: 'domain', files: ['ok.cjs'], publicApi: ['ok.cjs'], sizeProfile: 'small' }],
+    layerRules: LAYER_RULES,
+    sizeProfiles: SIZE_PROFILES,
+  };
+  const okReport = checkProfile(okProfile, { root });
+  assert.equal(okReport.ok, true);
+});
+
+test('a non-expired exception raises the ceiling; an expired one no longer shields and is itself reported', () => {
+  const root = makeRoot();
+  const longBody = Array.from({ length: 11 }, (_, i) => `const x${i} = ${i};`).join('\n');
+  write(root, 'domain/big.cjs', `${longBody}\nmodule.exports = {};\n`);
+
+  const baseModules = [{ id: 'domain.big', layer: 'domain', dir: 'domain', files: ['big.cjs'], publicApi: ['big.cjs'], sizeProfile: 'small' }];
+
+  const shielded = checkProfile({
+    modules: baseModules,
+    layerRules: LAYER_RULES,
+    sizeProfiles: SIZE_PROFILES,
+    exceptions: [{ path: 'domain/big.cjs', rule: 'size', ceiling: 20, owner: 'test-owner', issue: '901', expires: '2999-01-01', reason: 'fixture' }],
+  }, { root, now: new Date('2026-01-01') });
+  assert.equal(shielded.ok, true);
+  assert.equal(shielded.exceptionsApplied.length, 1);
+
+  const expired = checkProfile({
+    modules: baseModules,
+    layerRules: LAYER_RULES,
+    sizeProfiles: SIZE_PROFILES,
+    exceptions: [{ path: 'domain/big.cjs', rule: 'size', ceiling: 20, owner: 'test-owner', issue: '901', expires: '2020-01-01', reason: 'fixture' }],
+  }, { root, now: new Date('2026-01-01') });
+  assert.equal(expired.ok, false);
+  assert.ok(expired.violations.find((v) => v.rule === 'expired-exception'));
+  assert.ok(expired.violations.find((v) => v.rule === 'size'), 'size should fail again once its exception expired');
+});
+
+test('extractImports finds require/import/dynamic-import/export-from specifiers', () => {
+  const source = [
+    "const a = require('./a.cjs');",
+    "import b from './b.js';",
+    "import './c.js';",
+    "export { x } from './d.js';",
+    "async function f() { const e = await import('./e.js'); }",
+  ].join('\n');
+  const specs = extractImports(source).map((i) => i.specifier).sort();
+  assert.deepEqual(specs, ['./a.cjs', './b.js', './c.js', './d.js', './e.js']);
+});
+
+test('countNonBlankLines ignores whitespace-only lines and a trailing newline', () => {
+  assert.equal(countNonBlankLines('a\n\nb\n   \nc\n'), 3);
+  assert.equal(countNonBlankLines('a\nb'), 2);
+});

--- a/scripts/nemo/lib/boundaries.cjs
+++ b/scripts/nemo/lib/boundaries.cjs
@@ -197,6 +197,18 @@ function tokenize(source) {
 function analyzeSource(source) {
   const tokens = tokenize(source), imports = [], globals = [], unsupported = [];
   const property = (i) => tokens[i - 1]?.type === 'punct' && ['.', '?.'].includes(tokens[i - 1].value);
+  const methodDeclaration = (i, openIndex) => {
+    if (tokens[i - 1]?.value !== '{' && tokens[i - 1]?.value !== ',') return false;
+    let depth = 0;
+    for (let j = openIndex; j < tokens.length; j++) {
+      if (tokens[j].value === '(') depth++;
+      else if (tokens[j].value === ')' && --depth === 0) {
+        // A newline could instead terminate a real call before a standalone block.
+        return tokens[j + 1]?.value === '{' && tokens[j + 1].line === tokens[j].line;
+      }
+    }
+    return false;
+  };
   const recordImport = (token, sourceToken) => {
     if (token?.type === 'string') imports.push({ specifier: token.value, line: sourceToken.line });
     else unsupported.push({ line: sourceToken.line, message: 'Import/require target must be a literal string; declare or rewrite dynamic loading before checking this profile' });
@@ -206,6 +218,7 @@ function analyzeSource(source) {
     if (token.type !== 'name' || property(i)) continue;
     const callOffset = token.value === 'require' && next?.value === '?.' ? 2 : 1;
     if ((token.value === 'require' || token.value === 'import') && tokens[i + callOffset]?.value === '(') {
+      if (token.value === 'require' && callOffset === 1 && methodDeclaration(i, i + callOffset)) continue;
       const target = tokens[i + callOffset + 1], tail = tokens[i + callOffset + 2]?.value;
       recordImport([')', ','].includes(tail) ? target : null, token);
     } else if (token.value === 'import' && next?.type === 'string') recordImport(next, token);
@@ -422,10 +435,22 @@ function checkProfile(profile, opts = {}) {
   }
 
   // --- cycle ---
+  // A cycle exception removes only dependency contributions originating in its
+  // exact file. Keep a module edge when any unexcepted file still contributes it.
+  const cycleEdges = new Map(profile.modules.map((m) => [m.id, new Set()]));
+  for (const [edgeKey, contributors] of edgeFiles) {
+    const [from, to] = JSON.parse(edgeKey);
+    if ([...contributors].some((file) => !activeExceptions.has(`${file}:cycle`))) cycleEdges.get(from).add(to);
+  }
   for (const cyclePath of findCycles(edges)) {
-    const cycleFiles = cyclePath.slice(0, -1).flatMap((id, i) => [...edgeFiles.get(JSON.stringify([id, cyclePath[i + 1]]))]);
-    const exception = cycleFiles.map((file) => activeExceptions.get(`${file}:cycle`)).find(Boolean);
-    if (exception) { applyException(exception, { cycle: cyclePath }); continue; }
+    cyclePath.slice(0, -1).forEach((id, i) => {
+      for (const file of edgeFiles.get(JSON.stringify([id, cyclePath[i + 1]])) || []) {
+        const exception = activeExceptions.get(`${file}:cycle`);
+        if (exception) applyException(exception, { cycle: cyclePath });
+      }
+    });
+  }
+  for (const cyclePath of findCycles(cycleEdges)) {
     violations.push({
       rule: 'cycle', module: cyclePath[0], file: null, line: null,
       message: `Import cycle: ${cyclePath.join(' -> ')}`,

--- a/scripts/nemo/lib/boundaries.cjs
+++ b/scripts/nemo/lib/boundaries.cjs
@@ -1,0 +1,273 @@
+'use strict';
+// Self-contained module-profile / dependency rule checker — R05 first increment
+// (engineering/remediation/04_MODULARITY_POLICY.md).
+//
+// This checks a hand- or tool-authored *profile* (a bounded list of modules the
+// caller is reviewing), not the whole application. It has no dependency on the
+// R01 current/target inventory or the R03 `scripts/nemo/inventory.cjs` scan —
+// see engineering/boundaries/README.md for the exact contract those work
+// packages should satisfy so their output can be handed to `checkProfile`
+// directly instead of a hand-authored profile.
+//
+// Rules implemented:
+//   cycle             — an import cycle between two or more declared modules.
+//   private-import    — a module reached through a file its owning module does
+//                        not list in `publicApi` (a deep/back-door import).
+//   layer-violation   — an import that crosses into a layer the importer's
+//                        layer is not allowed to depend on (`layerRules`).
+//   global-state      — `window.SM*` access from a layer other than
+//                        `adapters`/`bootstrap` (the legacy global bypass the
+//                        policy calls out).
+//   size              — nonblank physical line count over the module's
+//                        `sizeProfile` hard maximum, honoring a non-expired
+//                        exception's raised ceiling.
+//   expired-exception — an exception entry whose `expires` date is on/before
+//                        the check's `now`; it stops shielding its rule and is
+//                        itself reported as a violation.
+//
+// Known limitations (v1, intentionally not solved here): import extraction is
+// regex-based (no real parser), so a specifier inside a comment or string
+// literal that happens to look like `require('x')` would be misread; bare
+// (non-relative) specifiers are treated as external and never checked. Both
+// are acceptable for a bounded, hand-authored profile and are expected to be
+// superseded once R01/R03 supply a real parsed inventory.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const GLOBAL_SM_RE = /\bwindow\.(SM[A-Za-z0-9_]*)\b/g;
+
+// require('x') / require("x")
+const REQUIRE_RE = /require\(\s*(['"])([^'"]+)\1\s*\)/g;
+// import ... from 'x' (also matches multi-line named imports)
+const IMPORT_FROM_RE = /\bimport\s+[^'";]*?\sfrom\s+(['"])([^'"]+)\1/g;
+// import 'x' (side-effect only)
+const IMPORT_BARE_RE = /\bimport\s+(['"])([^'"]+)\1/g;
+// export ... from 'x'
+const EXPORT_FROM_RE = /\bexport\s+[^'";]*?\sfrom\s+(['"])([^'"]+)\1/g;
+// dynamic import('x')
+const DYNAMIC_IMPORT_RE = /\bimport\(\s*(['"])([^'"]+)\1\s*\)/g;
+
+function lineAt(text, index) {
+  let line = 1;
+  for (let i = 0; i < index && i < text.length; i++) if (text.charCodeAt(i) === 10) line++;
+  return line;
+}
+
+/** Extract `{ specifier, line }` for every static/dynamic import-like reference. */
+function extractImports(source) {
+  const out = [];
+  for (const re of [REQUIRE_RE, IMPORT_FROM_RE, IMPORT_BARE_RE, EXPORT_FROM_RE, DYNAMIC_IMPORT_RE]) {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(source))) out.push({ specifier: m[2], line: lineAt(source, m.index) });
+  }
+  return out;
+}
+
+function countNonBlankLines(source) {
+  const lines = source.split(/\r?\n/);
+  if (lines.length && lines[lines.length - 1] === '') lines.pop();
+  return lines.filter((l) => l.trim().length > 0).length;
+}
+
+function toPosix(p) {
+  return p.split(path.sep).join('/');
+}
+
+/** Resolve a relative specifier against the file that imported it. Returns an
+ * absolute path that exists on disk, or null (external, or not found). */
+function resolveSpecifier(specifier, fromFile) {
+  if (!specifier.startsWith('.') && !specifier.startsWith('/')) return null;
+  const base = path.resolve(path.dirname(fromFile), specifier);
+  const candidates = [
+    base,
+    `${base}.cjs`, `${base}.js`, `${base}.mjs`,
+    path.join(base, 'index.cjs'), path.join(base, 'index.js'), path.join(base, 'index.mjs'),
+  ];
+  for (const c of candidates) {
+    try {
+      if (fs.statSync(c).isFile()) return c;
+    } catch { /* try next candidate */ }
+  }
+  return null;
+}
+
+/** Build absPath -> { module, relFile, isPublic } for every file every module declares. */
+function buildFileIndex(profile, root) {
+  const index = new Map();
+  for (const m of profile.modules) {
+    for (const f of m.files) {
+      const abs = path.resolve(root, m.dir, f);
+      index.set(abs, { module: m, relFile: toPosix(path.join(m.dir, f)), isPublic: (m.publicApi || []).includes(f) });
+    }
+  }
+  return index;
+}
+
+function findException(profile, relPath, rule) {
+  return (profile.exceptions || []).find((e) => e.path === relPath && e.rule === rule);
+}
+
+/** Directed-graph cycle detection (DFS with a recursion stack). Returns one
+ * reported cycle (list of module ids, first repeated at the end) per back-edge
+ * found; the same simple cycle is not reported twice. */
+function findCycles(edges) {
+  const state = new Map(); // undefined=unvisited, 1=visiting, 2=done
+  const stack = [];
+  const cycles = [];
+  function dfs(node) {
+    state.set(node, 1);
+    stack.push(node);
+    for (const next of edges.get(node) || []) {
+      if (state.get(next) === 1) {
+        const idx = stack.indexOf(next);
+        cycles.push(stack.slice(idx).concat(next));
+      } else if (!state.get(next)) {
+        dfs(next);
+      }
+    }
+    stack.pop();
+    state.set(node, 2);
+  }
+  for (const node of edges.keys()) if (!state.get(node)) dfs(node);
+  return cycles;
+}
+
+/**
+ * Run every rule over `profile` and return a report.
+ * @param {object} profile - see engineering/boundaries/profile.schema.json
+ * @param {object} [opts]
+ * @param {string} [opts.root] - base dir module `dir`s are relative to (default cwd)
+ * @param {Date}   [opts.now]  - clock used for exception expiry (default: real now)
+ */
+function checkProfile(profile, opts = {}) {
+  const root = opts.root || process.cwd();
+  const now = opts.now || new Date();
+  const fileIndex = buildFileIndex(profile, root);
+  const violations = [];
+  const warnings = [];
+  const exceptionsApplied = [];
+  const edges = new Map(profile.modules.map((m) => [m.id, new Set()]));
+
+  for (const m of profile.modules) {
+    for (const f of m.files) {
+      const abs = path.resolve(root, m.dir, f);
+      const relPath = toPosix(path.join(m.dir, f));
+      const source = fs.readFileSync(abs, 'utf8');
+
+      // --- size ---
+      const lines = countNonBlankLines(source);
+      const sizeProfile = profile.sizeProfiles && profile.sizeProfiles[m.sizeProfile];
+      if (!sizeProfile) {
+        throw new Error(`checkProfile: module "${m.id}" declares unknown sizeProfile "${m.sizeProfile}"`);
+      }
+      const exception = findException(profile, relPath, 'size');
+      let shielded = false;
+      if (exception) {
+        const expired = new Date(exception.expires) <= now;
+        if (expired) {
+          violations.push({
+            rule: 'expired-exception', module: m.id, file: relPath, line: null,
+            message: `Exception for "size" on ${relPath} expired ${exception.expires} and no longer applies`,
+            detail: { exception },
+          });
+        } else {
+          exceptionsApplied.push({ ...exception, actualLines: lines });
+          shielded = true;
+          if (lines > exception.ceiling) {
+            violations.push({
+              rule: 'size', module: m.id, file: relPath, line: null,
+              message: `${lines} nonblank lines exceeds excepted ceiling ${exception.ceiling}`,
+              detail: { lines, ceiling: exception.ceiling, exception: true },
+            });
+          }
+        }
+      }
+      if (!shielded) {
+        if (lines > sizeProfile.hardMax) {
+          violations.push({
+            rule: 'size', module: m.id, file: relPath, line: null,
+            message: `${lines} nonblank lines exceeds hard maximum ${sizeProfile.hardMax} for profile "${m.sizeProfile}"`,
+            detail: { lines, hardMax: sizeProfile.hardMax },
+          });
+        } else if (lines > sizeProfile.warn) {
+          warnings.push({
+            rule: 'size', module: m.id, file: relPath, line: null,
+            message: `${lines} nonblank lines exceeds warn threshold ${sizeProfile.warn} for profile "${m.sizeProfile}"`,
+            detail: { lines, warn: sizeProfile.warn },
+          });
+        }
+      }
+
+      // --- global-state ---
+      if (m.layer !== 'adapters' && m.layer !== 'bootstrap') {
+        GLOBAL_SM_RE.lastIndex = 0;
+        const seen = new Set();
+        let gm;
+        while ((gm = GLOBAL_SM_RE.exec(source))) {
+          if (seen.has(gm[1])) continue;
+          seen.add(gm[1]);
+          violations.push({
+            rule: 'global-state', module: m.id, file: relPath, line: lineAt(source, gm.index),
+            message: `Implicit global "window.${gm[1]}" accessed from layer "${m.layer}" (only adapters/bootstrap may)`,
+            detail: { global: `window.${gm[1]}` },
+          });
+        }
+      }
+
+      // --- imports: private-import, layer-violation, cycle edges ---
+      for (const { specifier, line } of extractImports(source)) {
+        const abs2 = resolveSpecifier(specifier, abs);
+        if (!abs2) continue; // external or unresolved: not modeled in v1
+        const target = fileIndex.get(abs2);
+        if (!target || target.module.id === m.id) continue; // outside profile, or intra-module
+        edges.get(m.id).add(target.module.id);
+
+        if (!target.isPublic) {
+          violations.push({
+            rule: 'private-import', module: m.id, file: relPath, line,
+            message: `${relPath} imports "${specifier}" (${target.relFile}), which module "${target.module.id}" does not list in publicApi`,
+            detail: { specifier, targetModule: target.module.id, targetFile: target.relFile },
+          });
+        }
+
+        const rule = profile.layerRules && profile.layerRules[m.layer];
+        if (rule && Array.isArray(rule.allowedLayers) && !rule.allowedLayers.includes('*')) {
+          if (!rule.allowedLayers.includes(target.module.layer)) {
+            violations.push({
+              rule: 'layer-violation', module: m.id, file: relPath, line,
+              message: `Layer "${m.layer}" (module "${m.id}") may not depend on layer "${target.module.layer}" (module "${target.module.id}")`,
+              detail: { fromLayer: m.layer, toLayer: target.module.layer, targetModule: target.module.id },
+            });
+          }
+        }
+      }
+    }
+  }
+
+  // --- cycle ---
+  for (const cyclePath of findCycles(edges)) {
+    violations.push({
+      rule: 'cycle', module: cyclePath[0], file: null, line: null,
+      message: `Import cycle: ${cyclePath.join(' -> ')}`,
+      detail: { path: cyclePath },
+    });
+  }
+
+  return {
+    ok: violations.length === 0,
+    moduleCount: profile.modules.length,
+    violations,
+    warnings,
+    exceptionsApplied,
+  };
+}
+
+module.exports = {
+  checkProfile,
+  extractImports,
+  countNonBlankLines,
+  resolveSpecifier,
+  findCycles,
+};

--- a/scripts/nemo/lib/boundaries.cjs
+++ b/scripts/nemo/lib/boundaries.cjs
@@ -25,44 +25,211 @@
 //                        the check's `now`; it stops shielding its rule and is
 //                        itself reported as a violation.
 //
-// Known limitations (v1, intentionally not solved here): import extraction is
-// regex-based (no real parser), so a specifier inside a comment or string
-// literal that happens to look like `require('x')` would be misread; bare
-// (non-relative) specifiers are treated as external and never checked. Both
-// are acceptable for a bounded, hand-authored profile and are expected to be
-// superseded once R01/R03 supply a real parsed inventory.
+// This bounded checker uses a lexical scanner, not a full JavaScript AST or
+// binding resolver. Unsupported dynamic loads fail explicitly; bare specifiers
+// and undeclared files remain outside the profile. See the README before adoption.
 
 const fs = require('node:fs');
 const path = require('node:path');
 
-const GLOBAL_SM_RE = /\bwindow\.(SM[A-Za-z0-9_]*)\b/g;
+const EXCEPTION_RULES = ['size', 'private-import', 'layer-violation', 'global-state', 'cycle'];
 
-// require('x') / require("x")
-const REQUIRE_RE = /require\(\s*(['"])([^'"]+)\1\s*\)/g;
-// import ... from 'x' (also matches multi-line named imports)
-const IMPORT_FROM_RE = /\bimport\s+[^'";]*?\sfrom\s+(['"])([^'"]+)\1/g;
-// import 'x' (side-effect only)
-const IMPORT_BARE_RE = /\bimport\s+(['"])([^'"]+)\1/g;
-// export ... from 'x'
-const EXPORT_FROM_RE = /\bexport\s+[^'";]*?\sfrom\s+(['"])([^'"]+)\1/g;
-// dynamic import('x')
-const DYNAMIC_IMPORT_RE = /\bimport\(\s*(['"])([^'"]+)\1\s*\)/g;
-
-function lineAt(text, index) {
-  let line = 1;
-  for (let i = 0; i < index && i < text.length; i++) if (text.charCodeAt(i) === 10) line++;
-  return line;
+/** Reject malformed policy before looking at source; comparisons must never see NaN/undefined. */
+function validateProfile(profile) {
+  const fail = (message) => { throw new Error(`invalid profile: ${message}`); };
+  const object = (value, keys, label) => {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) fail(`${label} must be an object`);
+    for (const key of Object.keys(value)) if (!keys.includes(key)) fail(`${label}: unknown field ${key}`);
+  };
+  const text = (value, label) => { if (typeof value !== 'string' || !value.trim()) fail(`${label} must be a nonempty string`); };
+  const list = (value, label) => {
+    if (!Array.isArray(value)) fail(`${label} must be an array`);
+    for (const item of value) text(item, label);
+    if (new Set(value).size !== value.length) fail(`${label} contains duplicates`);
+  };
+  const relative = (value, label, allowDot = false) => {
+    text(value, label);
+    if (allowDot && value === '.') return;
+    if (value.includes('\\') || path.posix.isAbsolute(value) || value.split('/').some((x) => !x || x === '.' || x === '..')) fail(`${label} must be a normalized relative path`);
+  };
+  const integer = (value, label) => { if (!Number.isSafeInteger(value) || value < 0) fail(`${label} must be a finite nonnegative integer`); };
+  object(profile, ['modules', 'sizeProfiles', 'layerRules', 'exceptions'], 'profile');
+  if (!Array.isArray(profile.modules) || !profile.modules.length) fail('modules must be a nonempty array');
+  if (!profile.sizeProfiles || typeof profile.sizeProfiles !== 'object' || Array.isArray(profile.sizeProfiles)) fail('sizeProfiles must be an object');
+  for (const [name, limits] of Object.entries(profile.sizeProfiles)) {
+    text(name, 'sizeProfile name');
+    object(limits, ['warn', 'hardMax'], `sizeProfiles.${name}`);
+    integer(limits.warn, `${name}.warn`); integer(limits.hardMax, `${name}.hardMax`);
+    if (limits.warn > limits.hardMax) fail(`${name}.warn exceeds hardMax`);
+  }
+  const ids = new Set(), files = new Map();
+  for (const m of profile.modules) {
+    object(m, ['id', 'layer', 'dir', 'files', 'publicApi', 'sizeProfile'], 'module');
+    text(m.id, 'module.id'); text(m.layer, 'module.layer'); text(m.sizeProfile, 'module.sizeProfile');
+    if (ids.has(m.id)) fail(`duplicate module id ${m.id}`);
+    ids.add(m.id);
+    relative(m.dir, `${m.id}.dir`, true);
+    list(m.files, `${m.id}.files`); list(m.publicApi, `${m.id}.publicApi`);
+    if (!m.files.length) fail(`${m.id}.files must not be empty`);
+    if (!Object.hasOwn(profile.sizeProfiles, m.sizeProfile)) fail(`unknown sizeProfile ${m.sizeProfile}`);
+    for (const f of m.files) {
+      relative(f, `${m.id}.files`);
+      const rel = path.posix.join(m.dir, f);
+      if (files.has(rel)) fail(`file ${rel} belongs to multiple modules`);
+      files.set(rel, m);
+    }
+    for (const f of m.publicApi) if (!m.files.includes(f)) fail(`${m.id}.publicApi contains unlisted file ${f}`);
+  }
+  if (profile.layerRules !== undefined) {
+    if (!profile.layerRules || typeof profile.layerRules !== 'object' || Array.isArray(profile.layerRules)) fail('layerRules must be an object');
+    for (const [name, rule] of Object.entries(profile.layerRules)) {
+      text(name, 'layer name'); object(rule, ['allowedLayers'], `layerRules.${name}`);
+      list(rule.allowedLayers, `${name}.allowedLayers`);
+    }
+  }
+  if (profile.exceptions !== undefined && !Array.isArray(profile.exceptions)) fail('exceptions must be an array');
+  const exceptions = new Set();
+  for (const e of profile.exceptions || []) {
+    object(e, ['path', 'rule', 'ceiling', 'owner', 'issue', 'expires', 'reason'], 'exception');
+    for (const key of ['path', 'rule', 'owner', 'issue', 'expires', 'reason']) text(e[key], `exception.${key}`);
+    if (!EXCEPTION_RULES.includes(e.rule)) fail(`unknown exception rule ${e.rule}`);
+    if (!files.has(e.path)) fail(`exception path ${e.path} is not a declared file`);
+    const key = `${e.path}:${e.rule}`;
+    if (exceptions.has(key)) fail(`duplicate exception ${key}`);
+    exceptions.add(key);
+    const date = new Date(e.expires);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(e.expires) || !Number.isFinite(date.getTime()) || date.toISOString().slice(0, 10) !== e.expires) fail(`invalid exception expiry ${e.expires}`);
+    if (e.rule === 'size') {
+      integer(e.ceiling, 'size exception ceiling');
+      if (e.ceiling < profile.sizeProfiles[files.get(e.path).sizeProfile].hardMax) fail('size exception ceiling must not lower hardMax');
+    } else if (e.ceiling !== undefined) fail('ceiling is only valid for size exceptions');
+  }
 }
 
-/** Extract `{ specifier, line }` for every static/dynamic import-like reference. */
-function extractImports(source) {
-  const out = [];
-  for (const re of [REQUIRE_RE, IMPORT_FROM_RE, IMPORT_BARE_RE, EXPORT_FROM_RE, DYNAMIC_IMPORT_RE]) {
-    re.lastIndex = 0;
-    let m;
-    while ((m = re.exec(source))) out.push({ specifier: m[2], line: lineAt(source, m.index) });
+function lineAt(text, index) {
+  return text.slice(0, index).split('\n').length;
+}
+
+/** Small lexical scanner, not an AST/binding analyzer. Comments and literal text are opaque;
+ * template substitutions are scanned recursively so imports inside them stay in the graph. */
+function tokenize(source) {
+  const tokens = [];
+  let i = 0;
+  const add = (type, value, start) => tokens.push({ type, value, line: lineAt(source, start) });
+  function escape() {
+    const ch = source[i++];
+    const simple = { n: '\n', r: '\r', t: '\t', b: '\b', f: '\f', v: '\v', '0': '\0', '\n': '', '\r': '' };
+    if (/[1-9]/.test(ch) || (ch === '0' && /[0-9]/.test(source[i] || ''))) throw new Error('legacy numeric string escapes are unsupported');
+    if (ch === 'u' || ch === 'x') {
+      let hex;
+      if (ch === 'u' && source[i] === '{') { const end = source.indexOf('}', ++i); hex = source.slice(i, end); i = end + 1; }
+      else { const length = ch === 'u' ? 4 : 2; hex = source.slice(i, i + length); i += length; }
+      if (!hex || !/^[0-9a-f]+$/i.test(hex)) throw new Error('unsupported invalid string escape');
+      return String.fromCodePoint(parseInt(hex, 16));
+    }
+    if (ch === '\r' && source[i] === '\n') i++;
+    return Object.hasOwn(simple, ch) ? simple[ch] : ch;
   }
-  return out;
+  function literal(quote, start) {
+    let value = '', interpolated = false;
+    const token = { type: 'string', value: '', line: lineAt(source, start) };
+    tokens.push(token);
+    while (i < source.length) {
+      const ch = source[i++];
+      if (ch === quote) { token.value = value; return; }
+      if (ch === '\\') value += escape();
+      else if (quote === '`' && ch === '$' && source[i] === '{') {
+        i++; interpolated = true; token.type = 'template';
+        scan(true); // consumes its matching closing brace, including nested objects/templates
+      } else value += ch;
+    }
+    throw new Error(`unterminated ${interpolated ? 'template' : 'string'} literal at line ${token.line}`);
+  }
+  function scan(substitution = false) {
+    let braces = 0;
+    while (i < source.length) {
+      const start = i, ch = source[i];
+      if (/\s/.test(ch)) { i++; continue; }
+      if (source.startsWith('//', i) || (i === 0 && source.startsWith('#!', i))) { while (i < source.length && source[i] !== '\n') i++; continue; }
+      if (source.startsWith('/*', i)) {
+        const end = source.indexOf('*/', i + 2);
+        if (end < 0) throw new Error('unterminated block comment');
+        i = end + 2; continue;
+      }
+      if (ch === '"' || ch === "'" || ch === '`') { i++; literal(ch, start); continue; }
+      const previous = tokens.at(-1);
+      // A slash after these tokens needs statement/expression AST context.
+      // Refuse that ambiguity instead of potentially swallowing a real import as regex text.
+      if (ch === '/' && previous?.type === 'punct' && [')', '}'].includes(previous.value)) throw new Error(`ambiguous slash after ${previous.value} at line ${lineAt(source, start)}; requires an AST inventory`);
+      const expressionStart = !previous || (previous.type === 'name' && /^(return|throw|yield|case|delete|void|typeof|new|else|do)$/.test(previous.value)) || (previous.type === 'punct' && ![')', ']', '}', '++', '--'].includes(previous.value));
+      if (ch === '/' && expressionStart) {
+        i++; let bracket = false, closed = false;
+        while (i < source.length) {
+          const c = source[i++];
+          if (c === '\\') { i++; continue; }
+          if (c === '[') bracket = true;
+          if (c === ']') bracket = false;
+          if (c === '/' && !bracket) { closed = true; break; }
+          if (c === '\n') break;
+        }
+        if (!closed) throw new Error(`unsupported or unterminated regex at line ${lineAt(source, start)}`);
+        while (/[a-z]/i.test(source[i] || '') && i < source.length) i++;
+        add('regex', '', start); continue;
+      }
+      if (/[A-Za-z_$]/.test(ch)) {
+        i++; while (i < source.length && /[A-Za-z0-9_$]/.test(source[i])) i++;
+        add('name', source.slice(start, i), start); continue;
+      }
+      if (ch === '\\') throw new Error(`escaped identifiers are unsupported at line ${lineAt(source, start)}`);
+      if (/\d/.test(ch)) { i++; while (i < source.length && /[\w.]/.test(source[i])) i++; add('number', source.slice(start, i), start); continue; }
+      if (ch === '{') braces++;
+      if (ch === '}' && substitution && braces-- === 0) { i++; return; }
+      if (['?.', '++', '--'].includes(source.slice(i, i + 2))) i += 2;
+      else i++;
+      add('punct', source.slice(start, i), start);
+    }
+    if (substitution) throw new Error('unterminated template substitution');
+  }
+  scan();
+  return tokens;
+}
+
+function analyzeSource(source) {
+  const tokens = tokenize(source), imports = [], globals = [], unsupported = [];
+  const property = (i) => tokens[i - 1]?.type === 'punct' && ['.', '?.'].includes(tokens[i - 1].value);
+  const recordImport = (token, sourceToken) => {
+    if (token?.type === 'string') imports.push({ specifier: token.value, line: sourceToken.line });
+    else unsupported.push({ line: sourceToken.line, message: 'Import/require target must be a literal string; declare or rewrite dynamic loading before checking this profile' });
+  };
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i], next = tokens[i + 1];
+    if (token.type !== 'name' || property(i)) continue;
+    const callOffset = token.value === 'require' && next?.value === '?.' ? 2 : 1;
+    if ((token.value === 'require' || token.value === 'import') && tokens[i + callOffset]?.value === '(') {
+      const target = tokens[i + callOffset + 1], tail = tokens[i + callOffset + 2]?.value;
+      recordImport([')', ','].includes(tail) ? target : null, token);
+    } else if (token.value === 'import' && next?.type === 'string') recordImport(next, token);
+    else if (['import', 'export'].includes(token.value) && !['.', '('].includes(next?.value)) {
+      for (let j = i + 1; j < tokens.length && ![';', '='].includes(tokens[j].value); j++) {
+        if (tokens[j].value === 'from' && tokens[j + 1]?.type === 'string') { recordImport(tokens[j + 1], token); break; }
+        if (j > i + 1 && ['import', 'export', 'const', 'function', 'class'].includes(tokens[j].value)) break;
+      }
+    }
+    if (token.value === 'window') {
+      let j = i + 1, member;
+      if (tokens[j]?.value === '?.') j++;
+      if (tokens[j]?.value === '.') j++;
+      if (tokens[j]?.type === 'name' && ['.', '?.'].includes(tokens[j - 1]?.value)) member = tokens[j];
+      else if (tokens[j]?.value === '[' && tokens[j + 1]?.type === 'string' && tokens[j + 2]?.value === ']') member = tokens[j + 1];
+      else if (tokens[j]?.value === '[') unsupported.push({ rule: 'unsupported-global', line: token.line, message: 'Computed window access requires a literal property name in a reviewed profile' });
+      if (member && /^SM[A-Za-z0-9_]*$/.test(member.value)) globals.push({ name: member.value, line: token.line });
+    }
+  }
+  return { imports, globals, unsupported };
+}
+
+function extractImports(source) {
+  return analyzeSource(source).imports;
 }
 
 function countNonBlankLines(source) {
@@ -105,10 +272,6 @@ function buildFileIndex(profile, root) {
   return index;
 }
 
-function findException(profile, relPath, rule) {
-  return (profile.exceptions || []).find((e) => e.path === relPath && e.rule === rule);
-}
-
 /** Directed-graph cycle detection (DFS with a recursion stack). Returns one
  * reported cycle (list of module ids, first repeated at the end) per back-edge
  * found; the same simple cycle is not reported twice. */
@@ -142,13 +305,34 @@ function findCycles(edges) {
  * @param {Date}   [opts.now]  - clock used for exception expiry (default: real now)
  */
 function checkProfile(profile, opts = {}) {
+  validateProfile(profile);
   const root = opts.root || process.cwd();
   const now = opts.now || new Date();
+  if (!(now instanceof Date) || !Number.isFinite(now.getTime())) throw new Error('invalid check clock');
   const fileIndex = buildFileIndex(profile, root);
   const violations = [];
   const warnings = [];
   const exceptionsApplied = [];
   const edges = new Map(profile.modules.map((m) => [m.id, new Set()]));
+  const edgeFiles = new Map();
+  const activeExceptions = new Map();
+  const applied = new Set();
+  const applyException = (exception, extra = {}) => {
+    if (!applied.has(exception)) exceptionsApplied.push({ ...exception, ...extra });
+    applied.add(exception);
+  };
+  for (const exception of profile.exceptions || []) {
+    if (new Date(exception.expires) <= now) {
+      violations.push({ rule: 'expired-exception', module: null, file: exception.path, line: null,
+        message: `Exception for "${exception.rule}" on ${exception.path} expired ${exception.expires}`,
+        detail: { exception } });
+    } else activeExceptions.set(`${exception.path}:${exception.rule}`, exception);
+  }
+  const reportViolation = (violation) => {
+    const exception = activeExceptions.get(`${violation.file}:${violation.rule}`);
+    if (exception && violation.rule !== 'size') applyException(exception);
+    else violations.push(violation);
+  };
 
   for (const m of profile.modules) {
     for (const f of m.files) {
@@ -162,26 +346,14 @@ function checkProfile(profile, opts = {}) {
       if (!sizeProfile) {
         throw new Error(`checkProfile: module "${m.id}" declares unknown sizeProfile "${m.sizeProfile}"`);
       }
-      const exception = findException(profile, relPath, 'size');
-      let shielded = false;
+      const exception = activeExceptions.get(`${relPath}:size`);
+      const shielded = Boolean(exception);
       if (exception) {
-        const expired = new Date(exception.expires) <= now;
-        if (expired) {
-          violations.push({
-            rule: 'expired-exception', module: m.id, file: relPath, line: null,
-            message: `Exception for "size" on ${relPath} expired ${exception.expires} and no longer applies`,
-            detail: { exception },
-          });
-        } else {
-          exceptionsApplied.push({ ...exception, actualLines: lines });
-          shielded = true;
-          if (lines > exception.ceiling) {
-            violations.push({
-              rule: 'size', module: m.id, file: relPath, line: null,
-              message: `${lines} nonblank lines exceeds excepted ceiling ${exception.ceiling}`,
-              detail: { lines, ceiling: exception.ceiling, exception: true },
-            });
-          }
+        applyException(exception, { actualLines: lines });
+        if (lines > exception.ceiling) {
+          violations.push({ rule: 'size', module: m.id, file: relPath, line: null,
+            message: `${lines} nonblank lines exceeds excepted ceiling ${exception.ceiling}`,
+            detail: { lines, ceiling: exception.ceiling, exception: true } });
         }
       }
       if (!shielded) {
@@ -200,32 +372,35 @@ function checkProfile(profile, opts = {}) {
         }
       }
 
-      // --- global-state ---
+      const analysis = analyzeSource(source);
+      for (const issue of analysis.unsupported) {
+        violations.push({ rule: 'unsupported-import', module: m.id, file: relPath, ...issue });
+      }
+      // Scan the same tokens used for dependencies, including literal bracket/optional access.
       if (m.layer !== 'adapters' && m.layer !== 'bootstrap') {
-        GLOBAL_SM_RE.lastIndex = 0;
         const seen = new Set();
-        let gm;
-        while ((gm = GLOBAL_SM_RE.exec(source))) {
-          if (seen.has(gm[1])) continue;
-          seen.add(gm[1]);
-          violations.push({
-            rule: 'global-state', module: m.id, file: relPath, line: lineAt(source, gm.index),
-            message: `Implicit global "window.${gm[1]}" accessed from layer "${m.layer}" (only adapters/bootstrap may)`,
-            detail: { global: `window.${gm[1]}` },
-          });
+        for (const global of analysis.globals) {
+          if (seen.has(global.name)) continue;
+          seen.add(global.name);
+          reportViolation({ rule: 'global-state', module: m.id, file: relPath, line: global.line,
+            message: `Implicit global "window.${global.name}" accessed from layer "${m.layer}" (only adapters/bootstrap may)`,
+            detail: { global: `window.${global.name}` } });
         }
       }
 
       // --- imports: private-import, layer-violation, cycle edges ---
-      for (const { specifier, line } of extractImports(source)) {
+      for (const { specifier, line } of analysis.imports) {
         const abs2 = resolveSpecifier(specifier, abs);
         if (!abs2) continue; // external or unresolved: not modeled in v1
         const target = fileIndex.get(abs2);
         if (!target || target.module.id === m.id) continue; // outside profile, or intra-module
         edges.get(m.id).add(target.module.id);
+        const edgeKey = JSON.stringify([m.id, target.module.id]);
+        if (!edgeFiles.has(edgeKey)) edgeFiles.set(edgeKey, new Set());
+        edgeFiles.get(edgeKey).add(relPath);
 
         if (!target.isPublic) {
-          violations.push({
+          reportViolation({
             rule: 'private-import', module: m.id, file: relPath, line,
             message: `${relPath} imports "${specifier}" (${target.relFile}), which module "${target.module.id}" does not list in publicApi`,
             detail: { specifier, targetModule: target.module.id, targetFile: target.relFile },
@@ -235,7 +410,7 @@ function checkProfile(profile, opts = {}) {
         const rule = profile.layerRules && profile.layerRules[m.layer];
         if (rule && Array.isArray(rule.allowedLayers) && !rule.allowedLayers.includes('*')) {
           if (!rule.allowedLayers.includes(target.module.layer)) {
-            violations.push({
+            reportViolation({
               rule: 'layer-violation', module: m.id, file: relPath, line,
               message: `Layer "${m.layer}" (module "${m.id}") may not depend on layer "${target.module.layer}" (module "${target.module.id}")`,
               detail: { fromLayer: m.layer, toLayer: target.module.layer, targetModule: target.module.id },
@@ -248,6 +423,9 @@ function checkProfile(profile, opts = {}) {
 
   // --- cycle ---
   for (const cyclePath of findCycles(edges)) {
+    const cycleFiles = cyclePath.slice(0, -1).flatMap((id, i) => [...edgeFiles.get(JSON.stringify([id, cyclePath[i + 1]]))]);
+    const exception = cycleFiles.map((file) => activeExceptions.get(`${file}:cycle`)).find(Boolean);
+    if (exception) { applyException(exception, { cycle: cyclePath }); continue; }
     violations.push({
       rule: 'cycle', module: cyclePath[0], file: null, line: null,
       message: `Import cycle: ${cyclePath.join(' -> ')}`,
@@ -266,6 +444,7 @@ function checkProfile(profile, opts = {}) {
 
 module.exports = {
   checkProfile,
+  validateProfile,
   extractImports,
   countNonBlankLines,
   resolveSpecifier,


### PR DESCRIPTION
This first R05 increment adds a module-boundary checker for explicitly declared source profiles. It reports dependency cycles, private imports, forbidden layer edges, direct `window.SM*` access, size violations and expired exceptions. The library and CLI reject malformed policy before scanning source files.

Review corrections close policy-validation and lexical-scanning defects in the recovered implementation. Cycle exceptions remove only dependencies from the named file, so an unexcepted sibling file cannot inherit the exemption. Supported object methods named `require` are distinguished from real loader calls. Behavioral regressions cover the reproduced failures.

Validation at `72e8bce0781f5a63a939c83359b7b976f23f2c39`:

- `node --test scripts/nemo/boundaries.test.cjs`: 64/64 pass.
- `npm run doctor` and `npm run check`: pass; six checks pass and unavailable capabilities remain explicit.
- `npm run verify`: pass on the clean commit, with 70 Node and 15 Rust tests.
- JS syntax and `git diff --check`: pass.

Keep #901 open. This increment checks declared profiles using a lexical scanner; it does not establish whole-project coverage. Ambiguous lexical syntax fails explicitly, and a `require` method whose body brace starts on a later line remains unsupported. Reviewed application profiles, comparison against the prior size baseline, and standard command/CI integration remain subsequent R05 acceptance gates. No browser or Tauri behavior changes or platform acceptance are claimed.
