### PR TITLE
Add isolated browser preview launcher and source handshake

### DIFF
--- a/engineering/runtime-isolation.md
+++ b/engineering/runtime-isolation.md
@@ -2,9 +2,9 @@
 
 [R06 / #902](https://github.com/mysteropodes/nemo/issues/902) requires concurrent
 tasks to keep their source, browser/desktop state, ports, caches, builds and
-reports separate. This increment supplies a **local coordination library and
-debug CLI**, not an integrated application launcher. Full R06 acceptance remains
-open until the consumers listed below are implemented and exercised.
+reports separate. The coordination library and browser preview launcher provide
+local ownership checks, distinct task origins and a served source/build identity.
+Full R06 acceptance remains open for the desktop and remaining consumers below.
 
 ## API and guarantees
 
@@ -38,9 +38,8 @@ its current limitation that untracked-file contents are not hashed separately.
 
 Despite its historical name, `verifyHandshake()` reads local launcher metadata;
 it does **not** challenge a running server or establish which checkout serves a
-URL. A real launcher still needs a served endpoint that returns its task, owner,
-source and build identity. Browser/Tauri acceptance must check that endpoint or
-equivalent process protocol before trusting the application instance.
+URL. The browser launcher adds the served endpoint described below. Tauri still
+requires an equivalent runtime handshake before trusting its application instance.
 
 Each mutation creates an atomic directory under `<runtime>/mutations/`, with an
 `owner.json` identifying the mutating PID. Normal completion removes the guard.
@@ -84,6 +83,56 @@ node scripts/nemo/isolation.cjs release --task my-task
 a momentary availability probe, not a lasting reservation. The CLI exposes
 `slot-acquire` and `slot-release` for explicit resource coordination as well.
 
+## Browser preview launcher
+
+`node scripts/nemo/browser.cjs start --task preview-a` starts a long-lived HTTP
+server bound to loopback on an OS-assigned port. Its first stdout line is JSON
+with the actual origin, PID, task roots and owner token. Keep that token in the
+controlling process. Start a second task with a different ID to obtain a distinct
+origin and mutable roots; the server holds its listening socket until shutdown.
+
+The server serves this checkout's `src/` files with no-store responses and
+appropriate JavaScript/WASM MIME types. It rejects writes, traversal and symlinks
+that escape that source directory. It does not expose the rest of the checkout.
+
+Open the returned `identityUrl` (`/.well-known/nemo-runtime.json`) before using
+an instance. The response identifies task/PID/origin and compares startup and
+current R02 source/build snapshots. It never includes the owner token or Git
+origin URL. A changed source/build or invalid owner record returns HTTP 409;
+static requests also fail closed once the mismatch is observed. Static requests
+cache the check for up to one second; identity requests refresh it immediately.
+The source fingerprint retains R02's documented untracked-content limitation.
+
+Browser launch is explicit:
+
+```sh
+node scripts/nemo/browser.cjs start --task preview-a --browser auto
+node scripts/nemo/browser.cjs start --task preview-b --browser auto --headless
+```
+
+`--browser auto` finds an installed Chromium-family browser, or use an absolute
+executable path. The launched process receives this task's `--user-data-dir` and
+`--disk-cache-dir`, along with isolated temporary/cache/report environment paths.
+Without that option, only the server runs: opening its URL in an existing browser
+does not configure a separate profile. Inspect `browser.integrated`, `active`
+and `error` in the identity response; a healthy HTTP server alone does not prove
+that a browser started or that Nemo's application workflow passed.
+
+From a separate controlling process:
+
+```sh
+node scripts/nemo/browser.cjs status --task preview-a --owner <token>
+node scripts/nemo/browser.cjs stop --task preview-a --owner <token>
+```
+
+`status` checks local ownership/source metadata; use the served identity endpoint
+for the build and actual URL identity. `stop` refuses a mismatched owner, waits
+for its launcher to exit, then removes that task's mutable roots, including its
+browser profile. These are disposable task profiles: retain any wanted artifacts
+before stopping. Graceful launcher shutdown closes its browser and HTTP server;
+forced termination and interrupted records still require the reconciliation
+rules above. No unrelated browser or task is selected by name.
+
 ## Validation and remaining integration
 
 Run `node --test scripts/nemo/isolation.test.cjs`. The 20 behavioral tests cover
@@ -97,10 +146,10 @@ and sockets; they do not launch Nemo's browser or desktop application.
 Still required for the full acceptance contract in
 [the parallel-work specification](remediation/07_GITHUB_PROJECT_AND_PARALLEL_WORK.md#isolation):
 
-- Wire these helpers into the actual launcher, including source/build endpoint
-  verification and tool environment/configuration for temp, cache and build paths.
-- Configure and exercise isolated browser profiles/origins. No browser harness is
-  integrated here; `test:browser` remains blocked in R02.
+- Complete automated browser/application workflow coverage and standard harness
+  integration. The preview launcher supplies real origins, explicit Chromium
+  profiles and the served identity, while R02 `test:browser` still requires its
+  separate Playwright harness. A browser preview does not build WASM or the app.
 - Configure and exercise isolated Tauri data/autosave paths. Merely creating a
   `tauri-data` directory does not make the app use it. The platform owner must
   implement and validate the actual runtime override; no untested Tauri launch
@@ -111,5 +160,9 @@ Still required for the full acceptance contract in
 - Include the focused suite in normal `npm test`, `check` or `verify` discovery.
   The existing package test glob does not include `scripts/nemo/isolation.test.cjs`.
 
-Those integrations require shared package/job/platform files beyond the four
-files owned by this increment. No browser, Tauri or GPU acceptance is claimed.
+Those remaining integrations require shared package/job/platform files. The
+preview launcher is a bounded browser increment; it does not establish Tauri,
+GPU, export or complete R06 acceptance. Its focused tests are run with
+`node --test scripts/nemo/browser-runtime.test.cjs`. They exercise concurrent
+real servers, served source bytes and identities, source drift, ownership, stale
+process recovery, failed startup, duplicate launch and static path confinement.

--- a/scripts/nemo/browser-runtime.test.cjs
+++ b/scripts/nemo/browser-runtime.test.cjs
@@ -1,0 +1,159 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const http = require('node:http');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { after, test } = require('node:test');
+
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-browser-preview-test-'));
+process.env.NEMO_ISOLATION_ROOT = path.join(scratch, 'runtime');
+const isolation = require('./lib/isolation.cjs');
+const { browserLaunchConfig } = require('./lib/browser-runtime.cjs');
+const cli = path.join(__dirname, 'browser.cjs');
+const repoRoot = path.resolve(__dirname, '..', '..');
+after(() => fs.rmSync(scratch, { recursive: true, force: true }));
+
+function exited(child) {
+  if (child.exitCode != null || child.signalCode != null) return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  return new Promise((resolve) => child.once('exit', (code, signal) => resolve({ code, signal })));
+}
+
+function firstLine(child) {
+  return new Promise((resolve, reject) => {
+    let data = ''; const timer = setTimeout(() => done(new Error('readiness timed out')), 10000);
+    function done(error, value) { clearTimeout(timer); child.stdout.off('data', read); child.off('exit', early); error ? reject(error) : resolve(value); }
+    function read(chunk) { data += chunk; const newline = data.indexOf('\n'); if (newline !== -1) done(null, data.slice(0, newline)); }
+    function early(code) { done(new Error(`launcher exited before readiness (${code}): ${data}`)); }
+    child.stdout.on('data', read); child.once('exit', early);
+  });
+}
+
+async function launch(task, extra = []) {
+  const child = spawn(process.execPath, [cli, 'start', '--task', task, ...extra], {
+    cwd: repoRoot, env: { ...process.env }, stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return { child, info: JSON.parse(await firstLine(child)) };
+}
+
+function command(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [cli, ...args], { cwd: repoRoot, env: { ...process.env }, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = ''; let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; }); child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.once('exit', (code, signal) => resolve({ code, signal, stdout, stderr }));
+  });
+}
+
+function request(url, options = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(url, options, (res) => {
+      const chunks = []; res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: Buffer.concat(chunks) }));
+    });
+    req.on('error', reject); req.end();
+  });
+}
+
+async function stopOwned(instance) {
+  if (!instance || !isolation.pidAlive(instance.child.pid)) return;
+  const result = await isolation.requestStop(instance.info.taskId, instance.info.ownerToken, { timeoutMs: 5000 });
+  assert.equal(result.stopped, true); await exited(instance.child);
+  assert.equal(isolation.releaseTask(instance.info.taskId, instance.info.ownerToken).released, true);
+}
+
+test('two real preview processes hold distinct origins and serve exact source bytes and identity', async () => {
+  const a = await launch(`preview-a-${process.pid}`); const b = await launch(`preview-b-${process.pid}`);
+  try {
+    assert.notEqual(a.info.origin, b.info.origin); assert.notEqual(a.info.roots.root, b.info.roots.root);
+    const [indexA, indexB, identityA, wasmHead] = await Promise.all([
+      request(a.info.url), request(b.info.origin + '/index.html'), request(a.info.identityUrl),
+      request(a.info.origin + '/wasm/geometry_wasm_bg.wasm', { method: 'HEAD' }),
+    ]);
+    const expected = fs.readFileSync(path.join(repoRoot, 'src', 'index.html'));
+    assert.equal(indexA.status, 200); assert.deepEqual(indexA.body, expected);
+    assert.equal(indexB.status, 200); assert.deepEqual(indexB.body, expected);
+    assert.equal(wasmHead.status, 200); assert.equal(wasmHead.headers['content-type'], 'application/wasm'); assert.equal(wasmHead.body.length, 0);
+    const served = JSON.parse(identityA.body);
+    assert.equal(identityA.status, 200); assert.equal(served.healthy, true); assert.equal(served.taskId, a.info.taskId);
+    assert.equal(served.source.matches, true); assert.equal(served.build.matches, true);
+    assert.equal(served.browser.integrated, false); assert.equal(JSON.stringify(served).includes(a.info.ownerToken), false);
+    assert.equal(served.environment.TMPDIR, a.info.roots.temp);
+    assert.equal(served.environment.XDG_CACHE_HOME, a.info.roots.cache);
+    assert.equal(served.environment.NEMO_REPORT_DIR, a.info.roots.reports);
+    assert.equal(served.environment.NEMO_BROWSER_PROFILE, a.info.roots.browserProfile);
+  } finally { await stopOwned(a); await stopOwned(b); }
+});
+
+test('owner mismatch is refused and stale process state is detected and recoverable', async () => {
+  const instance = await launch(`preview-owner-${process.pid}`);
+  const refused = await isolation.requestStop(instance.info.taskId, 'wrong-token', { timeoutMs: 50 });
+  assert.equal(refused.stopped, false); assert.equal(isolation.pidAlive(instance.child.pid), true);
+  instance.child.kill('SIGKILL'); await exited(instance.child);
+  const stale = isolation.verifyHandshake(instance.info.taskId, { ownerToken: instance.info.ownerToken, checkSource: true });
+  assert.equal(stale.ok, false); assert.match(stale.reason, /not running/);
+  assert.equal(isolation.releaseTask(instance.info.taskId, instance.info.ownerToken).released, true);
+  assert.equal(fs.existsSync(instance.info.roots.root), false);
+});
+
+test('CLI status and stop enforce ownership and remove roots', async () => {
+  const instance = await launch(`preview-cli-${process.pid}`);
+  const bad = await command(['stop', '--task', instance.info.taskId, '--owner', 'wrong-token']);
+  assert.equal(bad.code, 1); assert.equal(JSON.parse(bad.stdout).stopped, false); assert.equal(isolation.pidAlive(instance.child.pid), true);
+  const status = await command(['status', '--task', instance.info.taskId, '--owner', instance.info.ownerToken]);
+  assert.equal(status.code, 0); assert.equal(JSON.parse(status.stdout).ok, true);
+  const stopping = exited(instance.child);
+  const stopped = await command(['stop', '--task', instance.info.taskId, '--owner', instance.info.ownerToken]);
+  await stopping; const result = JSON.parse(stopped.stdout);
+  assert.equal(stopped.code, 0); assert.equal(result.stopped, true); assert.equal(result.released.released, true);
+  assert.equal(fs.existsSync(instance.info.roots.root), false);
+});
+
+test('source change is reported and static content fails closed', async () => {
+  const instance = await launch(`preview-source-${process.pid}`);
+  const marker = path.join(repoRoot, `.browser-preview-source-change-${process.pid}`);
+  try {
+    fs.writeFileSync(marker, 'change');
+    const response = await request(instance.info.identityUrl); const body = JSON.parse(response.body);
+    assert.equal(response.status, 409); assert.equal(body.healthy, false); assert.equal(body.source.matches, false);
+    assert.equal((await request(instance.info.url)).status, 409);
+  } finally { fs.rmSync(marker, { force: true }); await stopOwned(instance); }
+});
+
+test('static server rejects writes, traversal and escaping symlinks', async () => {
+  const link = path.join(repoRoot, 'src', `.browser-preview-escape-${process.pid}`);
+  fs.symlinkSync(path.join(repoRoot, 'package.json'), link);
+  const instance = await launch(`preview-path-${process.pid}`);
+  try {
+    assert.equal((await request(instance.info.origin + '/package.json')).status, 404);
+    assert.equal((await request(instance.info.origin + '/%2e%2e/package.json')).status, 404);
+    assert.equal((await request(instance.info.origin + '/' + path.basename(link))).status, 403);
+    const post = await request(instance.info.url, { method: 'POST' });
+    assert.equal(post.status, 405); assert.equal(post.headers.allow, 'GET, HEAD');
+  } finally { await stopOwned(instance); fs.rmSync(link, { force: true }); }
+});
+
+test('startup bind failure leaves no launcher record or task roots', async () => {
+  const blocker = http.createServer(); await new Promise((resolve) => blocker.listen(0, '127.0.0.1', resolve));
+  const task = `preview-fail-${process.pid}`;
+  const failed = await command(['start', '--task', task, '--port', String(blocker.address().port)]);
+  await new Promise((resolve) => blocker.close(resolve));
+  assert.equal(failed.code, 1); assert.match(failed.stderr, /EADDRINUSE/);
+  assert.equal(isolation.readLauncher(task), null); assert.equal(fs.existsSync(isolation.taskRoot(task)), false);
+});
+
+test('duplicate startup preserves the first owner and browser profiles require explicit launch', async () => {
+  const task = `preview-duplicate-${process.pid}`; const first = await launch(task);
+  try {
+    const duplicate = await command(['start', '--task', task]);
+    assert.equal(duplicate.code, 1); assert.match(duplicate.stderr, /already registered/);
+    assert.equal(isolation.readLauncher(task).ownerToken, first.info.ownerToken);
+    assert.equal((await request(first.info.identityUrl)).status, 200);
+    const config = browserLaunchConfig(first.info.roots, first.info.url, { browser: process.execPath, headless: true });
+    assert.ok(config.args.includes(`--user-data-dir=${first.info.roots.browserProfile}`));
+    assert.ok(config.args.includes(`--disk-cache-dir=${path.join(first.info.roots.cache, 'browser')}`));
+    assert.ok(config.args.includes('--headless=new'));
+  } finally { await stopOwned(first); }
+});

