### PR TITLE
R05: prevent committed size baselines from growing

### DIFF
--- a/engineering/boundaries/README.md
+++ b/engineering/boundaries/README.md
@@ -1,4 +1,4 @@
-# Boundaries checker — R05 first increment
+# Boundaries checker — R05 bounded enforcement
 
 Implements the enforcement half of
 [`engineering/remediation/04_MODULARITY_POLICY.md`](../remediation/04_MODULARITY_POLICY.md)
@@ -7,8 +7,9 @@ application. Code lives in [`scripts/nemo/lib/boundaries.cjs`](../../scripts/nem
 (the checker, pure functions, no I/O beyond reading the files a profile names) and
 [`scripts/nemo/boundaries.cjs`](../../scripts/nemo/boundaries.cjs) (a standalone CLI). Behavioral
 tests are in [`scripts/nemo/boundaries.test.cjs`](../../scripts/nemo/boundaries.test.cjs)
-(`node --test scripts/nemo/boundaries.test.cjs`). The library validates the profile before
-reading its sources; the CLI uses the same validation and exits 2 on malformed policy.
+and [`scripts/nemo/boundaries-ratchet.test.cjs`](../../scripts/nemo/boundaries-ratchet.test.cjs).
+The library validates the profile before reading its sources; the CLI uses the same validation
+and exits 2 on malformed policy or baseline input.
 
 This is **not wired into `npm run check`/`verify`, `scripts/nemo/lib/jobs.cjs` or
 `package.json`** in this packet — see "What's pending" below.
@@ -36,11 +37,58 @@ imports, new cycles, ... or UI imports into domain."
 
 ```bash
 node scripts/nemo/boundaries.cjs <profile.json> [--root <dir>] [--json]
+node scripts/nemo/boundaries.cjs <profile.json> --baseline <prior-profile.json> [--root <dir>] [--json]
 ```
 
 Exit 0 = no violations, 1 = one or more, 2 = bad usage or a profile that could not run (e.g.
 an unknown `sizeProfile` key, malformed exception, missing file, or unsupported lexical syntax).
 Unknown flags, missing option values and extra positional arguments also exit 2.
+
+The second form enables the size-baseline ratchet. `<prior-profile.json>` must be the explicit,
+previously reviewed profile from the commit being compared; the checker does not guess a Git
+revision or silently fall back when that file is missing. The original invocation remains
+unchanged and runs the profile rules without a baseline comparison.
+
+`--baseline` is a caller-supplied trust boundary. Future CI must materialize this file from the
+protected base revision and pass that path to the checker; it must never accept a baseline from
+candidate-controlled contents. This CLI validates and compares the supplied document, but it
+cannot prove which Git revision supplied it.
+
+## Size-baseline ratchet
+
+[`scripts/nemo/lib/boundaries-ratchet.cjs`](../../scripts/nemo/lib/boundaries-ratchet.cjs)
+compares the prior and candidate profiles by normalized root-relative file path. Module IDs and
+`sizeProfile` names are metadata, not ratchet identity. For each exact path, the effective
+ceiling is its policy value: the size exception's `ceiling` when one exists, otherwise the
+assigned profile's `hardMax`.
+
+Baseline mode fails when:
+
+- a retained named size profile raises its ordinary `hardMax`, or a newly named profile exceeds
+  the largest ordinary hard maximum in the prior adopted policy;
+- a candidate effective ceiling exceeds the prior exact-path ceiling, including after a module
+  reassignment or `sizeProfile` rename;
+- a prior path still exists in the source tree but was deleted from the candidate profile;
+- a prior size exception is deleted while an ordinary profile preserves the same enlarged
+  allowance, which would discard its owner/issue/expiry accountability; or
+- a size exception appears on a path absent from the prior baseline, including an exception
+  moved or renamed onto a new source path.
+
+A lower effective ceiling is accepted and recorded in `ratchet.reductions` with its current
+nonblank line count. A prior profile entry whose source was actually removed is accepted and
+recorded in `ratchet.removals`. The ordinary candidate check still reads every declared source
+and rejects actual line count above the candidate ceiling; unchanged policy therefore cannot
+hide source growth above its committed ceiling. JSON output adds a `ratchet` object only when
+`--baseline` is supplied. Text output reports ratchet violations, reductions and removals.
+
+The ratchet is intentionally policy-to-policy. Source renames that do not carry a size
+exception are treated as retired and new paths, but the new path still cannot use an enlarged
+ordinary policy: same-budget profile renames and new files at or below the prior adopted maximum
+remain valid. Full source coverage and classification remain the R01/R03 inventory gate. Review
+the reported removals rather than treating them as proof that code was deleted intentionally.
+The comparator does not infer file types or detect content moves, and a new path may use any
+still-adopted ordinary profile. Reviewing each path's profile assignment and making baseline
+provenance immutable are responsibilities of the R01/R03 and CI adoption gate.
 
 ## Limitations (v1, deliberate scope cut)
 
@@ -91,9 +139,8 @@ An active exception for private imports, layer edges or globals applies only to 
 file/rule. A cycle exception removes only dependency contributions originating in its exact
 file; another file contributing the same module edge remains in the prohibited graph. Applied
 exceptions are recorded in the report. Unsupported-source diagnostics
-cannot be waived by an exception. This validation does not compare policy changes against an
-older Git baseline; preventing an authorized ceiling from being raised in a later revision
-still requires the R01/R03 baseline/CI adoption work.
+cannot be waived by an exception. Supplying `--baseline` compares the candidate against an
+explicitly selected older profile; the checker never infers which Git revision is authoritative.
 
 ## Integration contract for R01/R03 (pending)
 
@@ -133,6 +180,9 @@ contract:
 - No real, reviewed profile for any part of the actual `src/js` tree — only the illustrative
   fixtures inside `boundaries.test.cjs`. Producing one is R01/R03's job, not this checker's;
   fabricating a "reviewed" profile here would misrepresent unreviewed code as audited.
+- No canonical committed baseline yet. This increment supplies the comparison mechanism; R01/R03
+  still supply reviewed real profiles and a later integration packet must materialize the
+  protected-base copy in standard commands/CI.
 - `layer-violation` was implemented alongside the five rules the R05 acceptance criteria name
   (cycle, private-import, global-state, size, expired-exception) because it falls out of the
   same module graph at near-zero extra cost, and the policy explicitly calls out forbidden

--- a/scripts/nemo/boundaries-ratchet.test.cjs
+++ b/scripts/nemo/boundaries-ratchet.test.cjs
@@ -1,0 +1,219 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { compareSizeBaseline } = require('./lib/boundaries-ratchet.cjs');
+
+function makeRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-boundaries-ratchet-'));
+  test.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+function write(root, relative, source) {
+  const target = path.join(root, relative);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, source);
+}
+
+function profile({ profileName = 'legacy', hardMax = 10, ceiling = 20, sourcePath = 'src/legacy.cjs' } = {}) {
+  const slash = sourcePath.lastIndexOf('/');
+  const dir = sourcePath.slice(0, slash);
+  const file = sourcePath.slice(slash + 1);
+  return {
+    modules: [{ id: 'legacy.module', layer: 'domain', dir, files: [file], publicApi: [file], sizeProfile: profileName }],
+    sizeProfiles: { [profileName]: { warn: Math.min(5, hardMax), hardMax } },
+    layerRules: { domain: { allowedLayers: ['domain'] } },
+    exceptions: ceiling === null ? [] : [{
+      path: sourcePath, rule: 'size', ceiling, owner: 'maintainer', issue: '901', expires: '2999-01-01', reason: 'legacy module',
+    }],
+  };
+}
+
+function lines(count) {
+  return Array.from({ length: count }, (_, i) => `const value${i} = ${i};`).join('\n');
+}
+
+test('an exact-path size exception ceiling cannot grow', () => {
+  const root = makeRoot();
+  write(root, 'src/legacy.cjs', lines(18));
+  const report = compareSizeBaseline(profile(), profile({ ceiling: 21 }), { root });
+  assert.equal(report.ok, false);
+  assert.equal(report.violations[0].rule, 'size-baseline-growth');
+  assert.deepEqual(report.violations[0].detail, {
+    priorCeiling: 20, candidateCeiling: 21, actualLines: 18,
+    priorSizeProfile: 'legacy', candidateSizeProfile: 'legacy',
+  });
+});
+
+test('renaming or reassigning a size profile cannot raise an exact-path ceiling', () => {
+  const root = makeRoot();
+  write(root, 'src/legacy.cjs', lines(18));
+  const baseline = profile({ ceiling: null, hardMax: 20 });
+  const candidate = profile({ profileName: 'renamed-large', ceiling: null, hardMax: 25 });
+  candidate.modules[0].id = 'reassigned.module';
+  const report = compareSizeBaseline(baseline, candidate, { root });
+  assert.equal(report.ok, false);
+  const pathGrowth = report.violations.find((item) => item.rule === 'size-baseline-growth');
+  assert.ok(pathGrowth);
+  assert.equal(pathGrowth.detail.priorSizeProfile, 'legacy');
+  assert.equal(pathGrowth.detail.candidateSizeProfile, 'renamed-large');
+});
+
+test('retired-path debt cannot move under a newly inflated ordinary profile', () => {
+  const root = makeRoot();
+  write(root, 'src/replacement.cjs', lines(7));
+  const baseline = profile({ hardMax: 3, ceiling: 6 });
+  const candidate = profile({ profileName: 'renamed-large', hardMax: 50, ceiling: null, sourcePath: 'src/replacement.cjs' });
+  const report = compareSizeBaseline(baseline, candidate, { root });
+  assert.equal(report.ok, false);
+  assert.equal(report.violations[0].rule, 'size-baseline-new-profile');
+  assert.deepEqual(report.violations[0].detail, {
+    sizeProfile: 'renamed-large', priorOrdinaryMax: 3, candidateHardMax: 50,
+  });
+});
+
+test('prototype property names cannot conceal a newly inflated ordinary profile', async (t) => {
+  for (const profileName of ['toString', 'constructor', '__proto__']) await t.test(profileName, () => {
+    const root = makeRoot();
+    write(root, 'src/replacement.cjs', lines(7));
+    const baseline = profile({ hardMax: 3, ceiling: 6 });
+    const candidate = JSON.parse(JSON.stringify(
+      profile({ profileName, hardMax: 50, ceiling: null, sourcePath: 'src/replacement.cjs' }),
+    ));
+    assert.equal(Object.hasOwn(candidate.sizeProfiles, profileName), true);
+
+    const report = compareSizeBaseline(baseline, candidate, { root });
+    assert.equal(report.ok, false);
+    const violation = report.violations.find((item) => item.rule === 'size-baseline-new-profile');
+    assert.ok(violation);
+    assert.deepEqual(violation.detail, { sizeProfile: profileName, priorOrdinaryMax: 3, candidateHardMax: 50 });
+  });
+});
+
+test('raising a retained named ordinary profile fails even when only a new path uses it', () => {
+  const root = makeRoot();
+  write(root, 'src/replacement.cjs', lines(7));
+  const baseline = profile({ hardMax: 3, ceiling: 6 });
+  const candidate = profile({ hardMax: 50, ceiling: null, sourcePath: 'src/replacement.cjs' });
+  const report = compareSizeBaseline(baseline, candidate, { root });
+  assert.equal(report.ok, false);
+  assert.equal(report.violations[0].rule, 'size-baseline-profile-growth');
+  assert.deepEqual(report.violations[0].detail, {
+    sizeProfile: 'legacy', priorHardMax: 3, candidateHardMax: 50,
+  });
+});
+
+test('same-budget profile rename and a new file remain valid', () => {
+  const root = makeRoot();
+  write(root, 'src/replacement.cjs', lines(3));
+  const baseline = profile({ hardMax: 3, ceiling: null });
+  const candidate = profile({ profileName: 'renamed-same-budget', hardMax: 3, ceiling: null, sourcePath: 'src/replacement.cjs' });
+  const report = compareSizeBaseline(baseline, candidate, { root });
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.removals, [{ file: 'src/legacy.cjs', priorCeiling: 3, reason: 'source-removed' }]);
+});
+
+test('deleting a still-present path from the candidate profile fails', () => {
+  const root = makeRoot();
+  write(root, 'src/legacy.cjs', lines(8));
+  write(root, 'src/other.cjs', lines(2));
+  const candidate = profile({ sourcePath: 'src/other.cjs', ceiling: null });
+  const report = compareSizeBaseline(profile(), candidate, { root });
+  assert.equal(report.ok, false);
+  assert.equal(report.violations[0].rule, 'size-baseline-path');
+  assert.equal(report.violations[0].detail.actualLines, 8);
+});
+
+test('moving a legacy exception to a new path is rejected', () => {
+  const root = makeRoot();
+  write(root, 'src/renamed.cjs', lines(18));
+  const report = compareSizeBaseline(profile(), profile({ sourcePath: 'src/renamed.cjs' }), { root });
+  assert.equal(report.ok, false);
+  assert.deepEqual(report.violations.map((item) => item.rule), ['size-baseline-new-exception']);
+  assert.deepEqual(report.removals, [{ file: 'src/legacy.cjs', priorCeiling: 20, reason: 'source-removed' }]);
+});
+
+test('deleting exception accountability without lowering its allowance fails', () => {
+  const root = makeRoot();
+  write(root, 'src/legacy.cjs', lines(18));
+  const candidate = profile({ ceiling: null, hardMax: 20 });
+  const report = compareSizeBaseline(profile(), candidate, { root });
+  assert.equal(report.ok, false);
+  assert.ok(report.violations.some((item) => item.rule === 'size-baseline-exception'));
+});
+
+test('documented ceiling reductions and retired source paths pass', () => {
+  const root = makeRoot();
+  write(root, 'src/legacy.cjs', lines(15));
+  const reduced = compareSizeBaseline(profile(), profile({ ceiling: 15 }), { root });
+  assert.equal(reduced.ok, true);
+  assert.deepEqual(reduced.reductions, [{ file: 'src/legacy.cjs', priorCeiling: 20, candidateCeiling: 15, actualLines: 15 }]);
+
+  fs.rmSync(path.join(root, 'src/legacy.cjs'));
+  const candidate = profile({ sourcePath: 'src/replacement.cjs', ceiling: null });
+  write(root, 'src/replacement.cjs', lines(4));
+  const retired = compareSizeBaseline(profile(), candidate, { root });
+  assert.equal(retired.ok, true);
+  assert.deepEqual(retired.removals, [{ file: 'src/legacy.cjs', priorCeiling: 20, reason: 'source-removed' }]);
+});
+
+test('removing an exception after shrinking below the ordinary hard maximum passes', () => {
+  const root = makeRoot();
+  write(root, 'src/legacy.cjs', lines(8));
+  const report = compareSizeBaseline(profile(), profile({ ceiling: null }), { root });
+  assert.equal(report.ok, true);
+  assert.deepEqual(report.reductions, [{ file: 'src/legacy.cjs', priorCeiling: 20, candidateCeiling: 10, actualLines: 8 }]);
+});
+
+test('missing and malformed baseline objects fail explicitly', () => {
+  const candidate = profile();
+  assert.throws(() => compareSizeBaseline(null, candidate), /invalid baseline profile: baseline is required/);
+  assert.throws(() => compareSizeBaseline({}, candidate), /invalid baseline profile: invalid profile/);
+  assert.throws(() => compareSizeBaseline(candidate, {}), /invalid candidate profile: invalid profile/);
+});
+
+test('CLI baseline mode reports ratchet failures while the original invocation remains compatible', () => {
+  const root = makeRoot();
+  const cli = path.join(__dirname, 'boundaries.cjs');
+  const baselinePath = path.join(root, 'baseline.json');
+  const candidatePath = path.join(root, 'candidate.json');
+  write(root, 'src/legacy.cjs', lines(18));
+  fs.writeFileSync(baselinePath, JSON.stringify(profile()));
+  fs.writeFileSync(candidatePath, JSON.stringify(profile({ ceiling: 21 })));
+
+  const original = spawnSync(process.execPath, [cli, candidatePath, '--root', root, '--json'], { encoding: 'utf8' });
+  assert.equal(original.status, 0);
+  assert.equal(JSON.parse(original.stdout).ratchet, undefined);
+
+  const ratcheted = spawnSync(process.execPath, [cli, candidatePath, '--baseline', baselinePath, '--root', root, '--json'], { encoding: 'utf8' });
+  assert.equal(ratcheted.status, 1);
+  const report = JSON.parse(ratcheted.stdout);
+  assert.equal(report.ok, false);
+  assert.equal(report.ratchet.violations[0].rule, 'size-baseline-growth');
+
+  const missing = spawnSync(process.execPath, [cli, candidatePath, '--baseline', path.join(root, 'missing.json'), '--root', root], { encoding: 'utf8' });
+  assert.equal(missing.status, 2);
+  assert.match(missing.stderr, /could not read\/parse baseline/);
+});
+
+test('CLI still rejects actual source growth beyond an unchanged committed ceiling', () => {
+  const root = makeRoot();
+  const cli = path.join(__dirname, 'boundaries.cjs');
+  const baselinePath = path.join(root, 'baseline.json');
+  const candidatePath = path.join(root, 'candidate.json');
+  write(root, 'src/legacy.cjs', lines(21));
+  fs.writeFileSync(baselinePath, JSON.stringify(profile()));
+  fs.writeFileSync(candidatePath, JSON.stringify(profile()));
+
+  const run = spawnSync(process.execPath, [cli, candidatePath, '--baseline', baselinePath, '--root', root, '--json'], { encoding: 'utf8' });
+  assert.equal(run.status, 1);
+  const report = JSON.parse(run.stdout);
+  assert.equal(report.violations[0].rule, 'size');
+  assert.equal(report.violations[0].detail.lines, 21);
+  assert.equal(report.ratchet.ok, true, 'unchanged policy is clean; the source-size check is the failing gate');
+});

