### PR TITLE
R01: expose portable contributor and agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# Nemo repository agent entry point
+
+These instructions apply to Codex, Claude, and their child agents in this repository.
+GitHub is canonical for source, issues, pull requests, CI, and review. Keep the active task
+in its issue, pull request, or lead-designated queue; do not create a competing shared ledger.
+
+## Find the project contract
+
+- Start with [the remediation handbook](engineering/remediation/README.md) and its
+  [manifest](engineering/remediation/MANIFEST.md). Respect each document's Current,
+  Proposed, Gate, and Future labels.
+- Read [current and target architecture](engineering/remediation/01_CURRENT_AND_TARGET.md),
+  then the relevant source and the relevant section of `CLAUDE.md` before editing.
+- Use [testing and debugging](engineering/remediation/03_TESTING_AND_DEBUGGING.md) and
+  [modularity policy](engineering/remediation/04_MODULARITY_POLICY.md) for quality gates.
+- Use [Buzz/A2A and authority](engineering/remediation/06_BUZZ_A2A_AND_ENROLLMENT.md) and
+  [parallel work](engineering/remediation/07_GITHUB_PROJECT_AND_PARALLEL_WORK.md) for
+  coordination, ownership, worktrees, commits, and integration.
+- Start writable work from the [task packet](engineering/remediation/templates/TASK_PACKET.md)
+  and report it with the [handoff receipt](engineering/remediation/templates/HANDOFF_RECEIPT.md).
+
+## Work safely
+
+- Read `CONTRIBUTING.md`, inspect current source, related branches and existing ownership,
+  then use a dedicated branch and isolated worktree for tracked changes.
+- Record the outcome, scope, dependencies, base, branch/worktree, acceptance checks,
+  reviewer, and publication authority before writing. Repository-relative paths coordinate
+  ownership; they are not a user-maintained filesystem permission list.
+- The dedicated Nemo Buzz workspace supplies authenticated Project/repository participation
+  and runtime instructions to enrolled collaborators. Do not ask users to configure manual
+  path grants, revision pins, or agent assignments. Tool availability does not broaden the
+  current task or authorize publishing, merging, deployment, enrollment, or release.
+- Treat relay storage, `processed`, `accepted`, progress, and terminal results as distinct
+  A2A states. Never replay an indeterminate operation without reconciling its actual effects.
+- Preserve other contributors' edits and scoped commits. Keep credentials, private machine
+  paths, private evidence, and protected infrastructure details out of source and receipts.
+
+## Preserve Nemo invariants
+
+- Source and directly observed behavior settle facts; historical prose and agent summaries
+  are navigation aids.
+- For a persistent field or item type, verify every applicable consumer: save, load,
+  undo/redo, selection, animation, render, export, and native bridges.
+- Validate browser and Tauri behavior on their relevant surfaces. Compile success or a
+  screenshot does not establish save/reload, timing, export, or packaged desktop behavior.
+- Before giving instructions about a node's settings, read its local documentation and
+  implementation.
+- Run focused checks for the affected behavior and record exact source/candidate SHAs,
+  results, limitations, and the next acceptance step. A green branch or merged PR alone
+  does not close a remediation or product-acceptance gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,11 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
 @AGENTS.md
 
 # Nemo — guidelines pour éviter les bugs déjà rencontrés

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+@AGENTS.md
+
 # Nemo — guidelines pour éviter les bugs déjà rencontrés
 
 Tauri v2, hybride Paper.js (modèle de document, source de vérité) + Rust/vello WebGPU

--- a/engineering/remediation/06_BUZZ_A2A_AND_ENROLLMENT.md
+++ b/engineering/remediation/06_BUZZ_A2A_AND_ENROLLMENT.md
@@ -9,19 +9,18 @@
 # Buzz collaboration, A2A and enrollment
 
 Protocol: **NEMO-A2A-1**<br>
-Expected canonical skill path after adoption: `.agents/skills/nemo-a2a/SKILL.md`
+Runtime workspace contract: **1.4.0**
 
 ## Status boundary
 
-Current pilot behavior includes authenticated desktop chat, distinct human and managed-agent
-identities, self-service owner-backed agent admission, normal inline replies, a Nemo Project
-bound to the canonical GitHub repository and a narrow issue/PR/run link bridge. GitHub remains
-canonical.
+The dedicated Nemo workspace contract supplies current project instructions and full
+repository participation to each enrolled collaborator's managed agents. Buzz carries
+authenticated conversation and coordination; GitHub remains canonical. Repository-relative
+task paths coordinate writer ownership and do not form a host filesystem sandbox.
 
