### PR TITLE
R07: run PR checks with a fail-closed aggregate

### DIFF
--- a/.github/workflows/nemo-validation.yml
+++ b/.github/workflows/nemo-validation.yml
@@ -1,0 +1,99 @@
+name: Nemo validation
+
+on:
+  pull_request:
+    branches: [main]
+
+# Untrusted PR code runs only on disposable GitHub-hosted runners.
+permissions:
+  contents: read
+
+concurrency:
+  group: nemo-validation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  NEMO_CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
+jobs:
+  quick:
+    name: Nemo / local quick
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - run: node scripts/nemo/ci.cjs quick
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: nemo-quick-receipts
+          path: reports/
+          if-no-files-found: error
+
+  boundaries:
+    name: Nemo / boundaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - run: node scripts/nemo/ci.cjs boundaries
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: nemo-boundary-receipts
+          path: reports/ci/
+          if-no-files-found: error
+
+  surfaces:
+    name: Nemo / affected surfaces
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - run: node scripts/nemo/ci.cjs surfaces
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: nemo-surface-receipts
+          path: reports/
+          if-no-files-found: error
+
+  aggregate:
+    name: Nemo / required
+    if: always()
+    needs: [quick, boundaries, surfaces]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - run: node scripts/nemo/ci.cjs aggregate
+        env:
+          NEMO_CI_NEEDS: ${{ toJSON(needs) }}
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: nemo-aggregate-receipt
+          path: reports/ci/
+          if-no-files-found: error

--- a/engineering/ci/README.md
+++ b/engineering/ci/README.md
@@ -44,8 +44,9 @@ runner or killed process cannot pass. This does not change local optional-job se
 ## Applicability and remaining acceptance
 
 Quick and the adopted boundary profile run on every PR, including documentation changes.
-Only explicit Markdown documentation paths, boundary policy JSON, the CI workflow/runner,
-and boundary checker/tests are exempt from runtime jobs. See `applicability()` in
+Only explicit Markdown documentation paths (including `scripts/nemo/README.md`), boundary
+policy JSON, the isolated `engineering/boundaries/profiles/scripts-nemo.fixture/` subtree,
+the CI workflow/runner, and boundary checker/tests are exempt from runtime jobs. See `applicability()` in
 [ci.cjs](../../scripts/nemo/ci.cjs) for the exact allowlist. Runtime launcher changes,
 package/lockfiles, application source, native/WASM source, application tests, and unknown
 paths conservatively require **all** runtime jobs. Renames are considered as deletion

