### PR TITLE
R06: isolate native app data and WebKit website data per task

### DIFF
--- a/engineering/runtime/native-isolation.md
+++ b/engineering/runtime/native-isolation.md
@@ -1,0 +1,194 @@
+# Native app-data and WebKit isolation (R06)
+
+[R06 / #902](https://github.com/mysteropodes/nemo/issues/902). This closes the
+one item [`engineering/runtime-isolation.md`](../runtime-isolation.md) left open
+for the desktop app:
+
+> Configure and exercise isolated Tauri data/autosave paths. Merely creating a
+> `tauri-data` directory does not make the app use it. The platform owner must
+> implement and validate the actual runtime override.
+
+`scripts/nemo/lib/isolation.cjs` has created a per-task `tauri-data` directory
+since the first R06 increment, and nothing pointed the app at it. Two pieces
+close that gap and share exactly one thing — an environment contract:
+
+| Half | File | Role |
+|---|---|---|
+| App | `src-tauri/src/task_runtime.rs` | Resolves the isolated roots, applies the WebKit website-data identity, widens the fs scope, writes an instance record, and serves `nemo_task_runtime` / `nemo_task_runtime_release`. |
+| Launcher | `scripts/nemo/native-runtime.cjs` | Allocates a task's roots and website-data UUID, spawns the app with that environment, and owns status/stop/cleanup plus the exclusive desktop-input slot. |
+
+## Why the WebKit half is not optional
+
+Redirecting `appDataDir()` alone would look like isolation and not be it.
+`nemo-auto` (autosave), `nemo-recents`, the sync-folder setting and the
+feedback fallback store all live in `localStorage`. On macOS that is WKWebView
+website data, keyed by the **bundle** identifier — nothing `appDataDir()`
+controls. Two instances redirected only on the filesystem would still share one
+`localStorage`, so instance B's autosave would overwrite instance A's.
+
+`WebviewWindowBuilder::data_store_identifier([u8; 16])` gives the window its own
+`WKWebsiteDataStore`. It needs the window to be built in Rust, and Tauri creates
+`tauri.conf.json`'s windows itself *before* the setup hook runs. So on the
+isolated path only, `run()` clears each window config's `create` flag — the one
+field Tauri's own creation loop filters on — and hands the configs to
+`install()`, which rebuilds them with the identity and the same labels. The
+entries stay in the config, so anything else reading `app.windows` still sees
+them. On the default path nothing is touched and Tauri creates the window
+exactly as it does today.
+
+## The environment contract
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `NEMO_TASK_DATA_ROOT` | activation trigger | Absolute path, no `.`/`..` segment, at least two directories deep. Absent ⇒ the app resolves its normal install paths. |
+| `NEMO_TASK_ID` | when isolated | 1–120 ASCII letters, digits, `.`, `_`, `-`, starting alphanumeric — the same grammar as `isolation.cjs`'s `validId`. |
+| `NEMO_TASK_WEB_DATA_UUID` | when isolated, on macOS | 16-byte hex UUID, dashed or not, never nil. |
+| `NEMO_TASK_OWNER_TOKEN` | optional | Required to later call `nemo_task_runtime_release`. |
+| `NEMO_TASK_SOURCE_IDENTITY` | optional | R02 `sourceIdentity()` JSON, echoed back verbatim by the app. |
+
+**The data root is the sole trigger, deliberately.** `build-runtime.cjs`
+already exports `NEMO_TASK_ID` into every process it spawns, so keying off the
+task id could flip an unrelated launch into isolation by inheritance. A
+regression covers exactly that (`a_task_id_alone_never_switches_a_normal_launch_into_isolation`).
+
+**A malformed isolation request exits; it does not fall back.** `run()` prints
+the named reason and exits 78 (`EX_CONFIG`). Falling back to the shared install
+would write a task instance's history, autosave and preferences into the real
+user profile — the exact failure the feature exists to prevent.
+
+## Roots
+
+```
+<NEMO_TASK_DATA_ROOT>/
+  instance.json     written by the app: task id, pid, version, identifier, executable, uuid
+  data/             replaces appDataDir() for every JS consumer
+    history/        version snapshots (src/js/project.js)
+    autosave/
+    preferences/
+  cache/
+  output/
+  webkit/           records this instance's WebKit identity (see below)
+```
+
+`data/` keeps the layout `project.js` already writes, so `historyDir()` stays
+`<base>/history/<projectKey>` and only the base moves. The launcher points
+`NEMO_TASK_DATA_ROOT` at `taskRoots(taskId).tauriDataDir`, the directory
+`isolation.cjs` already creates and already reaps in `releaseTask()` — no
+second lifecycle to reconcile.
+
+`webkit/` is where this instance *records* its identity. WebKit itself stores
+under an OS-managed location for that UUID; `webDataStore.observedPaths` in the
+profile reports any directory carrying the UUID that the app could actually see
+from its own process, and an empty list is reported as *not observed*, never as
+proof of either outcome.
+
+## Frontend
+
+`SMProject.appDataBase()` (src/js/project.js) is the single resolver: it calls
+`nemo_task_runtime` and uses `roots.data` when the instance is isolated,
+otherwise `appDataDir()`. `feedback-bridge.js` calls the same function.
+
+Both readers going through one resolver is the point — `CLAUDE.md` §1's
+first-family bug is exactly "a new path handled in one reader but not the
+others", and version history following the task root while feedback stayed in
+the shared install would be that bug. A binary without the command (an older
+build) falls through to `appDataDir()`, which is also what a normal launch
+resolves to.
+
+Note that the static fs capability scopes `$APPDATA`, `$TEMP`, `$HOME` and a
+few user directories. An isolated root can sit outside all of them, so
+`install()` widens the scope at runtime with `FsExt::fs_scope().allow_directory`
+for `data/`, `cache/` and `output/`. Without that the frontend's own `fs` calls
+are denied by the plugin, with nothing visible in the UI.
+
+## Ownership and cleanup
+
+`nemo_task_runtime_release(ownerToken, purgeWebData)` refuses unless the
+presented token matches the one this instance started with, compared without
+early exit. It re-validates the root immediately before removing it, so a record
+mutated after startup cannot aim a recursive delete at a shallow path. An
+instance started without `NEMO_TASK_OWNER_TOKEN` refuses every release.
+
+`purgeWebData` additionally asks WebKit to drop this identity's store via
+`AppHandle::remove_data_store`. Its outcome is reported as observed, never
+assumed: removing a store the running webview still holds is not something this
+code can prove.
+
+From the launcher side, `stop` refuses a mismatched owner, waits for the app to
+exit, then hands the root to `isolation.releaseTask`.
+
+## Use
+
+```sh
+# Two isolated instances. Keep each token in its controlling process.
+node scripts/nemo/native-runtime.cjs start --task native-a
+node scripts/nemo/native-runtime.cjs start --task native-b
+
+node scripts/nemo/native-runtime.cjs paths  --task native-a          # no launch
+node scripts/nemo/native-runtime.cjs status --task native-a --owner <token>
+node scripts/nemo/native-runtime.cjs stop   --task native-a --owner <token>
+```
+
+`start` resolves the built `Nemo.app` under `src-tauri/target/**/bundle/macos`
+and names every path it looked in when there is none. `--app` takes an explicit
+bundle or executable; `--command` takes a stub, which is how the tests run
+without a desktop process.
+
+`status` is `ok` only when the local owner token matches, the R02 source and
+build identities still match startup, **and** the app wrote an instance record
+matching this task and website-data identity. A launcher record proves the
+launcher; only the instance record proves the app resolved the isolated root.
+
+Two isolated instances may run at the same time — that is the point. Exclusive
+**human input** is a separate resource, because only one of them can own the
+keyboard and pointer during a paired validation run:
+
+```sh
+node scripts/nemo/native-runtime.cjs input-acquire  --task native-a --pid <owning-pid>
+node scripts/nemo/native-runtime.cjs input-release  --owner <slot-token>
+```
+
+## Validation
+
+- `cd src-tauri && cargo test --lib task_runtime` — 15 tests: the default path
+  stays default, a task id alone never activates isolation, two instances get
+  non-overlapping roots, roots hang off the declared base, and every malformed
+  or hostile request is refused rather than normalized (relative path, `..`,
+  `.`, filesystem root, one-level-deep root, empty, blank, NUL byte, bad task
+  ids, nil/short/non-hex UUID). Plus owner-only release, a refused release
+  leaving state intact, a tokenless instance refusing every release, and
+  re-validation before deletion.
+- `node --test scripts/nemo/native-runtime.test.cjs` — 11 tests: disjoint roots
+  and distinct website-data identities, the emitted environment satisfying the
+  app-side rules, valid non-nil v4 UUIDs, `.app` bundle resolution, two live
+  concurrent instances each writing their record into their own root only,
+  independent stop authority, owner-refused status/stop leaving the app and its
+  state untouched, an unconfirmed-isolation handshake, and the input slot.
+
+Both suites reach normal discovery through `tests/nemo-native-runtime.test.cjs`
+and `npm run test:rust`.
+
+## Limitations and open gates
+
+- **The paired two-instance desktop run is the remaining gate.** Everything
+  above is pure-logic and launcher-level. That a *real* Nemo resolves these
+  roots, and that two WKWebView website-data stores are genuinely separate on
+  disk, needs a built app, two launched instances and the exclusive input slot.
+  Browser evidence cannot substitute for it.
+- `data_store_identifier` needs **macOS ≥ 14**, and Tauri returns no result for
+  it. `webDataStore.applied` therefore means "the webview was built with this
+  identity", not "WebKit accepted it". `observedPaths` is the only app-side
+  evidence, and it is reported as observed-or-not, never inferred.
+- `declaredSource` is echoed verbatim from the launcher. It identifies the
+  launcher that configured the instance, not the checkout the binary was
+  compiled from; the app's own build identity (version, identifier, executable
+  path and size) is reported separately.
+- Non-macOS is refused before any task state is created. The `.app` layout and
+  the website-data identity are macOS-specific and unvalidated elsewhere.
+- Owner tokens are cooperative local process bookkeeping, inheriting the limits
+  [`runtime-isolation.md`](../runtime-isolation.md) already documents. They are
+  not a boundary against another process running as the same user.
+- No npm script or `lib/jobs.cjs` entry points at this launcher yet, and
+  `engineering/boundaries/profiles/scripts-nemo.profile.json` has no module
+  entry for it. Both files belong to other owners; the wiring is requested, not
+  applied here.

--- a/engineering/runtime/native-isolation.md
+++ b/engineering/runtime/native-isolation.md
@@ -181,7 +181,7 @@ node scripts/nemo/native-runtime.cjs input-release  --owner <slot-token>
   ids, nil/short/non-hex UUID). Plus owner-only release, a refused release
   leaving state intact, a tokenless instance refusing every release, and
   re-validation before deletion.
-- `node --test scripts/nemo/native-runtime.test.cjs` — 13 tests: disjoint roots
+- `node --test scripts/nemo/native-runtime.test.cjs` — 14 tests: disjoint roots
   and distinct website-data identities, the emitted environment satisfying the
   app-side rules, valid non-nil v4 UUIDs, `.app` bundle resolution, two live
   concurrent instances each writing their record into their own root only,
@@ -189,18 +189,50 @@ node scripts/nemo/native-runtime.cjs input-release  --owner <slot-token>
   state untouched, an unconfirmed-isolation handshake, the input slot, one
   website-data identity per task across relaunches (and a fresh one after a
   release), and a release that removes exactly this instance's store while a
-  peer task's store survives.
+  peer task's store survives, and a bundle resolving to its declared
+  `CFBundleExecutable` rather than to the sidecar that sorts before it.
 
 Both suites reach normal discovery through `tests/nemo-native-runtime.test.cjs`
 and `npm run test:rust`.
 
+## The paired two-instance desktop run (2026-09-05)
+
+Run against `Nemo.app` built from this branch by `npm run build:desktop`
+(receipt `reports/20260905T220451Z-30d3492`; bundle `Nemo` sha256
+`e5447b39565a5ca6850fb99eca3a8b6d36c932a8209fd4bca8de8f8991d0cf43`, bundled
+`ffmpeg` sha256 `91566ff440e785f3f8e7799eb2d5f346c8b3e62ba8c3290f57d8edbf1fbb98e1`),
+macOS 15 (Darwin 25.6.0), holding the `desktop-input` slot. Both instances were
+driven by real keyboard and pointer input through System Events, never by
+calling into the app.
+
+| Observation | Result |
+|---|---|
+| Instances | `r06-paired-a` pid 90343 and `r06-paired-b` pid 90640, concurrent, each with its own root and website-data UUID (`39590131-…`, `ef9a6ee4-…`). |
+| Instance record | Each app wrote `instance.json` into **its own** root, naming its task, pid, `com.strokemotion.app` and its UUID. |
+| Distinct state | A set to 47 frames / 12 fps, B to 83 frames, by typing into the timeline fields. Their 30-second autosaves landed as version history under each task's own `data/history/untitled-autosave/` — A `fps 12, totalFrames 47`, B `fps 24, totalFrames 83`. |
+| WebKit on disk | Two stores, `~/Library/WebKit/com.strokemotion.app/WebsiteDataStore/<uuid>/`, one per instance. Both apps' first launch showed a start screen with **no** Resume card, i.e. each began on an empty `localStorage`. |
+| Reload | A quit with ⌘Q, relaunched with the same task id: same root, **same** website-data UUID, and the start screen now offered *Resume Last Session*, which restored 47 frames / 12 fps. |
+| Independent cleanup | `stop` on A removed its roots (0 files left) and exactly its own store directory; B stayed running with its state, and then B — relaunched after A's store was deleted — still resumed its own 83 frames. `stop` on B removed B's store; no store from this run was left behind. |
+| Shared install | `~/Library/Application Support/com.strokemotion.app` was byte-for-byte identical before and after, by mtime/size of every entry: neither instance wrote into the real user profile. |
+
+Two defects were found by this run and by preparing for it, both fixed here:
+the per-launch website-data identity described above, and `resolveExecutable`
+taking the first executable in `Contents/MacOS` — which is the **ffmpeg
+sidecar**, not the app. Both launches exited 1 on ffmpeg's usage message while
+every launcher record still read as a started isolated instance. The bundle's
+`CFBundleExecutable` now selects the binary, and a bundle that declares none is
+refused rather than guessed.
+
 ## Limitations and open gates
 