--- a/scripts/nemo/browser-runtime.test.cjs
+++ b/scripts/nemo/browser-runtime.test.cjs
@@ -157,3 +157,36 @@ test('duplicate startup preserves the first owner and browser profiles require e
     assert.ok(config.args.includes('--headless=new'));
   } finally { await stopOwned(first); }
 });
+
+
+test('an exited requested browser is reported and shutdown waits for a stubborn browser', {
+  skip: process.platform === 'win32' ? 'POSIX signal and executable fixtures require a Unix host' : false,
+}, async () => {
+  const failedBrowser = path.join(scratch, 'browser-exits');
+  fs.writeFileSync(failedBrowser, '#!/bin/sh\nexit 23\n', { mode: 0o700 });
+  const failed = await launch(`preview-browser-exits-${process.pid}`, ['--browser', failedBrowser]);
+  try {
+    let body;
+    for (let i = 0; i < 100; i++) {
+      body = JSON.parse((await request(failed.info.identityUrl)).body);
+      if (body.browser.error) break;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(body.browser.integrated, false);
+    assert.equal(body.browser.active, false);
+    assert.match(body.browser.error, /code 23/);
+  } finally { await stopOwned(failed); }
+  const stubborn = path.join(scratch, 'browser-stubborn');
+  const ready = path.join(scratch, 'stubborn-ready');
+  fs.writeFileSync(stubborn, `#!${process.execPath}\nprocess.on('SIGTERM', () => {});\nrequire('node:fs').writeFileSync(${JSON.stringify(ready)}, 'ready');\nsetInterval(() => {}, 1000);\n`, { mode: 0o700 });
+  const instance = await launch(`preview-browser-stubborn-${process.pid}`, ['--browser', stubborn]);
+  try {
+    for (let i = 0; i < 100 && !fs.existsSync(ready); i++) await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(fs.existsSync(ready), true);
+    const pid = instance.info.browser.pid;
+    assert.equal(isolation.pidAlive(pid), true);
+    await stopOwned(instance);
+    assert.equal(isolation.pidAlive(pid), false);
+    assert.equal(fs.existsSync(instance.info.roots.root), false);
+  } finally { if (isolation.pidAlive(instance.child.pid)) await stopOwned(instance); }
+});

--- a/scripts/nemo/browser.cjs
+++ b/scripts/nemo/browser.cjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+'use strict';
+
+const isolation = require('./lib/isolation.cjs');
+const { IDENTITY_PATH, startBrowserRuntime } = require('./lib/browser-runtime.cjs');
+
+function parse(argv) {
+  const out = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) { out._.push(arg); continue; }
+    const key = arg.slice(2); const next = argv[i + 1];
+    if (next == null || next.startsWith('--')) out[key] = true;
+    else { out[key] = next; i += 1; }
+  }
+  return out;
+}
+
+function output(value) { process.stdout.write(JSON.stringify(value) + '\n'); }
+
+async function start(args) {
+  const runtime = await startBrowserRuntime({
+    taskId: args.task, host: args.host, port: args.port,
+    browser: args.browser, headless: !!args.headless,
+  });
+  output({
+    started: true, taskId: runtime.taskId, pid: process.pid,
+    origin: runtime.origin, url: runtime.origin + '/', identityUrl: runtime.origin + IDENTITY_PATH,
+    ownerToken: runtime.ownerToken, roots: runtime.roots,
+    browser: {
+      requested: !!args.browser, integrated: !!runtime.browserChild,
+      pid: runtime.browserChild ? runtime.browserChild.pid : null,
+      profileDir: runtime.roots.browserProfile, error: runtime.browserError,
+    },
+  });
+  let closing = false;
+  const shutdown = async () => {
+    if (closing) return; closing = true;
+    await runtime.close().catch(() => {}); process.exit(0);
+  };
+  process.once('SIGTERM', shutdown); process.once('SIGINT', shutdown);
+}
+
+async function stop(args) {
+  if (!args.task || !args.owner) throw new Error('stop requires --task ID and --owner TOKEN');
+  const stopped = await isolation.requestStop(args.task, args.owner, {
+    signal: args.signal, timeoutMs: args['timeout-ms'] == null ? undefined : Number(args['timeout-ms']),
+  });
+  const released = stopped.stopped ? isolation.releaseTask(args.task, args.owner) : null;
+  output({ ...stopped, released });
+  process.exit(stopped.stopped && released && released.released ? 0 : 1);
+}
+
+async function status(args) {
+  if (!args.task || !args.owner) throw new Error('status requires --task ID and --owner TOKEN');
+  const result = isolation.verifyHandshake(args.task, { ownerToken: args.owner, checkSource: true });
+  output({ ok: result.ok, reason: result.reason, taskId: args.task, pid: result.launcher ? result.launcher.pid : null });
+  process.exit(result.ok ? 0 : 1);
+}
+
+async function main() {
+  const args = parse(process.argv.slice(2)); const command = args._[0] || 'start';
+  if (command === 'start') return start(args);
+  if (command === 'stop') return stop(args);
+  if (command === 'status') return status(args);
+  throw new Error('usage: browser.cjs start [--task ID] [--host 127.0.0.1|::1] [--port N] [--browser auto|/path] [--headless] | stop --task ID --owner TOKEN | status --task ID --owner TOKEN');
+}
+
+main().catch((err) => { process.stderr.write((err.stack || String(err)) + '\n'); process.exit(1); });

