### PR TITLE
Fix runtime test fixtures when the Node path contains spaces

### DIFF
--- a/scripts/nemo/browser-runtime.test.cjs
+++ b/scripts/nemo/browser-runtime.test.cjs
@@ -178,7 +178,7 @@ test('an exited requested browser is reported and shutdown waits for a stubborn 
   } finally { await stopOwned(failed); }
   const stubborn = path.join(scratch, 'browser-stubborn');
   const ready = path.join(scratch, 'stubborn-ready');
-  fs.writeFileSync(stubborn, `#!${process.execPath}\nprocess.on('SIGTERM', () => {});\nrequire('node:fs').writeFileSync(${JSON.stringify(ready)}, 'ready');\nsetInterval(() => {}, 1000);\n`, { mode: 0o700 });
+  fs.writeFileSync(stubborn, `#!/usr/bin/env node\nprocess.on('SIGTERM', () => {});\nrequire('node:fs').writeFileSync(${JSON.stringify(ready)}, 'ready');\nsetInterval(() => {}, 1000);\n`, { mode: 0o700 });
   const instance = await launch(`preview-browser-stubborn-${process.pid}`, ['--browser', stubborn]);
   try {
     for (let i = 0; i < 100 && !fs.existsSync(ready); i++) await new Promise((resolve) => setTimeout(resolve, 10));

--- a/scripts/nemo/build-runtime.test.cjs
+++ b/scripts/nemo/build-runtime.test.cjs
@@ -15,7 +15,7 @@ const cli = path.join(__dirname, 'build.cjs');
 const repoRoot = path.resolve(__dirname, '..', '..');
 
 const stub = path.join(scratch, 'build-stub');
-fs.writeFileSync(stub, `#!${process.execPath}\n` + String.raw`
+fs.writeFileSync(stub, `#!/usr/bin/env node\n` + String.raw`
 const fs = require('node:fs');
 const [capture, delay, exitCode] = process.argv.slice(2);
 fs.writeFileSync(capture, JSON.stringify({
@@ -30,7 +30,7 @@ setTimeout(() => process.exit(Number(exitCode || 0)), Number(delay || 0));
 `, { mode: 0o700 });
 
 const stubbornStub = path.join(scratch, 'stubborn-build-stub');
-fs.writeFileSync(stubbornStub, `#!${process.execPath}\n` + String.raw`
+fs.writeFileSync(stubbornStub, `#!/usr/bin/env node\n` + String.raw`
 const fs = require('node:fs');
 fs.writeFileSync(process.argv[2], String(process.pid));
 process.on('SIGTERM', () => {});
@@ -38,7 +38,7 @@ setInterval(() => {}, 1000);
 `, { mode: 0o700 });
 
 const orphaningStub = path.join(scratch, 'orphaning-build-stub');
-fs.writeFileSync(orphaningStub, `#!${process.execPath}\n` + String.raw`
+fs.writeFileSync(orphaningStub, `#!/usr/bin/env node\n` + String.raw`
 const fs = require('node:fs');
 const { spawn } = require('node:child_process');
 const descendant = spawn(process.execPath, ['-e', "process.on('SIGTERM',()=>{});process.send('ready');setInterval(()=>{},1000)"], {


### PR DESCRIPTION
Runtime fixture executables fail with `ENOENT` when Node is installed in a path containing spaces, as in Buzz. Their shebangs embedded `process.execPath` directly, causing five build-runtime tests and one browser-runtime test to fail before their intended behavior ran.

Use `/usr/bin/env node` for the four generated executable fixtures. This changes only test setup and removes the host-path failure before R07 CI integration. Part of #902 and #903; neither issue is closed by this change.

Validation on macOS arm64 with Buzz Node 24.18.0 in a spaced application path:
- Clean `main` at `35f0f5f`: reproduced build 1/6 and browser 7/8 passing; a direct fixture probe confirmed the interpreter-path failure.
- Corrected focused wrappers: 14/14 pass.
- Required `npm run verify -- --profile quick`: doctor and check pass, unit 185/185, Rust 15/15; overall PASS.
- Receipt: `reports/20260905T163037Z-35f0f5f-dirty/receipt.json` (pre-commit candidate, tracked changes limited to these four lines).