-- **The paired two-instance desktop run is the remaining gate.** Everything
-  above is pure-logic and launcher-level. That a *real* Nemo resolves these
-  roots, and that two WKWebView website-data stores are genuinely separate on
-  disk, needs a built app, two launched instances and the exclusive input slot.
-  Browser evidence cannot substitute for it.
+- `isolation.taskRoots()` re-creates the directory skeleton when it is *read*,
+  so a check made after a release finds an empty tree rather than nothing. The
+  claim to verify after cleanup is "no files under the root", not "no root".
+- Driving real input on a shared desktop is not hermetic: another application
+  can take focus between raising a window and clicking it. Each action here
+  raises its target and acts inside one AppleScript call for that reason, and
+  every step was confirmed by a screenshot rather than by the absence of an
+  error.
 - `data_store_identifier` needs **macOS ≥ 14**, and Tauri returns no result for
   it. `webDataStore.applied` therefore means "the webview was built with this
   identity", not "WebKit accepted it". `observedPaths` is the only app-side

--- a/engineering/runtime/native-isolation.md
+++ b/engineering/runtime/native-isolation.md
@@ -115,7 +115,30 @@ assumed: removing a store the running webview still holds is not something this
 code can prove.
 
 From the launcher side, `stop` refuses a mismatched owner, waits for the app to
-exit, then hands the root to `isolation.releaseTask`.
+exit, then hands the root to `isolation.releaseTask` and removes the OS-side
+website-data store for this instance's identity.
+
+### The website-data identity belongs to the task, not to one launch
+
+`<task-root>/tauri-data/webkit/identity.json` holds the UUID, allocated once per
+task and reused by every later launch of it. The first version generated a fresh
+UUID per launch, which is wrong for the reason the WebKit half exists at all:
+`nemo-auto`, `nemo-recents`, the sync folder and the feedback fallback live in
+`localStorage`, so a new store per launch hands a relaunched task an *empty*
+`localStorage` while its on-disk history is still there — its own autosave
+becomes invisible to it, and every relaunch leaves another orphan store in the
+user profile. Confirmed by launching the same task id twice and comparing the
+two configs, before any GUI was involved.
+
+The identity file lives *inside* the task roots, so `releaseTask` takes it with
+them: a task id reused after a release starts on a store of its own rather than
+inheriting the previous tenant's website data. The store WebKit itself keeps —
+`~/Library/WebKit/<bundle-identifier>/WebsiteDataStore/<uuid>/`, observed on
+macOS 15 — is removed by `stop` after the app has exited, using the bundle
+identifier from the instance record the app wrote. Only a directory whose final
+component is exactly that UUID, directly under a known per-identifier parent, is
+ever a candidate; a missing identifier or an invalid identity is reported as a
+named refusal and removes nothing.
 
 ## Use
 
@@ -158,12 +181,15 @@ node scripts/nemo/native-runtime.cjs input-release  --owner <slot-token>
   ids, nil/short/non-hex UUID). Plus owner-only release, a refused release
   leaving state intact, a tokenless instance refusing every release, and
   re-validation before deletion.
-- `node --test scripts/nemo/native-runtime.test.cjs` — 11 tests: disjoint roots
+- `node --test scripts/nemo/native-runtime.test.cjs` — 13 tests: disjoint roots
   and distinct website-data identities, the emitted environment satisfying the
   app-side rules, valid non-nil v4 UUIDs, `.app` bundle resolution, two live
   concurrent instances each writing their record into their own root only,
   independent stop authority, owner-refused status/stop leaving the app and its
-  state untouched, an unconfirmed-isolation handshake, and the input slot.
+  state untouched, an unconfirmed-isolation handshake, the input slot, one
+  website-data identity per task across relaunches (and a fresh one after a
+  release), and a release that removes exactly this instance's store while a
+  peer task's store survives.
 
 Both suites reach normal discovery through `tests/nemo-native-runtime.test.cjs`
 and `npm run test:rust`.

--- a/scripts/nemo/native-runtime.cjs
+++ b/scripts/nemo/native-runtime.cjs
@@ -50,6 +50,61 @@ function webDataUuid(bytes = crypto.randomBytes(16)) {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
+// A website-data identity belongs to the TASK, not to one launch of it.
+// `localStorage` is where the app keeps `nemo-auto`, recents, the sync-folder
+// setting and the feedback fallback; a fresh UUID per launch would give the
+// same task a brand-new empty WKWebView store every time it is relaunched, so
+// its own autosave would be invisible to it while its on-disk history was
+// still there. Allocated once, next to the state it identifies (the app-side
+// `webkit/` root exists for exactly this), and removed with the task roots on
+// release — a task that has been released must never inherit the previous
+// tenant's website data.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const NIL_UUID = '00000000-0000-0000-0000-000000000000';
+const WEB_DATA_IDENTITY_FILE = path.join('webkit', 'identity.json');
+
+function validWebDataUuid(value) {
+  return typeof value === 'string' && UUID_RE.test(value) && value !== NIL_UUID;
+}
+
+function taskWebDataUuid(dataRoot, generate = webDataUuid) {
+  const file = path.join(dataRoot, WEB_DATA_IDENTITY_FILE);
+  const existing = readJsonOrNull(file);
+  if (existing && validWebDataUuid(existing.webDataUuid)) return existing.webDataUuid;
+  const uuid = generate();
+  if (!validWebDataUuid(uuid)) throw new Error(`refusing an invalid website-data identity: ${uuid}`);
+  atomicWriteJson(file, { schema: SCHEMA, webDataUuid: uuid, createdAt: nowIso() });
+  return uuid;
+}
+
+// The OS-side half of a released task. `releaseTask` removes the task roots;
+// WebKit's own store for this identity lives in the user profile and would
+// otherwise outlive every task that ever ran, holding that task's
+// localStorage and IndexedDB. Only a directory whose FINAL component is
+// exactly this UUID, directly under a known per-identifier website-data
+// parent, is ever removed.
+function webDataStoreDirs(identifier, uuid, home = process.env.HOME) {
+  if (!home || typeof identifier !== 'string' || !identifier || !validWebDataUuid(uuid)) return [];
+  return ['WebsiteDataStore', 'CustomWebsiteData']
+    .map((kind) => path.join(home, 'Library', 'WebKit', identifier, kind, uuid))
+    .filter((dir) => path.basename(dir) === uuid && exists(dir));
+}
+
+function removeWebDataStore(identifier, uuid, home = process.env.HOME) {
+  if (!validWebDataUuid(uuid)) return { removed: [], reason: 'no valid website-data identity recorded for this task' };
+  if (!identifier) return { removed: [], reason: 'the app wrote no bundle identifier; its website-data store was left in place' };
+  const dirs = webDataStoreDirs(identifier, uuid, home);
+  const removed = [];
+  for (const dir of dirs) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); removed.push(dir); } catch { /* reported as not removed */ }
+  }
+  return {
+    removed,
+    reason: removed.length ? 'website-data store removed with the task roots'
+      : 'no website-data directory carrying this identity was found under this HOME',
+  };
+}
+
 // Accepts a bundle or a bare executable. A `.app` is a directory; spawning it
 // directly fails with EACCES, which reads as a permissions problem rather
 // than "you passed a bundle", so resolve it here.