--- a/scripts/nemo/boundaries.cjs
+++ b/scripts/nemo/boundaries.cjs
@@ -7,20 +7,26 @@
 // they do.
 //
 // Usage:
-//   node scripts/nemo/boundaries.cjs <profile.json> [--root <dir>] [--json]
+//   node scripts/nemo/boundaries.cjs <profile.json> [--baseline <prior-profile.json>]
+//     [--root <dir>] [--json]
 //
-// Exit codes: 0 = no violations, 1 = one or more violations, 2 = bad usage or
-// a profile that could not be loaded/run (unknown sizeProfile, missing file).
+// Exit codes: 0 = no violations, 1 = one or more checker/ratchet violations,
+// 2 = bad usage or an input that could not be loaded/run.
 
 const fs = require('node:fs');
 const path = require('node:path');
 const { checkProfile } = require('./lib/boundaries.cjs');
+const { compareSizeBaseline } = require('./lib/boundaries-ratchet.cjs');
 
 function parseArgs(argv) {
-  const out = { profilePath: null, root: process.cwd(), json: false };
+  const out = { profilePath: null, baselinePath: null, root: process.cwd(), json: false };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--json') out.json = true;
+    else if (a === '--baseline') {
+      if (!argv[i + 1] || argv[i + 1].startsWith('--')) throw new Error('--baseline requires a prior profile');
+      out.baselinePath = argv[++i];
+    }
     else if (a === '--root') {
       if (!argv[i + 1] || argv[i + 1].startsWith('--')) throw new Error('--root requires a directory');
       out.root = argv[++i];
@@ -40,7 +46,7 @@ function main() {
     process.exit(2);
   }
   if (!args.profilePath) {
-    console.error('usage: node scripts/nemo/boundaries.cjs <profile.json> [--root <dir>] [--json]');
+    console.error('usage: node scripts/nemo/boundaries.cjs <profile.json> [--baseline <prior-profile.json>] [--root <dir>] [--json]');
     process.exit(2);
   }
 
@@ -60,6 +66,23 @@ function main() {
     process.exit(2);
   }
 
+  if (args.baselinePath) {
+    let baseline;
+    try {
+      baseline = JSON.parse(fs.readFileSync(path.resolve(args.baselinePath), 'utf8'));
+    } catch (err) {
+      console.error(`could not read/parse baseline "${args.baselinePath}": ${err.message}`);
+      process.exit(2);
+    }
+    try {
+      const ratchet = compareSizeBaseline(baseline, profile, { root: path.resolve(args.root) });
+      report = { ...report, ok: report.ok && ratchet.ok, ratchet };
+    } catch (err) {
+      console.error(`baseline comparison could not run: ${err.message}`);
+      process.exit(2);
+    }
+  }
+
   if (args.json) {
     console.log(JSON.stringify(report, null, 2));
   } else {
@@ -69,6 +92,18 @@ function main() {
     }
     for (const w of report.warnings) {
       console.log(`  WARN  ${w.rule.padEnd(18)} ${w.file || w.module}${w.line ? `:${w.line}` : ''} — ${w.message}`);
+    }
+    if (report.ratchet) {
+      console.log(`ratchet: ${report.ratchet.violations.length} violation(s), ${report.ratchet.reductions.length} reduction(s), ${report.ratchet.removals.length} removal(s)`);
+      for (const v of report.ratchet.violations) {
+        console.log(`  FAIL  ${v.rule.padEnd(30)} ${v.file || v.detail?.sizeProfile || 'policy'} — ${v.message}`);
+      }
+      for (const reduction of report.ratchet.reductions) {
+        console.log(`  INFO  ${'size-baseline-reduction'.padEnd(30)} ${reduction.file} — ceiling ${reduction.priorCeiling} -> ${reduction.candidateCeiling}, actual ${reduction.actualLines}`);
+      }
+      for (const removal of report.ratchet.removals) {
+        console.log(`  INFO  ${'size-baseline-removal'.padEnd(30)} ${removal.file} — source absent; prior ceiling ${removal.priorCeiling}`);
+      }
     }
   }
   process.exit(report.ok ? 0 : 1);

--- a/scripts/nemo/lib/boundaries-ratchet.cjs
+++ b/scripts/nemo/lib/boundaries-ratchet.cjs
@@ -1,0 +1,187 @@
+'use strict';
+// Exact-path size-baseline comparison for the R05 boundary checker.
+//
+// Both inputs use engineering/boundaries/profile.schema.json. The baseline is
+// the previously reviewed/committed profile and the candidate is the policy
+// being checked. Profile names and module assignments are deliberately not
+// identities here: the root-relative source path and its effective ceiling are.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { countNonBlankLines, validateProfile } = require('./boundaries.cjs');
+
+function sizeEntries(profile) {
+  validateProfile(profile);
+  const exceptions = new Map(
+    (profile.exceptions || [])
+      .filter((exception) => exception.rule === 'size')
+      .map((exception) => [exception.path, exception]),
+  );
+  const entries = new Map();
+  for (const module of profile.modules) {
+    const limits = profile.sizeProfiles[module.sizeProfile];
+    for (const file of module.files) {
+      const sourcePath = path.posix.join(module.dir, file);
+      const exception = exceptions.get(sourcePath) || null;
+      entries.set(sourcePath, {
+        module: module.id,
+        sizeProfile: module.sizeProfile,
+        hardMax: limits.hardMax,
+        ceiling: exception ? exception.ceiling : limits.hardMax,
+        exception,
+      });
+    }
+  }
+  return entries;
+}
+
+function sourceState(root, sourcePath) {
+  const absolute = path.resolve(root, ...sourcePath.split('/'));
+  try {
+    const stat = fs.statSync(absolute);
+    if (!stat.isFile()) return { present: true, actualLines: null };
+    return { present: true, actualLines: countNonBlankLines(fs.readFileSync(absolute, 'utf8')) };
+  } catch (error) {
+    if (error && error.code === 'ENOENT') return { present: false, actualLines: null };
+    throw error;
+  }
+}
+
+/**
+ * Compare a candidate profile with its explicit prior baseline.
+ *
+ * This is a policy comparison, not a Git lookup. Callers must provide the
+ * committed baseline file explicitly so a missing/unreadable reference fails
+ * at the CLI boundary instead of silently disabling the ratchet.
+ */
+function compareSizeBaseline(baselineProfile, candidateProfile, opts = {}) {
+  if (baselineProfile === undefined || baselineProfile === null) {
+    throw new Error('invalid baseline profile: baseline is required');
+  }
+  if (candidateProfile === undefined || candidateProfile === null) {
+    throw new Error('invalid candidate profile: candidate is required');
+  }
+  let baseline;
+  let candidate;
+  try {
+    baseline = sizeEntries(baselineProfile);
+  } catch (error) {
+    throw new Error(`invalid baseline profile: ${error.message}`);
+  }
+  try {
+    candidate = sizeEntries(candidateProfile);
+  } catch (error) {
+    throw new Error(`invalid candidate profile: ${error.message}`);
+  }
+
+  const root = path.resolve(opts.root || process.cwd());
+  const violations = [];
+  const reductions = [];
+  const removals = [];
+
+  // Ratchet the ordinary policy as well as per-path effective ceilings. A
+  // retained profile name cannot grow. A renamed/new profile may reuse or
+  // lower an adopted budget, but cannot introduce a larger ordinary maximum.
+  const priorOrdinaryMax = Math.max(
+    ...Object.values(baselineProfile.sizeProfiles).map((limits) => limits.hardMax),
+  );
+  for (const [name, limits] of Object.entries(candidateProfile.sizeProfiles)) {
+    const priorLimits = Object.hasOwn(baselineProfile.sizeProfiles, name)
+      ? baselineProfile.sizeProfiles[name]
+      : null;
+    if (priorLimits && limits.hardMax > priorLimits.hardMax) {
+      violations.push({
+        rule: 'size-baseline-profile-growth', module: null, file: null, line: null,
+        message: `Size profile "${name}" hard maximum increased from ${priorLimits.hardMax} to ${limits.hardMax}`,
+        detail: { sizeProfile: name, priorHardMax: priorLimits.hardMax, candidateHardMax: limits.hardMax },
+      });
+    } else if (!priorLimits && limits.hardMax > priorOrdinaryMax) {
+      violations.push({
+        rule: 'size-baseline-new-profile', module: null, file: null, line: null,
+        message: `New size profile "${name}" hard maximum ${limits.hardMax} exceeds the prior ordinary maximum ${priorOrdinaryMax}`,
+        detail: { sizeProfile: name, priorOrdinaryMax, candidateHardMax: limits.hardMax },
+      });
+    }
+  }
+
+  for (const [sourcePath, prior] of baseline) {
+    const next = candidate.get(sourcePath);
+    const source = sourceState(root, sourcePath);
+    if (!next) {
+      if (source.present) {
+        violations.push({
+          rule: 'size-baseline-path', module: prior.module, file: sourcePath, line: null,
+          message: `Previously baselined path ${sourcePath} is still present but missing from the candidate profile`,
+          detail: { priorCeiling: prior.ceiling, actualLines: source.actualLines },
+        });
+      } else {
+        removals.push({ file: sourcePath, priorCeiling: prior.ceiling, reason: 'source-removed' });
+      }
+      continue;
+    }
+
+    if (next.ceiling > prior.ceiling) {
+      violations.push({
+        rule: 'size-baseline-growth', module: next.module, file: sourcePath, line: null,
+        message: `Size ceiling for ${sourcePath} increased from ${prior.ceiling} to ${next.ceiling}`,
+        detail: {
+          priorCeiling: prior.ceiling,
+          candidateCeiling: next.ceiling,
+          actualLines: source.actualLines,
+          priorSizeProfile: prior.sizeProfile,
+          candidateSizeProfile: next.sizeProfile,
+        },
+      });
+      continue;
+    }
+
+    // A legacy exception carries owner/issue/expiry accountability. It may be
+    // removed only when the resulting ordinary profile ceiling is lower.
+    if (prior.exception && !next.exception && next.ceiling >= prior.ceiling) {
+      violations.push({
+        rule: 'size-baseline-exception', module: next.module, file: sourcePath, line: null,
+        message: `Size exception for ${sourcePath} was removed without reducing its ${prior.ceiling}-line allowance`,
+        detail: {
+          priorCeiling: prior.ceiling,
+          candidateCeiling: next.ceiling,
+          actualLines: source.actualLines,
+          priorException: prior.exception,
+        },
+      });
+      continue;
+    }
+
+    if (next.ceiling < prior.ceiling) {
+      reductions.push({
+        file: sourcePath,
+        priorCeiling: prior.ceiling,
+        candidateCeiling: next.ceiling,
+        actualLines: source.actualLines,
+      });
+    }
+  }
+
+  // A new exact-path exception is new legacy debt. Reassigning or renaming an
+  // old exception therefore cannot make it disappear from the comparison.
+  for (const [sourcePath, next] of candidate) {
+    if (!baseline.has(sourcePath) && next.exception) {
+      const source = sourceState(root, sourcePath);
+      violations.push({
+        rule: 'size-baseline-new-exception', module: next.module, file: sourcePath, line: null,
+        message: `Candidate adds a size exception for path absent from the prior baseline: ${sourcePath}`,
+        detail: { candidateCeiling: next.ceiling, actualLines: source.actualLines, exception: next.exception },
+      });
+    }
+  }
+
+  return {
+    ok: violations.length === 0,
+    baselinePathCount: baseline.size,
+    candidatePathCount: candidate.size,
+    violations,
+    reductions,
+    removals,
+  };
+}
+
+module.exports = { compareSizeBaseline };


### PR DESCRIPTION
The boundary checker previously validated only the candidate policy, allowing a later revision to increase its own size allowance. This adds an explicit `--baseline` comparison that rejects growth of ordinary profiles and exact-path ceilings, retained paths dropped from coverage, and exception reassignment bypasses. Reductions and source removals are reported for review; the existing CLI invocation is preserved.

Validation on `1b0e77d77165f9a120aace877efeda26798bd588`: 81 focused boundary/ratchet tests passed, syntax and diff checks passed, and the required doctor/check/verify receipts passed on the clean commit (70 registered Node tests and 15 Rust tests). Independent bounded review found no actionable issues.

Part of #901. Reviewed application profiles still depend on #897/#899; standard-command and CI adoption remain follow-up work. CI must obtain the explicit baseline from the protected base revision. This increment does not close R05 or claim browser/Tauri acceptance.