-Automatic immutable project-instruction preloading, the complete typed A2A grant/settings
-surface, hardened execution lifecycle and team-distributable cross-platform builds must pass
-fresh final-build acceptance before being called generally deployed. Nemo's product Rust MCP
-is a separate future product surface.
+This tracked contract does not by itself prove BZ0 live-transport or release acceptance.
+Revalidate those gates on the identified Buzz build and runtime before claiming general
+deployment. Nemo's product Rust MCP is a separate future product surface.
 
 ## Roles and permissions
 
@@ -31,7 +30,7 @@ Keep these independent:
 2. Buzz community membership;
 3. Project/channel membership;
 4. managed-agent response policy and provider login;
-5. local checkout capability/path/branch/worktree grant;
+5. current task outcome, ownership and repository-relative file scope;
 6. publication, merge, deployment and release authority.
 
 Membership or an agent persona does not imply source authority. Each agent has one accountable
@@ -48,7 +47,7 @@ human sponsor, a distinct public identity and least-privilege channel/grant scop
    a named operational need for `admin`.
 5. Developer joins using the team relay URL obtained from the operator and selects their local
    profile name.
-6. Operator adds only the required Project/channel access.
+6. Verify the dedicated workspace exposes the intended Project and channel access.
 7. Verify signed connection, message/reply, relaunch history and denial of an ungranted channel.
 
 An invitation link is a convenience for connection details. It never replaces collaborator
@@ -67,10 +66,11 @@ Agent creation is self-service after human enrollment:
    secrets in the local protected store.
 4. Start the agent. The relay grants virtual membership only while the attestation and direct
    human membership are valid. The agent is not inserted as a direct human member.
-5. Add the required Project/channel, then create a separate worktree and an exact local
-   checkout grant for capability, path prefixes, base SHA, branch and worktree ID.
-6. Verify process, signed admission, directed request/reply, negative scope tests, reconnect
-   and no duplicate execution.
+5. Verify the dedicated workspace exposes the Nemo Project and intended channels. Do not
+   manually assign the managed agent to the Project or configure path grants; the task still
+   records its base, branch/worktree, owned paths and acceptance checks.
+6. Verify process, signed admission, directed request/reply, reconnect and no duplicate
+   execution.
 
 Each developer's agents use that machine's own Codex/Claude provider login unless deliberately
 configured otherwise. Buzz identity does not select or share an AI-provider billing account.
@@ -84,26 +84,22 @@ configured otherwise. Buzz identity does not select or share an AI-provider bill
    - one Project home channel.
 3. Resolve the existing checkout only when its canonical path stays under the configured root
    and Git `origin` matches the announcement.
-4. Add admitted humans/agents to the Project channel.
-5. Give each writer an isolated worktree and scoped checkout grant.
+4. Verify enrolled collaborators and their managed agents resolve the Project and intended
+   channel participation through the workspace.
+5. Give each writer an isolated worktree and non-overlapping task scope.
 6. Keep Buzz tasks out of the canonical backlog. The GitHub bridge posts only signed,
    idempotent links/status for allowed issue, PR and workflow-run events.
 
-## Workspace and agent settings
+## Workspace and task settings
 
-The operator configures one workspace Project binding per relay:
+The managed runtime binds the dedicated Nemo Project, repository, current instructions and
+verified peer roster. Enrolled collaborators do not manually maintain agent assignments,
+instruction pins or allowed-path forms. Each writable task still declares its outcome, base,
+branch/worktree, repository-relative owned paths, dependencies, checks and publication scope.
 
-- Project address and home-channel ID;
-- canonical repository/display name;
-- exact immutable instruction revision;
-- allowed peers and A2A capabilities;
-- per-agent repository-relative path prefixes;
-- exact base SHA, branch and logical worktree ID;
-- owner-only or explicit response allowlist.
-
-Machine-local checkout roots stay in local protected settings and never enter signed A2A events
-or model prompts. Changing the immutable instruction revision or Project binding requires new
-provider sessions; missing or ambiguous policy fails before work starts.
+Machine-local checkout roots stay in protected runtime configuration and never enter signed
+A2A events or model prompts. Missing or ambiguous Project/repository binding fails before work
+starts.
 
 ## Typed A2A tools
 
@@ -112,6 +108,7 @@ Managed agents use:
 | Intent | Tool |
 |---|---|
 | Reply in the current human conversation | `buzz_chat_send` |
+| Discover verified collaborators | `buzz_a2a_peers` |
 | Delegate one bounded job | `buzz_a2a_dispatch` |
 | Discover addressed work | `buzz_a2a_inbox` |
 | Follow one exact request | `buzz_a2a_status` |
@@ -128,9 +125,10 @@ Before dispatch:
 
 1. inspect the active task queue and existing A2A status;
 2. choose disjoint repository-relative paths, worktree and acceptance checks;
