### PR TITLE
docs: align Nemo collaboration with runtime contract 1.5

### DIFF
--- a/engineering/remediation/06_BUZZ_A2A_AND_ENROLLMENT.md
+++ b/engineering/remediation/06_BUZZ_A2A_AND_ENROLLMENT.md
@@ -9,7 +9,7 @@
 # Buzz collaboration, A2A and enrollment
 
 Protocol: **NEMO-A2A-1**<br>
-Runtime workspace contract: **1.4.0**
+Runtime workspace contract: **1.5.0**
 
 ## Status boundary
 
@@ -33,8 +33,15 @@ Keep these independent:
 5. current task outcome, ownership and repository-relative file scope;
 6. publication, merge, deployment and release authority.
 
-Membership or an agent persona does not imply source authority. Each agent has one accountable
-human sponsor, a distinct public identity and least-privilege channel/grant scope.
+Each agent has one accountable human sponsor and a distinct verified public identity.
+In the dedicated Nemo workspace, enrollment supplies Project/repository participation and
+full repository access. The current task determines which work is authorized; tool or account
+availability does not authorize unrelated work or publication.
+
+Conversations and delegated jobs use ordinary host Codex/Claude agents, their selected provider
+permission mode, native file/shell tools and subagents, configured MCP servers, and existing
+host accounts. Optional Buzz Project Git tools are not the only route for authorized GitHub
+work. Preserve source ownership, separate worktrees, scoped commits and branch protections.
 
 ## Enroll a human developer
 
@@ -75,19 +82,22 @@ Agent creation is self-service after human enrollment:
 Each developer's agents use that machine's own Codex/Claude provider login unless deliberately
 configured otherwise. Buzz identity does not select or share an AI-provider billing account.
 
-## Attach Nemo as a Buzz Project
+## Resolve the existing Nemo Project
 
-1. Configure the local repositories root to the parent of the developer's Nemo checkout.
-2. Create/open one Project named Nemo with:
+The dedicated community already has one Nemo Project. Agents use its runtime-supplied binding;
+they do not create a duplicate or ask contributors to configure per-agent access. Initial
+Project administration belongs to the authenticated operator or a typed administration tool.
+
+1. Open the existing Project and verify its canonical repository:
    - clone URL `https://github.com/mysteropodes/nemo.git`;
    - web URL `https://github.com/mysteropodes/nemo`;
    - one Project home channel.
-3. Resolve the existing checkout only when its canonical path stays under the configured root
-   and Git `origin` matches the announcement.
-4. Verify enrolled collaborators and their managed agents resolve the Project and intended
+2. Start from the runtime checkout and verify Git `origin` matches the Project repository.
+   A repository-relative ownership scope does not restrict ordinary host filesystem access.
+3. Verify enrolled collaborators and their managed agents resolve the Project and intended
    channel participation through the workspace.
-5. Give each writer an isolated worktree and non-overlapping task scope.
-6. Keep Buzz tasks out of the canonical backlog. The GitHub bridge posts only signed,
+4. Give each writer an isolated worktree and non-overlapping task scope.
+5. Keep Buzz tasks out of the canonical backlog. The GitHub bridge posts only signed,
    idempotent links/status for allowed issue, PR and workflow-run events.
 
 ## Workspace and task settings
@@ -97,9 +107,10 @@ verified peer roster. Enrolled collaborators do not manually maintain agent assi
 instruction pins or allowed-path forms. Each writable task still declares its outcome, base,
 branch/worktree, repository-relative owned paths, dependencies, checks and publication scope.
 
-Machine-local checkout roots stay in protected runtime configuration and never enter signed
-A2A events or model prompts. Missing or ambiguous Project/repository binding fails before work
-starts.
+Use repository-relative paths in shared receipts and task ownership coordinates. Trusted
+runtime context may supply a local checkout path for execution; do not publish private machine
+or infrastructure details. Report a missing required binding as a concrete setup failure;
+do not invent credentials or ask contributors to reconstruct runtime grants.
 
 ## Typed A2A tools
 
@@ -107,7 +118,13 @@ Managed agents use:
 
 | Intent | Tool |
 |---|---|
-| Reply in the current human conversation | `buzz_chat_send` |
+| Reply in the current or explicitly addressed conversation | `buzz_chat_send` |
+| Create a visible shared task discussion | `buzz_chat_thread_create` |
+| Read bounded signed task history | `buzz_chat_read` |
+| Ask a peer and await the correlated reply | `buzz_peer_ask`, `buzz_peer_wait` |
+| Answer an addressed peer question | `buzz_peer_reply` |
+| Read effective organization and thread participants | `buzz_organization_read` |
+| Apply an authorized reversible organization change | `buzz_organization_apply` |
 | Discover verified collaborators | `buzz_a2a_peers` |
 | Delegate one bounded job | `buzz_a2a_dispatch` |
 | Discover addressed work | `buzz_a2a_inbox` |
@@ -115,9 +132,25 @@ Managed agents use:
 | Request cancellation | `buzz_a2a_cancel` |
 | Release/transfer owned execution | `buzz_a2a_handoff` |
 