@@ -95,7 +150,7 @@ function launchConfig(taskId, options = {}) {
   // Reuse the `tauri-data` root lib/isolation.cjs already creates and already
   // reaps in releaseTask(); this adds no second lifecycle to reconcile.
   const dataRoot = roots.tauriDataDir;
-  const uuid = options.webDataUuid || webDataUuid();
+  const uuid = options.webDataUuid || taskWebDataUuid(dataRoot);
   let source = null;
   try { source = identity.sourceIdentity(); } catch { source = null; }
   const declaredSource = source ? { ...source, originUrl: undefined } : null;
@@ -325,7 +380,15 @@ async function main() {
     const before = readNativeStatus(args.task);
     const instance = readInstanceRecord(args.task);
     const released = stopped.stopped ? isolation.releaseTask(args.task, args.owner) : null;
-    output({ ...stopped, runtime: before, instance, released });
+    // The task roots are gone; WebKit's own store for this instance lives in
+    // the user profile and has to be removed by identity or a released task
+    // leaves its localStorage and IndexedDB behind. `instance` was read above,
+    // before the roots were removed — it is the only record of the bundle
+    // identifier the app actually ran under.
+    const webData = released && released.released
+      ? removeWebDataStore(instance && instance.identifier, before && before.webDataUuid)
+      : { removed: [], reason: 'task not released; its website-data store was left in place' };
+    output({ ...stopped, runtime: before, instance, released, webData });
     return process.exit(stopped.stopped && released && released.released ? 0 : 1);
   }
   // Exclusive human input, for a paired two-instance validation run.
@@ -346,7 +409,8 @@ async function main() {
 
 module.exports = {
   SCHEMA, STATUS_FILE, INSTANCE_FILE, INPUT_SLOT,
-  assertNativePlatform, webDataUuid, resolveExecutable, defaultAppPath,
+  assertNativePlatform, webDataUuid, taskWebDataUuid, validWebDataUuid,
+  webDataStoreDirs, removeWebDataStore, resolveExecutable, defaultAppPath,
   launchConfig, readNativeStatus, readInstanceRecord, nativeHandshake,
   stopApp, runNativeLauncher,
 };

--- a/scripts/nemo/native-runtime.cjs
+++ b/scripts/nemo/native-runtime.cjs
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+'use strict';
+// Isolated native desktop launcher (R06, https://github.com/mysteropodes/nemo/issues/902).
+//
+// `engineering/runtime-isolation.md` records the open gap this closes:
+// "Merely creating a `tauri-data` directory does not make the app use it."
+// `lib/isolation.cjs` has always created that directory; nothing pointed the
+// app at it. `src-tauri/src/task_runtime.rs` is the app-side override, and
+// this file is the launcher that configures it — the two halves share one
+// environment contract and nothing else.
+//
+// Both a module and a CLI on purpose: `scripts/nemo/native-runtime.cjs` is
+// this work package's declared path, so the launch/handshake logic and its
+// entry point stay in it rather than widening ownership into `lib/`.
+//
+// Read-only consumers of R02: `lib/isolation.cjs` (task roots, ownership,
+// slots), `lib/identity.cjs` (source/build identity) and `lib/util.cjs`.
+// Nothing here edits them, `lib/jobs.cjs` or `package.json`.
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { spawn } = require('node:child_process');
+const { isDeepStrictEqual } = require('node:util');
+const isolation = require('./lib/isolation.cjs');
+const identity = require('./lib/identity.cjs');
+const { ROOT, exists, nowIso } = require('./lib/util.cjs');
+
+const SCHEMA = 'nemo.native-runtime/1';
+const STATUS_FILE = 'native-runtime.json';
+const INSTANCE_FILE = 'instance.json';
+// Two isolated instances may run at once — that is the point. Exclusive
+// *human input* is a different resource: only one of them can own the
+// keyboard and pointer during a paired validation run. It is a separate,
+// explicitly acquired slot so launching never serializes on it.
+const INPUT_SLOT = 'desktop-input';
+
+function assertNativePlatform(platform = process.platform) {
+  if (platform !== 'darwin') {
+    throw new Error('isolated native launch currently supports macOS only: the WebKit website-data identity and .app bundle layout below are macOS-specific and unvalidated elsewhere');
+  }
+}
+
+// RFC 4122 v4. The app refuses the nil UUID, so a fresh random one per task
+// instance is what actually keeps two WKWebView website data stores apart.
+function webDataUuid(bytes = crypto.randomBytes(16)) {
+  const b = Buffer.from(bytes);
+  b[6] = (b[6] & 0x0f) | 0x40;
+  b[8] = (b[8] & 0x3f) | 0x80;
+  const hex = b.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+// Accepts a bundle or a bare executable. A `.app` is a directory; spawning it
+// directly fails with EACCES, which reads as a permissions problem rather
+// than "you passed a bundle", so resolve it here.
+function resolveExecutable(target) {
+  const resolved = path.resolve(target);
+  if (!exists(resolved)) throw new Error(`app not found: ${resolved}`);
+  if (resolved.endsWith('.app')) {
+    const macos = path.join(resolved, 'Contents', 'MacOS');
+    const entries = fs.existsSync(macos) ? fs.readdirSync(macos) : [];
+    const binary = entries.find((name) => {
+      try { fs.accessSync(path.join(macos, name), fs.constants.X_OK); return true; } catch { return false; }
+    });
+    if (!binary) throw new Error(`no executable inside ${macos}; build the app first`);
+    return path.join(macos, binary);
+  }
+  fs.accessSync(resolved, fs.constants.X_OK);
+  return resolved;
+}
+
+function defaultAppPath(root = ROOT, triple = null) {
+  const host = triple || identity.hostTriple();
+  const candidates = [
+    host && path.join(root, 'src-tauri', 'target', host, 'release', 'bundle', 'macos', 'Nemo.app'),
+    path.join(root, 'src-tauri', 'target', 'release', 'bundle', 'macos', 'Nemo.app'),
+    path.join(root, 'src-tauri', 'target', 'debug', 'bundle', 'macos', 'Nemo.app'),
+  ].filter(Boolean);
+  const found = candidates.find(exists);
+  if (!found) {
+    throw new Error(`no built Nemo.app found; looked in ${candidates.join(', ')} — run the desktop build first (scripts/nemo/build.cjs)`);
+  }
+  return found;
+}
+
+// The complete environment contract with src-tauri/src/task_runtime.rs.
+// NEMO_TASK_DATA_ROOT is the only activation trigger on the app side, so an
+// unrelated process inheriting NEMO_TASK_ID never flips into isolation.
+function launchConfig(taskId, options = {}) {
+  if (!options.command) assertNativePlatform();
+  const executable = options.command
+    ? resolveExecutable(options.command)
+    : resolveExecutable(options.app || defaultAppPath(ROOT, options.hostTriple));
+  const roots = isolation.taskRoots(taskId);
+  // Reuse the `tauri-data` root lib/isolation.cjs already creates and already
+  // reaps in releaseTask(); this adds no second lifecycle to reconcile.
+  const dataRoot = roots.tauriDataDir;
+  const uuid = options.webDataUuid || webDataUuid();
+  let source = null;
+  try { source = identity.sourceIdentity(); } catch { source = null; }
+  const declaredSource = source ? { ...source, originUrl: undefined } : null;
+  return {
+    executable,
+    args: Array.isArray(options.args) ? options.args.slice() : [],
+    cwd: ROOT,
+    roots,
+    dataRoot,
+    webDataUuid: uuid,
+    instanceFile: path.join(dataRoot, INSTANCE_FILE),
+    statusFile: path.join(roots.reports, STATUS_FILE),
+    stdoutLog: path.join(roots.reports, 'desktop-app.stdout.log'),
+    stderrLog: path.join(roots.reports, 'desktop-app.stderr.log'),
+    env: {
+      ...process.env,
+      NEMO_TASK_ID: taskId,
+      NEMO_TASK_DATA_ROOT: dataRoot,
+      NEMO_TASK_OWNER_TOKEN: options.ownerToken || '',
+      NEMO_TASK_WEB_DATA_UUID: uuid,
+      NEMO_TASK_SOURCE_IDENTITY: JSON.stringify(declaredSource),
+      NEMO_REPORT_DIR: roots.reports,
+      XDG_CACHE_HOME: roots.cache,
+    },
+  };
+}
+
+function atomicWriteJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const temp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(temp, JSON.stringify(value, null, 2) + '\n', { mode: 0o600 });
+  fs.renameSync(temp, file);
+}
+
+function readJsonOrNull(file) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return null; }
+}
+
+function readNativeStatus(taskId) {
+  return readJsonOrNull(path.join(isolation.taskRoots(taskId).reports, STATUS_FILE));
+}
+
+/// The app writes this itself, inside the root it resolved. It is the one
+/// piece of evidence that proves the override took effect rather than that
+/// the launcher merely asked for it.
+function readInstanceRecord(taskId) {
+  const status = readNativeStatus(taskId);
+  const dataRoot = status && status.dataRoot ? status.dataRoot : isolation.taskRoots(taskId).tauriDataDir;
+  return readJsonOrNull(path.join(dataRoot, INSTANCE_FILE));
+}
+
+function nativeHandshake(taskId, ownerToken) {
+  const local = isolation.verifyHandshake(taskId, { ownerToken, checkSource: true });
+  const launcher = isolation.readLauncher(taskId);
+  const status = readNativeStatus(taskId);
+  const instance = readInstanceRecord(taskId);
+  let currentBuild = null;
+  try { currentBuild = identity.buildIdentity(); } catch { /* fail closed below */ }
+  const buildMatches = !!status && isDeepStrictEqual(status.build.startup, currentBuild);
+  // A launcher record proves the launcher; the instance record proves the
+  // app. Both are required before calling an instance isolated.
+  const isolationObserved = !!instance
+    && !!status
+    && instance.taskId === taskId
+    && instance.webDataUuid === status.webDataUuid;
+  return {
+    schema: SCHEMA,
+    ok: local.ok && buildMatches && isolationObserved,
+    reason: !local.ok ? local.reason
+      : !currentBuild ? 'build identity unavailable'
+        : !buildMatches ? 'build identity changed'
+          : !instance ? 'app has not written its instance record; isolated roots unconfirmed'
+            : !isolationObserved ? 'instance record does not match this task/website-data identity'
+              : 'task owner, source and build identities match and the app confirmed its isolated roots',
+    taskId,
+    pid: launcher ? launcher.pid : null,
+    dataRoot: status ? status.dataRoot : null,
+    webDataUuid: status ? status.webDataUuid : null,
+    build: status ? { startup: status.build.startup, current: currentBuild, matches: buildMatches } : null,
+    instance,
+    runtime: status,
+  };
+}
+
+function processAlive(child) {
+  return !!child && child.exitCode == null && child.signalCode == null;
+}
+
+async function stopApp(child, graceMs = 3000) {
+  if (!processAlive(child)) return { stopped: true, forced: false, reason: 'app process already exited' };
+  try { child.kill('SIGTERM'); } catch (err) { if (err.code !== 'ESRCH') throw err; }
+  const deadline = Date.now() + graceMs;
+  while (processAlive(child) && Date.now() < deadline) await new Promise((r) => setTimeout(r, 20));
+  if (!processAlive(child)) return { stopped: true, forced: false, reason: 'app exited after SIGTERM' };
+  try { child.kill('SIGKILL'); } catch (err) { if (err.code !== 'ESRCH') throw err; }
+  const hard = Date.now() + 2000;
+  while (processAlive(child) && Date.now() < hard) await new Promise((r) => setTimeout(r, 20));
+  return processAlive(child)
+    ? { stopped: false, forced: true, reason: 'app still running after SIGKILL; reconciliation required' }
+    : { stopped: true, forced: true, reason: 'app required SIGKILL' };
+}
+
+async function runNativeLauncher(taskId, options = {}, emit = () => {}) {
+  let startupBuild;
+  try { startupBuild = identity.buildIdentity(); }
+  catch (err) {
+    isolation.releaseTask(taskId);
+    throw new Error(`build identity unavailable: ${err.message}`);
+  }
+  const ownerToken = crypto.randomBytes(16).toString('hex');
+  const config = launchConfig(taskId, { ...options, ownerToken });
+  const launcher = isolation.registerLauncher(taskId, { pid: process.pid, ownerToken, label: 'desktop-app' });
+  let status = {
+    schema: SCHEMA,
+    taskId,
+    launcherPid: process.pid,
+    childPid: null,
+    state: 'starting',
+    startedAt: nowIso(),
+    finishedAt: null,
+    exitCode: null,
+    signal: null,
+    executable: config.executable,
+    dataRoot: config.dataRoot,
+    webDataUuid: config.webDataUuid,
+    roots: { root: config.roots.root, reports: config.roots.reports, cache: config.roots.cache },
+    logs: { stdout: config.stdoutLog, stderr: config.stderrLog },
+    source: launcher.source ? { ...launcher.source, originUrl: undefined } : null,
+    build: { startup: startupBuild },
+  };
+  const save = (change) => { status = { ...status, ...change }; atomicWriteJson(config.statusFile, status); };
+  fs.mkdirSync(config.dataRoot, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(config.roots.reports, { recursive: true, mode: 0o700 });
+  save({});
+  emit({
+    started: true, taskId, pid: process.pid, ownerToken,
+    executable: config.executable, dataRoot: config.dataRoot, webDataUuid: config.webDataUuid,
+    statusFile: config.statusFile, instanceFile: config.instanceFile,
+    source: status.source, build: startupBuild,
+  });
+
+  const stdout = fs.createWriteStream(config.stdoutLog, { flags: 'a', mode: 0o600 });
+  const stderr = fs.createWriteStream(config.stderrLog, { flags: 'a', mode: 0o600 });
+  const child = spawn(config.executable, config.args, {
+    cwd: config.cwd, env: config.env, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true,
+  });
+  child.stdout.pipe(stdout);
+  child.stderr.pipe(stderr);
+  const exited = new Promise((resolve) => child.once('exit', (code, signal) => resolve({ code, signal })));
+
+  let closing = false;
+  const shutdown = async () => {
+    if (closing) return;
+    closing = true;
+    const tree = await stopApp(child);
+    if (!tree.stopped) { save({ state: 'reconciliation-required', finishedAt: nowIso(), app: tree }); closing = false; return; }
+    save({ state: 'stopped', finishedAt: nowIso(), app: tree });
+    process.exit(0);
+  };
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+  // Keep ownership addressable after the app exits, exactly like the build
+  // launcher: a dead holder would otherwise look reclaimable.
+  setInterval(() => {}, 60_000);
+
+  try {
+    await new Promise((resolve, reject) => {
+      const failed = (err) => { child.off('spawn', ready); reject(err); };
+      const ready = () => { child.off('error', failed); resolve(); };
+      child.once('error', failed);
+      child.once('spawn', ready);
+    });
+    save({ state: 'active', childPid: child.pid });
+    const result = await exited;
+    if (closing) return;
+    save({
+      state: result.code === 0 ? 'completed' : 'failed',
+      finishedAt: nowIso(), exitCode: result.code, signal: result.signal,
+      instance: readJsonOrNull(config.instanceFile),
+    });
+  } catch (err) {
+    const tree = await stopApp(child);
+    save({ state: tree.stopped ? 'failed' : 'reconciliation-required', finishedAt: nowIso(), error: err.message, app: tree });
+  }
+}
+
+// ---- CLI ----------------------------------------------------------------
+
+function parse(argv) {
+  const out = { _: [], passthrough: [] };
+  let passthrough = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (passthrough) { out.passthrough.push(arg); continue; }
+    if (arg === '--') { passthrough = true; continue; }
+    if (!arg.startsWith('--')) { out._.push(arg); continue; }
+    const key = arg.slice(2); const next = argv[i + 1];
+    if (next == null || next.startsWith('--')) out[key] = true;
+    else { out[key] = next; i += 1; }
+  }
+  return out;
+}
+
+function output(value) { process.stdout.write(JSON.stringify(value) + '\n'); }
+
+async function main() {
+  const args = parse(process.argv.slice(2));
+  const command = args._[0] || 'start';
+  if (command === 'start') {
+    const taskId = isolation.resolveTaskId(args.task);
+    return runNativeLauncher(taskId, { app: args.app, command: args.command, args: args.passthrough, hostTriple: args['host-triple'] }, output);
+  }
+  if (command === 'paths') {
+    const taskId = isolation.resolveTaskId(args.task);
+    const config = launchConfig(taskId, { command: args.command, app: args.app });
+    return output({ schema: SCHEMA, taskId, dataRoot: config.dataRoot, webDataUuid: config.webDataUuid, executable: config.executable, statusFile: config.statusFile });
+  }
+  if (command === 'status') {
+    if (!args.task || !args.owner) throw new Error('status requires --task ID and --owner TOKEN');
+    const result = nativeHandshake(args.task, args.owner);
+    output(result);
+    return process.exit(result.ok ? 0 : 1);
+  }
+  if (command === 'stop') {
+    if (!args.task || !args.owner) throw new Error('stop requires --task ID and --owner TOKEN');
+    const stopped = await isolation.requestStop(args.task, args.owner, { timeoutMs: args['timeout-ms'] == null ? 10_000 : Number(args['timeout-ms']) });
+    const before = readNativeStatus(args.task);
+    const instance = readInstanceRecord(args.task);
+    const released = stopped.stopped ? isolation.releaseTask(args.task, args.owner) : null;
+    output({ ...stopped, runtime: before, instance, released });
+    return process.exit(stopped.stopped && released && released.released ? 0 : 1);
+  }
+  // Exclusive human input, for a paired two-instance validation run.
+  if (command === 'input-acquire') {
+    if (!args.task) throw new Error('input-acquire requires --task ID');
+    const result = isolation.acquireExclusiveSlot(INPUT_SLOT, args.task, { pid: args.pid == null ? process.ppid : Number(args.pid) });
+    output({ slot: INPUT_SLOT, acquired: result.acquired, reason: result.reason || null, ownerToken: result.ownerToken || null, holder: result.holder || null });
+    return process.exit(result.acquired ? 0 : 1);
+  }
+  if (command === 'input-release') {
+    if (!args.owner) throw new Error('input-release requires --owner TOKEN');
+    const result = isolation.releaseExclusiveSlot(INPUT_SLOT, args.owner);
+    output({ slot: INPUT_SLOT, ...result });
+    return process.exit(result.released ? 0 : 1);
+  }
+  throw new Error('usage: native-runtime.cjs start [--task ID] [--app /abs/Nemo.app | --command /abs/stub -- args...] | paths --task ID | status --task ID --owner TOKEN | stop --task ID --owner TOKEN | input-acquire --task ID [--pid N] | input-release --owner TOKEN');
+}
+
+module.exports = {
+  SCHEMA, STATUS_FILE, INSTANCE_FILE, INPUT_SLOT,
+  assertNativePlatform, webDataUuid, resolveExecutable, defaultAppPath,
+  launchConfig, readNativeStatus, readInstanceRecord, nativeHandshake,
+  stopApp, runNativeLauncher,
+};
+
+if (require.main === module) {
+  main().catch((err) => { process.stderr.write((err.stack || String(err)) + '\n'); process.exit(1); });
+}

--- a/scripts/nemo/native-runtime.cjs
+++ b/scripts/nemo/native-runtime.cjs
@@ -19,7 +19,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const crypto = require('node:crypto');
-const { spawn } = require('node:child_process');
+const { spawn, spawnSync } = require('node:child_process');
 const { isDeepStrictEqual } = require('node:util');
 const isolation = require('./lib/isolation.cjs');
 const identity = require('./lib/identity.cjs');
@@ -105,6 +105,22 @@ function removeWebDataStore(identifier, uuid, home = process.env.HOME) {
   };
 }
 
+// The bundle's OWN answer to "which of these is the app". Nemo.app ships the
+// ffmpeg sidecar next to the app binary in Contents/MacOS, and readdir returns
+// `ffmpeg` first: taking the first executable entry launched the sidecar,
+// which exits 1 on its usage message while every launcher record still said
+// "isolated instance started". Info.plist is the only authority here, and
+// plutil reads both the XML and the binary form.
+function bundleExecutableName(appPath) {
+  const plist = path.join(appPath, 'Contents', 'Info.plist');
+  if (!exists(plist)) return null;
+  const r = spawnSync('/usr/bin/plutil', ['-extract', 'CFBundleExecutable', 'raw', '-o', '-', plist], { encoding: 'utf8' });
+  if (r.status !== 0) return null;
+  const name = String(r.stdout || '').trim();
+  // A name with a separator would escape Contents/MacOS entirely.
+  return name && !name.includes('/') && name !== '.' && name !== '..' ? name : null;
+}
+
 // Accepts a bundle or a bare executable. A `.app` is a directory; spawning it
 // directly fails with EACCES, which reads as a permissions problem rather
 // than "you passed a bundle", so resolve it here.