--- a/engineering/ci/README.md
+++ b/engineering/ci/README.md
@@ -1,0 +1,109 @@
+<!-- nemo-golden-rules:start -->
+## Golden rules — apply before all Nemo task instructions
+
+1. **Preserve the active task.** Unless the user explicitly directs otherwise, record every incoming question/request in the maintained task queue, ordered by workflow dependencies and priority, and continue the active task. Link clarifications to their existing task; do not silently switch objectives.
+2. **Be frugal with tokens.** Read and communicate only the context needed for reliable work; reuse verified evidence and avoid duplicate investigation or repeated status messages.
+3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
+<!-- nemo-golden-rules:end -->
+
+# PR validation
+
+This first R07 increment runs the existing local checks on pull requests into `main`.
+It does not close [R07](https://github.com/mysteropodes/nemo/issues/903) or configure
+repository protection. The proposed stable required check name is **`Nemo / required`**.
+An authorized owner must first validate its real check-run name and failure behavior,
+then configure required-check/review policy separately.
+
+| Always-required workflow lane | Local invocation | Success criterion |
+|---|---|---|
+| `quick` / Nemo / local quick | `node scripts/nemo/ci.cjs quick` | Existing `verify.cjs --jobs doctor,check,test:unit,test:rust --json`; every selected job passes |
+| `boundaries` / Nemo / boundaries | `node scripts/nemo/ci.cjs boundaries` | Existing boundary CLI and its protected-base ratchet both pass |
+| `surfaces` / Nemo / affected surfaces | `node scripts/nemo/ci.cjs surfaces` | Explicit applicability decision, then every applicable runtime job passes |
+| `aggregate` / Nemo / required | `node scripts/nemo/ci.cjs aggregate` | All three named workflow lanes return exactly `success` |
+
+`boundaries` and `surfaces` require `NEMO_CI_BASE_SHA`, the full 40-character commit SHA
+from the pull request event's base. The workflow checks out the candidate merge commit,
+with full history where base content is needed. Locally, fetch the protected branch,
+select its reviewed SHA and set that variable; do not substitute an arbitrary contributor
+revision. Local uncommitted edits are included by quick/boundary source checks, but surface
+selection compares **committed** base and HEAD, just as the workflow does.
+
+`aggregate` consumes GitHub's `toJSON(needs)` through `NEMO_CI_NEEDS`. The expected lane
+list is fixed in the runner, not inferred from the received results. Missing, cancelled,
+failed, skipped, blocked, unavailable and unknown results all fail. The job uses
+[`if: always()` with explicit dependencies](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idneeds)
+so a failed prerequisite does not silently skip aggregation. Cancelling the aggregate
+itself cannot produce success. No workflow path filters or `continue-on-error` are used.
+
+The existing local registry permits some optional jobs to return `blocked`/`not-run`
+with an overall zero exit. CI independently requires exactly one `pass` receipt entry
+per selected job, a passing summary, and a zero process exit. Missing or duplicate
+entries, invalid JSON/schema, contradictory exits and unexpected jobs fail. An absent
+runner or killed process cannot pass. This does not change local optional-job semantics.
+
+## Applicability and remaining acceptance
+
+Quick and the adopted boundary profile run on every PR, including documentation changes.
+Only explicit Markdown documentation paths, boundary policy JSON, the CI workflow/runner,
+and boundary checker/tests are exempt from runtime jobs. See `applicability()` in
+[ci.cjs](../../scripts/nemo/ci.cjs) for the exact allowlist. Runtime launcher changes,
+package/lockfiles, application source, native/WASM source, application tests, and unknown
+paths conservatively require **all** runtime jobs. Renames are considered as deletion
+plus addition, so moving application code into a docs path cannot hide its former surface.
+
+When applicable, the runner invokes the established verifier with `test:integration`,
+`test:browser`, `test:rust-tauri`, `build:wasm`, `build:desktop`, and `test:desktop`.
+The current dependency/suite gaps deliberately prevent a green aggregate:
+
+- Document-contract suites are not yet defined (R12/R13).
+- Playwright and the browser acceptance suite are not yet installed/defined (R03/R07).
+- Packaged desktop test harness and installed-artifact acceptance remain open (R06/R21).
+- Native builds require toolchain/dependencies and usable sidecar packaging. R04's unsigned
+  desktop build/sidecar correction is separate work. This workflow does not supply signing,
+  updater, notarization, deployment, or feedback credentials.
+- WASM builds require `wasm-pack` and its target. The current local job builds geometry only;
+  vectorize rebuild/parity and GPU acceptance remain outside that job's success claim.
+- Only the adopted `scripts/nemo` boundary profile is enforced here. Full application
+  architecture profiles and coverage for newly introduced tooling files remain the R05
+  adoption/integration gate. A profile passing is not proof of whole-application coverage.
+
+There are no placeholder green browser/native jobs and no label-based bypass. A green
+tooling/docs PR reports runtime jobs as **not applicable**, not tested or accepted.
+Application-affecting PRs will remain blocked until the required harnesses and build
+prerequisites land. Full R07 acceptance still needs actual browser and packaged-native
+receipts on their supported environments; CPU tests cannot supply that evidence.
+
+## Protected base and PR trust
+
+The runner materializes
+`engineering/boundaries/profiles/scripts-nemo.profile.json` directly with `git show`
+from the event base SHA into a unique temporary directory. It passes that absolute file
+to the existing `boundaries.cjs --baseline` CLI against the candidate profile/root.
+It records the base SHA, source path and content SHA-256. Missing commit/profile or
+malformed baseline fails closed. Candidate `scripts-nemo.baseline.json` is never used
+as the trusted prior policy. Temporary materialization is removed after the checker runs.
+
+The workflow uses `pull_request`, a read-only contents token, nonpersistent checkout
+credentials and disposable GitHub-hosted runners. No personal/self-hosted runner,
+`pull_request_target`, settings API, privileged follow-up workflow, cache reuse, or
+secret injection is involved. macOS arm64 matches the only committed FFmpeg sidecar;
+Linux runs the pure boundary/aggregate checks. Existing release/deploy workflows are
+outside this increment. PR workflow/checker changes remain reviewable candidate code;
+base provenance does not make that code immutable or replace required maintainer review.
+
+## Evidence
+
+Each completed lane writes `reports/ci/<lane>.json`; the established verifier also writes
+its normal source/build/platform receipt and logs. GitHub uploads a separate artifact for
+each lane even on failure, and missing artifacts fail their upload step. A setup error,
+runner crash or cancellation may leave no receipt; the aggregate still rejects the lane.
+No source-build identity is inferred from historical receipts.
+
+Run focused regressions with `node --test tests/nemo-ci.test.cjs`; the wrapper includes
+them in `npm test` and `npm run verify`. Tests exercise real CLI invocation, a zero-exit
+blocked verifier, missing/duplicate receipts, all nonsuccess aggregate states, conservative
+selection and a Git fixture where candidate policy differs from the protected base.
+
+[PR #945](https://github.com/mysteropodes/nemo/pull/945) is a separate test-fixture
+prerequisite for Node executable paths containing spaces. Until integrated, those existing
+fixtures can fail on affected hosts; this CI runner does not mask or patch them.

--- a/scripts/nemo/ci.cjs
+++ b/scripts/nemo/ci.cjs
@@ -46,6 +46,8 @@ function applicability(files) {
   // Unknown files, executable docs, dependency/build changes and app tests require all surfaces.
   const exempt = (file) => /^(?:docs|engineering)\/.*\.md$/.test(file)
     || /^engineering\/boundaries\/.*\.json$/.test(file)
+    || file.startsWith('engineering/boundaries/profiles/scripts-nemo.fixture/')
+    || file === 'scripts/nemo/README.md'
     || /^(?:README|CONTRIBUTING|CLAUDE|AGENTS|THIRD_PARTY_NOTICES)\.md$/.test(file)
     || file === 'LICENSE' || file === '.github/workflows/nemo-validation.yml'
     || /^scripts\/nemo\/(?:ci|boundaries|boundaries-ratchet)(?:\.test)?\.cjs$/.test(file)

--- a/scripts/nemo/ci.cjs
+++ b/scripts/nemo/ci.cjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+'use strict';
+// PR orchestration over the same command surface used locally. See engineering/ci.
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { spawnSync } = require('node:child_process');
+
+const ROOT = path.resolve(__dirname, '../..');
+const PROFILE = 'engineering/boundaries/profiles/scripts-nemo.profile.json';
+const LANES = ['quick', 'boundaries', 'surfaces'];
+const QUICK = ['doctor', 'check', 'test:unit', 'test:rust'];
+const SURFACES = ['test:integration', 'test:browser', 'test:rust-tauri', 'build:wasm', 'build:desktop', 'test:desktop'];
+
+function aggregate(needs) {
+  const problems = [];
+  for (const lane of LANES) {
+    if (!needs || needs[lane]?.result !== 'success') problems.push(`${lane}: ${needs?.[lane]?.result || 'missing'}`);
+  }
+  return { ok: problems.length === 0, problems };
+}
+
+function validateReceipt(receipt, required, processStatus) {
+  const problems = [];
+  if (processStatus !== 0) problems.push(`runner exit: ${processStatus ?? 'unavailable'}`);
+  if (receipt?.schema !== 'nemo.receipt/1' || !Array.isArray(receipt?.jobs)) {
+    return { ok: false, problems: problems.concat('missing or malformed nemo.receipt/1') };
+  }
+  if (!required.length) problems.push('required job list is empty');
+  if (receipt.summary?.overall !== 'pass' || receipt.summary?.exitCode !== 0) problems.push('receipt summary did not pass');
+  for (const name of required) {
+    const entries = receipt.jobs.filter((job) => job?.name === name);
+    if (entries.length !== 1) problems.push(`${name}: expected one result, got ${entries.length}`);
+    else if (entries[0].status !== 'pass') problems.push(`${name}: ${entries[0].status || 'missing status'} (${entries[0].reason || 'no reason'})`);
+    else if (entries[0].exitCode != null && entries[0].exitCode !== 0) problems.push(`${name}: nonzero exit despite pass`);
+  }
+  for (const job of receipt.jobs) {
+    if (!required.includes(job?.name)) problems.push(`unexpected receipt job: ${job?.name || 'malformed'}`);
+  }
+  return { ok: !problems.length, problems };
+}
+
+function applicability(files) {
+  // Explicit exemption only for documentation and the isolated tooling command surface.
+  // Unknown files, executable docs, dependency/build changes and app tests require all surfaces.
+  const exempt = (file) => /^(?:docs|engineering)\/.*\.md$/.test(file)
+    || /^engineering\/boundaries\/.*\.json$/.test(file)
+    || /^(?:README|CONTRIBUTING|CLAUDE|AGENTS|THIRD_PARTY_NOTICES)\.md$/.test(file)
+    || file === 'LICENSE' || file === '.github/workflows/nemo-validation.yml'
+    || /^scripts\/nemo\/(?:ci|boundaries|boundaries-ratchet)(?:\.test)?\.cjs$/.test(file)
+    || /^scripts\/nemo\/lib\/boundaries(?:-ratchet)?\.cjs$/.test(file)
+    || /^tests\/nemo-(?:ci|boundaries|boundaries-ratchet)\.test\.cjs$/.test(file);
+  const affected = files.filter((file) => !exempt(file));
+  return { required: affected.length ? [...SURFACES] : [], affected,
+    reason: affected.length ? 'Application, build, test or unclassified paths require all runtime surfaces.'
+      : 'Only explicitly exempt documentation/tooling paths changed; quick and boundaries remain required.' };
+}
+
+function command(commandName, args, root = ROOT) {
+  return spawnSync(commandName, args, { cwd: root, encoding: 'utf8', shell: false,
+    timeout: 60 * 60 * 1000, maxBuffer: 64 * 1024 * 1024, env: process.env });
+}
+
+function git(args, root) {
+  const result = command('git', args, root);
+  if (result.status !== 0) throw new Error(`git ${args[0]} failed: ${result.stderr || result.error || result.signal}`);
+  return result.stdout;
+}
+
+function checkedBase(base, root) {
+  if (!/^[0-9a-f]{40}$/.test(base || '')) throw new Error('NEMO_CI_BASE_SHA must be the full protected event base SHA');
+  git(['cat-file', '-e', `${base}^{commit}`], root);
+  return base;
+}
+
+function changedFiles(base, root = ROOT) {
+  checkedBase(base, root);
+  // --no-renames keeps BOTH sides of a rename in the applicability decision.
+  return git(['diff', '--name-only', '--no-renames', '-z', base, 'HEAD', '--'], root).split('\0').filter(Boolean);
+}
+
+function materializeBaseline(base, directory, root = ROOT) {
+  checkedBase(base, root);
+  const content = git(['show', `${base}:${PROFILE}`], root);
+  JSON.parse(content); // malformed/missing policy fails before calling the checker
+  const file = path.join(directory, 'protected-base-profile.json');
+  fs.writeFileSync(file, content, { flag: 'wx' });
+  return { file, base, sourcePath: PROFILE, sha256: crypto.createHash('sha256').update(content).digest('hex') };
+}
+
+function verify(required, root = ROOT) {
+  const result = command(process.execPath, ['scripts/nemo/verify.cjs', '--jobs', required.join(','), '--json'], root);
+  let receipt;
+  try { receipt = JSON.parse(result.stdout); } catch { /* rejected below */ }
+  return { ...validateReceipt(receipt, required, result.status), required,
+    jobs: receipt?.jobs || [], receiptRunId: receipt?.runId || null,
+    runnerError: result.error?.code || result.signal || null,
+    stderr: result.stderr || null };
+}
+
+function boundaries(base, root = ROOT) {
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-ci-baseline-'));
+  try {
+    const baseline = materializeBaseline(base, scratch, root);
+    const result = command(process.execPath, ['scripts/nemo/boundaries.cjs', PROFILE,
+      '--baseline', baseline.file, '--root', root, '--json'], root);
+    let report;
+    try { report = JSON.parse(result.stdout); } catch { /* rejected below */ }
+    const ok = result.status === 0 && report?.ok === true && report?.ratchet?.ok === true;
+    return { ok, problems: ok ? [] : ['boundary checker or required baseline ratchet did not pass'],
+      baseline: { base: baseline.base, sourcePath: baseline.sourcePath, sha256: baseline.sha256 },
+      report: report || null, stderr: result.stderr || null };
+  } finally { fs.rmSync(scratch, { recursive: true, force: true }); }
+}
+
+function main(argv = process.argv.slice(2)) {
+  const lane = argv[0];
+  if (argv.length !== 1 || ![...LANES, 'aggregate'].includes(lane)) throw new Error('usage: node scripts/nemo/ci.cjs quick|boundaries|surfaces|aggregate');
+  let result;
+  if (lane === 'aggregate') result = aggregate(JSON.parse(process.env.NEMO_CI_NEEDS || 'null'));
+  else if (lane === 'quick') result = verify(QUICK);
+  else if (lane === 'boundaries') result = boundaries(process.env.NEMO_CI_BASE_SHA);
+  else {
+    const files = changedFiles(process.env.NEMO_CI_BASE_SHA);
+    const selection = applicability(files);
+    result = { ...(selection.required.length ? verify(selection.required) : { ok: true, problems: [] }), selection, files };
+  }
+  result = { schema: 'nemo.ci/1', lane, source: { head: git(['rev-parse', 'HEAD'], ROOT).trim(),
+    base: process.env.NEMO_CI_BASE_SHA || null }, ...result };
+  const dir = process.env.NEMO_CI_REPORT_DIR || path.join(ROOT, 'reports', 'ci');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${lane}.json`), JSON.stringify(result, null, 2) + '\n');
+  console.log(JSON.stringify(result, null, 2));
+  return result.ok ? 0 : 1;
+}
+
+if (require.main === module) {
+  try { process.exitCode = main(); }
+  catch (err) { console.error(`CI blocked: ${err.message}`); process.exitCode = 1; }
+}
+module.exports = { LANES, QUICK, SURFACES, PROFILE, aggregate, validateReceipt, applicability,
+  changedFiles, materializeBaseline, verify, boundaries, main };

--- a/scripts/nemo/ci.test.cjs
+++ b/scripts/nemo/ci.test.cjs
@@ -1,0 +1,153 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const ci = require('./ci.cjs');
+const ROOT = path.resolve(__dirname, '../..');
+
+function passingNeeds() { return Object.fromEntries(ci.LANES.map((lane) => [lane, { result: 'success' }])); }
+function receipt(jobs = [{ name: 'test:browser', status: 'pass', exitCode: 0 }]) {
+  return { schema: 'nemo.receipt/1', jobs, summary: { overall: 'pass', exitCode: 0 } };
+}
+function scratch(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo ci test '));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+function git(root, args) {
+  const r = spawnSync('git', args, { cwd: root, encoding: 'utf8' });
+  assert.equal(r.status, 0, r.stderr);
+  return r.stdout.trim();
+}
+
+test('aggregate requires every named lane, including absent and unavailable results', () => {
+  assert.equal(ci.aggregate(passingNeeds()).ok, true);
+  assert.equal(ci.aggregate(null).ok, false);
+  assert.equal(ci.aggregate({}).ok, false);
+  for (const lane of ci.LANES) {
+    for (const result of ['failure', 'cancelled', 'skipped', 'blocked', 'not-run', 'unavailable', 'pending', '', null]) {
+      const needs = passingNeeds();
+      needs[lane] = { result };
+      assert.equal(ci.aggregate(needs).ok, false, `${lane}: ${result}`);
+    }
+    const needs = passingNeeds();
+    delete needs[lane];
+    assert.equal(ci.aggregate(needs).ok, false, `missing ${lane}`);
+  }
+});
+
+test('zero-exit optional jobs cannot conceal blocked/not-run/failure or malformed receipts', () => {
+  const required = ['test:browser'];
+  assert.equal(ci.validateReceipt(receipt(), required, 0).ok, true);
+  for (const status of ['blocked', 'not-run', 'fail', 'failure', 'cancelled', 'unavailable', undefined]) {
+    assert.equal(ci.validateReceipt(receipt([{ name: required[0], status }]), required, 0).ok, false, status);
+  }
+  for (const bad of [null, {}, { schema: 'other', jobs: [] }, receipt([]), receipt([null]),
+    receipt([{ name: required[0], status: 'pass' }, { name: required[0], status: 'pass' }]),
+    receipt([{ name: required[0], status: 'pass', exitCode: 1 }]),
+    { ...receipt(), summary: { overall: 'blocked', exitCode: 0 } }]) {
+    assert.equal(ci.validateReceipt(bad, required, 0).ok, false);
+  }
+  assert.equal(ci.validateReceipt(receipt(), [], 0).ok, false);
+  for (const exit of [1, 2, null]) assert.equal(ci.validateReceipt(receipt(), required, exit).ok, false);
+});
+
+test('surface applicability exempts explicit tooling/docs only and treats unknown paths conservatively', () => {
+  assert.deepEqual(ci.applicability(['engineering/ci/README.md', 'scripts/nemo/ci.cjs',
+    'tests/nemo-ci.test.cjs', '.github/workflows/nemo-validation.yml']).required, []);
+  for (const file of ['src/js/app.js', 'src/wasm/x.wasm', 'src-tauri/src/lib.rs', 'geometry-wasm/Cargo.toml',
+    'vectorize-wasm/src/lib.rs', 'package-lock.json', 'package.json', 'tests/browser/foo.spec.js',
+    'tests/animation.test.cjs', '.github/workflows/release.yml', 'new-module/unknown.js',
+    'docs/example.js', 'engineering/fixtures/document.json', 'scripts/nemo/build.cjs',
+    'scripts/nemo/lib/jobs.cjs', 'scripts/nemo/lib/browser-runtime.cjs']) {
+    assert.deepEqual(ci.applicability(['README.md', file]).required, ci.SURFACES, file);
+  }
+});
+
+test('baseline is materialized from the explicit base commit, never candidate policy or a moving branch', (t) => {
+  const root = scratch(t);
+  git(root, ['init', '-q']);
+  git(root, ['config', 'user.name', 'CI fixture']);
+  git(root, ['config', 'user.email', 'ci@example.invalid']);
+  const policy = path.join(root, ci.PROFILE);
+  fs.mkdirSync(path.dirname(policy), { recursive: true });
+  fs.writeFileSync(policy, '{"protected":true}\n');
+  fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'src', 'app.js'), '// app\n');
+  git(root, ['add', '.']);
+  git(root, ['-c', 'commit.gpgsign=false', 'commit', '-qm', 'base']);
+  const base = git(root, ['rev-parse', 'HEAD']);
+  fs.writeFileSync(policy, '{"protected":false}\n');
+  git(root, ['mv', 'src/app.js', 'README.md']);
+  git(root, ['add', '.']);
+  git(root, ['-c', 'commit.gpgsign=false', 'commit', '-qm', 'candidate changes policy and renames app']);
+  const output = scratch(t);
+  const materialized = ci.materializeBaseline(base, output, root);
+  assert.deepEqual(JSON.parse(fs.readFileSync(materialized.file)), { protected: true });
+  assert.equal(materialized.base, base);
+  assert.match(materialized.sha256, /^[a-f0-9]{64}$/);
+  assert.deepEqual(ci.applicability(ci.changedFiles(base, root)).required, ci.SURFACES);
+  fs.mkdirSync(path.join(root, 'scripts/nemo'), { recursive: true });
+  const checker = path.join(root, 'scripts/nemo/boundaries.cjs');
+  for (const [report, ok] of [[{ ok: true }, false], [{ ok: true, ratchet: { ok: false } }, false],
+    [{ ok: false, ratchet: { ok: true } }, false], [{ ok: true, ratchet: { ok: true } }, true]]) {
+    fs.writeFileSync(checker, `const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.writeFileSync('boundary-invocation.json', JSON.stringify({ args,
+  baseline: JSON.parse(fs.readFileSync(args[args.indexOf('--baseline') + 1])) }));
+console.log(${JSON.stringify(JSON.stringify(report))});`);
+    assert.equal(ci.boundaries(base, root).ok, ok);
+    const invocation = JSON.parse(fs.readFileSync(path.join(root, 'boundary-invocation.json')));
+    assert.equal(invocation.args[0], ci.PROFILE);
+    assert.deepEqual(invocation.args.slice(3), ['--root', root, '--json']);
+    assert.deepEqual(invocation.baseline, { protected: true });
+    assert.equal(fs.existsSync(invocation.args[2]), false, 'temporary baseline removed after checker');
+  }
+  for (const invalid of [undefined, 'origin/main', '--help', '0'.repeat(40)]) {
+    assert.throws(() => ci.materializeBaseline(invalid, scratch(t), root));
+  }
+  fs.rmSync(policy);
+  git(root, ['add', '.']);
+  git(root, ['-c', 'commit.gpgsign=false', 'commit', '-qm', 'remove profile']);
+  assert.throws(() => ci.materializeBaseline(git(root, ['rev-parse', 'HEAD']), scratch(t), root));
+});
+
+test('CI invokes established verify with explicit jobs and rejects a real zero-exit blocked receipt', (t) => {
+  const root = scratch(t);
+  fs.mkdirSync(path.join(root, 'scripts/nemo'), { recursive: true });
+  const runner = path.join(root, 'scripts/nemo/verify.cjs');
+  fs.writeFileSync(runner, `const fs = require('node:fs');
+fs.writeFileSync('invocation.json', JSON.stringify(process.argv.slice(2)));
+console.log(${JSON.stringify(JSON.stringify(receipt([{ name: 'test:browser', status: 'blocked', reason: 'fixture runner unavailable' }])))});
+`);
+  const result = ci.verify(['test:browser'], root);
+  assert.deepEqual(JSON.parse(fs.readFileSync(path.join(root, 'invocation.json'))), ['--jobs', 'test:browser', '--json']);
+  assert.equal(result.ok, false);
+  assert.match(result.problems.join('\n'), /blocked.*fixture runner unavailable/);
+  fs.writeFileSync(runner, `console.log(${JSON.stringify(JSON.stringify(receipt()))});`);
+  assert.equal(ci.verify(['test:browser'], root).ok, true);
+  fs.rmSync(runner);
+  assert.equal(ci.verify(['test:browser'], root).ok, false);
+});
+
+test('workflow invokes each CLI lane and always aggregates exact dependencies without PR privileges', (t) => {
+  const workflow = fs.readFileSync(path.join(ROOT, '.github/workflows/nemo-validation.yml'), 'utf8');
+  const invocations = [...workflow.matchAll(/^\s+- run: node scripts\/nemo\/ci.cjs (\w+)$/gm)].map((m) => m[1]);
+  assert.deepEqual(invocations, [...ci.LANES, 'aggregate']);
+  assert.match(workflow, /aggregate:\n\s+name: Nemo \/ required\n\s+if: always\(\)\n\s+needs: \[quick, boundaries, surfaces\]/);
+  assert.match(workflow, /NEMO_CI_NEEDS: \$\{\{ toJSON\(needs\) \}\}/);
+  assert.match(workflow, /NEMO_CI_BASE_SHA: \$\{\{ github.event.pull_request.base.sha \}\}/);
+  assert.doesNotMatch(workflow, /pull_request_target|secrets\.|self-hosted|contents: write|continue-on-error|paths-ignore:|paths:/);
+  assert.equal((workflow.match(/uses: actions\/checkout@/g) || []).length,
+    (workflow.match(/persist-credentials: false/g) || []).length);
+  const dir = scratch(t);
+  for (const [needs, status] of [[passingNeeds(), 0], [{ ...passingNeeds(), quick: { result: 'cancelled' } }, 1], [{}, 1]]) {
+    const r = spawnSync(process.execPath, ['scripts/nemo/ci.cjs', 'aggregate'], { cwd: ROOT, encoding: 'utf8',
+      env: { ...process.env, NEMO_CI_NEEDS: JSON.stringify(needs), NEMO_CI_REPORT_DIR: dir } });
+    assert.equal(r.status, status, r.stderr);
+    assert.equal(JSON.parse(fs.readFileSync(path.join(dir, 'aggregate.json'))).ok, status === 0);
+  }
+});

--- a/scripts/nemo/ci.test.cjs
+++ b/scripts/nemo/ci.test.cjs
@@ -67,6 +67,50 @@ test('surface applicability exempts explicit tooling/docs only and treats unknow
   }
 });
 
+const benignPaths = ['scripts/nemo/README.md',
+  'engineering/boundaries/profiles/scripts-nemo.fixture/src/cycle-a.cjs'];
+for (const file of benignPaths) {
+  test(`benign-only ${file} does not require runtime jobs; mixed application changes still do`, () => {
+    assert.deepEqual(ci.applicability([file]).required, []);
+    assert.deepEqual(ci.applicability([file]).affected, []);
+    const mixed = ci.applicability([file, 'src/js/app.js']);
+    assert.deepEqual(mixed.required, ci.SURFACES);
+    assert.deepEqual(mixed.affected, ['src/js/app.js']);
+  });
+}
+
+test('renames into and out of exempt command docs and boundary fixtures retain both endpoints', (t) => {
+  const root = scratch(t);
+  git(root, ['init', '-q']);
+  git(root, ['config', 'user.name', 'CI fixture']);
+  git(root, ['config', 'user.email', 'ci@example.invalid']);
+  git(root, ['config', 'maintenance.auto', 'false']);
+  git(root, ['config', 'gc.auto', '0']);
+  const appPaths = ['src/js/app.js', 'src/js/other.js'];
+  fs.mkdirSync(path.join(root, 'src/js'), { recursive: true });
+  for (const file of appPaths) fs.writeFileSync(path.join(root, file), `// ${file}\n`);
+  git(root, ['add', '.']);
+  git(root, ['-c', 'commit.gpgsign=false', 'commit', '-qm', 'application sources']);
+  for (const [from, to] of [[appPaths, benignPaths], [benignPaths, appPaths]]) {
+    const base = git(root, ['rev-parse', 'HEAD']);
+    for (let i = 0; i < from.length; i++) {
+      fs.mkdirSync(path.dirname(path.join(root, to[i])), { recursive: true });
+      git(root, ['mv', from[i], to[i]]);
+    }
+    git(root, ['-c', 'commit.gpgsign=false', 'commit', '-qm', 'rename sources']);
+    const files = ci.changedFiles(base, root);
+    assert.deepEqual(files.sort(), [...appPaths, ...benignPaths].sort());
+    const selection = ci.applicability(files);
+    assert.deepEqual(selection.required, ci.SURFACES);
+    assert.deepEqual(selection.affected.sort(), appPaths);
+  }
+  for (const file of ['scripts/nemo/README.cjs',
+    'engineering/boundaries/profiles/scripts-nemo.fixture-other/src/cycle-a.cjs',
+    'engineering/boundaries/profiles/other.fixture/src/cycle-a.cjs']) {
+    assert.deepEqual(ci.applicability([file]).required, ci.SURFACES, file);
+  }
+});
+
 test('baseline is materialized from the explicit base commit, never candidate policy or a moving branch', (t) => {
   const root = scratch(t);
   git(root, ['init', '-q']);

--- a/scripts/nemo/ci.test.cjs
+++ b/scripts/nemo/ci.test.cjs
@@ -14,7 +14,7 @@ function receipt(jobs = [{ name: 'test:browser', status: 'pass', exitCode: 0 }])
 }
 function scratch(t) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo ci test '));
-  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
   return dir;
 }
 function git(root, args) {
@@ -72,6 +72,8 @@ test('baseline is materialized from the explicit base commit, never candidate po
   git(root, ['init', '-q']);
   git(root, ['config', 'user.name', 'CI fixture']);
   git(root, ['config', 'user.email', 'ci@example.invalid']);
+  git(root, ['config', 'maintenance.auto', 'false']);
+  git(root, ['config', 'gc.auto', '0']);
   const policy = path.join(root, ci.PROFILE);
   fs.mkdirSync(path.dirname(policy), { recursive: true });
   fs.writeFileSync(policy, '{"protected":true}\n');

--- a/tests/nemo-ci.test.cjs
+++ b/tests/nemo-ci.test.cjs
@@ -1,0 +1,3 @@
+'use strict';
+// Include the CI regressions in the established npm test / verify command.
+require('../scripts/nemo/ci.test.cjs');


### PR DESCRIPTION
PRs currently have no Nemo validation aggregate, and the local verifier can return zero when an optional registry job is blocked or not run. Add a PR workflow that runs the established quick and boundary commands, selects runtime surfaces conservatively, and requires exactly one passing receipt for every selected job. The stable aggregate `Nemo / required` rejects missing, cancelled, skipped, failed and unavailable prerequisites.

The boundary ratchet materializes `scripts-nemo.profile.json` from the event base SHA and records its content provenance. PR execution uses read-only permissions, nonpersistent checkout credentials and disposable hosted runners. Required-check settings remain unchanged.

The applicability correction exempts the exact command README (`scripts/nemo/README.md`) and isolated `engineering/boundaries/profiles/scripts-nemo.fixture/` subtree. Quick and boundaries remain required. Mixed application changes, both rename endpoints, launcher/jobs/package changes and unknown paths still require all runtime jobs.

Validation at PR head `4f72560e89e9983a89ff9e8db8aa1cdbe00bca5f`:

- Hosted run https://github.com/mysteropodes/nemo/actions/runs/33994927463: **PASS**, including `Nemo / local quick`, `Nemo / boundaries`, `Nemo / affected surfaces` and `Nemo / required`.
- Uploaded receipts identify tested merge candidate `976305a3829955e2d3fdbcc6fd5136a30aad9695` against event base `a87eb54a33d225f77cff903809a0538f7e9d0179`. Quick passed 194 Node tests and 15 Rust tests; boundary checker and protected-base ratchet passed. Surfaces explicitly selected no runtime jobs for this five-file CI change.
- Local required doctor, check and quick verify passed on clean PR head: 194 Node tests and 15 Rust tests.
- Both review counterexamples failed before correction. All nine focused CI regressions pass afterward, including benign-only, mixed application, both rename directions, receipt failures and cancelled/missing aggregate inputs. An isolated deliberate overbroad-exemption mutation is rejected by the new regressions.
- Actual integration/browser/desktop missing-harness receipts are rejected by the CI wrapper despite the local verifier's optional-job semantics. Production source and owner checks remain intact.

The candidate includes root integration's independently reviewed browser-test source-isolation fix from #951, merged as `a87eb54a33d225f77cff903809a0538f7e9d0179`. This resolves the earlier hosted browser/build test race and is separate from Claudirizer's native lane. The earlier failed run https://github.com/mysteropodes/nemo/actions/runs/33993905542 remains failure evidence; its aggregate correctly failed.

Part of #903; this does not close R07. Full document contracts, browser workflows and packaged-native/installed-artifact acceptance remain open. A tooling-only green result means runtime jobs are not applicable, not accepted. Native/WASM environment prerequisites, vectorize/GPU parity, and full application boundary adoption remain separate gates. No PR merge, release, issue closure, signing or protection changes are included.