-Do not use shell commands, the unrestricted human CLI, raw relay events or reconstructed
-credentials as substitutes. One-shot job sessions cannot send arbitrary chat, browse unrelated
-inbox work or dispatch unrelated jobs; they may use native local subagents within their packet.
+Use these typed tools for Buzz chat, relay, signing and coordination. Do not substitute the
+human-only Buzz CLI, raw relay calls or credential access. This boundary does not restrict
+ordinary host file/shell tools or already-authorized Git/GitHub operations.
+
+Every delegated task is visible in a shared thread before execution. Progress, peer questions,
+replies and the terminal result remain correlated there. A delegated worker may ask any enrolled
+peer for information and continue its current task with the reply; no human relay or recursive
+job dispatch is needed. One-shot workers stay on their assigned outcome and may use native
+subagents for independent support.
+
+Thread participants control automatic following of future human messages. Before changing
+them, read the effective list, resolve exact agent identities through the verified roster,
+preserve everyone who should remain, and submit the complete desired list. An empty list removes
+all agent participants. Participation does not change repository/channel access or restrict
+direct addressed questions. Organization changes require the user's applicable task authority.
+
+Timers deliver the user's exact prompt through the normal conversation queue. A timer does
+not create a separate completion protocol or standing authority beyond the delivered prompt.
+When that prompt says to wait if there is no new work, remain idle.
 
 ## Dispatch contract
 
@@ -129,7 +162,8 @@ Before dispatch:
 4. create a fresh operation UUID and stable non-secret idempotency key;
 5. include the required runtime job coordinates; paths coordinate ownership rather than
    technical filesystem permission;
-6. keep credentials, machine-local paths and executable shell strings out of the envelope.
+6. include only task-relevant execution context; keep credentials and private infrastructure
+   details out of prompts, shared messages and receipts.
 
 Save the returned `request_event_id`. Relay acknowledgement means only that an event was stored.
 Work is owned only after the exact recipient publishes both:
@@ -150,7 +184,10 @@ request -> processed -> accepted -> progress* -> completed
 ```
 
 Cancellation after a claim is two-stage: requester publishes `cancel_requested`; worker
-quiesces and publishes `cancelled`. Silence is not cancellation.
+quiesces and publishes `cancelled`. Silence is not cancellation. Interrupted execution may
+instead terminate as `indeterminate` when effects still require reconciliation; do not wait
+for a second `cancelled` result or replay that operation automatically. Inspect actual affected
+state: an empty optional Buzz Git journal does not prove native tools made no changes.
 
 A handoff releases the current worker but does not assign its successor. The coordinator
 dispatches the same operation to the authorized successor with the next coordinator epoch and
@@ -161,13 +198,15 @@ Byte-equivalent retries reuse the original key and signed bytes. Changed semanti
 new idempotency key. An accepted operation that crashes without a terminal receipt becomes
 `indeterminate` and requires reconciliation; it is never automatically rerun.
 
-Fail closed on missing required tools or task authority, ambiguous Project binding,
-origin/branch/HEAD drift,
-expired authority, path escape, signature/lifecycle mismatch or unreachable relay state.
+Report missing required tools, ambiguous Project binding, expired task authority or a
+signature/lifecycle failure precisely. Reconcile source or branch drift before writing; use an
+appropriate current branch/worktree through ordinary host Git tools. Repository-relative owned
+paths coordinate concurrent writers rather than imposing host-access gates. Do not repeat an
+unchanged setup failure, fabricate success or reconstruct signing/relay requests.
 
 ## Revocation
 
-Freeze and reconcile active grants first. Stop the agent, remove its channels, revoke/ban its
+Stop and reconcile affected active tasks first. Stop the agent, remove its channels, revoke/ban its
 exact identity and delete its local secret/provider configuration. For a departing human,
 revoke every sponsored agent before removing the human's direct membership and repository/
 infrastructure permissions. Verify fresh WebSocket, protected HTTP/media and job authorization

--- a/engineering/remediation/MANIFEST.md
+++ b/engineering/remediation/MANIFEST.md
@@ -10,7 +10,7 @@
 
 Status: **R01 adoption candidate for maintainer review**<br>
 Prepared: **2026-09-04**<br>
-Package version: **0.2.0**
+Package version: **0.2.1**
 Repository: <https://github.com/mysteropodes/nemo>
 
 This package is the portable starting point for Nemo's foundation remediation. It contains
@@ -56,3 +56,10 @@ with the dedicated Nemo workspace contract: enrolled collaborators receive Proje
 participation and current A2A instructions from the runtime. Repository-relative task paths
 coordinate concurrent ownership; contributors do not configure manual path grants or revision
 pins. BZ0 transport acceptance and clean-clone Codex/Claude rehearsal remain required gates.
+
+## Migration note for 0.2.1
+
+Aligns the collaboration chapter with runtime contract 1.5.0: ordinary host tools in conversations
+and delegated jobs, existing automatic Project participation, thread-visible tasks and peer
+consultation, persistent following, timer delivery, and indeterminate-effect reconciliation.
+This documentation update does not itself establish installed behavior or release acceptance.


### PR DESCRIPTION
The tracked collaboration chapter still limited delegated workers to older chat/tool behavior and described Project/path restrictions that no longer match the dedicated Nemo runtime. Align it with contract 1.5: automatic repository participation, ordinary host tools, thread-visible jobs and peer consultation, persistent following, timer delivery, and reconciliation after interrupted effects.

Updates the package migration note to 0.2.1. Relates to #896 and #897; neither is closed by documentation alone. Actual new R05 and BZ0 jobs returned signed successful results, while an R06 result was rejected as `invalid_terminal_envelope`; that live failure remains an explicit acceptance gate.

Validation: changed-document relative links, privacy markers, symlinks, required instruction prefix, scoped diff and whitespace checks passed. No application behavior changed; application tests were not run.