-3. select an already authorized recipient and exact Project/repository grant;
+3. discover and select a verified recipient from the runtime roster;
 4. create a fresh operation UUID and stable non-secret idempotency key;
-5. include base SHA, branch, logical worktree, expiry and inert contract references;
+5. include the required runtime job coordinates; paths coordinate ownership rather than
+   technical filesystem permission;
 6. keep credentials, machine-local paths and executable shell strings out of the envelope.
 
 Save the returned `request_event_id`. Relay acknowledgement means only that an event was stored.
@@ -163,7 +161,8 @@ Byte-equivalent retries reuse the original key and signed bytes. Changed semanti
 new idempotency key. An accepted operation that crashes without a terminal receipt becomes
 `indeterminate` and requires reconciliation; it is never automatically rerun.
 
-Fail closed on missing tools/grants, ambiguous Project binding, origin/branch/HEAD drift,
+Fail closed on missing required tools or task authority, ambiguous Project binding,
+origin/branch/HEAD drift,
 expired authority, path escape, signature/lifecycle mismatch or unreachable relay state.
 
 ## Revocation

--- a/engineering/remediation/MANIFEST.md
+++ b/engineering/remediation/MANIFEST.md
@@ -8,9 +8,9 @@
 
 # Nemo foundation remediation package
 
-Status: **proposal for maintainer review**<br>
+Status: **R01 adoption candidate for maintainer review**<br>
 Prepared: **2026-09-04**<br>
-Package version: **0.1.0**
+Package version: **0.2.0**
 Repository: <https://github.com/mysteropodes/nemo>
 
 This package is the portable starting point for Nemo's foundation remediation. It contains
@@ -48,3 +48,11 @@ The package deliberately separates:
 - **Proposed:** designed but not yet implemented or adopted.
 - **Gate:** evidence required before a proposal can be called delivered.
 - **Future:** product breadth beyond foundation remediation.
+
+## Migration note for 0.2.0
+
+The adoption candidate adds portable Codex and Claude entry points and aligns the handbook
+with the dedicated Nemo workspace contract: enrolled collaborators receive Project/repository
+participation and current A2A instructions from the runtime. Repository-relative task paths
+coordinate concurrent ownership; contributors do not configure manual path grants or revision
+pins. BZ0 transport acceptance and clean-clone Codex/Claude rehearsal remain required gates.

--- a/engineering/remediation/README.md
+++ b/engineering/remediation/README.md
@@ -18,11 +18,11 @@ task packet and module documentation in addition to the repository's contributor
 2. Review and accept, amend or reject the proposed ADR-level decisions.
 3. Choose the tracked destination, for example `engineering/remediation/`, and move this
    directory as one unit so its internal links remain valid.
-4. Point the repository's Codex and Claude entry files at the adopted documents. Keep those
-   entry files short.
-5. During adoption, install or retain `.agents/skills/nemo-a2a/` as the canonical A2A skill;
-   this proposal package does not include that runtime skill. Test clean-clone discovery in
-   both clients.
+4. Keep the repository's Codex and Claude entry files short and point them at the adopted
+   documents.
+5. The dedicated Nemo workspace supplies its current A2A instructions at agent startup; do
+   not add a mandatory repository skill reference unless that skill is tracked in the same
+   candidate. Test clean-clone instruction discovery in both clients.
 6. Create the GitHub Project fields/views and real CI workflow before making their checks
    required.
 7. Open R00-R22 as parent/child issues only after current owners, dependencies and acceptance

--- a/engineering/remediation/templates/TASK_PACKET.md
+++ b/engineering/remediation/templates/TASK_PACKET.md
@@ -28,6 +28,7 @@
 - Runtime resources/isolated data/ports:
 - Required platforms/capabilities:
 - Acceptance fixtures and checks:
+- Evidence/artifact location and source identity:
 - Reviewer:
 - Checkpoint/expiry:
 - Publication/PR/merge/release authority:


### PR DESCRIPTION
A fresh clone now exposes tracked Codex/Claude entry points that lead to the same architecture, quality, task and receipt guidance. The shared A2A chapter follows the current dedicated Nemo workspace contract and removes obsolete manual path-grant, revision-pin and agent-assignment onboarding. Task packets now include an explicit evidence location and source identity.

Preserves the existing engineering invariants and distinguishes proposed remediation from implemented behavior. This advances #897; it does not close R01 or claim BZ0 acceptance.

Validation: clean-archive navigation and relative-link checks passed; scoped files contain no private local notes, machine/credential markers or symlinks; diff checks passed. Independent review covered the original five-file candidate; the integration correction adds the required shared instruction prefix and evidence field. Documentation-only change, so no application tests were run.

Remaining R01 gates: actual clean-clone Codex/Claude task-and-receipt rehearsals, populated Ready-item field evidence, and BZ0 live acceptance.