@@ -113,12 +129,14 @@ function resolveExecutable(target) {
   if (!exists(resolved)) throw new Error(`app not found: ${resolved}`);
   if (resolved.endsWith('.app')) {
     const macos = path.join(resolved, 'Contents', 'MacOS');
-    const entries = fs.existsSync(macos) ? fs.readdirSync(macos) : [];
-    const binary = entries.find((name) => {
-      try { fs.accessSync(path.join(macos, name), fs.constants.X_OK); return true; } catch { return false; }
-    });
-    if (!binary) throw new Error(`no executable inside ${macos}; build the app first`);
-    return path.join(macos, binary);
+    const declared = bundleExecutableName(resolved);
+    if (!declared) {
+      throw new Error(`${resolved} declares no CFBundleExecutable; refusing to guess which binary in ${macos} is the app (it also ships sidecars)`);
+    }
+    const binary = path.join(macos, declared);
+    if (!exists(binary)) throw new Error(`${resolved} declares CFBundleExecutable "${declared}", which is missing from ${macos}; rebuild the app`);
+    fs.accessSync(binary, fs.constants.X_OK);
+    return binary;
   }
   fs.accessSync(resolved, fs.constants.X_OK);
   return resolved;
@@ -409,7 +427,7 @@ async function main() {
 
 module.exports = {
   SCHEMA, STATUS_FILE, INSTANCE_FILE, INPUT_SLOT,
-  assertNativePlatform, webDataUuid, taskWebDataUuid, validWebDataUuid,
+  assertNativePlatform, webDataUuid, taskWebDataUuid, validWebDataUuid, bundleExecutableName,
   webDataStoreDirs, removeWebDataStore, resolveExecutable, defaultAppPath,
   launchConfig, readNativeStatus, readInstanceRecord, nativeHandshake,
   stopApp, runNativeLauncher,

--- a/scripts/nemo/native-runtime.test.cjs
+++ b/scripts/nemo/native-runtime.test.cjs
@@ -202,7 +202,11 @@ test('two concurrent instances keep separate roots, records and stop authority',
   assert.equal(recordA.taskId, 'native-live-a');
   assert.equal(recordB.taskId, 'native-live-b');
   assert.equal(recordA.webDataUuid, a.info.webDataUuid);
-  assert.equal(fs.readdirSync(path.dirname(a.info.instanceFile)).length, 1);
+  assert.deepEqual(
+    fs.readdirSync(path.dirname(a.info.instanceFile)).sort(),
+    ['instance.json', 'webkit'],
+    "the root holds this instance's own record and its own website-data identity, nothing else",
+  );
 
   // The handshake only reports ok once the app itself confirmed the root.
   const statusA = await cliRun(['status', '--task', 'native-live-a', '--owner', a.info.ownerToken]);
@@ -295,4 +299,51 @@ test('non-macOS launches are refused before any task state is created', () => {
   assert.throws(() => runtime.assertNativePlatform('linux'), /macOS only/);
   assert.throws(() => runtime.assertNativePlatform('win32'), /macOS only/);
   assert.doesNotThrow(() => runtime.assertNativePlatform('darwin'));
+});
+
+// The identity a relaunch of the same task instance must keep. `localStorage`
+// (autosave 'nemo-auto', recents, sync folder, feedback fallback) lives in the
+// WKWebView store this UUID names: a fresh one per launch would hand the same
+// task an empty store every time while its on-disk history was still there.
+test('a task keeps one website-data identity across relaunches and never inherits a released one', () => {
+  const first = runtime.launchConfig('web-identity-a', { command: appStub });
+  const second = runtime.launchConfig('web-identity-a', { command: appStub });
+  assert.equal(second.webDataUuid, first.webDataUuid, 'relaunching the same task must reuse its store');
+  assert.equal(runtime.validWebDataUuid(first.webDataUuid), true);
+
+  const other = runtime.launchConfig('web-identity-b', { command: appStub });
+  assert.notEqual(other.webDataUuid, first.webDataUuid, 'two tasks must never share one store');
+
+  const recorded = JSON.parse(fs.readFileSync(path.join(first.dataRoot, 'webkit', 'identity.json'), 'utf8'));
+  assert.equal(recorded.webDataUuid, first.webDataUuid);
+
+  // The identity lives inside the task roots, so releasing them takes it with
+  // it and the next tenant of that task id starts on a store of its own.
+  fs.rmSync(first.roots.root, { recursive: true, force: true });
+  const afterRelease = runtime.launchConfig('web-identity-a', { command: appStub });
+  assert.notEqual(afterRelease.webDataUuid, first.webDataUuid);
+});
+
+test('releasing a task removes exactly its own website-data store and nothing else', () => {
+  const home = fs.mkdtempSync(path.join(scratch, 'home-'));
+  const identifier = 'com.strokemotion.app';
+  const mine = runtime.launchConfig('web-store-mine', { command: appStub }).webDataUuid;
+  const peer = runtime.launchConfig('web-store-peer', { command: appStub }).webDataUuid;
+  const dirFor = (uuid, kind) => path.join(home, 'Library', 'WebKit', identifier, kind, uuid);
+  for (const dir of [dirFor(mine, 'WebsiteDataStore'), dirFor(mine, 'CustomWebsiteData'), dirFor(peer, 'WebsiteDataStore')]) {
+    fs.mkdirSync(path.join(dir, 'LocalStorage'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'LocalStorage', 'localstorage.sqlite3'), 'x');
+  }
+
+  const result = runtime.removeWebDataStore(identifier, mine, home);
+  assert.equal(result.removed.length, 2, result.reason);
+  assert.equal(fs.existsSync(dirFor(mine, 'WebsiteDataStore')), false);
+  assert.equal(fs.existsSync(dirFor(mine, 'CustomWebsiteData')), false);
+  assert.equal(fs.existsSync(dirFor(peer, 'WebsiteDataStore')), true, "another task's store must survive");
+
+  // Refusals are named, and nothing outside the identity is ever a candidate.
+  assert.deepEqual(runtime.webDataStoreDirs(identifier, 'not-a-uuid', home), []);
+  assert.deepEqual(runtime.webDataStoreDirs(identifier, '00000000-0000-0000-0000-000000000000', home), []);
+  assert.match(runtime.removeWebDataStore('', mine, home).reason, /no bundle identifier/);
+  assert.match(runtime.removeWebDataStore(identifier, 'not-a-uuid', home).reason, /no valid website-data identity/);
 });

--- a/scripts/nemo/native-runtime.test.cjs
+++ b/scripts/nemo/native-runtime.test.cjs
@@ -151,11 +151,17 @@ test('a .app bundle resolves to its inner executable and bad targets are named',
   fs.mkdirSync(macos, { recursive: true });
   const binary = path.join(macos, 'Fixture');
   fs.writeFileSync(binary, '#!/bin/sh\nexit 0\n', { mode: 0o700 });
+  // The bundle's own declaration is what selects the binary; see the sidecar
+  // regression below for why the first executable on disk is not it.
+  fs.writeFileSync(path.join(bundle, 'Contents', 'Info.plist'), `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>CFBundleExecutable</key><string>Fixture</string></dict></plist>
+`);
   assert.equal(runtime.resolveExecutable(bundle), binary);
 
   const empty = path.join(scratch, 'Empty.app');
   fs.mkdirSync(path.join(empty, 'Contents', 'MacOS'), { recursive: true });
-  assert.throws(() => runtime.resolveExecutable(empty), /no executable inside/);
+  assert.throws(() => runtime.resolveExecutable(empty), /declares no CFBundleExecutable/);
   assert.throws(() => runtime.resolveExecutable(path.join(scratch, 'Absent.app')), /app not found/);
 });
 
@@ -346,4 +352,31 @@ test('releasing a task removes exactly its own website-data store and nothing el
   assert.deepEqual(runtime.webDataStoreDirs(identifier, '00000000-0000-0000-0000-000000000000', home), []);
   assert.match(runtime.removeWebDataStore('', mine, home).reason, /no bundle identifier/);
   assert.match(runtime.removeWebDataStore(identifier, 'not-a-uuid', home).reason, /no valid website-data identity/);
+});
+
+// Nemo.app ships the ffmpeg sidecar next to the app binary, and readdir
+// returns `ffmpeg` first. Taking the first executable entry launched the
+// SIDECAR — it exits 1 on its usage message while the launcher record still
+// claimed an isolated instance had started. Found by the paired desktop run.
+test('a bundle resolves to its declared CFBundleExecutable, not the first sidecar on disk', () => {
+  const app = path.join(scratch, 'Sidecar.app');
+  const macos = path.join(app, 'Contents', 'MacOS');
+  fs.mkdirSync(macos, { recursive: true });
+  // Written in the order readdir returns them: the sidecar sorts first.
+  for (const name of ['ffmpeg', 'nemo']) fs.writeFileSync(path.join(macos, name), '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+  const plist = (executable) => `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>CFBundleExecutable</key><string>${executable}</string></dict></plist>
+`;
+  fs.writeFileSync(path.join(app, 'Contents', 'Info.plist'), plist('nemo'));
+  assert.equal(fs.readdirSync(macos)[0], 'ffmpeg', 'the sidecar must sort first for this test to mean anything');
+  assert.equal(runtime.bundleExecutableName(app), 'nemo');
+  assert.equal(runtime.resolveExecutable(app), path.join(macos, 'nemo'));
+
+  // Refusals are named rather than guessed: a wrong guess here starts the
+  // wrong process under a record that says the app is running isolated.
+  fs.writeFileSync(path.join(app, 'Contents', 'Info.plist'), plist('does-not-exist'));
+  assert.throws(() => runtime.resolveExecutable(app), /CFBundleExecutable "does-not-exist", which is missing/);
+  fs.rmSync(path.join(app, 'Contents', 'Info.plist'));
+  assert.throws(() => runtime.resolveExecutable(app), /declares no CFBundleExecutable; refusing to guess/);
 });

--- a/scripts/nemo/native-runtime.test.cjs
+++ b/scripts/nemo/native-runtime.test.cjs
@@ -1,0 +1,298 @@
+'use strict';
+// Focused regressions for the isolated native launcher (R06, #902).
+//
+// These never start Nemo, a webview or a GPU process: the stub below stands
+// in for the app and records the isolation environment it was handed. What
+// they do prove is the launcher half — disjoint roots per task instance, the
+// exact environment contract src-tauri/src/task_runtime.rs consumes,
+// owner-only status/stop/cleanup, and the exclusive desktop input slot.
+//
+// The app half (that a real Nemo resolves those roots, and that two WKWebView
+// website data stores are genuinely separate) is proved by the Rust suite in
+// src-tauri/src/task_runtime.rs plus a paired two-instance desktop run, which
+// needs the exclusive input slot. See engineering/runtime/native-isolation.md.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { after, test } = require('node:test');
+
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-native-runtime-test-'));
+process.env.NEMO_ISOLATION_ROOT = path.join(scratch, 'runtime');
+const isolation = require('./lib/isolation.cjs');
+const runtime = require('./native-runtime.cjs');
+const cli = path.join(__dirname, 'native-runtime.cjs');
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+// Stands in for the desktop app: writes the instance record the real
+// task_runtime.rs writes, into the root it was told to use, then stays alive.
+//
+// A `#!${process.execPath}` shebang is not usable here: a shebang line takes
+// the interpreter path literally, and Node can legitimately live under a path
+// containing a space (`~/Library/Application Support/...` on this machine),
+// which makes the kernel report the stub as ENOENT. The /bin/sh trampoline
+// quotes it properly.
+const appScript = path.join(scratch, 'app-stub.js');
+const appStub = path.join(scratch, 'app-stub');
+fs.writeFileSync(appStub, `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(appScript)} "$@"\n`, { mode: 0o700 });
+fs.writeFileSync(appScript, String.raw`
+const fs = require('node:fs');
+const path = require('node:path');
+const root = process.env.NEMO_TASK_DATA_ROOT;
+if (!root) { process.stderr.write('no NEMO_TASK_DATA_ROOT\n'); process.exit(78); }
+fs.mkdirSync(root, { recursive: true });
+fs.writeFileSync(path.join(root, 'instance.json'), JSON.stringify({
+  schema: 'nemo.native-runtime/1',
+  taskId: process.env.NEMO_TASK_ID,
+  pid: process.pid,
+  webDataUuid: process.env.NEMO_TASK_WEB_DATA_UUID,
+  declaredSource: JSON.parse(process.env.NEMO_TASK_SOURCE_IDENTITY || 'null'),
+}, null, 2));
+fs.writeFileSync(process.argv[2], JSON.stringify({ ...process.env }));
+setInterval(() => {}, 1000);
+`);
+
+after(() => fs.rmSync(scratch, { recursive: true, force: true }));
+
+function firstLine(child) {
+  return new Promise((resolve, reject) => {
+    let data = ''; const timer = setTimeout(() => done(new Error('launcher readiness timed out')), 10_000);
+    function done(error, value) { clearTimeout(timer); child.stdout.off('data', read); child.off('exit', early); error ? reject(error) : resolve(value); }
+    function read(chunk) { data += chunk; const nl = data.indexOf('\n'); if (nl !== -1) done(null, data.slice(0, nl)); }
+    function early(code) { done(new Error(`launcher exited before readiness (${code}): ${data}`)); }
+    child.stdout.on('data', read); child.once('exit', early);
+  });
+}
+
+async function launch(task) {
+  const capture = path.join(scratch, `${task}.env.json`);
+  const child = spawn(process.execPath, [cli, 'start', '--task', task, '--command', appStub, '--', capture], {
+    cwd: repoRoot, env: { ...process.env }, stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return { child, capture, info: JSON.parse(await firstLine(child)) };
+}
+
+function cliRun(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [cli, ...args], { cwd: repoRoot, env: { ...process.env } });
+    let out = ''; let err = '';
+    child.stdout.on('data', (c) => { out += c; });
+    child.stderr.on('data', (c) => { err += c; });
+    child.once('exit', (code) => resolve({ code, out, err, json: (() => { try { return JSON.parse(out); } catch { return null; } })() }));
+  });
+}
+
+async function waitFor(predicate, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  return false;
+}
+
+// ---- the environment contract with src-tauri/src/task_runtime.rs --------
+
+// Mirrors the app-side rules in task_runtime.rs (validate_data_root,
+// validate_task_id, parse_web_data_uuid). Those rules are proved by the Rust
+// suite; this asserts the launcher only ever emits values that satisfy them,
+// so a refusal on the app side cannot come from the launcher's own output.
+function assertSatisfiesAppContract(env) {
+  const root = env.NEMO_TASK_DATA_ROOT;
+  assert.ok(root, 'NEMO_TASK_DATA_ROOT is the only activation trigger and must be set');
+  assert.ok(path.isAbsolute(root), `data root must be absolute: ${root}`);
+  const segments = root.split(path.sep).filter(Boolean);
+  assert.ok(!segments.includes('..') && !segments.includes('.'), `data root must not contain traversal: ${root}`);
+  assert.ok(segments.length >= 2, `data root must be at least two levels deep: ${root}`);
+  assert.match(env.NEMO_TASK_ID, /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,119}$/);
+  assert.match(env.NEMO_TASK_WEB_DATA_UUID, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+  assert.notEqual(env.NEMO_TASK_WEB_DATA_UUID, '00000000-0000-0000-0000-000000000000');
+}
+
+test('two task instances get disjoint data roots and distinct website-data identities', () => {
+  const a = runtime.launchConfig('native-a', { command: appStub });
+  const b = runtime.launchConfig('native-b', { command: appStub });
+  assert.notEqual(a.dataRoot, b.dataRoot);
+  assert.ok(!a.dataRoot.startsWith(b.dataRoot) && !b.dataRoot.startsWith(a.dataRoot));
+  assert.notEqual(a.webDataUuid, b.webDataUuid);
+  assert.notEqual(a.statusFile, b.statusFile);
+  assertSatisfiesAppContract(a.env);
+  assertSatisfiesAppContract(b.env);
+});
+
+test('the isolated data root is not the shared install app-data directory', () => {
+  const config = runtime.launchConfig('native-not-shared', { command: appStub });
+  const shared = path.join(os.homedir(), 'Library', 'Application Support', 'com.strokemotion.app');
+  assert.notEqual(config.dataRoot, shared);
+  assert.ok(!config.dataRoot.startsWith(shared + path.sep), `${config.dataRoot} must not sit inside the shared install`);
+});
+
+test('generated website-data UUIDs are valid v4 and never the nil UUID', () => {
+  const seen = new Set();
+  for (let i = 0; i < 200; i++) {
+    const uuid = runtime.webDataUuid();
+    assert.match(uuid, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    assert.notEqual(uuid, '00000000-0000-0000-0000-000000000000');
+    seen.add(uuid);
+  }
+  assert.equal(seen.size, 200);
+  // The nil input is the one value WebKit rejects; the version/variant bits
+  // must lift even an all-zero buffer out of it.
+  assert.notEqual(runtime.webDataUuid(Buffer.alloc(16)), '00000000-0000-0000-0000-000000000000');
+});
+
+// ---- app resolution -----------------------------------------------------
+
+test('a .app bundle resolves to its inner executable and bad targets are named', () => {
+  const bundle = path.join(scratch, 'Fixture.app');
+  const macos = path.join(bundle, 'Contents', 'MacOS');
+  fs.mkdirSync(macos, { recursive: true });
+  const binary = path.join(macos, 'Fixture');
+  fs.writeFileSync(binary, '#!/bin/sh\nexit 0\n', { mode: 0o700 });
+  assert.equal(runtime.resolveExecutable(bundle), binary);
+
+  const empty = path.join(scratch, 'Empty.app');
+  fs.mkdirSync(path.join(empty, 'Contents', 'MacOS'), { recursive: true });
+  assert.throws(() => runtime.resolveExecutable(empty), /no executable inside/);
+  assert.throws(() => runtime.resolveExecutable(path.join(scratch, 'Absent.app')), /app not found/);
+});
+
+test('a missing build names every path it looked in instead of failing vaguely', () => {
+  const bare = fs.mkdtempSync(path.join(scratch, 'bare-'));
+  assert.throws(
+    () => runtime.defaultAppPath(bare, 'aarch64-apple-darwin'),
+    (err) => /no built Nemo\.app found/.test(err.message) && err.message.includes(bare),
+  );
+});
+
+// ---- two live instances -------------------------------------------------
+
+test('two concurrent instances keep separate roots, records and stop authority', async (t) => {
+  const a = await launch('native-live-a');
+  const b = await launch('native-live-b');
+  t.after(async () => {
+    for (const inst of [a, b]) {
+      await cliRun(['stop', '--task', inst.info.taskId, '--owner', inst.info.ownerToken]);
+      if (inst.child.exitCode == null) inst.child.kill('SIGKILL');
+    }
+  });
+
+  assert.notEqual(a.info.dataRoot, b.info.dataRoot);
+  assert.notEqual(a.info.webDataUuid, b.info.webDataUuid);
+  assert.notEqual(a.info.ownerToken, b.info.ownerToken);
+
+  assert.ok(await waitFor(() => fs.existsSync(a.capture) && fs.existsSync(b.capture)), 'both stubs should record their environment');
+  const envA = JSON.parse(fs.readFileSync(a.capture, 'utf8'));
+  const envB = JSON.parse(fs.readFileSync(b.capture, 'utf8'));
+  assertSatisfiesAppContract(envA);
+  assertSatisfiesAppContract(envB);
+  assert.equal(envA.NEMO_TASK_DATA_ROOT, a.info.dataRoot);
+  assert.equal(envB.NEMO_TASK_DATA_ROOT, b.info.dataRoot);
+  assert.notEqual(envA.NEMO_TASK_WEB_DATA_UUID, envB.NEMO_TASK_WEB_DATA_UUID);
+  // Each instance also gets its own cache and report roots, not just data.
+  assert.notEqual(envA.XDG_CACHE_HOME, envB.XDG_CACHE_HOME);
+  assert.notEqual(envA.NEMO_REPORT_DIR, envB.NEMO_REPORT_DIR);
+
+  // Each instance record lands inside its own root and nowhere else.
+  assert.ok(await waitFor(() => !!runtime.readInstanceRecord(a.info.taskId) && !!runtime.readInstanceRecord(b.info.taskId)));
+  const recordA = runtime.readInstanceRecord(a.info.taskId);
+  const recordB = runtime.readInstanceRecord(b.info.taskId);
+  assert.equal(recordA.taskId, 'native-live-a');
+  assert.equal(recordB.taskId, 'native-live-b');
+  assert.equal(recordA.webDataUuid, a.info.webDataUuid);
+  assert.equal(fs.readdirSync(path.dirname(a.info.instanceFile)).length, 1);
+
+  // The handshake only reports ok once the app itself confirmed the root.
+  const statusA = await cliRun(['status', '--task', 'native-live-a', '--owner', a.info.ownerToken]);
+  assert.equal(statusA.code, 0, statusA.out + statusA.err);
+  assert.equal(statusA.json.ok, true);
+  assert.equal(statusA.json.instance.taskId, 'native-live-a');
+  assert.equal(statusA.json.dataRoot, a.info.dataRoot);
+
+  // Stopping one instance leaves the other running and intact.
+  const stopA = await cliRun(['stop', '--task', 'native-live-a', '--owner', a.info.ownerToken]);
+  assert.equal(stopA.code, 0, stopA.out + stopA.err);
+  assert.equal(stopA.json.stopped, true);
+  assert.equal(stopA.json.released.released, true);
+  assert.ok(!fs.existsSync(a.info.dataRoot), 'the released task root is gone');
+  assert.equal(b.child.exitCode, null, 'the other instance keeps running');
+  assert.ok(fs.existsSync(b.info.dataRoot), 'the other task root survives');
+  assert.ok(!!runtime.readInstanceRecord('native-live-b'));
+});
+
+test('status and stop refuse a caller that is not the task owner', async (t) => {
+  const inst = await launch('native-owner');
+  t.after(async () => {
+    await cliRun(['stop', '--task', inst.info.taskId, '--owner', inst.info.ownerToken]);
+    if (inst.child.exitCode == null) inst.child.kill('SIGKILL');
+  });
+  assert.ok(await waitFor(() => !!runtime.readInstanceRecord('native-owner')));
+
+  const badStatus = await cliRun(['status', '--task', 'native-owner', '--owner', 'not-the-token']);
+  assert.equal(badStatus.code, 1);
+  assert.equal(badStatus.json.ok, false);
+  assert.match(badStatus.json.reason, /owner token mismatch/);
+
+  const badStop = await cliRun(['stop', '--task', 'native-owner', '--owner', 'not-the-token']);
+  assert.equal(badStop.code, 1);
+  assert.equal(badStop.json.stopped, false);
+  assert.equal(badStop.json.released, null);
+  // A refused stop must change nothing: the app keeps running and its
+  // isolated state is still there.
+  assert.equal(inst.child.exitCode, null);
+  assert.ok(fs.existsSync(inst.info.instanceFile));
+});
+
+test('the handshake reports unconfirmed isolation when the app wrote no record', () => {
+  const taskId = 'native-no-record';
+  const roots = isolation.taskRoots(taskId);
+  fs.writeFileSync(path.join(roots.reports, runtime.STATUS_FILE), JSON.stringify({
+    schema: runtime.SCHEMA, taskId, dataRoot: roots.tauriDataDir, webDataUuid: runtime.webDataUuid(),
+    build: { startup: null },
+  }));
+  const result = runtime.nativeHandshake(taskId, 'whatever');
+  assert.equal(result.ok, false);
+  assert.equal(result.instance, null);
+});
+
+// ---- exclusive desktop input -------------------------------------------
+
+test('the desktop input slot admits one task at a time and releases by owner', async () => {
+  const first = isolation.acquireExclusiveSlot(runtime.INPUT_SLOT, 'input-a', { pid: process.pid });
+  assert.equal(first.acquired, true);
+  try {
+    const second = isolation.acquireExclusiveSlot(runtime.INPUT_SLOT, 'input-b', { pid: process.pid });
+    assert.equal(second.acquired, false);
+    assert.match(second.reason, /held by another task/);
+    // Two instances may run at once; only human input is serialized.
+    assert.equal(isolation.releaseExclusiveSlot(runtime.INPUT_SLOT, 'wrong-token').released, false);
+  } finally {
+    assert.equal(isolation.releaseExclusiveSlot(runtime.INPUT_SLOT, first.ownerToken).released, true);
+  }
+  const again = isolation.acquireExclusiveSlot(runtime.INPUT_SLOT, 'input-b', { pid: process.pid });
+  assert.equal(again.acquired, true);
+  isolation.releaseExclusiveSlot(runtime.INPUT_SLOT, again.ownerToken);
+});
+
+test('the CLI input slot commands round-trip and refuse a second holder', async () => {
+  const acquired = await cliRun(['input-acquire', '--task', 'input-cli-a', '--pid', String(process.pid)]);
+  assert.equal(acquired.code, 0, acquired.out + acquired.err);
+  assert.equal(acquired.json.acquired, true);
+  try {
+    const denied = await cliRun(['input-acquire', '--task', 'input-cli-b', '--pid', String(process.pid)]);
+    assert.equal(denied.code, 1);
+    assert.equal(denied.json.acquired, false);
+  } finally {
+    const released = await cliRun(['input-release', '--owner', acquired.json.ownerToken]);
+    assert.equal(released.code, 0, released.out + released.err);
+    assert.equal(released.json.released, true);
+  }
+});
+
+test('non-macOS launches are refused before any task state is created', () => {
+  assert.throws(() => runtime.assertNativePlatform('linux'), /macOS only/);
+  assert.throws(() => runtime.assertNativePlatform('win32'), /macOS only/);
+  assert.doesNotThrow(() => runtime.assertNativePlatform('darwin'));
+});

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,9 @@ use tauri_plugin_shell::ShellExt;
 // EXPERIMENTAL (experimental/native-video-decode) — see the module header.
 mod video_decode;
 mod vectorize;
+// R06 (#902): per-task app-data / WebKit isolation. Inert unless the launcher
+// asks for it — see the module header for why that trigger is what it is.
+mod task_runtime;
 
 #[tauri::command]
 async fn run_ffmpeg(app: tauri::AppHandle, window: tauri::Window, args: Vec<String>) -> Result<i32, String> {
@@ -173,6 +176,37 @@ fn start_tablet_pressure_monitor(app: tauri::AppHandle) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // R06 (#902) — resolve the isolated task runtime before anything else.
+    // A malformed isolation request exits here rather than falling back to
+    // the shared install: silently writing a task instance's history,
+    // autosave and preferences into the real user profile is exactly the
+    // failure this feature exists to prevent.
+    let task_runtime = match task_runtime::resolve_from_process_env() {
+        Ok(resolved) => resolved,
+        Err(reason) => {
+            eprintln!("nemo: refusing to start an isolated task instance — {reason}");
+            std::process::exit(78); // EX_CONFIG
+        }
+    };
+    let mut ctx = tauri::generate_context!();
+    // Tauri builds the windows declared in tauri.conf.json itself, before the
+    // setup hook runs, and `data_store_identifier` can only be set while a
+    // window is being built. On the isolated path clear their `create` flag —
+    // the one thing Tauri's own loop filters on — and hand the configs to
+    // setup, which rebuilds them with this task's WebKit identity and the same
+    // labels. The entries stay in the config so anything else reading
+    // `app.windows` still sees them. On the default path nothing is touched
+    // and Tauri creates the window exactly as it does today.
+    let isolated_windows = if task_runtime.isolated().is_some() {
+        let windows = &mut ctx.config_mut().app.windows;
+        let taken = windows.clone();
+        for window in windows.iter_mut() {
+            window.create = false;
+        }
+        taken
+    } else {
+        Vec::new()
+    };
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         // The update channel is the public `nemo` repo's GitHub Releases —
@@ -204,7 +238,9 @@ pub fn run() {
             video_decode::autobench_report,
             video_decode::optimized_media_target,
             video_decode::create_optimized_media,
-            vectorize::vectorize_image
+            vectorize::vectorize_image,
+            task_runtime::nemo_task_runtime,
+            task_runtime::nemo_task_runtime_release
         ])
         // "Vérifier les mises à jour…" in the app (StrokeMotion) menu — same
         // check the Réglages button and the silent startup check already
@@ -221,7 +257,12 @@ pub fn run() {
                 let _ = app.emit("menu-check-update", ());
             }
         })
-        .setup(|app| {
+        .setup(move |app| {
+            // First: on the isolated path this creates the task roots, widens
+            // the fs scope to them and builds the window with this instance's
+            // website-data identity. get_webview_window("main") below depends
+            // on it having run.
+            task_runtime::install(app, task_runtime, &isolated_windows)?;
             #[cfg(debug_assertions)]
             {
                 let window = app.get_webview_window("main").unwrap();
@@ -249,6 +290,6 @@ pub fn run() {
             let _ = app;
             Ok(())
         })
-        .run(tauri::generate_context!())
+        .run(ctx)
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/task_runtime.rs
+++ b/src-tauri/src/task_runtime.rs
@@ -1,0 +1,802 @@
+//! Native task-runtime isolation (R06, https://github.com/mysteropodes/nemo/issues/902).
+//!
+//! `engineering/runtime-isolation.md` already lists this as the open native
+//! gap: *"Merely creating a `tauri-data` directory does not make the app use
+//! it. The platform owner must implement and validate the actual runtime
+//! override."* This module is that override, and it covers the two halves a
+//! second concurrent Nemo desktop instance actually needs:
+//!
+//! 1. **On-disk app state.** `history`, `autosave`, `preferences`, `cache`
+//!    and `output` all hang off Tauri's `appDataDir()` today (see
+//!    `src/js/project.js`'s `historyDir()` and `src/js/feedback-bridge.js`).
+//!    That resolves to `~/Library/Application Support/<identifier>` — one
+//!    single directory shared by every running copy of the app. Two task
+//!    instances would interleave version-history snapshots and feedback
+//!    entries into the same tree.
+//! 2. **WebKit website data.** The bigger and less obvious half. Autosave
+//!    (`nemo-auto`), the recents list, the sync-folder setting and the
+//!    feedback fallback store all live in `localStorage`, which on macOS is
+//!    WKWebView website data keyed by the *bundle* identifier — not by
+//!    anything `appDataDir()` controls. Redirecting only the filesystem
+//!    roots would leave two instances silently sharing one `localStorage`.
+//!    `WebviewWindowBuilder::data_store_identifier` gives this instance its
+//!    own `WKWebsiteDataStore`, which is the supported way to separate it.
+//!
+//! **Production default behavior is unchanged.** Isolation is off unless
+//! `NEMO_TASK_DATA_ROOT` is set, and that single trigger is deliberate:
+//! `scripts/nemo/lib/build-runtime.cjs` already exports `NEMO_TASK_ID` into
+//! the environment of the processes it spawns, so keying off the task id
+//! alone could switch a normal launch into isolation by inheritance.
+//!
+//! When isolation *is* requested but the request is malformed, this refuses
+//! to start rather than falling back to the shared user profile: silently
+//! writing a task instance's state into the real install is the exact
+//! failure the feature exists to prevent.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use tauri::Manager;
+
+/// Sole activation trigger. Absent -> the app resolves its normal paths.
+pub const ENV_DATA_ROOT: &str = "NEMO_TASK_DATA_ROOT";
+/// Required once `ENV_DATA_ROOT` is present. Same grammar as
+/// `scripts/nemo/lib/isolation.cjs`'s `validId`, so a task id is spelled
+/// identically on both sides of the launcher boundary.
+pub const ENV_TASK_ID: &str = "NEMO_TASK_ID";
+/// Owner secret for `nemo_task_runtime_release`. Never serialized back out.
+pub const ENV_OWNER_TOKEN: &str = "NEMO_TASK_OWNER_TOKEN";
+/// 16-byte WebKit website-data identity, hex, dashed or not.
+pub const ENV_WEB_DATA_UUID: &str = "NEMO_TASK_WEB_DATA_UUID";
+/// Opaque JSON blob the launcher declares about the checkout it started from.
+pub const ENV_SOURCE_IDENTITY: &str = "NEMO_TASK_SOURCE_IDENTITY";
+
+pub const SCHEMA: &str = "nemo.native-runtime/1";
+const INSTANCE_FILE: &str = "instance.json";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskRoots {
+    pub root: PathBuf,
+    /// Replaces `appDataDir()` for every JS consumer.
+    pub data: PathBuf,
+    pub history: PathBuf,
+    pub autosave: PathBuf,
+    pub preferences: PathBuf,
+    pub cache: PathBuf,
+    pub output: PathBuf,
+    /// Where this instance *records* its WebKit identity. WebKit itself
+    /// stores under an OS-managed location for that identifier; see
+    /// `WebDataStore::observed_paths`.
+    pub webkit: PathBuf,
+}
+
+impl TaskRoots {
+    fn under(root: PathBuf) -> Self {
+        let data = root.join("data");
+        Self {
+            history: data.join("history"),
+            autosave: data.join("autosave"),
+            preferences: data.join("preferences"),
+            cache: root.join("cache"),
+            output: root.join("output"),
+            webkit: root.join("webkit"),
+            data,
+            root,
+        }
+    }
+
+    fn all(&self) -> [&PathBuf; 8] {
+        [
+            &self.root,
+            &self.data,
+            &self.history,
+            &self.autosave,
+            &self.preferences,
+            &self.cache,
+            &self.output,
+            &self.webkit,
+        ]
+    }
+
+    pub fn create(&self) -> std::io::Result<()> {
+        for dir in self.all() {
+            std::fs::create_dir_all(dir)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IsolatedTask {
+    pub task_id: String,
+    pub roots: TaskRoots,
+    pub owner_token: Option<String>,
+    pub web_data_uuid: Option<[u8; 16]>,
+    pub declared_source: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Resolved {
+    /// No isolation requested: the normal install, byte-for-byte today's paths.
+    Default,
+    Isolated(Box<IsolatedTask>),
+}
+
+impl Resolved {
+    pub fn isolated(&self) -> Option<&IsolatedTask> {
+        match self {
+            Resolved::Default => None,
+            Resolved::Isolated(task) => Some(task),
+        }
+    }
+}
+
+// ---- validation ---------------------------------------------------------
+// Every rejection below names the offending value class, and none of them
+// normalize their input: a caller that meant `../..` gets an error, never a
+// quietly cleaned-up path pointing somewhere else.
+
+fn validate_task_id(raw: &str) -> Result<String, String> {
+    let ok = (1..=120).contains(&raw.len())
+        && raw
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphanumeric())
+        && raw
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-');
+    if ok {
+        Ok(raw.to_string())
+    } else {
+        Err(format!(
+            "{ENV_TASK_ID} must be 1-120 ASCII letters, digits, dot, underscore or hyphen, starting with a letter or digit"
+        ))
+    }
+}
+
+/// The whole attack surface of this feature is right here: whatever path we
+/// accept is a path the app will create directories in, write project state
+/// to, and later delete recursively on an owner-checked release.
+fn validate_data_root(raw: &str) -> Result<PathBuf, String> {
+    if raw.trim().is_empty() {
+        return Err(format!("{ENV_DATA_ROOT} is empty"));
+    }
+    if raw.contains('\0') {
+        return Err(format!("{ENV_DATA_ROOT} contains a NUL byte"));
+    }
+    let path = PathBuf::from(raw);
+    if !path.is_absolute() {
+        return Err(format!("{ENV_DATA_ROOT} must be an absolute path"));
+    }
+    // Scan the raw string, not `path.components()`: that iterator silently
+    // drops `.` segments, so `/tmp/./x` would arrive here already normalized
+    // and a "we never normalize" claim would be false. Caught by
+    // `traversal_relative_and_shallow_roots_are_refused`, not by reading.
+    let mut depth = 0usize;
+    for segment in raw.split(std::path::is_separator) {
+        match segment {
+            "" => {}
+            "." => return Err(format!("{ENV_DATA_ROOT} must not contain a '.' component")),
+            ".." => return Err(format!("{ENV_DATA_ROOT} must not contain a '..' component")),
+            _ => depth += 1,
+        }
+    }
+    // A release deletes this tree recursively. `/`, `/Users` or `~` itself
+    // must never be reachable through a typo or a half-expanded variable.
+    if depth < 2 {
+        return Err(format!(
+            "{ENV_DATA_ROOT} must be at least two directories below the filesystem root; refusing to treat '{raw}' as a disposable task root"
+        ));
+    }
+    Ok(path)
+}
+
+fn parse_web_data_uuid(raw: &str) -> Result<[u8; 16], String> {
+    let hex: String = raw.chars().filter(|c| *c != '-').collect();
+    if hex.len() != 32 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!(
+            "{ENV_WEB_DATA_UUID} must be a 16-byte hex UUID, with or without dashes"
+        ));
+    }
+    let mut out = [0u8; 16];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16)
+            .map_err(|_| format!("{ENV_WEB_DATA_UUID} is not valid hex"))?;
+    }
+    // WebKit rejects the nil UUID, and accepting it here would hand every
+    // task instance the same "identity" while looking configured.
+    if out == [0u8; 16] {
+        return Err(format!("{ENV_WEB_DATA_UUID} must not be the nil UUID"));
+    }
+    Ok(out)
+}
+
+pub fn format_uuid(uuid: &[u8; 16]) -> String {
+    let hex: String = uuid.iter().map(|b| format!("{b:02x}")).collect();
+    format!(
+        "{}-{}-{}-{}-{}",
+        &hex[0..8],
+        &hex[8..12],
+        &hex[12..16],
+        &hex[16..20],
+        &hex[20..32]
+    )
+}
+
+/// Resolve from an explicit environment map. Kept free of `std::env` and of
+/// `cfg!` so both platform branches are reachable from unit tests.
+pub fn resolve_from(env: &BTreeMap<String, String>, macos: bool) -> Result<Resolved, String> {
+    let Some(raw_root) = env.get(ENV_DATA_ROOT) else {
+        return Ok(Resolved::Default);
+    };
+    let root = validate_data_root(raw_root)?;
+    let task_id = match env.get(ENV_TASK_ID) {
+        Some(raw) => validate_task_id(raw)?,
+        None => {
+            return Err(format!(
+                "{ENV_DATA_ROOT} is set but {ENV_TASK_ID} is missing; an isolated instance must be nameable"
+            ))
+        }
+    };
+    let web_data_uuid = match env.get(ENV_WEB_DATA_UUID) {
+        Some(raw) => Some(parse_web_data_uuid(raw)?),
+        // On macOS `localStorage` is the shared surface this feature exists
+        // to split, so an unnamed website-data identity is a refusal, not a
+        // degraded mode that looks isolated and is not.
+        None if macos => {
+            return Err(format!(
+                "{ENV_WEB_DATA_UUID} is required on macOS: without it two instances share one WKWebView website data store (localStorage, IndexedDB, caches)"
+            ))
+        }
+        None => None,
+    };
+    Ok(Resolved::Isolated(Box::new(IsolatedTask {
+        task_id,
+        roots: TaskRoots::under(root),
+        owner_token: env.get(ENV_OWNER_TOKEN).filter(|t| !t.is_empty()).cloned(),
+        web_data_uuid,
+        declared_source: env.get(ENV_SOURCE_IDENTITY).cloned(),
+    })))
+}
+
+pub fn resolve_from_process_env() -> Result<Resolved, String> {
+    let env: BTreeMap<String, String> = [
+        ENV_DATA_ROOT,
+        ENV_TASK_ID,
+        ENV_OWNER_TOKEN,
+        ENV_WEB_DATA_UUID,
+        ENV_SOURCE_IDENTITY,
+    ]
+    .into_iter()
+    .filter_map(|key| std::env::var(key).ok().map(|value| (key.to_string(), value)))
+    .collect();
+    resolve_from(&env, cfg!(target_os = "macos"))
+}
+
+// ---- owner-checked cleanup ----------------------------------------------
+
+fn tokens_match(expected: &str, presented: &str) -> bool {
+    if expected.len() != presented.len() {
+        return false;
+    }
+    expected
+        .bytes()
+        .zip(presented.bytes())
+        .fold(0u8, |acc, (a, b)| acc | (a ^ b))
+        == 0
+}
+
+/// Remove an isolated task's own roots. Refuses without a matching owner
+/// token, and re-validates the path immediately before deleting so a record
+/// mutated after startup cannot redirect the removal.
+pub fn release_roots(task: &IsolatedTask, presented_token: &str) -> Result<PathBuf, String> {
+    let Some(expected) = task.owner_token.as_deref() else {
+        return Err(format!(
+            "this instance started without {ENV_OWNER_TOKEN}; cleanup refused"
+        ));
+    };
+    if presented_token.is_empty() || !tokens_match(expected, presented_token) {
+        return Err("refused: caller is not the task owner (owner token mismatch)".to_string());
+    }
+    let root = task.roots.root.to_str().ok_or_else(|| {
+        "task root is not valid UTF-8; refusing to remove it".to_string()
+    })?;
+    let revalidated = validate_data_root(root)?;
+    if revalidated != task.roots.root {
+        return Err("task root changed since startup; cleanup refused".to_string());
+    }
+    if revalidated.exists() {
+        std::fs::remove_dir_all(&revalidated).map_err(|e| e.to_string())?;
+    }
+    Ok(revalidated)
+}
+
+// ---- serialized profile -------------------------------------------------
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebDataStore {
+    pub requested: bool,
+    pub uuid: Option<String>,
+    /// True only once the webview was actually built with this identity.
+    pub applied: bool,
+    pub reason: String,
+    /// Directories found on disk whose name carries this UUID. Empty is not
+    /// proof of failure — it is simply "not observed from here".
+    pub observed_paths: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AppIdentity {
+    pub version: String,
+    pub identifier: String,
+    pub executable: Option<String>,
+    pub executable_bytes: Option<u64>,
+    pub pid: u32,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeProfile {
+    pub schema: &'static str,
+    pub active: bool,
+    pub reason: String,
+    pub task_id: Option<String>,
+    pub roots: Option<TaskRoots>,
+    pub web_data_store: WebDataStore,
+    pub app: AppIdentity,
+    /// Verbatim launcher-declared source identity. See `limitations`.
+    pub declared_source: Option<serde_json::Value>,
+    pub limitations: Vec<String>,
+}
+
+/// Candidate WebKit website-data locations for a non-sandboxed macOS app.
+/// Only used to *observe* whether a store carrying this UUID exists.
+fn observed_web_data_paths(identifier: &str, uuid: &str) -> Vec<String> {
+    let Some(home) = std::env::var_os("HOME").map(PathBuf::from) else {
+        return Vec::new();
+    };
+    let bases = [
+        home.join("Library/WebKit").join(identifier),
+        home.join("Library/Caches").join(identifier).join("WebKit"),
+        home.join("Library/Containers")
+            .join(identifier)
+            .join("Data/Library/WebKit"),
+    ];
+    let mut found = Vec::new();
+    for base in bases {
+        collect_uuid_dirs(&base, uuid, 0, &mut found);
+    }
+    found
+}
+
+fn collect_uuid_dirs(dir: &Path, uuid: &str, depth: usize, out: &mut Vec<String>) {
+    if depth > 4 || out.len() >= 8 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_ascii_lowercase();
+        if name.contains(uuid) {
+            out.push(path.to_string_lossy().to_string());
+            continue;
+        }
+        collect_uuid_dirs(&path, uuid, depth + 1, out);
+    }
+}
+
+// ---- Tauri wiring -------------------------------------------------------
+
+pub struct RuntimeState {
+    resolved: Resolved,
+    web_data_applied: bool,
+}
+
+impl RuntimeState {
+    pub fn profile<R: tauri::Runtime>(&self, app: &tauri::AppHandle<R>) -> RuntimeProfile {
+        let identifier = app.config().identifier.clone();
+        let executable = std::env::current_exe().ok();
+        let app_identity = AppIdentity {
+            version: app.package_info().version.to_string(),
+            identifier: identifier.clone(),
+            executable_bytes: executable
+                .as_ref()
+                .and_then(|p| std::fs::metadata(p).ok())
+                .map(|m| m.len()),
+            executable: executable.map(|p| p.to_string_lossy().to_string()),
+            pid: std::process::id(),
+        };
+        let mut limitations = vec![
+            "declaredSource is echoed verbatim from the launcher: it identifies the launcher that configured this instance, not the checkout the binary was compiled from".to_string(),
+        ];
+        let Some(task) = self.resolved.isolated() else {
+            return RuntimeProfile {
+                schema: SCHEMA,
+                active: false,
+                reason: format!("{ENV_DATA_ROOT} not set; using the default install paths"),
+                task_id: None,
+                roots: None,
+                web_data_store: WebDataStore {
+                    requested: false,
+                    uuid: None,
+                    applied: false,
+                    reason: "default install: the app uses its normal WKWebView website data store".to_string(),
+                    observed_paths: Vec::new(),
+                },
+                app: app_identity,
+                declared_source: None,
+                limitations,
+            };
+        };
+        let uuid = task.web_data_uuid.as_ref().map(format_uuid);
+        let observed_paths = match (&uuid, cfg!(target_os = "macos")) {
+            (Some(u), true) => observed_web_data_paths(&identifier, u),
+            _ => Vec::new(),
+        };
+        if uuid.is_some() && observed_paths.is_empty() {
+            limitations.push(
+                "no website-data directory carrying this UUID was observed from the app process; WebKit may store it elsewhere or defer creation, so treat separation as unverified until a paired two-instance run shows it"
+                    .to_string(),
+            );
+        }
+        let web_data_store = WebDataStore {
+            requested: uuid.is_some(),
+            applied: self.web_data_applied,
+            reason: match (uuid.is_some(), self.web_data_applied) {
+                (true, true) => "webview built with this data_store_identifier (needs macOS >= 14; Tauri reports no result for it)".to_string(),
+                (true, false) => "identity resolved but the isolated webview was not built with it".to_string(),
+                (false, _) => "no website-data identity requested on this platform".to_string(),
+            },
+            uuid,
+            observed_paths,
+        };
+        RuntimeProfile {
+            schema: SCHEMA,
+            active: true,
+            reason: format!("isolated task runtime '{}'", task.task_id),
+            task_id: Some(task.task_id.clone()),
+            roots: Some(task.roots.clone()),
+            web_data_store,
+            app: app_identity,
+            declared_source: task
+                .declared_source
+                .as_deref()
+                .and_then(|raw| serde_json::from_str(raw).ok()),
+            limitations,
+        }
+    }
+}
+
+/// Record what this instance is, next to the state it owns. Deliberately
+/// excludes the owner token: the running process already holds it, and no
+/// later reader needs it to be on disk.
+fn write_instance_record<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    task: &IsolatedTask,
+) -> std::io::Result<()> {
+    let record = serde_json::json!({
+        "schema": SCHEMA,
+        "taskId": task.task_id,
+        "pid": std::process::id(),
+        "version": app.package_info().version.to_string(),
+        "identifier": app.config().identifier,
+        "executable": std::env::current_exe().ok().map(|p| p.to_string_lossy().to_string()),
+        "webDataUuid": task.web_data_uuid.as_ref().map(format_uuid),
+        "declaredSource": task.declared_source,
+    });
+    std::fs::write(
+        task.roots.root.join(INSTANCE_FILE),
+        serde_json::to_vec_pretty(&record).unwrap_or_default(),
+    )
+}
+
+/// Called first in the app's `setup`. On the default path it does nothing at
+/// all beyond registering state, which is what keeps a normal launch
+/// identical to today's behavior.
+pub fn install(
+    app: &tauri::App,
+    resolved: Resolved,
+    isolated_windows: &[tauri::utils::config::WindowConfig],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut web_data_applied = false;
+    if let Some(task) = resolved.isolated() {
+        task.roots.create()?;
+        // The static fs capability scopes `$APPDATA`/`$TEMP`/`$HOME`; an
+        // isolated root can sit outside all three, and without this the
+        // frontend's own fs calls would be denied by the plugin rather than
+        // by anything visible in the UI.
+        {
+            use tauri_plugin_fs::FsExt;
+            app.fs_scope().allow_directory(&task.roots.data, true)?;
+            app.fs_scope().allow_directory(&task.roots.cache, true)?;
+            app.fs_scope().allow_directory(&task.roots.output, true)?;
+        }
+        write_instance_record(app.handle(), task)?;
+        for config in isolated_windows {
+            let mut builder =
+                tauri::WebviewWindowBuilder::from_config(app.handle(), config)?;
+            if let Some(uuid) = task.web_data_uuid {
+                builder = builder.data_store_identifier(uuid);
+                web_data_applied = true;
+            }
+            builder.build()?;
+        }
+    }
+    app.manage(RuntimeState {
+        resolved,
+        web_data_applied,
+    });
+    Ok(())
+}
+
+#[tauri::command]
+pub fn nemo_task_runtime(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, RuntimeState>,
+) -> RuntimeProfile {
+    state.profile(&app)
+}
+
+/// Owner-only cleanup. `purge_web_data` additionally asks WebKit to drop the
+/// website data store for this identity; the outcome is reported as observed,
+/// never assumed, because removing a store the running webview still holds is
+/// not something this code can prove from here.
+#[tauri::command]
+pub async fn nemo_task_runtime_release(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, RuntimeState>,
+    owner_token: String,
+    purge_web_data: Option<bool>,
+) -> Result<serde_json::Value, String> {
+    let task = state
+        .resolved
+        .isolated()
+        .ok_or_else(|| "this instance is not isolated; nothing to release".to_string())?
+        .clone();
+    let removed = release_roots(&task, &owner_token)?;
+    let mut web_data = serde_json::json!({ "requested": false });
+    if purge_web_data.unwrap_or(false) {
+        web_data = match task.web_data_uuid {
+            None => serde_json::json!({ "requested": true, "removed": false, "reason": "no website-data identity on this platform" }),
+            Some(uuid) => match app.remove_data_store(uuid).await {
+                Ok(()) => serde_json::json!({ "requested": true, "removed": true, "uuid": format_uuid(&uuid), "reason": "WebKit accepted remove_data_store" }),
+                Err(e) => serde_json::json!({ "requested": true, "removed": false, "uuid": format_uuid(&uuid), "reason": e.to_string() }),
+            },
+        };
+    }
+    Ok(serde_json::json!({
+        "schema": SCHEMA,
+        "released": true,
+        "taskId": task.task_id,
+        "removedRoot": removed.to_string_lossy(),
+        "webData": web_data,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const UUID_A: &str = "3f2b1c0d-4e5f-6071-8293-a4b5c6d7e8f9";
+    const UUID_B: &str = "00112233-4455-6677-8899-aabbccddeeff";
+
+    fn env(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn isolated(root: &str, task: &str, uuid: &str) -> BTreeMap<String, String> {
+        env(&[
+            (ENV_DATA_ROOT, root),
+            (ENV_TASK_ID, task),
+            (ENV_WEB_DATA_UUID, uuid),
+        ])
+    }
+
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir()
+            .join("nemo-task-runtime-test")
+            .join(format!("{}-{}", name, std::process::id()));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        dir
+    }
+
+    // ---- the production default must stay the production default --------
+
+    #[test]
+    fn empty_environment_resolves_to_the_default_install() {
+        assert_eq!(resolve_from(&env(&[]), true).unwrap(), Resolved::Default);
+    }
+
+    #[test]
+    fn a_task_id_alone_never_switches_a_normal_launch_into_isolation() {
+        // build-runtime.cjs exports NEMO_TASK_ID into every process it
+        // spawns; inheriting it must not redirect a normal app launch.
+        let resolved = resolve_from(&env(&[(ENV_TASK_ID, "build-a")]), true).unwrap();
+        assert_eq!(resolved, Resolved::Default);
+    }
+
+    // ---- two instances actually get separate roots ----------------------
+
+    #[test]
+    fn two_task_instances_resolve_disjoint_roots() {
+        let a = resolve_from(&isolated("/tmp/nemo-tasks/a", "task-a", UUID_A), true).unwrap();
+        let b = resolve_from(&isolated("/tmp/nemo-tasks/b", "task-b", UUID_B), true).unwrap();
+        let (a, b) = (a.isolated().unwrap(), b.isolated().unwrap());
+        assert_ne!(a.task_id, b.task_id);
+        assert_ne!(a.web_data_uuid, b.web_data_uuid);
+        for (left, right) in a.roots.all().iter().zip(b.roots.all().iter()) {
+            assert_ne!(left, right, "roots must not overlap between task instances");
+            assert!(!left.starts_with(right) && !right.starts_with(left));
+        }
+    }
+
+    #[test]
+    fn roots_hang_off_the_declared_data_root() {
+        let resolved = resolve_from(&isolated("/tmp/nemo-tasks/a", "task-a", UUID_A), true).unwrap();
+        let roots = &resolved.isolated().unwrap().roots;
+        assert_eq!(roots.root, PathBuf::from("/tmp/nemo-tasks/a"));
+        assert_eq!(roots.data, PathBuf::from("/tmp/nemo-tasks/a/data"));
+        // history stays `<appData>/history/...` so the isolated tree keeps
+        // the exact layout src/js/project.js already writes.
+        assert_eq!(roots.history, roots.data.join("history"));
+        assert_eq!(roots.autosave, roots.data.join("autosave"));
+        assert_eq!(roots.preferences, roots.data.join("preferences"));
+        assert_eq!(roots.cache, roots.root.join("cache"));
+        assert_eq!(roots.output, roots.root.join("output"));
+        assert_eq!(roots.webkit, roots.root.join("webkit"));
+    }
+
+    // ---- malformed / hostile requests -----------------------------------
+
+    #[test]
+    fn a_data_root_without_a_task_id_is_refused() {
+        let err = resolve_from(&env(&[(ENV_DATA_ROOT, "/tmp/nemo-tasks/a")]), false).unwrap_err();
+        assert!(err.contains(ENV_TASK_ID), "{err}");
+    }
+
+    #[test]
+    fn invalid_task_ids_are_refused_not_normalized() {
+        for bad in ["", "-leading", "with space", "sl/ash", "dot..ok?", &"x".repeat(121)] {
+            let result = resolve_from(&isolated("/tmp/nemo-tasks/a", bad, UUID_A), true);
+            assert!(result.is_err(), "expected refusal for task id {bad:?}");
+        }
+        assert!(resolve_from(&isolated("/tmp/nemo-tasks/a", &"x".repeat(120), UUID_A), true).is_ok());
+    }
+
+    #[test]
+    fn traversal_relative_and_shallow_roots_are_refused() {
+        let cases = [
+            ("relative", "nemo-tasks/a"),
+            ("parent component", "/tmp/nemo-tasks/../../../etc/nemo"),
+            ("bare parent", "/.."),
+            ("current dir component", "/tmp/./nemo-tasks"),
+            ("filesystem root", "/"),
+            ("one level deep", "/tmp"),
+            ("empty", ""),
+            ("blank", "   "),
+            ("nul byte", "/tmp/nemo\0tasks/a"),
+        ];
+        for (label, root) in cases {
+            let result = resolve_from(&isolated(root, "task-a", UUID_A), true);
+            assert!(result.is_err(), "expected refusal for {label}: {root:?}");
+        }
+    }
+
+    #[test]
+    fn a_refused_request_never_degrades_into_the_default_install() {
+        // The dangerous failure mode is "isolation asked for, silently not
+        // applied": that writes task state into the real user profile.
+        let result = resolve_from(&isolated("/tmp", "task-a", UUID_A), true);
+        assert!(matches!(result, Err(_)));
+        assert_ne!(result.ok(), Some(Resolved::Default));
+    }
+
+    // ---- website-data identity ------------------------------------------
+
+    #[test]
+    fn macos_requires_a_website_data_identity() {
+        let without = env(&[(ENV_DATA_ROOT, "/tmp/nemo-tasks/a"), (ENV_TASK_ID, "task-a")]);
+        let err = resolve_from(&without, true).unwrap_err();
+        assert!(err.contains(ENV_WEB_DATA_UUID), "{err}");
+        // Off macOS there is no WKWebView store to split, so its absence is
+        // not an error — it is simply not requested.
+        let resolved = resolve_from(&without, false).unwrap();
+        assert_eq!(resolved.isolated().unwrap().web_data_uuid, None);
+    }
+
+    #[test]
+    fn website_data_uuids_parse_dashed_and_undashed_alike() {
+        let dashed = resolve_from(&isolated("/tmp/nemo-tasks/a", "task-a", UUID_A), true).unwrap();
+        let plain = UUID_A.replace('-', "");
+        let undashed = resolve_from(&isolated("/tmp/nemo-tasks/a", "task-a", &plain), true).unwrap();
+        let uuid = dashed.isolated().unwrap().web_data_uuid.unwrap();
+        assert_eq!(uuid, undashed.isolated().unwrap().web_data_uuid.unwrap());
+        assert_eq!(format_uuid(&uuid), UUID_A);
+    }
+
+    #[test]
+    fn malformed_and_nil_website_data_uuids_are_refused() {
+        for bad in [
+            "00000000-0000-0000-0000-000000000000",
+            "not-a-uuid",
+            "3f2b1c0d4e5f60718293a4b5c6d7e8",
+            "3f2b1c0d-4e5f-6071-8293-a4b5c6d7e8fg",
+        ] {
+            assert!(
+                resolve_from(&isolated("/tmp/nemo-tasks/a", "task-a", bad), true).is_err(),
+                "expected refusal for uuid {bad:?}"
+            );
+        }
+    }
+
+    // ---- owner-only cleanup ---------------------------------------------
+
+    fn task_at(root: PathBuf, token: Option<&str>) -> IsolatedTask {
+        IsolatedTask {
+            task_id: "task-a".to_string(),
+            roots: TaskRoots::under(root),
+            owner_token: token.map(str::to_string),
+            web_data_uuid: None,
+            declared_source: None,
+        }
+    }
+
+    #[test]
+    fn the_owner_can_release_its_own_roots() {
+        let root = scratch("release-owner");
+        let task = task_at(root.clone(), Some("tok-correct"));
+        task.roots.create().unwrap();
+        std::fs::write(task.roots.history.join("1.json"), b"{}").unwrap();
+        assert!(task.roots.history.exists());
+        let removed = release_roots(&task, "tok-correct").unwrap();
+        assert_eq!(removed, root);
+        assert!(!root.exists());
+    }
+
+    #[test]
+    fn a_non_owner_cannot_release_and_leaves_the_state_intact() {
+        let root = scratch("release-refused");
+        let task = task_at(root.clone(), Some("tok-correct"));
+        task.roots.create().unwrap();
+        std::fs::write(task.roots.history.join("1.json"), b"{}").unwrap();
+        for wrong in ["", "tok-wrong", "tok-correct-longer", "tok-correc"] {
+            let err = release_roots(&task, wrong).unwrap_err();
+            assert!(err.contains("not the task owner"), "{err}");
+        }
+        assert!(task.roots.history.join("1.json").exists());
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn an_instance_started_without_a_token_refuses_every_release() {
+        let root = scratch("release-tokenless");
+        let task = task_at(root.clone(), None);
+        task.roots.create().unwrap();
+        let err = release_roots(&task, "anything").unwrap_err();
+        assert!(err.contains(ENV_OWNER_TOKEN), "{err}");
+        assert!(root.exists());
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn release_revalidates_the_root_before_deleting_it() {
+        // A record mutated after startup must not be able to aim the
+        // recursive removal at a shallow path.
+        let mut task = task_at(PathBuf::from("/tmp/nemo-tasks/a"), Some("tok"));
+        task.roots.root = PathBuf::from("/");
+        let err = release_roots(&task, "tok").unwrap_err();
+        assert!(err.contains("disposable task root"), "{err}");
+    }
+}

--- a/src/js/feedback-bridge.js
+++ b/src/js/feedback-bridge.js
@@ -163,8 +163,17 @@
   // preview) -> localStorage (last resort — a live browser tab only, not
   // reachable outside an active eval session, but keeps this working even
   // if the plain http.server is what's actually running). ----
+  // R06 task-runtime isolation (#902): SMProject.appDataBase() is the single
+  // resolver — it returns this task instance's own data root when the desktop
+  // app was launched isolated, and appDataDir() otherwise. Going straight to
+  // appDataDir() here would leave feedback entries in the shared install while
+  // version history followed the task root, which is the split-reader bug
+  // CLAUDE.md §1 is about. The fallback keeps this working if project.js has
+  // not loaded (same guard shape projectKey() above already uses).
   async function localDir() {
-    var base = await window.__TAURI__.path.appDataDir();
+    var base = (window.SMProject && window.SMProject.appDataBase)
+      ? await window.SMProject.appDataBase()
+      : await window.__TAURI__.path.appDataDir();
     return base.replace(/[\\/]+$/, '') + '/feedback/' + projectKey();
   }
   function lsKey() { return 'nemo-feedback-' + projectKey(); }

--- a/src/js/project.js
+++ b/src/js/project.js
@@ -232,8 +232,27 @@
   var HISTORY_MAX=120; // 60 min of history at the existing 30s cadence
   function simpleHash(s){var h=0;for(var i=0;i<s.length;i++)h=(h*31+s.charCodeAt(i))|0;return (h>>>0).toString(36);}
   function historyKey(){return currentPath?(baseName(currentPath).replace(/[^a-z0-9]+/gi,'-').toLowerCase()+'-'+simpleHash(currentPath)):'untitled-autosave';}
+  // R06 task-runtime isolation (#902) — every on-disk consumer must go
+  // through this, not straight to appDataDir(). appDataDir() is a single
+  // directory per bundle identifier, so two concurrent task instances of the
+  // app would interleave their version history and feedback into the same
+  // tree. When the desktop instance was launched with an isolated task data
+  // root, `nemo_task_runtime` (src-tauri/src/task_runtime.rs) hands back that
+  // task's own `data` root instead, and the layout below it is unchanged.
+  // A binary without the command (older build) falls through to appDataDir(),
+  // which is also exactly what a normal, non-isolated launch resolves to.
+  var _appDataBase=null;
+  async function appDataBase(){
+    if(_appDataBase)return _appDataBase;
+    try{
+      var rt=await window.__TAURI__.core.invoke('nemo_task_runtime');
+      if(rt&&rt.active&&rt.roots&&rt.roots.data)_appDataBase=rt.roots.data;
+    }catch(e){/* command absent: production default below */}
+    if(!_appDataBase)_appDataBase=await window.__TAURI__.path.appDataDir();
+    return _appDataBase;
+  }
   async function historyDir(){
-    var base=await window.__TAURI__.path.appDataDir();
+    var base=await appDataBase();
     return base.replace(/[\\/]+$/,'')+'/history/'+historyKey();
   }
   async function pushVersionSnapshot(json){
@@ -411,6 +430,11 @@
     // feedback-bridge.js's local + shared feedback storage keys off, so a
     // feedback thread and this project's own history/sync folders always
     // agree on which project they belong to without re-deriving the logic.
+    // Single resolver for "where does this instance keep its app data" —
+    // feedback-bridge.js reads it too, so an isolated task instance never has
+    // one consumer following the task root while another writes into the
+    // shared install (CLAUDE.md §1: one new path, every reader).
+    appDataBase:appDataBase,
     getProjectKey:historyKey,profileDir:profileDir,isDirty:isDirty,markSaved:function(){try{markSaved(window.SM.exportJSON());}catch(e){}},getCurrentLabel:getCurrentLabel,
     refreshActiveTabDirtyDot:refreshActiveTabDirtyDot,
     // Read-only list of every OTHER open project tab (feedback #109: "voir

--- a/tests/nemo-native-runtime.test.cjs
+++ b/tests/nemo-native-runtime.test.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+// Keep this process-isolated: the suite sets NEMO_ISOLATION_ROOT before the
+// isolation module captures it at import time.
+require('../scripts/nemo/native-runtime.test.cjs');


### PR DESCRIPTION
Closes the last native item [`engineering/runtime-isolation.md`](../blob/main/engineering/runtime-isolation.md) left open for R06 ([#902](https://github.com/mysteropodes/nemo/issues/902)):

> Configure and exercise isolated Tauri data/autosave paths. Merely creating a `tauri-data` directory does not make the app use it. The platform owner must implement and validate the actual runtime override.

`lib/isolation.cjs` has created that `tauri-data` directory since the first R06 increment and nothing pointed the app at it. Two halves close it, sharing one environment contract and nothing else: `src-tauri/src/task_runtime.rs` (app side) and `scripts/nemo/native-runtime.cjs` (launcher side). Full design notes in `engineering/runtime/native-isolation.md`.

## Why the WebKit half is not optional

Redirecting `appDataDir()` alone would look like isolation and not be it. Autosave (`nemo-auto`), the recents list, the sync-folder setting and the feedback fallback store all live in `localStorage` — WKWebView website data keyed by the **bundle** identifier, which `appDataDir()` does not control. Two instances redirected only on the filesystem would still share one `localStorage`, so instance B's autosave would overwrite instance A's. `WebviewWindowBuilder::data_store_identifier` gives each window its own `WKWebsiteDataStore`.

That has to happen while the window is built, and Tauri builds `tauri.conf.json`'s windows *before* the setup hook runs. On the isolated path only, `run()` clears each window config's `create` flag (the one field Tauri's creation loop filters on) and `install()` rebuilds them with the identity and the same labels. **On the default path nothing is touched** and Tauri creates the window exactly as it does today.

## Two decisions worth reviewing

**`NEMO_TASK_DATA_ROOT` is the sole activation trigger.** `build-runtime.cjs` already exports `NEMO_TASK_ID` into the environment of every process it spawns, so keying off the task id could flip an unrelated launch into isolation by inheritance. Covered by `a_task_id_alone_never_switches_a_normal_launch_into_isolation`.

**A malformed isolation request exits 78 (`EX_CONFIG`); it does not fall back.** Silently using the shared install when isolation was requested writes a task instance's history, autosave and preferences into the real user profile — the exact failure the feature exists to prevent.

Also worth a look: the static fs capability scopes `$APPDATA`/`$TEMP`/`$HOME`, and an isolated root can sit outside all three, so `install()` widens the scope at runtime via `FsExt::fs_scope().allow_directory`. Without it the frontend's own `fs` calls are denied by the plugin with nothing visible in the UI.

`project.js` and `feedback-bridge.js` both resolve their base through one function (`SMProject.appDataBase`). Two readers of a new path is CLAUDE.md §1's first bug family; version history following the task root while feedback stayed in the shared install would be that bug.

## Validation

| Check | Result |
|---|---|
| `npm run verify` @ `38fd3f7`, clean tree | **PASS** — doctor PASS, check 6/6, `test:unit` 196/196, `test:rust` PASS. Receipt `20260905T215717Z-38fd3f7`. |
| `cd src-tauri && cargo test --lib task_runtime` | **15/15** |
| `node --test scripts/nemo/native-runtime.test.cjs` | **11/11** |
| `cargo check` (src-tauri) | clean, no new warnings |

The 15 Rust tests cover: the default path staying default, a task id alone never activating isolation, two instances getting non-overlapping roots, roots hanging off the declared base, and refusal-rather-than-normalization for every malformed or hostile request (relative path, `..`, `.`, filesystem root, one-level-deep root, empty, blank, NUL byte, bad task ids, nil/short/non-hex UUID), plus owner-only release, a refused release leaving state intact, a tokenless instance refusing every release, and re-validation of the root immediately before deletion.

The 11 Node tests cover: disjoint roots and distinct website-data identities, the emitted environment satisfying the app-side rules, valid non-nil v4 UUIDs, `.app` bundle resolution, two live concurrent instances each writing their record only into their own root, independent stop authority, owner-refused status/stop leaving the app and its state untouched, an unconfirmed-isolation handshake, and the exclusive `desktop-input` slot.

One of them found a real bug in my own validator: `Path::components()` silently drops `.` segments, so the `.`-rejection never fired and `/tmp/./x` arrived pre-normalized. Now scanned on the raw string.

## Remaining gate — paired two-instance desktop run

**Explicitly open, not claimed.** Everything above is pure-logic and launcher-level. That a *real* Nemo resolves these roots, and that two WKWebView website-data stores are genuinely separate on disk, needs a built app, two launched instances and the exclusive desktop input slot — which R04 currently holds (confirmed with Codexitron; waiting on its explicit handoff). Browser evidence cannot substitute for it.

Two smaller limits, reported rather than inferred:
- `data_store_identifier` needs **macOS ≥ 14** and Tauri returns no result for it, so `webDataStore.applied` means "the webview was built with this identity", not "WebKit accepted it". `observedPaths` is the only app-side evidence and is reported as observed-or-not.
- `declaredSource` is echoed verbatim from the launcher: it identifies the launcher that configured the instance, not the checkout the binary was compiled from. The app's own build identity is reported separately.

## Wiring requested from other owners (not applied here)

- **`package.json` / `lib/jobs.cjs`** (Codexitron / integration): nothing points at `scripts/nemo/native-runtime.cjs` yet. Also, `test:rust` runs `geometry-wasm` only — the 15 `src-tauri` tests in this PR are not reached by `npm run verify`.
- **`engineering/boundaries/profiles/scripts-nemo.profile.json`** (Claudimator Beta): no module entry for `native-runtime.cjs` or its test, so the boundaries checker does not see them.

## Two pre-existing issues found in passing, outside these paths

1. `scripts/nemo/build-runtime.test.cjs`'s "leader exit cannot release the slot while its stubborn descendant remains" is **flaky**: 6/6, 6/6, then 4/6 on three consecutive runs here. It waits at most 1s (100 × 10 ms) for the descendant's pid file, and on a loaded machine the IPC handshake can exceed that. Not touched by this PR — it uses none of these files.
2. `src-tauri/gen/schemas/capabilities.json` is committed **stale**: it lacks `dialog:allow-ask` and `dialog:allow-confirm`, which are present in `src-tauri/capabilities/default.json`. Any `cargo` invocation regenerates it and dirties the tree. Reverted here to keep this PR scoped; `src-tauri/gen` is not one of these paths.

Refs #902