--- a/scripts/nemo/lib/browser-runtime.cjs
+++ b/scripts/nemo/lib/browser-runtime.cjs
@@ -1,0 +1,269 @@
+'use strict';
+
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { isDeepStrictEqual } = require('node:util');
+const isolation = require('./isolation.cjs');
+const identity = require('./identity.cjs');
+const { ROOT } = require('./util.cjs');
+
+const IDENTITY_PATH = '/.well-known/nemo-runtime.json';
+const SCHEMA = 'nemo.browser-runtime/1';
+const LOOPBACK = new Set(['127.0.0.1', '::1']);
+const MIME = new Map([
+  ['.css', 'text/css; charset=utf-8'], ['.gif', 'image/gif'],
+  ['.html', 'text/html; charset=utf-8'], ['.ico', 'image/x-icon'],
+  ['.jpeg', 'image/jpeg'], ['.jpg', 'image/jpeg'],
+  ['.js', 'text/javascript; charset=utf-8'], ['.json', 'application/json; charset=utf-8'],
+  ['.mjs', 'text/javascript; charset=utf-8'], ['.mp3', 'audio/mpeg'],
+  ['.mp4', 'video/mp4'], ['.ogg', 'audio/ogg'], ['.otf', 'font/otf'],
+  ['.png', 'image/png'], ['.riv', 'application/octet-stream'],
+  ['.svg', 'image/svg+xml'], ['.ttf', 'font/ttf'],
+  ['.wasm', 'application/wasm'], ['.wav', 'audio/wav'],
+  ['.webm', 'video/webm'], ['.webp', 'image/webp'],
+  ['.woff', 'font/woff'], ['.woff2', 'font/woff2'],
+]);
+
+function publicSource(source) {
+  if (!source) return source;
+  const { originUrl: _originUrl, ...safe } = source;
+  return safe;
+}
+
+function publicRoots(roots) {
+  return {
+    temp: roots.temp, cache: roots.cache, build: roots.build,
+    reports: roots.reports, browserProfile: roots.browserProfile,
+  };
+}
+
+function applyTaskEnvironment(taskId, roots) {
+  process.env.NEMO_TASK_ID = taskId;
+  process.env.NEMO_REPORT_DIR = roots.reports;
+  process.env.NEMO_BROWSER_PROFILE = roots.browserProfile;
+  process.env.XDG_CACHE_HOME = roots.cache;
+  process.env.TMPDIR = roots.temp;
+  process.env.TMP = roots.temp;
+  process.env.TEMP = roots.temp;
+}
+
+function browserCandidates() {
+  if (process.platform === 'darwin') return [
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+  ];
+  if (process.platform === 'win32') return [
+    path.join(process.env.PROGRAMFILES || '', 'Google', 'Chrome', 'Application', 'chrome.exe'),
+    path.join(process.env['PROGRAMFILES(X86)'] || '', 'Microsoft', 'Edge', 'Application', 'msedge.exe'),
+  ];
+  return ['/usr/bin/google-chrome', '/usr/bin/chromium', '/usr/bin/chromium-browser', '/usr/bin/microsoft-edge'];
+}
+
+function browserLaunchConfig(roots, url, options = {}) {
+  let executable = options.browser;
+  if (!executable || executable === 'auto') executable = browserCandidates().find((file) => file && fs.existsSync(file));
+  else executable = path.resolve(executable);
+  if (!executable || !fs.existsSync(executable)) throw new Error('browser executable not found; pass --browser auto or an absolute Chromium path');
+  fs.accessSync(executable, fs.constants.X_OK);
+  const cache = path.join(roots.cache, 'browser');
+  fs.mkdirSync(cache, { recursive: true });
+  const args = [
+    `--user-data-dir=${roots.browserProfile}`,
+    `--disk-cache-dir=${cache}`,
+    '--no-first-run', '--no-default-browser-check', '--disable-background-networking', '--disable-sync',
+  ];
+  if (options.headless) args.push('--headless=new');
+  if (Array.isArray(options.extraArgs)) args.push(...options.extraArgs);
+  args.push(url);
+  return {
+    executable, args, cwd: ROOT, url,
+    env: {
+      ...process.env, TMPDIR: roots.temp, TMP: roots.temp, TEMP: roots.temp,
+      XDG_CACHE_HOME: roots.cache, NEMO_REPORT_DIR: roots.reports,
+    },
+    profileDir: roots.browserProfile, cacheDir: cache,
+  };
+}
+
+function spawnBrowser(config) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(config.executable, config.args, {
+      cwd: config.cwd, env: config.env, stdio: 'ignore',
+    });
+    child.once('error', reject);
+    child.once('spawn', () => { child.off('error', reject); resolve(child); });
+  });
+}
+
+async function stopBrowser(child) {
+  if (!child || child.exitCode != null || child.signalCode != null) return;
+  child.kill('SIGTERM');
+  await Promise.race([
+    new Promise((resolve) => child.once('exit', resolve)),
+    new Promise((resolve) => setTimeout(resolve, 2000)),
+  ]);
+  if (child.exitCode == null && child.signalCode == null) child.kill('SIGKILL');
+}
+
+function json(res, status, value, headOnly) {
+  const body = Buffer.from(JSON.stringify(value, null, 2) + '\n');
+  res.writeHead(status, {
+    'Cache-Control': 'no-store', 'Content-Length': body.length,
+    'Content-Type': 'application/json; charset=utf-8', 'X-Content-Type-Options': 'nosniff',
+  });
+  res.end(headOnly ? undefined : body);
+}
+
+function plain(res, status, value, headOnly, extra = {}) {
+  const body = Buffer.from(value);
+  res.writeHead(status, {
+    'Cache-Control': 'no-store', 'Content-Length': body.length,
+    'Content-Type': 'text/plain; charset=utf-8', 'X-Content-Type-Options': 'nosniff', ...extra,
+  });
+  res.end(headOnly ? undefined : body);
+}
+
+function inside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === '' || (relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+}
+
+function resolveStaticFile(srcRoot, pathname) {
+  let decoded;
+  try { decoded = decodeURIComponent(pathname); }
+  catch { return { status: 400, reason: 'invalid URL encoding' }; }
+  if (decoded.includes('\0') || decoded.includes('\\')) return { status: 400, reason: 'invalid path' };
+  const lexical = path.resolve(srcRoot, decoded.replace(/^\/+/, '') || 'index.html');
+  if (!inside(srcRoot, lexical)) return { status: 403, reason: 'path escapes source root' };
+  let real;
+  try {
+    real = fs.realpathSync(lexical);
+    if (fs.statSync(real).isDirectory()) real = fs.realpathSync(path.join(real, 'index.html'));
+  } catch (err) {
+    if (err.code === 'ENOENT' || err.code === 'ENOTDIR') return { status: 404, reason: 'not found' };
+    return { status: 500, reason: 'file lookup failed' };
+  }
+  if (!inside(srcRoot, real)) return { status: 403, reason: 'symlink escapes source root' };
+  const stat = fs.statSync(real);
+  return stat.isFile() ? { status: 200, file: real, stat } : { status: 404, reason: 'not found' };
+}
+
+function listen(server, host, port) {
+  return new Promise((resolve, reject) => {
+    const failed = (err) => { server.off('listening', ready); reject(err); };
+    const ready = () => { server.off('error', failed); resolve(server.address()); };
+    server.once('error', failed); server.once('listening', ready);
+    server.listen({ host, port, exclusive: true });
+  });
+}
+
+function closeServer(server) {
+  if (!server.listening) return Promise.resolve();
+  if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
+  return new Promise((resolve, reject) => server.close((err) => err ? reject(err) : resolve()));
+}
+
+async function startBrowserRuntime(options = {}) {
+  const host = options.host || '127.0.0.1';
+  if (!LOOPBACK.has(host)) throw new Error('preview host must be loopback (127.0.0.1 or ::1)');
+  const port = options.port == null ? 0 : Number(options.port);
+  if (!Number.isSafeInteger(port) || port < 0 || port > 65535) throw new Error('port must be an integer from 0 through 65535');
+  const taskId = isolation.resolveTaskId(options.taskId);
+  const roots = isolation.taskRoots(taskId);
+  applyTaskEnvironment(taskId, roots);
+  const srcRoot = fs.realpathSync(options.srcRoot || path.join(ROOT, 'src'));
+  const startupSource = identity.sourceIdentity();
+  const startupBuild = identity.buildIdentity();
+  let launcher = null;
+  let browserChild = null;
+  let browserError = null;
+  let runtime = null;
+  let observed = { source: startupSource, build: startupBuild, sourceMatches: true, buildMatches: true, checkedAt: Date.now() };
+
+  function health(force) {
+    const local = launcher ? isolation.verifyHandshake(taskId, { ownerToken: launcher.ownerToken }) : { ok: false, reason: 'launcher registration incomplete' };
+    if (force || Date.now() - observed.checkedAt >= 1000) {
+      const source = identity.sourceIdentity(); const build = identity.buildIdentity();
+      observed = {
+        source, build, sourceMatches: isDeepStrictEqual(startupSource, source),
+        buildMatches: isDeepStrictEqual(startupBuild, build), checkedAt: Date.now(),
+      };
+    }
+    return { ...observed, local, healthy: local.ok && observed.sourceMatches && observed.buildMatches };
+  }
+
+  const server = http.createServer((req, res) => {
+    const method = req.method || 'GET';
+    if (method !== 'GET' && method !== 'HEAD') { plain(res, 405, 'method not allowed\n', false, { Allow: 'GET, HEAD' }); return; }
+    let url;
+    try { url = new URL(req.url || '/', `http://${host.includes(':') ? `[${host}]` : host}`); }
+    catch { plain(res, 400, 'invalid URL\n', method === 'HEAD'); return; }
+    const state = health(url.pathname === IDENTITY_PATH);
+    if (url.pathname === IDENTITY_PATH) {
+      const browserActive = !!browserChild && browserChild.exitCode == null && browserChild.signalCode == null;
+      json(res, !launcher ? 503 : (state.healthy ? 200 : 409), {
+        schema: SCHEMA, healthy: state.healthy,
+        reason: state.healthy ? 'task owner, source and build identities match' : (!state.local.ok ? state.local.reason : 'source or build identity changed'),
+        taskId, pid: process.pid, origin: runtime && runtime.origin,
+        source: { startup: publicSource(startupSource), current: publicSource(state.source), matches: state.sourceMatches },
+        build: { startup: startupBuild, current: state.build, matches: state.buildMatches },
+        roots: publicRoots(roots),
+        environment: {
+          TMPDIR: process.env.TMPDIR, XDG_CACHE_HOME: process.env.XDG_CACHE_HOME,
+          NEMO_REPORT_DIR: process.env.NEMO_REPORT_DIR,
+          NEMO_BROWSER_PROFILE: process.env.NEMO_BROWSER_PROFILE,
+        },
+        browser: {
+          requested: !!options.browser, integrated: !!browserChild, active: browserActive,
+          pid: browserChild ? browserChild.pid : null, profileDir: roots.browserProfile,
+          error: browserError,
+        },
+      }, method === 'HEAD');
+      return;
+    }
+    // A browser explicitly launched with this server can request its first
+    // assets between the socket bind and the synchronous owner registration.
+    // Serve that brief startup window; after registration, fail closed on drift.
+    if (launcher && !state.healthy) { plain(res, 409, `runtime identity mismatch: ${!state.local.ok ? state.local.reason : 'source or build changed'}\n`, method === 'HEAD'); return; }
+    const resolved = resolveStaticFile(srcRoot, url.pathname);
+    if (!resolved.file) { plain(res, resolved.status, `${resolved.reason}\n`, method === 'HEAD'); return; }
+    res.writeHead(200, {
+      'Cache-Control': 'no-store', 'Content-Length': resolved.stat.size,
+      'Content-Type': MIME.get(path.extname(resolved.file).toLowerCase()) || 'application/octet-stream',
+      'X-Content-Type-Options': 'nosniff',
+    });
+    if (method === 'HEAD') { res.end(); return; }
+    const stream = fs.createReadStream(resolved.file);
+    stream.on('error', () => res.destroy()); stream.pipe(res);
+  });
+
+  try {
+    const address = await listen(server, host, port);
+    const origin = `http://${address.family === 'IPv6' ? `[${address.address}]` : address.address}:${address.port}`;
+    const browserConfig = options.browser
+      ? browserLaunchConfig(roots, origin + '/', { browser: options.browser, headless: options.headless, extraArgs: options.browserArgs })
+      : null;
+    launcher = isolation.registerLauncher(taskId, { pid: process.pid, label: 'browser-preview' });
+    if (options.browser) {
+      try { browserChild = await spawnBrowser(browserConfig); }
+      catch (err) { browserError = err.message; }
+    }
+    runtime = {
+      taskId, roots, server, origin, ownerToken: launcher.ownerToken,
+      source: startupSource, build: startupBuild, browserChild, browserError,
+      async close() { await stopBrowser(browserChild); await closeServer(server); },
+    };
+    return runtime;
+  } catch (err) {
+    await stopBrowser(browserChild).catch(() => {});
+    await closeServer(server).catch(() => {});
+    const existing = isolation.readLauncher(taskId);
+    if (!existing) { try { isolation.releaseTask(taskId); } catch { /* fail closed */ } }
+    throw err;
+  }
+}
+
+module.exports = { IDENTITY_PATH, SCHEMA, browserLaunchConfig, startBrowserRuntime };

