### PR TITLE
R06: isolate desktop build outputs and own their process lifetime

### DIFF
--- a/engineering/runtime-isolation.md
+++ b/engineering/runtime-isolation.md
@@ -139,9 +139,13 @@ rules above. No unrelated browser or task is selected by name.
 Tauri CLI as `tauri build --target <host> -b app --no-sign`. It writes Cargo
 output under that task's `build/tauri-target`, routes temporary, cache and
 report paths through the task roots, and holds an exclusive slot derived from
-the exact worktree path while the build child is active. Different worktrees
-have different slots. A second build in the same worktree is refused before it
-starts, avoiding concurrent writes by Tauri/Cargo to shared generated source.
+the exact worktree path until the complete owned build process group exits.
+Different worktrees have different slots. A second build in the same worktree
+is refused before it starts, avoiding concurrent writes by Tauri/Cargo to shared
+generated source. Direct build-leader exit does not establish group completion:
+remaining descendants are terminated and verified absent before slot release.
+If that cannot be established, the launcher and slot remain live with a
+`reconciliation-required` result.
 
 The first stdout line is JSON containing the task roots, owner token, source and
 build identities. Build stdout/stderr go to the reported log files. The launcher
@@ -161,6 +165,10 @@ that task's disposable roots. Copy wanted artifacts before stopping. Forced or
 external launcher termination can still leave child processes or stale records
 that require the reconciliation procedure above.
 
+The native default currently supports macOS only. Other platforms are rejected
+before task roots, slots or launcher records are created because their bundle
+arguments and process-tree ownership have not been implemented or validated.
+
 This serializes same-worktree builds and isolates Cargo output; it does not make
 the checkout immutable. Tauri or its build scripts can still update generated
 files under `src-tauri/gen/`. Treat those as shared-writer paths: inspect the
@@ -172,10 +180,10 @@ owned by R03/R04.
 The focused non-native regressions run with
 `node --test scripts/nemo/build-runtime.test.cjs`. They use executable stubs to
 cover disjoint paths, same-worktree slot refusal/release, nonzero build results,
-owner-only status/stop, active process-group reaping and retained artifacts
-without starting a Tauri, desktop or GPU process. The core isolation suite
-already covers source-identity drift without adding a second concurrent
-worktree mutation to normal test discovery.
+owner-only status/stop, active process-group reaping, leader-before-descendant
+exit and retained artifacts without starting a Tauri, desktop or GPU process.
+The core isolation suite already covers source-identity drift without adding a
+second concurrent worktree mutation to normal test discovery.
 
 ## Validation and remaining integration
 

--- a/engineering/runtime-isolation.md
+++ b/engineering/runtime-isolation.md
@@ -133,6 +133,50 @@ before stopping. Graceful launcher shutdown closes its browser and HTTP server;
 forced termination and interrupted records still require the reconciliation
 rules above. No unrelated browser or task is selected by name.
 
+## Desktop build launcher
+
+`node scripts/nemo/build.cjs start --task build-a` invokes the installed local
+Tauri CLI as `tauri build --target <host> -b app --no-sign`. It writes Cargo
+output under that task's `build/tauri-target`, routes temporary, cache and
+report paths through the task roots, and holds an exclusive slot derived from
+the exact worktree path while the build child is active. Different worktrees
+have different slots. A second build in the same worktree is refused before it
+starts, avoiding concurrent writes by Tauri/Cargo to shared generated source.
+
+The first stdout line is JSON containing the task roots, owner token, source and
+build identities. Build stdout/stderr go to the reported log files. The launcher
+stays alive after success or failure so its ownership handshake and artifacts
+remain addressable; completion releases the build slot. Inspect or stop it from
+a separate controlling process:
+
+```sh
+node scripts/nemo/build.cjs status --task build-a --owner <token>
+node scripts/nemo/build.cjs stop --task build-a --owner <token>
+```
+
+`status` compares the current complete R02 source/build identity with startup
+and reports the child state and result. `stop` refuses a mismatched token,
+terminates an active build process group, waits for launcher exit and removes
+that task's disposable roots. Copy wanted artifacts before stopping. Forced or
+external launcher termination can still leave child processes or stale records
+that require the reconciliation procedure above.
+
+This serializes same-worktree builds and isolates Cargo output; it does not make
+the checkout immutable. Tauri or its build scripts can still update generated
+files under `src-tauri/gen/`. Treat those as shared-writer paths: inspect the
+source diff after a real build and coordinate any expected regeneration with
+its owner. Actual paired native-build evidence and integration with the R02/R03
+`build:desktop` job remain separate work because that job surface is currently
+owned by R03/R04.
+
+The focused non-native regressions run with
+`node --test scripts/nemo/build-runtime.test.cjs`. They use executable stubs to
+cover disjoint paths, same-worktree slot refusal/release, nonzero build results,
+owner-only status/stop, active process-group reaping and retained artifacts
+without starting a Tauri, desktop or GPU process. The core isolation suite
+already covers source-identity drift without adding a second concurrent
+worktree mutation to normal test discovery.
+
 ## Validation and remaining integration
 
 Run `node --test scripts/nemo/isolation.test.cjs`. The 20 behavioral tests cover
@@ -155,10 +199,14 @@ Still required for the full acceptance contract in
   implement and validate the actual runtime override; no untested Tauri launch
   configuration is prescribed by this document.
 - Wire exclusive slots into desktop input and reference GPU benchmark consumers.
