### PR TITLE
test: run boundary and runtime regressions in normal verification

### DIFF
--- a/engineering/boundaries/README.md
+++ b/engineering/boundaries/README.md
@@ -11,8 +11,10 @@ and [`scripts/nemo/boundaries-ratchet.test.cjs`](../../scripts/nemo/boundaries-r
 The library validates the profile before reading its sources; the CLI uses the same validation
 and exits 2 on malformed policy or baseline input.
 
-This is **not wired into `npm run check`/`verify`, `scripts/nemo/lib/jobs.cjs` or
-`package.json`** in this packet — see "What's pending" below.
+The behavioral suites run in normal `npm test` / `verify` through the
+`tests/nemo-boundaries*.test.cjs` entries. Production profile enforcement is
+**not wired into `npm run check`/`verify` or `scripts/nemo/lib/jobs.cjs`** — see
+"What's pending" below. Passing the regressions does not audit application source.
 
 ## What it checks
 

--- a/scripts/nemo/isolation.test.cjs
+++ b/scripts/nemo/isolation.test.cjs
@@ -1,8 +1,7 @@
 'use strict';
 // Behavioral tests for R06 task-runtime isolation (scripts/nemo/lib/isolation.cjs).
-// Not wired into `npm test` (tests/*.test.cjs glob in package.json, out of
-// scope for this increment — see engineering/runtime-isolation.md). Run
-// directly:
+// Included in `npm test` / `verify` through tests/nemo-isolation.test.cjs.
+// Run this suite directly:
 //   node --test scripts/nemo/isolation.test.cjs
 //
 // NEMO_ISOLATION_ROOT is redirected to a throwaway tmp dir *before*

--- a/tests/nemo-boundaries-ratchet.test.cjs
+++ b/tests/nemo-boundaries-ratchet.test.cjs
@@ -1,0 +1,4 @@
+'use strict';
+
+// Run the existing behavioral suite; do not duplicate its fixtures or assertions.
+require('../scripts/nemo/boundaries-ratchet.test.cjs');

--- a/tests/nemo-boundaries.test.cjs
+++ b/tests/nemo-boundaries.test.cjs
@@ -1,0 +1,4 @@
+'use strict';
+
+// Keep the tooling regressions in the normal npm test / verify discovery path.
+require('../scripts/nemo/boundaries.test.cjs');

--- a/tests/nemo-browser-runtime.test.cjs
+++ b/tests/nemo-browser-runtime.test.cjs
@@ -1,0 +1,4 @@
+'use strict';
+
+// A separate process keeps the browser suite's environment and module cache private.
+require('../scripts/nemo/browser-runtime.test.cjs');

--- a/tests/nemo-isolation.test.cjs
+++ b/tests/nemo-isolation.test.cjs
@@ -1,0 +1,4 @@
+'use strict';
+
+// A separate test entry preserves this suite's process-local isolation root.
+require('../scripts/nemo/isolation.test.cjs');


### PR DESCRIPTION
The normal `npm test` glob skipped the R05 boundary/ratchet and R06 isolation/browser regression files under `scripts/nemo/`. Add four test entry files so the existing behavioral suites run through both `npm test` and `npm run verify`, bringing normal discovery from 70 to 179 tests.

Each runtime suite retains a separate Node test process so its temporary isolation-root environment and module cache do not leak into another suite. Existing tests and fixtures are reused without copying assertions. Update the affected documentation/header to distinguish running checker regressions from enforcing reviewed application profiles.

Validation on `874726d33f06287cd48854e8216e02a31d2ee0c7`: `npm test` passed 179/179; doctor, check and verify passed on the clean commit, including 179 Node tests and 15 Rust tests. No package or job-registration changes.

Advances #901 and #902. Reviewed source profiles, production enforcement/CI adoption, and full Tauri/build/GPU acceptance remain open.