--- a/scripts/nemo/lib/browser-runtime.cjs
+++ b/scripts/nemo/lib/browser-runtime.cjs
@@ -100,12 +100,16 @@ function spawnBrowser(config) {
 
 async function stopBrowser(child) {
   if (!child || child.exitCode != null || child.signalCode != null) return;
+  const exited = new Promise((resolve) => child.once('exit', resolve));
+  let timer;
+  const grace = new Promise((resolve) => { timer = setTimeout(resolve, 2000); });
   child.kill('SIGTERM');
-  await Promise.race([
-    new Promise((resolve) => child.once('exit', resolve)),
-    new Promise((resolve) => setTimeout(resolve, 2000)),
-  ]);
-  if (child.exitCode == null && child.signalCode == null) child.kill('SIGKILL');
+  await Promise.race([exited, grace]);
+  clearTimeout(timer);
+  if (child.exitCode == null && child.signalCode == null) {
+    child.kill('SIGKILL');
+    await exited;
+  }
 }
 
 function json(res, status, value, headOnly) {
@@ -162,8 +166,10 @@ function listen(server, host, port) {
 
 function closeServer(server) {
   if (!server.listening) return Promise.resolve();
-  if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
-  return new Promise((resolve, reject) => server.close((err) => err ? reject(err) : resolve()));
+  return new Promise((resolve, reject) => {
+    server.close((err) => err ? reject(err) : resolve());
+    if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
+  });
 }
 
 async function startBrowserRuntime(options = {}) {
@@ -217,7 +223,7 @@ async function startBrowserRuntime(options = {}) {
           NEMO_BROWSER_PROFILE: process.env.NEMO_BROWSER_PROFILE,
         },
         browser: {
-          requested: !!options.browser, integrated: !!browserChild, active: browserActive,
+          requested: !!options.browser, integrated: browserActive, active: browserActive,
           pid: browserChild ? browserChild.pid : null, profileDir: roots.browserProfile,
           error: browserError,
         },
@@ -248,7 +254,12 @@ async function startBrowserRuntime(options = {}) {
       : null;
     launcher = isolation.registerLauncher(taskId, { pid: process.pid, label: 'browser-preview' });
     if (options.browser) {
-      try { browserChild = await spawnBrowser(browserConfig); }
+      try {
+        browserChild = await spawnBrowser(browserConfig);
+        browserChild.once('exit', (code, signal) => {
+          browserError = `browser exited (${signal || `code ${code}`})`;
+        });
+      }
       catch (err) { browserError = err.message; }
     }
     runtime = {


### PR DESCRIPTION
Concurrent browser previews previously had isolated directory helpers but no application launcher or served source identity. This change adds `node scripts/nemo/browser.cjs`: each task holds its own loopback HTTP server, serves this checkout's `src/`, and exposes a source/build handshake. Explicit `--browser auto` launches Chromium with separate profile/cache/temp paths. Owner-controlled stop shuts down its browser and server before removing task roots.

Static serving rejects writes and escaping paths. Source/build drift is reported and blocks static responses after detection; static checks have a documented one-second cache, while identity requests refresh immediately. Browser exit is reported, and forced browser shutdown waits for actual exit before cleanup. The existing isolation library is unchanged.

Validation on `9d16c1f6bd67a27e1f912775b6586fd3b75d22a2` (macOS arm64):

- 28 focused browser/runtime-isolation tests passed, including immediate browser failure and stubborn-browser shutdown.
- `npm run doctor`, `npm run check` (6/6), and `npm run verify` passed; verify includes 70 Node and 15 geometry-wasm Rust tests. Receipt: `20260905T131508Z-9d16c1f`.
- Two real headless Chrome processes loaded Nemo's startup UI (six canvases each) from distinct task origins and reported the exact source/build identity.
- Separate profiles retained independent localStorage even when navigated to the same origin; reload preserved the first profile's value.
- Cross-owner stop was refused; stopping one task left the other browser/server alive. Both owned browser and launcher PIDs exited before their roots were removed.

Part of #902; does not close it. Tauri data/autosave, same-worktree build isolation, desktop/GPU reservation consumers, and standard suite discovery remain open. This is browser startup/isolation evidence, not document-edit/export or packaged-desktop acceptance. Direct Ctrl-C retains the launcher record for explicit owner release after exit; the controller `stop` command performs that release.