-- Isolate/serialize simultaneous desktop builds within one worktree. Separate
-  worktrees normally separate `src-tauri/target`; same-worktree builds still share it.
-- Include the focused suite in normal `npm test`, `check` or `verify` discovery.
-  The existing package test glob does not include `scripts/nemo/isolation.test.cjs`.
+- Validate two real native builds through the standalone isolated launcher,
+  inspect their source diffs and then integrate it with the standard R02/R03
+  `build:desktop` job after that shared surface is available.
+- Production profile/launcher adoption remains separate from test discovery.
+  Normal `npm test`/`verify` discovery reaches the five focused suites through
+  isolated entry processes under `tests/nemo-{boundaries,boundaries-ratchet,
+  isolation,browser-runtime,build-runtime}.test.cjs`; each suite can still be
+  invoked directly while developing it.
 
 Those remaining integrations require shared package/job/platform files. The
 preview launcher is a bounded browser increment; it does not establish Tauri,

--- a/scripts/nemo/build-runtime.test.cjs
+++ b/scripts/nemo/build-runtime.test.cjs
@@ -1,0 +1,197 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { after, test } = require('node:test');
+
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-build-runtime-test-'));
+process.env.NEMO_ISOLATION_ROOT = path.join(scratch, 'runtime');
+const isolation = require('./lib/isolation.cjs');
+const runtime = require('./lib/build-runtime.cjs');
+const cli = path.join(__dirname, 'build.cjs');
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+const stub = path.join(scratch, 'build-stub');
+fs.writeFileSync(stub, `#!${process.execPath}\n` + String.raw`
+const fs = require('node:fs');
+const [capture, delay, exitCode] = process.argv.slice(2);
+fs.writeFileSync(capture, JSON.stringify({
+  pid: process.pid,
+  target: process.env.CARGO_TARGET_DIR,
+  temp: process.env.TMPDIR,
+  cache: process.env.XDG_CACHE_HOME,
+  reports: process.env.NEMO_REPORT_DIR,
+  task: process.env.NEMO_TASK_ID,
+}));
+setTimeout(() => process.exit(Number(exitCode || 0)), Number(delay || 0));
+`, { mode: 0o700 });
+
+const stubbornStub = path.join(scratch, 'stubborn-build-stub');
+fs.writeFileSync(stubbornStub, `#!${process.execPath}\n` + String.raw`
+const fs = require('node:fs');
+fs.writeFileSync(process.argv[2], String(process.pid));
+process.on('SIGTERM', () => {});
+setInterval(() => {}, 1000);
+`, { mode: 0o700 });
+
+after(() => fs.rmSync(scratch, { recursive: true, force: true }));
+
+function exited(child) {
+  if (child.exitCode != null || child.signalCode != null) return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  return new Promise((resolve) => child.once('exit', (code, signal) => resolve({ code, signal })));
+}
+
+function firstLine(child) {
+  return new Promise((resolve, reject) => {
+    let data = ''; const timer = setTimeout(() => done(new Error('launcher readiness timed out')), 10_000);
+    function done(error, value) { clearTimeout(timer); child.stdout.off('data', read); child.off('exit', early); error ? reject(error) : resolve(value); }
+    function read(chunk) { data += chunk; const newline = data.indexOf('\n'); if (newline !== -1) done(null, data.slice(0, newline)); }
+    function early(code) { done(new Error(`launcher exited before readiness (${code}): ${data}`)); }
+    child.stdout.on('data', read); child.once('exit', early);
+  });
+}
+
+async function launch(task, capture, delay = 200, exitCode = 0) {
+  const child = spawn(process.execPath, [cli, 'start', '--task', task, '--command', stub, '--', capture, String(delay), String(exitCode)], {
+    cwd: repoRoot,
+    env: { ...process.env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return { child, info: JSON.parse(await firstLine(child)) };
+}
+
+function command(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [cli, ...args], { cwd: repoRoot, env: { ...process.env }, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = ''; let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.once('exit', (code, signal) => resolve({ code, signal, stdout, stderr }));
+  });
+}
+
+async function waitForState(task, state, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = runtime.readBuildStatus(task);
+    if (value && value.state === state) return value;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`timed out waiting for ${task} state ${state}`);
+}
+
+async function stopOwned(instance) {
+  if (!instance || !isolation.pidAlive(instance.child.pid)) return;
+  const result = await command(['stop', '--task', instance.info.taskId, '--owner', instance.info.ownerToken]);
+  assert.equal(result.code, 0, result.stderr || result.stdout);
+  await exited(instance.child);
+}
+
+test('launch plans isolate mutable build paths and serialize only the same worktree', () => {
+  const a = runtime.buildLaunchConfig('build-plan-a', { command: stub, args: [] });
+  const b = runtime.buildLaunchConfig('build-plan-b', { command: stub, args: [] });
+  assert.notEqual(a.targetDir, b.targetDir);
+  assert.notEqual(a.roots.reports, b.roots.reports);
+  assert.notEqual(a.roots.temp, b.roots.temp);
+  assert.notEqual(a.roots.cache, b.roots.cache);
+  assert.equal(a.slot, b.slot);
+  assert.notEqual(runtime.worktreeBuildSlot(repoRoot), runtime.worktreeBuildSlot(scratch));
+  assert.equal(a.env.CARGO_TARGET_DIR, a.targetDir);
+  assert.equal(a.env.NEMO_REPORT_DIR, a.roots.reports);
+  assert.deepEqual(runtime.tauriBuildArgs('aarch64-test-host'), [
+    'build', '--target', 'aarch64-test-host', '-b', 'app', '--no-sign',
+  ]);
+  assert.throws(() => runtime.tauriBuildArgs(null), /host triple unavailable/);
+});
+
+test('active build holds the worktree slot, completion releases it, and artifacts remain owner-addressable', async () => {
+  const captureA = path.join(scratch, 'capture-a.json');
+  const captureB = path.join(scratch, 'capture-b.json');
+  const a = await launch(`build-active-a-${process.pid}`, captureA, 350);
+  let b;
+  try {
+    await waitForState(a.info.taskId, 'active');
+    const refused = await command(['start', '--task', `build-active-b-${process.pid}`, '--command', stub, '--', captureB, '1', '0']);
+    assert.equal(refused.code, 1);
+    assert.match(refused.stderr, /same-worktree desktop build unavailable/);
+    assert.equal(fs.existsSync(captureB), false);
+    await waitForState(a.info.taskId, 'completed');
+    assert.equal(runtime.readBuildStatus(a.info.taskId).slotRelease.released, true);
+    assert.equal(isolation.pidAlive(a.child.pid), true, 'completed launcher retains artifacts and owner status');
+    b = await launch(`build-after-a-${process.pid}`, captureB, 10);
+    await waitForState(b.info.taskId, 'completed');
+    const envA = JSON.parse(fs.readFileSync(captureA));
+    const envB = JSON.parse(fs.readFileSync(captureB));
+    assert.equal(envA.target, a.info.targetDir);
+    assert.equal(envA.reports, a.info.roots.reports);
+    assert.notEqual(envA.target, envB.target);
+    assert.notEqual(envA.temp, envB.temp);
+  } finally {
+    await stopOwned(a);
+    await stopOwned(b);
+  }
+});
+
+test('status and stop require the owner and preserve peer launchers', async () => {
+  const capture = path.join(scratch, 'capture-owner.json');
+  const instance = await launch(`build-owner-${process.pid}`, capture, 20);
+  try {
+    await waitForState(instance.info.taskId, 'completed');
+    const badStatus = await command(['status', '--task', instance.info.taskId, '--owner', 'wrong-token']);
+    assert.equal(badStatus.code, 1);
+    assert.match(JSON.parse(badStatus.stdout).reason, /owner token mismatch/);
+    const badStop = await command(['stop', '--task', instance.info.taskId, '--owner', 'wrong-token']);
+    assert.equal(badStop.code, 1);
+    assert.equal(isolation.pidAlive(instance.child.pid), true);
+    const goodStatus = await command(['status', '--task', instance.info.taskId, '--owner', instance.info.ownerToken]);
+    const body = JSON.parse(goodStatus.stdout);
+    assert.equal(goodStatus.code, 0);
+    assert.equal(body.ok, true);
+    assert.equal(body.runtime.state, 'completed');
+    await stopOwned(instance);
+    assert.equal(fs.existsSync(instance.info.roots.root), false);
+  } finally {
+    if (isolation.pidAlive(instance.child.pid)) await stopOwned(instance);
+  }
+});
+
+test('owner stop reaps an active stubborn build group before releasing roots', {
+  skip: process.platform === 'win32' ? 'POSIX process-group termination coverage' : false,
+}, async () => {
+  const capture = path.join(scratch, 'capture-stubborn.pid');
+  const child = spawn(process.execPath, [cli, 'start', '--task', `build-stubborn-${process.pid}`, '--command', stubbornStub, '--', capture], {
+    cwd: repoRoot,
+    env: { ...process.env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const instance = { child, info: JSON.parse(await firstLine(child)) };
+  try {
+    await waitForState(instance.info.taskId, 'active');
+    for (let i = 0; i < 100 && !fs.existsSync(capture); i++) await new Promise((resolve) => setTimeout(resolve, 10));
+    const buildPid = Number(fs.readFileSync(capture, 'utf8'));
+    assert.equal(isolation.pidAlive(buildPid), true);
+    const stopped = await command(['stop', '--task', instance.info.taskId, '--owner', instance.info.ownerToken]);
+    assert.equal(stopped.code, 0, stopped.stderr || stopped.stdout);
+    assert.equal(JSON.parse(stopped.stdout).runtime.state, 'stopped');
+    await exited(child);
+    assert.equal(isolation.pidAlive(buildPid), false);
+    assert.equal(fs.existsSync(instance.info.roots.root), false);
+  } finally {
+    if (isolation.pidAlive(child.pid)) await stopOwned(instance);
+  }
+});
+
+test('nonzero child result remains inspectable until owner cleanup', async () => {
+  const capture = path.join(scratch, 'capture-failure.json');
+  const instance = await launch(`build-failure-${process.pid}`, capture, 10, 17);
+  try {
+    const status = await waitForState(instance.info.taskId, 'failed');
+    assert.equal(status.exitCode, 17);
+    assert.equal(isolation.pidAlive(instance.child.pid), true);
+    assert.equal(fs.existsSync(status.logs.stdout), true);
+    assert.equal(fs.existsSync(status.logs.stderr), true);
+  } finally { await stopOwned(instance); }
+});

--- a/scripts/nemo/build-runtime.test.cjs
+++ b/scripts/nemo/build-runtime.test.cjs
@@ -37,6 +37,20 @@ process.on('SIGTERM', () => {});
 setInterval(() => {}, 1000);
 `, { mode: 0o700 });
 
+const orphaningStub = path.join(scratch, 'orphaning-build-stub');
+fs.writeFileSync(orphaningStub, `#!${process.execPath}\n` + String.raw`
+const fs = require('node:fs');
+const { spawn } = require('node:child_process');
+const descendant = spawn(process.execPath, ['-e', "process.on('SIGTERM',()=>{});process.send('ready');setInterval(()=>{},1000)"], {
+  stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+});
+descendant.once('message', () => {
+  fs.writeFileSync(process.argv[2], String(descendant.pid));
+  descendant.unref();
+  process.exit(0);
+});
+`, { mode: 0o700 });
+
 after(() => fs.rmSync(scratch, { recursive: true, force: true }));
 
 function exited(child) {
@@ -54,8 +68,9 @@ function firstLine(child) {
   });
 }
 
-async function launch(task, capture, delay = 200, exitCode = 0) {
-  const child = spawn(process.execPath, [cli, 'start', '--task', task, '--command', stub, '--', capture, String(delay), String(exitCode)], {
+async function launch(task, capture, delay = 200, exitCode = 0, executable = stub) {
+  const args = executable === stub ? [capture, String(delay), String(exitCode)] : [capture];
+  const child = spawn(process.execPath, [cli, 'start', '--task', task, '--command', executable, '--', ...args], {
     cwd: repoRoot,
     env: { ...process.env },
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -74,13 +89,18 @@ function command(args) {
 }
 
 async function waitForState(task, state, timeoutMs = 5000) {
+  return waitForStates(task, [state], timeoutMs);
+}
+
+async function waitForStates(task, states, timeoutMs = 5000) {
   const deadline = Date.now() + timeoutMs;
+  let value = null;
   while (Date.now() < deadline) {
-    const value = runtime.readBuildStatus(task);
-    if (value && value.state === state) return value;
+    value = runtime.readBuildStatus(task);
+    if (value && states.includes(value.state)) return value;
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
-  throw new Error(`timed out waiting for ${task} state ${state}`);
+  throw new Error(`timed out waiting for ${task} state ${states.join(' or ')}; last status ${JSON.stringify(value)}`);
 }
 
 async function stopOwned(instance) {
@@ -105,6 +125,8 @@ test('launch plans isolate mutable build paths and serialize only the same workt
     'build', '--target', 'aarch64-test-host', '-b', 'app', '--no-sign',
   ]);
   assert.throws(() => runtime.tauriBuildArgs(null), /host triple unavailable/);
+  assert.throws(() => runtime.assertNativePlatform('win32'), /supports macOS only/);
+  assert.throws(() => runtime.assertNativePlatform('linux'), /supports macOS only/);
 });
 
 test('active build holds the worktree slot, completion releases it, and artifacts remain owner-addressable', async () => {
@@ -182,6 +204,34 @@ test('owner stop reaps an active stubborn build group before releasing roots', {
   } finally {
     if (isolation.pidAlive(child.pid)) await stopOwned(instance);
   }
+});
+
+test('leader exit cannot release the slot while its stubborn descendant remains', {
+  skip: process.platform === 'win32' ? 'POSIX process-group termination coverage' : false,
+}, async () => {
+  const capture = path.join(scratch, 'capture-descendant.pid');
+  const orphaning = await launch(`build-orphan-${process.pid}`, capture, 0, 0, orphaningStub);
+  try {
+    for (let i = 0; i < 100 && !fs.existsSync(capture); i++) await new Promise((resolve) => setTimeout(resolve, 10));
+    const descendantPid = Number(fs.readFileSync(capture, 'utf8'));
+    const status = await waitForStates(orphaning.info.taskId, ['failed', 'reconciliation-required'], 8000);
+    assert.equal(status.exitCode, 0);
+    assert.equal(status.processTree.forced, true);
+    if (status.state === 'failed') {
+      assert.equal(status.slotRelease.released, true);
+      assert.equal(isolation.pidAlive(descendantPid), false);
+    } else {
+      assert.equal(status.slotRelease, undefined);
+      const refused = await command(['start', '--task', `build-orphan-peer-${process.pid}`, '--command', stub, '--', path.join(scratch, 'capture-orphan-peer'), '1', '0']);
+      assert.equal(refused.code, 1);
+      assert.match(refused.stderr, /same-worktree desktop build unavailable/);
+      const deadline = Date.now() + 5000;
+      while (runtime.buildProcessTreeAlive({ pid: status.childPid }) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      assert.equal(runtime.buildProcessTreeAlive({ pid: status.childPid }), false);
+    }
+  } finally { await stopOwned(orphaning); }
 });
 
 test('nonzero child result remains inspectable until owner cleanup', async () => {

--- a/scripts/nemo/build.cjs
+++ b/scripts/nemo/build.cjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+'use strict';
+
+const isolation = require('./lib/isolation.cjs');
+const {
+  buildHandshake,
+  readBuildStatus,
+  runBuildLauncher,
+} = require('./lib/build-runtime.cjs');
+
+function parse(argv) {
+  const out = { _: [], passthrough: [] };
+  let passthrough = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (passthrough) { out.passthrough.push(arg); continue; }
+    if (arg === '--') { passthrough = true; continue; }
+    if (!arg.startsWith('--')) { out._.push(arg); continue; }
+    const key = arg.slice(2); const next = argv[i + 1];
+    if (next == null || next.startsWith('--')) out[key] = true;
+    else { out[key] = next; i += 1; }
+  }
+  return out;
+}
+
+function output(value) { process.stdout.write(JSON.stringify(value) + '\n'); }
+
+async function start(args) {
+  const taskId = isolation.resolveTaskId(args.task);
+  await runBuildLauncher(taskId, {
+    command: args.command,
+    args: args.passthrough,
+    hostTriple: args['host-triple'],
+  }, output);
+}
+
+function status(args) {
+  if (!args.task || !args.owner) throw new Error('status requires --task ID and --owner TOKEN');
+  const result = buildHandshake(args.task, args.owner);
+  output(result);
+  process.exit(result.ok ? 0 : 1);
+}
+
+async function stop(args) {
+  if (!args.task || !args.owner) throw new Error('stop requires --task ID and --owner TOKEN');
+  const stopped = await isolation.requestStop(args.task, args.owner, {
+    timeoutMs: args['timeout-ms'] == null ? 10_000 : Number(args['timeout-ms']),
+  });
+  const statusBeforeRelease = readBuildStatus(args.task);
+  const released = stopped.stopped ? isolation.releaseTask(args.task, args.owner) : null;
+  output({ ...stopped, runtime: statusBeforeRelease, released });
+  process.exit(stopped.stopped && released && released.released ? 0 : 1);
+}
+
+async function main() {
+  const args = parse(process.argv.slice(2));
+  const command = args._[0] || 'start';
+  if (command === 'start') return start(args);
+  if (command === 'status') return status(args);
+  if (command === 'stop') return stop(args);
+  throw new Error('usage: build.cjs start [--task ID] [--command /absolute/test/stub -- args...] | status --task ID --owner TOKEN | stop --task ID --owner TOKEN [--timeout-ms N]');
+}
+
+main().catch((err) => { process.stderr.write((err.stack || String(err)) + '\n'); process.exit(1); });

--- a/scripts/nemo/lib/build-runtime.cjs
+++ b/scripts/nemo/lib/build-runtime.cjs
@@ -4,6 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const crypto = require('node:crypto');
 const { spawn } = require('node:child_process');
+const { finished } = require('node:stream/promises');
 const { isDeepStrictEqual } = require('node:util');
 const isolation = require('./isolation.cjs');
 const identity = require('./identity.cjs');
@@ -31,7 +32,14 @@ function tauriBuildArgs(hostTriple) {
   return ['build', '--target', hostTriple, '-b', 'app', '--no-sign'];
 }
 
+function assertNativePlatform(platform = process.platform) {
+  if (platform !== 'darwin') {
+    throw new Error('native desktop build launcher currently supports macOS only; platform bundle arguments and process-tree ownership are not validated here');
+  }
+}
+
 function buildLaunchConfig(taskId, options = {}) {
+  if (!options.command) assertNativePlatform();
   const executable = options.command ? path.resolve(options.command) : localTauriExecutable();
   if (!exists(executable)) throw new Error(`build command not found: ${executable}`);
   if (process.platform !== 'win32') fs.accessSync(executable, fs.constants.X_OK);
@@ -100,25 +108,44 @@ function waitForExit(child) {
   return new Promise((resolve) => child.once('exit', (code, signal) => resolve({ code, signal })));
 }
 
-function signalBuild(child, signal) {
-  if (!child || child.exitCode != null || child.signalCode != null) return;
+function buildProcessTreeAlive(child) {
+  if (!child || !Number.isSafeInteger(child.pid) || child.pid <= 0) return false;
   if (process.platform !== 'win32') {
-    try { process.kill(-child.pid, signal); return; } catch (err) { if (err.code !== 'ESRCH') throw err; }
+    try { process.kill(-child.pid, 0); return true; }
+    catch (err) { if (err.code === 'ESRCH') return false; return err.code === 'EPERM'; }
   }
-  try { child.kill(signal); } catch (err) { if (err.code !== 'ESRCH') throw err; }
+  return child.exitCode == null && child.signalCode == null;
+}
+
+function signalBuild(child, signal) {
+  if (!child || !Number.isSafeInteger(child.pid) || child.pid <= 0) return;
+  if (process.platform !== 'win32') {
+    try { process.kill(-child.pid, signal); return; } catch (err) { if (err.code !== 'ESRCH') throw err; return; }
+  }
+  if (child.exitCode == null && child.signalCode == null) {
+    try { child.kill(signal); } catch (err) { if (err.code !== 'ESRCH') throw err; }
+  }
+}
+
+async function waitForBuildProcessTree(child, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (buildProcessTreeAlive(child) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return !buildProcessTreeAlive(child);
 }
 
 async function stopBuild(child, graceMs = 1500) {
-  if (!child || child.exitCode != null || child.signalCode != null) return;
-  const exited = waitForExit(child);
+  if (!buildProcessTreeAlive(child)) return { stopped: true, forced: false, reason: 'owned build process tree already exited' };
   signalBuild(child, 'SIGTERM');
-  let timer;
-  await Promise.race([exited, new Promise((resolve) => { timer = setTimeout(resolve, graceMs); })]);
-  clearTimeout(timer);
-  if (child.exitCode == null && child.signalCode == null) {
-    signalBuild(child, 'SIGKILL');
-    await exited;
+  if (await waitForBuildProcessTree(child, graceMs)) {
+    return { stopped: true, forced: false, reason: 'owned build process tree exited after SIGTERM' };
   }
+  signalBuild(child, 'SIGKILL');
+  if (await waitForBuildProcessTree(child, 2000)) {
+    return { stopped: true, forced: true, reason: 'owned build process tree required SIGKILL' };
+  }
+  return { stopped: false, forced: true, reason: 'owned build process tree still exists after SIGKILL; reconciliation required' };
 }
 
 function spawnBuild(config) {
@@ -135,7 +162,13 @@ function spawnBuild(config) {
   });
   child.stdout.pipe(stdout);
   child.stderr.pipe(stderr);
-  return { child, stdout, stderr };
+  const closed = new Promise((resolve) => child.once('close', (code, signal) => resolve({ code, signal })));
+  const logsDone = Promise.all([finished(stdout), finished(stderr)]);
+  const drained = Promise.all([closed, logsDone]);
+  // A later await handles the result; attach now so an early stream error is
+  // never reported as an unhandled rejection while the leader is still live.
+  drained.catch(() => {});
+  return { child, stdout, stderr, closed, logsDone, drained };
 }
 
 function buildHandshake(taskId, ownerToken) {
@@ -229,17 +262,30 @@ async function runBuildLauncher(taskId, options = {}, emit = () => {}) {
   const shutdown = async (signal) => {
     if (closing) return;
     closing = true;
-    await stopBuild(processInfo && processInfo.child).catch(() => {});
-    const slotRelease = releaseSlot();
-    save({ state: 'stopped', finishedAt: nowIso(), signal: signal || 'SIGTERM', slotRelease });
-    if (processInfo) {
-      processInfo.stdout.end();
-      processInfo.stderr.end();
+    let tree;
+    try { tree = await stopBuild(processInfo && processInfo.child); }
+    catch (err) { tree = { stopped: false, forced: false, reason: err.message }; }
+    if (!tree.stopped) {
+      save({ state: 'reconciliation-required', finishedAt: nowIso(), signal: signal || 'SIGTERM', processTree: tree });
+      closing = false;
+      return;
     }
+    if (processInfo) {
+      await processInfo.closed.catch(() => {});
+      await processInfo.logsDone.catch(() => {});
+    }
+    const slotRelease = releaseSlot();
+    save({ state: 'stopped', finishedAt: nowIso(), signal: signal || 'SIGTERM', processTree: tree, slotRelease });
     process.exit(0);
   };
-  process.once('SIGTERM', () => shutdown('SIGTERM'));
-  process.once('SIGINT', () => shutdown('SIGINT'));
+  // Retain cooperative handlers after an unproved cleanup so the owner can
+  // retry instead of turning the next stop request into an unhandled exit.
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  // Ownership must remain live on every post-registration return path. In
+  // particular, reconciliation-required must not degrade into a reclaimable
+  // dead-holder slot merely because the direct child and its pipes exited.
+  setInterval(() => {}, 60_000);
 
   try {
     processInfo = spawnBuild(config);
@@ -251,28 +297,53 @@ async function runBuildLauncher(taskId, options = {}, emit = () => {}) {
     });
     save({ state: 'active', childPid: processInfo.child.pid });
     const result = await waitForExit(processInfo.child);
-    processInfo.stdout.end();
-    processInfo.stderr.end();
+    // Let normal leader teardown and pipe closure settle before probing its
+    // process group. If descendants inherited the pipes this stays pending,
+    // and the group probe below remains authoritative.
+    await Promise.race([
+      processInfo.drained.catch(() => {}),
+      new Promise((resolve) => setTimeout(resolve, 100)),
+    ]);
+    let tree;
+    try { tree = await stopBuild(processInfo.child); }
+    catch (err) { tree = { stopped: false, forced: false, reason: err.message }; }
+    if (closing) return;
+    if (!tree.stopped) {
+      save({
+        state: 'reconciliation-required',
+        finishedAt: nowIso(),
+        exitCode: result.code,
+        signal: result.signal,
+        processTree: tree,
+      });
+      return;
+    }
+    await processInfo.closed;
+    await processInfo.logsDone;
     const slotRelease = releaseSlot();
     save({
-      state: result.code === 0 ? 'completed' : 'failed',
+      state: result.code === 0 && !tree.forced ? 'completed' : 'failed',
       finishedAt: nowIso(),
       exitCode: result.code,
       signal: result.signal,
+      error: tree.forced ? 'build leader exited while descendants remained; owned process group required forced cleanup' : undefined,
+      processTree: tree,
       slotRelease,
     });
   } catch (err) {
+    let tree = { stopped: true, forced: false, reason: 'build process was not spawned' };
     if (processInfo) {
-      processInfo.stdout.end();
-      processInfo.stderr.end();
+      try { tree = await stopBuild(processInfo.child); }
+      catch (stopErr) { tree = { stopped: false, forced: false, reason: stopErr.message }; }
     }
+    if (!tree.stopped) {
+      save({ state: 'reconciliation-required', finishedAt: nowIso(), error: err.message, processTree: tree });
+      return;
+    }
+    if (processInfo) await processInfo.logsDone.catch(() => {});
     const slotRelease = releaseSlot();
-    save({ state: 'failed', finishedAt: nowIso(), error: err.message, slotRelease });
+    save({ state: 'failed', finishedAt: nowIso(), error: err.message, processTree: tree, slotRelease });
   }
-
-  // Keep the ownership record live so status remains trustworthy and build
-  // artifacts stay available. The owner copies artifacts, then calls stop.
-  setInterval(() => {}, 60_000);
 }
 
 module.exports = {
@@ -281,9 +352,11 @@ module.exports = {
   worktreeBuildSlot,
   localTauriExecutable,
   tauriBuildArgs,
+  assertNativePlatform,
   buildLaunchConfig,
   readBuildStatus,
   buildHandshake,
+  buildProcessTreeAlive,
   stopBuild,
   runBuildLauncher,
 };

--- a/scripts/nemo/lib/build-runtime.cjs
+++ b/scripts/nemo/lib/build-runtime.cjs
@@ -1,0 +1,289 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { spawn } = require('node:child_process');
+const { isDeepStrictEqual } = require('node:util');
+const isolation = require('./isolation.cjs');
+const identity = require('./identity.cjs');
+const { ROOT, exists, nowIso } = require('./util.cjs');
+
+const SCHEMA = 'nemo.build-runtime/1';
+const STATUS_FILE = 'build-runtime.json';
+
+function worktreeBuildSlot(worktree = ROOT) {
+  const resolved = fs.realpathSync(worktree);
+  const key = crypto.createHash('sha256').update(resolved).digest('hex').slice(0, 24);
+  return `desktop-build-${key}`;
+}
+
+function localTauriExecutable(root = ROOT) {
+  const name = process.platform === 'win32' ? 'tauri.cmd' : 'tauri';
+  const executable = path.join(root, 'node_modules', '.bin', name);
+  if (!exists(executable)) throw new Error('installed Tauri CLI not found at node_modules/.bin/tauri; run npm ci in this worktree');
+  if (process.platform !== 'win32') fs.accessSync(executable, fs.constants.X_OK);
+  return executable;
+}
+
+function tauriBuildArgs(hostTriple) {
+  if (!hostTriple) throw new Error('rustc host triple unavailable; cannot form the Tauri build command');
+  return ['build', '--target', hostTriple, '-b', 'app', '--no-sign'];
+}
+
+function buildLaunchConfig(taskId, options = {}) {
+  const executable = options.command ? path.resolve(options.command) : localTauriExecutable();
+  if (!exists(executable)) throw new Error(`build command not found: ${executable}`);
+  if (process.platform !== 'win32') fs.accessSync(executable, fs.constants.X_OK);
+  const triple = options.hostTriple || identity.hostTriple();
+  const args = options.command
+    ? (Array.isArray(options.args) ? options.args.slice() : [])
+    : tauriBuildArgs(triple);
+  const roots = isolation.taskRoots(taskId);
+  const targetDir = path.join(roots.build, 'tauri-target');
+  return {
+    executable,
+    args,
+    cwd: ROOT,
+    slot: worktreeBuildSlot(ROOT),
+    roots,
+    targetDir,
+    stdoutLog: path.join(roots.reports, 'desktop-build.stdout.log'),
+    stderrLog: path.join(roots.reports, 'desktop-build.stderr.log'),
+    statusFile: path.join(roots.reports, STATUS_FILE),
+    env: {
+      ...process.env,
+      CARGO_TARGET_DIR: targetDir,
+      NEMO_TASK_ID: taskId,
+      NEMO_REPORT_DIR: roots.reports,
+      XDG_CACHE_HOME: roots.cache,
+      TMPDIR: roots.temp,
+      TMP: roots.temp,
+      TEMP: roots.temp,
+    },
+  };
+}
+
+function publicSource(source) {
+  if (!source) return source;
+  const { originUrl: _originUrl, ...safe } = source;
+  return safe;
+}
+
+function publicRoots(roots) {
+  return {
+    root: roots.root,
+    temp: roots.temp,
+    cache: roots.cache,
+    build: roots.build,
+    reports: roots.reports,
+  };
+}
+
+function atomicWriteJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const temp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(temp, JSON.stringify(value, null, 2) + '\n', { mode: 0o600 });
+  fs.renameSync(temp, file);
+}
+
+function readBuildStatus(taskId) {
+  const file = path.join(isolation.taskRoots(taskId).reports, STATUS_FILE);
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); }
+  catch { return null; }
+}
+
+function waitForExit(child) {
+  if (!child || child.exitCode != null || child.signalCode != null) {
+    return Promise.resolve({ code: child && child.exitCode, signal: child && child.signalCode });
+  }
+  return new Promise((resolve) => child.once('exit', (code, signal) => resolve({ code, signal })));
+}
+
+function signalBuild(child, signal) {
+  if (!child || child.exitCode != null || child.signalCode != null) return;
+  if (process.platform !== 'win32') {
+    try { process.kill(-child.pid, signal); return; } catch (err) { if (err.code !== 'ESRCH') throw err; }
+  }
+  try { child.kill(signal); } catch (err) { if (err.code !== 'ESRCH') throw err; }
+}
+
+async function stopBuild(child, graceMs = 1500) {
+  if (!child || child.exitCode != null || child.signalCode != null) return;
+  const exited = waitForExit(child);
+  signalBuild(child, 'SIGTERM');
+  let timer;
+  await Promise.race([exited, new Promise((resolve) => { timer = setTimeout(resolve, graceMs); })]);
+  clearTimeout(timer);
+  if (child.exitCode == null && child.signalCode == null) {
+    signalBuild(child, 'SIGKILL');
+    await exited;
+  }
+}
+
+function spawnBuild(config) {
+  fs.mkdirSync(config.targetDir, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(config.roots.reports, { recursive: true, mode: 0o700 });
+  const stdout = fs.createWriteStream(config.stdoutLog, { flags: 'a', mode: 0o600 });
+  const stderr = fs.createWriteStream(config.stderrLog, { flags: 'a', mode: 0o600 });
+  const child = spawn(config.executable, config.args, {
+    cwd: config.cwd,
+    env: config.env,
+    detached: process.platform !== 'win32',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+  child.stdout.pipe(stdout);
+  child.stderr.pipe(stderr);
+  return { child, stdout, stderr };
+}
+
+function buildHandshake(taskId, ownerToken) {
+  const local = isolation.verifyHandshake(taskId, { ownerToken, checkSource: true });
+  const launcher = isolation.readLauncher(taskId);
+  const status = readBuildStatus(taskId);
+  let currentBuild = null;
+  try { currentBuild = identity.buildIdentity(); } catch { /* fail closed below */ }
+  const buildMatches = !!status && isDeepStrictEqual(status.build.startup, currentBuild);
+  return {
+    ok: local.ok && buildMatches,
+    reason: !local.ok ? local.reason : (!currentBuild ? 'build identity unavailable' : (buildMatches ? 'task owner, source and build identities match' : 'build identity changed')),
+    taskId,
+    pid: launcher ? launcher.pid : null,
+    source: launcher ? { startup: publicSource(launcher.source), matches: local.ok } : null,
+    build: status ? { startup: status.build.startup, current: currentBuild, matches: buildMatches } : null,
+    runtime: status,
+  };
+}
+
+async function runBuildLauncher(taskId, options = {}, emit = () => {}) {
+  const config = buildLaunchConfig(taskId, options);
+  // Resolve the complete startup identity before acquiring ownership. A failed
+  // identity probe must not leave a live launcher that never disclosed its token.
+  let startupBuild;
+  try { startupBuild = identity.buildIdentity(); }
+  catch (err) {
+    isolation.releaseTask(taskId);
+    throw new Error(`build identity unavailable: ${err.message}`);
+  }
+  const slot = isolation.acquireExclusiveSlot(config.slot, taskId, { pid: process.pid });
+  if (!slot.acquired) {
+    isolation.releaseTask(taskId);
+    throw new Error(`same-worktree desktop build unavailable: ${slot.reason}`);
+  }
+  let launcher;
+  try {
+    launcher = isolation.registerLauncher(taskId, {
+      pid: process.pid,
+      ownerToken: slot.ownerToken,
+      label: 'desktop-build',
+    });
+  } catch (err) {
+    slot.release();
+    throw err;
+  }
+  let status = {
+    schema: SCHEMA,
+    taskId,
+    launcherPid: process.pid,
+    childPid: null,
+    state: 'starting',
+    startedAt: nowIso(),
+    finishedAt: null,
+    exitCode: null,
+    signal: null,
+    slot: config.slot,
+    targetDir: config.targetDir,
+    roots: publicRoots(config.roots),
+    logs: { stdout: config.stdoutLog, stderr: config.stderrLog },
+    source: publicSource(launcher.source),
+    build: { startup: startupBuild },
+  };
+  const save = (change) => {
+    status = { ...status, ...change };
+    atomicWriteJson(config.statusFile, status);
+  };
+  save({});
+  emit({
+    started: true,
+    taskId,
+    pid: process.pid,
+    ownerToken: launcher.ownerToken,
+    slot: config.slot,
+    roots: publicRoots(config.roots),
+    targetDir: config.targetDir,
+    statusFile: config.statusFile,
+    source: publicSource(launcher.source),
+    build: startupBuild,
+  });
+
+  let processInfo = null;
+  let slotReleased = false;
+  const releaseSlot = () => {
+    if (slotReleased) return { released: true, alreadyReleased: true };
+    const result = slot.release();
+    if (result.released) slotReleased = true;
+    return result;
+  };
+  let closing = false;
+  const shutdown = async (signal) => {
+    if (closing) return;
+    closing = true;
+    await stopBuild(processInfo && processInfo.child).catch(() => {});
+    const slotRelease = releaseSlot();
+    save({ state: 'stopped', finishedAt: nowIso(), signal: signal || 'SIGTERM', slotRelease });
+    if (processInfo) {
+      processInfo.stdout.end();
+      processInfo.stderr.end();
+    }
+    process.exit(0);
+  };
+  process.once('SIGTERM', () => shutdown('SIGTERM'));
+  process.once('SIGINT', () => shutdown('SIGINT'));
+
+  try {
+    processInfo = spawnBuild(config);
+    await new Promise((resolve, reject) => {
+      const failed = (err) => { processInfo.child.off('spawn', ready); reject(err); };
+      const ready = () => { processInfo.child.off('error', failed); resolve(); };
+      processInfo.child.once('error', failed);
+      processInfo.child.once('spawn', ready);
+    });
+    save({ state: 'active', childPid: processInfo.child.pid });
+    const result = await waitForExit(processInfo.child);
+    processInfo.stdout.end();
+    processInfo.stderr.end();
+    const slotRelease = releaseSlot();
+    save({
+      state: result.code === 0 ? 'completed' : 'failed',
+      finishedAt: nowIso(),
+      exitCode: result.code,
+      signal: result.signal,
+      slotRelease,
+    });
+  } catch (err) {
+    if (processInfo) {
+      processInfo.stdout.end();
+      processInfo.stderr.end();
+    }
+    const slotRelease = releaseSlot();
+    save({ state: 'failed', finishedAt: nowIso(), error: err.message, slotRelease });
+  }
+
+  // Keep the ownership record live so status remains trustworthy and build
+  // artifacts stay available. The owner copies artifacts, then calls stop.
+  setInterval(() => {}, 60_000);
+}
+
+module.exports = {
+  SCHEMA,
+  STATUS_FILE,
+  worktreeBuildSlot,
+  localTauriExecutable,
+  tauriBuildArgs,
+  buildLaunchConfig,
+  readBuildStatus,
+  buildHandshake,
+  stopBuild,
+  runBuildLauncher,
+};

--- a/tests/nemo-build-runtime.test.cjs
+++ b/tests/nemo-build-runtime.test.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+// Keep this process-isolated: the suite sets NEMO_ISOLATION_ROOT before the
+// isolation module captures it at import time.
+require('../scripts/nemo/build-runtime.test.cjs');


### PR DESCRIPTION
Concurrent desktop builds in one worktree previously shared their Cargo output and could write generated source simultaneously. Add a standalone macOS build launcher that invokes the installed Tauri CLI with task-specific Cargo output, temporary paths and logs, and serializes builds by canonical worktree path. It provides source/build identity and owner-controlled status/stop while retaining completed artifacts until owner cleanup.

The build slot is released only after the complete owned process group is absent. Lead review reproduced a descendant surviving its build leader; the correction covers that sequence, including a descendant that ignores SIGTERM. Unconfirmed cleanup keeps the launcher and reservation live for reconciliation and owner retry. Other native platforms reject before creating task state.

Validation on `f1f378c8691db1a1520899a7d6db5a624944fc19`: six focused lifecycle tests passed; clean-commit doctor/check/verify passed with 185 Node and 15 Rust tests. Lead independently reran the original parent-exits-first reproduction and confirmed the descendant was gone. The installed macOS Tauri CLI help confirms the default build arguments. An 8 MiB-per-stream stub probe preserved both output files completely.

Advances #902. No actual native build was run in this increment. Paired native builds, generated-schema diff inspection, Tauri data/autosave, full cache-consumer coverage, and standard `build:desktop`/desktop-input/GPU integration remain open and coordinated with the existing R03/R04 owners. The wrapper sets `XDG_CACHE_HOME`; this is not evidence that every native cache consumer uses that directory.
