### PR TITLE
R06: isolate native app state per task

### DIFF
--- a/engineering/runtime-isolation.md
+++ b/engineering/runtime-isolation.md
@@ -247,8 +247,20 @@ node scripts/nemo/native.cjs stop --task app-a --owner <token>
 build identities, and a live app manifest naming this task agree. A manifest
 left by an earlier or different run is reported as such, never accepted as this
 instance's identity. `stop` refuses a mismatched owner, terminates the owned
-process group, waits for launcher exit and then removes that task's roots,
-including its `tauri-data`. Copy wanted artifacts first.
+process group, waits for launcher exit and then removes that task's roots.
+Copy wanted artifacts first.
+
+Removing the task root is not enough on its own: the isolated app directories
+are `<platform dir>/<identifier>`, so they live outside it and
+`isolation.releaseTask` never sees them, as does the WebKit store under
+`~/Library/WebKit/<bundle identifier>/WebsiteDataStore/<uuid>`. `stop` therefore
+reads the manifest the instance wrote, and removes each directory **whose last
+component carries this task's own identifier suffix** — recomputed locally from
+the task id, never trusted from the manifest. A manifest naming the shared
+`com.strokemotion.app` directory, another task's directory or a relative path is
+refused by name and reported in `appState.refused`. A start that fails does not
+release anything it did not acquire: task ids are reused across restarts, which
+is what lets an instance's state survive a stop.
 
 `--reserve` takes the shared resources this instance needs exclusively, before
 it starts: `desktop-input` for a run that drives the one keyboard and mouse,
@@ -263,8 +275,10 @@ use an executable stub that reproduces only the app's observable contract (the
 environment it is handed, the manifest it writes), so they cover two concurrent
 instances on disjoint roots, per-task keys, handshake refusal for a silent or
 foreign manifest, owner-only stop with root removal, explicit reservation
-refusal and release, and the missing-build blocker — without a desktop, a GPU or
-a window. The environment contract itself is asserted against
+refusal and release, the missing-build blocker, derivation-bound removal of the
+isolated app directories (refusing the production directory, another task's
+directory and a relative path), and a refused start leaving an earlier
+instance's state intact — without a desktop, a GPU or a window. The environment contract itself is asserted against
 `src-tauri/src/task_runtime.rs`, so renaming a variable on one side only fails
 the suite instead of silently returning the app to shared state. The native
 resolution rules (activation, fail-closed refusals, identifier and data-store
@@ -288,12 +302,20 @@ Still required for the full acceptance contract in
   integration. The preview launcher supplies real origins, explicit Chromium
   profiles and the served identity, while R02 `test:browser` still requires its
   separate Playwright harness. A browser preview does not build WASM or the app.
-- Run two real packaged instances at once and prove the isolated Tauri roots on
-  the live desktop: the identifier, data store and app-directory overrides above
-  are implemented and unit-proved, and the launcher's environment contract is
-  proved against an app stub, but no evidence here comes from two actual Nemo
-  windows saving and reloading a project side by side. That validation needs the
-  exclusive desktop slot and is the remaining half of this bullet.
+- Two real packaged instances were run at once on 2026-09-05 and the isolated
+  roots hold on the live desktop. Both apps reported distinct identifiers and
+  app directories from Tauri's own path resolver; WebKit materialised two
+  separate stores (`~/Library/WebKit/com.strokemotion.app/WebsiteDataStore/
+  99377ca9-…` and `80a136b6-…`); both autosaved real project JSON into their own
+  `history/untitled-autosave` directory with **zero shared filenames** (9 files
+  against 24); one instance was driven through its real UI (New Project dialog,
+  named project, Create) through the accessibility tree; and the shared
+  production state was byte-for-byte untouched — `com.strokemotion.app` stayed at
+  25 files / 464K with its newest mtime predating the run, and the production
+  WebKit and Caches directories likewise. A stopped instance's state survived
+  its app exit. Still open: a restart of the same task id reading back its own
+  saved document through the UI, which was interrupted when a parallel session
+  took the `desktop-input` slot.
 - `--reserve` gives desktop input and reference GPU measurements an explicit
   exclusive reservation with a real consumer. Benchmark and input-driving
   harnesses still have to ask for those slots from their own entry points.

--- a/engineering/runtime-isolation.md
+++ b/engineering/runtime-isolation.md
@@ -2,9 +2,11 @@
 
 [R06 / #902](https://github.com/mysteropodes/nemo/issues/902) requires concurrent
 tasks to keep their source, browser/desktop state, ports, caches, builds and
-reports separate. The coordination library and browser preview launcher provide
-local ownership checks, distinct task origins and a served source/build identity.
-Full R06 acceptance remains open for the desktop and remaining consumers below.
+reports separate. The coordination library, the browser preview launcher and the
+native app launcher provide local ownership checks, distinct task origins,
+per-task native state and a served or written source/build identity. Full R06
+acceptance remains open for the live two-instance desktop evidence and the
+remaining consumers below.
 
 ## API and guarantees
 
@@ -38,8 +40,9 @@ its current limitation that untracked-file contents are not hashed separately.
 
 Despite its historical name, `verifyHandshake()` reads local launcher metadata;
 it does **not** challenge a running server or establish which checkout serves a
-URL. The browser launcher adds the served endpoint described below. Tauri still
-requires an equivalent runtime handshake before trusting its application instance.
+URL. The browser launcher adds the served endpoint described below. The native app launcher adds the
+manifest the running instance writes for itself, which is what identifies the
+application instance rather than the launcher's own bookkeeping.
 
 Each mutation creates an atomic directory under `<runtime>/mutations/`, with an
 `owner.json` identifying the mutating PID. Normal completion removes the guard.
@@ -185,6 +188,89 @@ exit and retained artifacts without starting a Tauri, desktop or GPU process.
 The core isolation suite already covers source-identity drift without adding a
 second concurrent worktree mutation to normal test discovery.
 
+## Native app launcher
+
+`node scripts/nemo/native.cjs start --task app-a` starts a built Nemo with that
+task's isolated environment, owns the resulting process group, and reports what
+the running instance disclosed about itself. It resolves the app from an
+explicit `--app`/`--executable`, else this task's own build output, else the
+worktree's default target, and reads the bundle's `CFBundleExecutable` rather
+than guessing the binary name. A missing build is a named blocker listing every
+path it looked in.
+
+Isolation has two halves, because macOS keeps the two kinds of state in two
+different places:
+
+| State | Mechanism |
+|---|---|
+| App data, config, cache, logs | every `app_*_dir()` in Tauri resolves as `<platform dir>/<config identifier>`, so the bootstrap rewrites the identifier to `com.strokemotion.app.nemo-task-<16 hex>` before the app runs. Everything that goes through the path resolver — the fs plugin scope, `appDataDir()` in JS, the feedback and history folders — follows without knowing this exists. |
+| WebKit `localStorage`/IndexedDB | not under those directories at all; they follow the webview's data store, so the configured windows are created in `setup` with an explicit `data_store_identifier` (macOS >= 14). Window labels are untouched, so `capabilities/default.json` keeps applying to the same window. |
+
+Both derive from the task key — the SHA-256 of the exact task id that
+`isolation.cjs` already computes (`idKey`, exported for this). The native side
+takes it as input instead of recomputing it: a second derivation would be one
+more pair of functions that has to stay identical by hand.
+
+| Variable | Meaning |
+|---|---|
+| `NEMO_TAURI_DATA_DIR` | absolute path to this task's `tauri-data` root. **Its presence is what turns isolation on**; nothing else in the repository sets it. |
+| `NEMO_TASK_ID` | the task id, echoed in the manifest. |
+| `NEMO_TASK_KEY` | 64 lowercase hex characters, `idKey(taskId)`. |
+| `NEMO_TASK_OWNER_TOKEN` | optional. Without it the instance refuses every release request; a missing token is never read as "no check required". |
+
+With `NEMO_TAURI_DATA_DIR` absent nothing changes: the app resolves exactly the
+paths it always has. With it set and anything else missing or invalid, the app
+exits 2 naming the variable instead of starting on the shared production
+identifier — a silent fallback would write an isolated run's state into the
+user's real app data, which is the failure this work package exists to prevent.
+`NEMO_TASK_ID` alone is deliberately not enough, since the build launcher
+already exports it for every desktop build.
+
+The app writes `native-runtime.json` (schema `nemo.native-runtime/1`) into that
+root and prints the same document as its first stdout line: task id and key, the
+identifier and data store identifier actually in use, the app directories read
+back from Tauri's own path resolver, pid, executable and app version. It never
+contains the owner token. The `nemo_task_runtime` command returns the same
+document to the page, so an in-app check can assert which task's state it is
+looking at before writing anything. `nemo_task_runtime_release` takes the owner
+token, marks the manifest released and exits — the stop path that stays
+available when process-group termination does not, because an instance started
+through macOS `open` is reparented by launchd.
+
+```sh
+node scripts/nemo/native.cjs start --task app-a --reserve desktop-input
+node scripts/nemo/native.cjs status --task app-a --owner <token>
+node scripts/nemo/native.cjs stop --task app-a --owner <token>
+```
+
+`status` is `ok` only when all of the owner token, the complete R02 source and
+build identities, and a live app manifest naming this task agree. A manifest
+left by an earlier or different run is reported as such, never accepted as this
+instance's identity. `stop` refuses a mismatched owner, terminates the owned
+process group, waits for launcher exit and then removes that task's roots,
+including its `tauri-data`. Copy wanted artifacts first.
+
+`--reserve` takes the shared resources this instance needs exclusively, before
+it starts: `desktop-input` for a run that drives the one keyboard and mouse,
+`gpu-reference` for a reference measurement. A second launcher asking for a held
+slot is refused by name. Running two isolated instances at once is **not** what a
+slot restricts — that is the point of the roots above; a second instance that
+does not ask for the shared resource still starts.
+
+Focused regressions run with `node --test scripts/nemo/native-runtime.test.cjs`
+and reach normal discovery through `tests/nemo-native-runtime.test.cjs`. They
+use an executable stub that reproduces only the app's observable contract (the
+environment it is handed, the manifest it writes), so they cover two concurrent
+instances on disjoint roots, per-task keys, handshake refusal for a silent or
+foreign manifest, owner-only stop with root removal, explicit reservation
+refusal and release, and the missing-build blocker — without a desktop, a GPU or
+a window. The environment contract itself is asserted against
+`src-tauri/src/task_runtime.rs`, so renaming a variable on one side only fails
+the suite instead of silently returning the app to shared state. The native
+resolution rules (activation, fail-closed refusals, identifier and data-store
+derivation) are proved by `cargo test task_runtime` in `src-tauri`.
+
+
 ## Validation and remaining integration
 
 Run `node --test scripts/nemo/isolation.test.cjs`. The 20 behavioral tests cover
@@ -202,19 +288,23 @@ Still required for the full acceptance contract in
   integration. The preview launcher supplies real origins, explicit Chromium
   profiles and the served identity, while R02 `test:browser` still requires its
   separate Playwright harness. A browser preview does not build WASM or the app.
-- Configure and exercise isolated Tauri data/autosave paths. Merely creating a
-  `tauri-data` directory does not make the app use it. The platform owner must
-  implement and validate the actual runtime override; no untested Tauri launch
-  configuration is prescribed by this document.
-- Wire exclusive slots into desktop input and reference GPU benchmark consumers.
+- Run two real packaged instances at once and prove the isolated Tauri roots on
+  the live desktop: the identifier, data store and app-directory overrides above
+  are implemented and unit-proved, and the launcher's environment contract is
+  proved against an app stub, but no evidence here comes from two actual Nemo
+  windows saving and reloading a project side by side. That validation needs the
+  exclusive desktop slot and is the remaining half of this bullet.
+- `--reserve` gives desktop input and reference GPU measurements an explicit
+  exclusive reservation with a real consumer. Benchmark and input-driving
+  harnesses still have to ask for those slots from their own entry points.
 - Validate two real native builds through the standalone isolated launcher,
   inspect their source diffs and then integrate it with the standard R02/R03
   `build:desktop` job after that shared surface is available.
 - Production profile/launcher adoption remains separate from test discovery.
-  Normal `npm test`/`verify` discovery reaches the five focused suites through
+  Normal `npm test`/`verify` discovery reaches the six focused suites through
   isolated entry processes under `tests/nemo-{boundaries,boundaries-ratchet,
-  isolation,browser-runtime,build-runtime}.test.cjs`; each suite can still be
-  invoked directly while developing it.
+  isolation,browser-runtime,build-runtime,native-runtime}.test.cjs`; each suite
+  can still be invoked directly while developing it.
 
 Those remaining integrations require shared package/job/platform files. The
 preview launcher is a bounded browser increment; it does not establish Tauri,

--- a/scripts/nemo/lib/isolation.cjs
+++ b/scripts/nemo/lib/isolation.cjs
@@ -318,6 +318,11 @@ function releaseExclusiveSlot(slot, ownerToken) {
 module.exports = {
   RUNTIME_ROOT,
   PORT_RANGE,
+  // Exported so a consumer that must name this task's resources OUTSIDE these
+  // roots (the native app launcher derives its bundle identifier and WebKit
+  // data store from it) uses this exact derivation instead of writing a second
+  // one that has to stay identical by hand.
+  idKey,
   resolveTaskId,
   taskRoot,
   taskRoots,

--- a/scripts/nemo/lib/native-runtime.cjs
+++ b/scripts/nemo/lib/native-runtime.cjs
@@ -1,0 +1,415 @@
+'use strict';
+// Native (Tauri) task-instance launcher — R06, https://github.com/mysteropodes/nemo/issues/902.
+//
+// The isolation library already allocates a `tauri-data` root per task, and
+// src-tauri/src/task_runtime.rs makes the app resolve its identifier, app
+// directories and WebKit data store from it. This module is what actually puts
+// the two together: it starts a built Nemo with that task's environment, owns
+// the resulting process group, and reports the identity the running instance
+// disclosed so a second instance can be proved to share nothing with it.
+//
+// Ownership, stop semantics and the reconciliation rules are the same ones the
+// build launcher already documents; the process-group primitives are imported
+// from it rather than written a second time.
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { spawn } = require('node:child_process');
+const { finished } = require('node:stream/promises');
+const { isDeepStrictEqual } = require('node:util');
+const isolation = require('./isolation.cjs');
+const identity = require('./identity.cjs');
+const buildRuntime = require('./build-runtime.cjs');
+const { ROOT, exists, nowIso } = require('./util.cjs');
+
+const SCHEMA = 'nemo.native-launcher/1';
+const STATUS_FILE = 'native-launcher.json';
+// Written by the app itself (src-tauri/src/task_runtime.rs) into the task's
+// tauri-data root. This file, not our own bookkeeping, is what proves which
+// identifier and directories the running instance actually resolved.
+const APP_MANIFEST_FILE = 'native-runtime.json';
+const APP_MANIFEST_SCHEMA = 'nemo.native-runtime/1';
+
+function assertNativePlatform(platform = process.platform) {
+  if (platform !== 'darwin') {
+    throw new Error('native app launcher currently supports macOS only; bundle layout and process-tree ownership are not validated elsewhere');
+  }
+}
+
+// A .app bundle names its own executable; do not guess it from the product
+// name (Tauri's productName, the crate binary name and the bundle display
+// name are three different strings in this repository).
+function bundleExecutable(bundle) {
+  const plist = path.join(bundle, 'Contents', 'Info.plist');
+  if (!exists(plist)) throw new Error(`not an app bundle (no Contents/Info.plist): ${bundle}`);
+  const text = fs.readFileSync(plist, 'utf8');
+  const match = /<key>CFBundleExecutable<\/key>\s*<string>([^<]+)<\/string>/.exec(text);
+  if (!match) throw new Error(`Info.plist has no CFBundleExecutable: ${plist}`);
+  const executable = path.join(bundle, 'Contents', 'MacOS', match[1]);
+  if (!exists(executable)) throw new Error(`bundle executable missing: ${executable}`);
+  return executable;
+}
+
+function firstAppBundle(dir) {
+  if (!exists(dir)) return null;
+  const entry = fs.readdirSync(dir).filter((name) => name.endsWith('.app')).sort()[0];
+  return entry ? path.join(dir, entry) : null;
+}
+
+// Search order: an explicit path, then this task's own isolated build output
+// (where scripts/nemo/build.cjs puts it), then the worktree's default target.
+// Never another task's build directory: a stale binary from a different source
+// state is exactly what the source/build handshake exists to catch.
+function resolveApp(taskId, options = {}) {
+  const triple = options.hostTriple || identity.hostTriple();
+  const candidates = [];
+  if (options.app) candidates.push({ from: 'explicit', target: path.resolve(options.app) });
+  else {
+    // taskRoot(), not taskRoots(): merely looking for a binary must not
+    // create this task's roots, so a refused start leaves nothing behind.
+    const taskTarget = path.join(isolation.taskRoot(taskId), 'build', 'tauri-target');
+    for (const [from, base] of [['task-build', taskTarget], ['worktree-build', path.join(ROOT, 'src-tauri', 'target')]]) {
+      for (const profile of ['release', 'debug']) {
+        candidates.push({ from, target: path.join(base, triple, profile, 'bundle', 'macos') });
+      }
+    }
+  }
+  for (const candidate of candidates) {
+    let bundle = null;
+    if (candidate.from === 'explicit') {
+      if (!exists(candidate.target)) continue;
+      bundle = candidate.target.endsWith('.app') ? candidate.target : null;
+      if (!bundle) {
+        fs.accessSync(candidate.target, fs.constants.X_OK);
+        return { from: candidate.from, bundle: null, executable: candidate.target };
+      }
+    } else {
+      bundle = firstAppBundle(candidate.target);
+    }
+    if (!bundle) continue;
+    return { from: candidate.from, bundle, executable: bundleExecutable(bundle) };
+  }
+  const tried = candidates.map((c) => c.target).join(', ');
+  const error = new Error(`no built Nemo app found; run npm run build:desktop (or scripts/nemo/build.cjs) first. Looked in: ${tried}`);
+  error.code = 'ENOAPP';
+  throw error;
+}
+
+// Everything the isolated instance needs, and nothing that would let it fall
+// back to the shared production state. NEMO_TAURI_DATA_DIR is the activation
+// switch the native side keys on; the other three are refused unless valid.
+function nativeLaunchConfig(taskId, options = {}) {
+  if (!options.executable) assertNativePlatform();
+  const app = options.executable
+    ? { from: 'explicit', bundle: null, executable: path.resolve(options.executable) }
+    : resolveApp(taskId, options);
+  if (!exists(app.executable)) throw new Error(`app executable not found: ${app.executable}`);
+  fs.accessSync(app.executable, fs.constants.X_OK);
+  const roots = isolation.taskRoots(taskId);
+  const ownerToken = options.ownerToken || crypto.randomBytes(16).toString('hex');
+  return {
+    app,
+    ownerToken,
+    args: Array.isArray(options.args) ? options.args.slice() : [],
+    cwd: ROOT,
+    roots,
+    reserve: Array.isArray(options.reserve) ? options.reserve.slice() : [],
+    manifestFile: path.join(roots.tauriDataDir, APP_MANIFEST_FILE),
+    manifestTimeoutMs: Number.isFinite(options.manifestTimeoutMs) ? options.manifestTimeoutMs : 15_000,
+    stdoutLog: path.join(roots.reports, 'native-app.stdout.log'),
+    stderrLog: path.join(roots.reports, 'native-app.stderr.log'),
+    statusFile: path.join(roots.reports, STATUS_FILE),
+    env: {
+      ...process.env,
+      NEMO_TASK_ID: taskId,
+      NEMO_TASK_KEY: isolation.idKey(taskId),
+      NEMO_TAURI_DATA_DIR: roots.tauriDataDir,
+      NEMO_TASK_OWNER_TOKEN: ownerToken,
+      NEMO_REPORT_DIR: roots.reports,
+      XDG_CACHE_HOME: roots.cache,
+      TMPDIR: roots.temp,
+      TMP: roots.temp,
+      TEMP: roots.temp,
+    },
+  };
+}
+
+function publicSource(source) {
+  if (!source) return source;
+  const { originUrl: _originUrl, ...safe } = source;
+  return safe;
+}
+
+function publicRoots(roots) {
+  return {
+    root: roots.root,
+    temp: roots.temp,
+    cache: roots.cache,
+    reports: roots.reports,
+    tauriDataDir: roots.tauriDataDir,
+  };
+}
+
+function atomicWriteJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const temp = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(temp, JSON.stringify(value, null, 2) + '\n', { mode: 0o600 });
+  fs.renameSync(temp, file);
+}
+
+function readNativeStatus(taskId) {
+  const file = path.join(isolation.taskRoots(taskId).reports, STATUS_FILE);
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return null; }
+}
+
+// Read what the app disclosed about itself. A file that exists but is not this
+// schema, or names another task, is reported as such rather than accepted:
+// leftovers from an earlier run must not be read as this instance's identity.
+function readAppManifest(taskId) {
+  const file = path.join(isolation.taskRoots(taskId).tauriDataDir, APP_MANIFEST_FILE);
+  let manifest;
+  try { manifest = JSON.parse(fs.readFileSync(file, 'utf8')); }
+  catch { return null; }
+  if (!manifest || manifest.schema !== APP_MANIFEST_SCHEMA) {
+    return { valid: false, reason: 'app manifest is not a nemo.native-runtime/1 document', file };
+  }
+  if (manifest.taskId !== taskId) {
+    return { valid: false, reason: `app manifest belongs to task ${manifest.taskId}`, file, manifest };
+  }
+  return { valid: true, file, manifest };
+}
+
+async function waitForAppManifest(taskId, timeoutMs, alive) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const read = readAppManifest(taskId);
+    if (read && read.valid) return read;
+    if (Date.now() >= deadline || (alive && !alive())) {
+      return read || { valid: false, reason: 'app did not write its runtime manifest', file: path.join(isolation.taskRoots(taskId).tauriDataDir, APP_MANIFEST_FILE) };
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+function spawnApp(config) {
+  fs.mkdirSync(config.roots.reports, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(config.roots.tauriDataDir, { recursive: true, mode: 0o700 });
+  const stdout = fs.createWriteStream(config.stdoutLog, { flags: 'a', mode: 0o600 });
+  const stderr = fs.createWriteStream(config.stderrLog, { flags: 'a', mode: 0o600 });
+  const child = spawn(config.app.executable, config.args, {
+    cwd: config.cwd,
+    env: config.env,
+    detached: process.platform !== 'win32',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+  child.stdout.pipe(stdout);
+  child.stderr.pipe(stderr);
+  const closed = new Promise((resolve) => child.once('close', (code, signal) => resolve({ code, signal })));
+  const logsDone = Promise.all([finished(stdout), finished(stderr)]);
+  const drained = Promise.all([closed, logsDone]);
+  drained.catch(() => {});
+  return { child, closed, logsDone, drained };
+}
+
+// Source and build identity of the checkout, plus what the app itself
+// disclosed. `ok` requires all three: owner, unchanged source/build, and a
+// live app manifest that names this task.
+function nativeHandshake(taskId, ownerToken) {
+  const local = isolation.verifyHandshake(taskId, { ownerToken, checkSource: true });
+  const launcher = isolation.readLauncher(taskId);
+  const status = readNativeStatus(taskId);
+  const app = readAppManifest(taskId);
+  let currentBuild = null;
+  try { currentBuild = identity.buildIdentity(); } catch { /* fail closed below */ }
+  const buildMatches = !!status && isDeepStrictEqual(status.build.startup, currentBuild);
+  const appOk = !!(app && app.valid && app.manifest.isolated && app.manifest.state === 'active');
+  let reason = 'task owner, source and build identities match, and the app disclosed this task\'s isolated runtime';
+  if (!local.ok) reason = local.reason;
+  else if (!currentBuild) reason = 'build identity unavailable';
+  else if (!buildMatches) reason = 'build identity changed';
+  else if (!app) reason = 'app has not written its runtime manifest';
+  else if (!app.valid) reason = app.reason;
+  else if (!app.manifest.isolated) reason = 'app is running on the shared application state, not this task\'s roots';
+  else if (app.manifest.state !== 'active') reason = `app runtime state is ${app.manifest.state}`;
+  return {
+    ok: local.ok && buildMatches && appOk,
+    reason,
+    taskId,
+    pid: launcher ? launcher.pid : null,
+    source: launcher ? { startup: publicSource(launcher.source), matches: local.ok } : null,
+    build: status ? { startup: status.build.startup, current: currentBuild, matches: buildMatches } : null,
+    app: app && app.valid ? app.manifest : app,
+    runtime: status,
+  };
+}
+
+async function runNativeLauncher(taskId, options = {}, emit = () => {}) {
+  const config = nativeLaunchConfig(taskId, options);
+  let startupBuild;
+  try { startupBuild = identity.buildIdentity(); }
+  catch (err) {
+    isolation.releaseTask(taskId);
+    throw new Error(`build identity unavailable: ${err.message}`);
+  }
+  // Shared exclusive resources are reserved BEFORE the app starts and only when
+  // asked for. Two isolated instances are meant to run at the same time; it is
+  // driving the one keyboard/mouse, or measuring the one GPU, that has to be
+  // serialized (R06 acceptance: "explicit exclusive reservations").
+  const reservations = [];
+  for (const slot of config.reserve) {
+    const acquired = isolation.acquireExclusiveSlot(slot, taskId, { pid: process.pid });
+    if (!acquired.acquired) {
+      for (const held of reservations) held.release();
+      isolation.releaseTask(taskId);
+      throw new Error(`exclusive resource "${slot}" unavailable: ${acquired.reason}`);
+    }
+    reservations.push(acquired);
+  }
+  let launcher;
+  try {
+    launcher = isolation.registerLauncher(taskId, {
+      pid: process.pid,
+      ownerToken: config.ownerToken,
+      label: 'native-app',
+    });
+  } catch (err) {
+    for (const held of reservations) held.release();
+    throw err;
+  }
+
+  let status = {
+    schema: SCHEMA,
+    taskId,
+    launcherPid: process.pid,
+    childPid: null,
+    state: 'starting',
+    startedAt: nowIso(),
+    finishedAt: null,
+    exitCode: null,
+    signal: null,
+    app: { from: config.app.from, bundle: config.app.bundle, executable: config.app.executable },
+    reservations: config.reserve,
+    roots: publicRoots(config.roots),
+    manifestFile: config.manifestFile,
+    logs: { stdout: config.stdoutLog, stderr: config.stderrLog },
+    source: publicSource(launcher.source),
+    build: { startup: startupBuild },
+  };
+  const save = (change) => {
+    status = { ...status, ...change };
+    atomicWriteJson(config.statusFile, status);
+  };
+  save({});
+  emit({
+    started: true,
+    taskId,
+    pid: process.pid,
+    ownerToken: launcher.ownerToken,
+    app: status.app,
+    reservations: config.reserve,
+    roots: publicRoots(config.roots),
+    manifestFile: config.manifestFile,
+    statusFile: config.statusFile,
+    source: publicSource(launcher.source),
+    build: startupBuild,
+  });
+
+  let processInfo = null;
+  let released = false;
+  const releaseReservations = () => {
+    if (released) return [];
+    released = true;
+    return reservations.map((held) => ({ slot: held.slot, ...held.release() }));
+  };
+  let closing = false;
+  const shutdown = async (signal) => {
+    if (closing) return;
+    closing = true;
+    let tree;
+    try { tree = await buildRuntime.stopBuild(processInfo && processInfo.child); }
+    catch (err) { tree = { stopped: false, forced: false, reason: err.message }; }
+    if (!tree.stopped) {
+      save({ state: 'reconciliation-required', finishedAt: nowIso(), signal: signal || 'SIGTERM', processTree: tree });
+      closing = false;
+      return;
+    }
+    if (processInfo) {
+      await processInfo.closed.catch(() => {});
+      await processInfo.logsDone.catch(() => {});
+    }
+    save({ state: 'stopped', finishedAt: nowIso(), signal: signal || 'SIGTERM', processTree: tree, slotRelease: releaseReservations() });
+    process.exit(0);
+  };
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  // Keep the owning process alive for as long as the instance is addressable,
+  // exactly as the build launcher does.
+  setInterval(() => {}, 60_000);
+
+  try {
+    processInfo = spawnApp(config);
+    await new Promise((resolve, reject) => {
+      const failed = (err) => { processInfo.child.off('spawn', ready); reject(err); };
+      const ready = () => { processInfo.child.off('error', failed); resolve(); };
+      processInfo.child.once('error', failed);
+      processInfo.child.once('spawn', ready);
+    });
+    save({ state: 'active', childPid: processInfo.child.pid });
+    const manifest = await waitForAppManifest(
+      taskId,
+      config.manifestTimeoutMs,
+      () => buildRuntime.buildProcessTreeAlive(processInfo.child),
+    );
+    save(manifest.valid
+      ? { appRuntime: manifest.manifest }
+      : { appRuntime: null, appRuntimeError: manifest.reason });
+    emit({ appRuntime: manifest.valid ? manifest.manifest : null, appRuntimeError: manifest.valid ? null : manifest.reason });
+
+    const result = await processInfo.closed;
+    if (closing) return;
+    let tree;
+    try { tree = await buildRuntime.stopBuild(processInfo.child); }
+    catch (err) { tree = { stopped: false, forced: false, reason: err.message }; }
+    if (!tree.stopped) {
+      save({ state: 'reconciliation-required', finishedAt: nowIso(), exitCode: result.code, signal: result.signal, processTree: tree });
+      return;
+    }
+    await processInfo.logsDone.catch(() => {});
+    save({
+      state: result.code === 0 ? 'exited' : 'failed',
+      finishedAt: nowIso(),
+      exitCode: result.code,
+      signal: result.signal,
+      processTree: tree,
+      slotRelease: releaseReservations(),
+    });
+  } catch (err) {
+    let tree = { stopped: true, forced: false, reason: 'app process was not spawned' };
+    if (processInfo) {
+      try { tree = await buildRuntime.stopBuild(processInfo.child); }
+      catch (stopErr) { tree = { stopped: false, forced: false, reason: stopErr.message }; }
+    }
+    if (!tree.stopped) {
+      save({ state: 'reconciliation-required', finishedAt: nowIso(), error: err.message, processTree: tree });
+      return;
+    }
+    if (processInfo) await processInfo.logsDone.catch(() => {});
+    save({ state: 'failed', finishedAt: nowIso(), error: err.message, processTree: tree, slotRelease: releaseReservations() });
+  }
+}
+
+module.exports = {
+  SCHEMA,
+  STATUS_FILE,
+  APP_MANIFEST_FILE,
+  APP_MANIFEST_SCHEMA,
+  assertNativePlatform,
+  bundleExecutable,
+  resolveApp,
+  nativeLaunchConfig,
+  readNativeStatus,
+  readAppManifest,
+  nativeHandshake,
+  runNativeLauncher,
+};

--- a/scripts/nemo/lib/native-runtime.cjs
+++ b/scripts/nemo/lib/native-runtime.cjs
@@ -12,6 +12,7 @@
 // build launcher already documents; the process-group primitives are imported
 // from it rather than written a second time.
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
 const crypto = require('node:crypto');
 const { spawn } = require('node:child_process');
@@ -48,6 +49,17 @@ function bundleExecutable(bundle) {
   const executable = path.join(bundle, 'Contents', 'MacOS', match[1]);
   if (!exists(executable)) throw new Error(`bundle executable missing: ${executable}`);
   return executable;
+}
+
+// The WebKit store lives under the BUNDLE identifier from Info.plist, not the
+// per-task runtime identifier: macOS keys the container by bundle and the store
+// by its UUID inside it. Observed on macOS 26.6 as
+// ~/Library/WebKit/<bundle id>/WebsiteDataStore/<uuid>.
+function bundleIdentifier(bundle) {
+  const plist = path.join(bundle, 'Contents', 'Info.plist');
+  if (!exists(plist)) return null;
+  const match = /<key>CFBundleIdentifier<\/key>\s*<string>([^<]+)<\/string>/.exec(fs.readFileSync(plist, 'utf8'));
+  return match ? match[1] : null;
 }
 
 function firstAppBundle(dir) {
@@ -212,6 +224,70 @@ function spawnApp(config) {
   return { child, closed, logsDone, drained };
 }
 
+// ---- releasing the state that lives OUTSIDE the task root ------------------
+// The isolated app directories are `<platform dir>/<identifier>`, so they are
+// NOT under the task root and `isolation.releaseTask` never sees them. Found by
+// running it: two stopped instances left their Application Support, Caches and
+// Logs directories behind for good.
+//
+// Cleanup is bound to THIS task's own derivation, never to whatever a manifest
+// claims: only a directory whose last component carries this task's identifier
+// suffix is eligible. A corrupted or hostile manifest naming the production
+// `com.strokemotion.app` directory is refused by name instead of deleted.
+function taskIdentifierSuffix(taskId) {
+  return `.nemo-task-${isolation.idKey(taskId).slice(0, 16)}`;
+}
+
+// 32 hex characters as WebKit writes them: 8-4-4-4-12.
+function dataStoreUuid(taskId) {
+  const key = isolation.idKey(taskId).slice(0, 32);
+  return [key.slice(0, 8), key.slice(8, 12), key.slice(12, 16), key.slice(16, 20), key.slice(20, 32)].join('-');
+}
+
+function webkitStoreDir(bundle, taskId) {
+  const identifier = bundle ? bundleIdentifier(bundle) : null;
+  if (!identifier) return null;
+  return path.join(os.homedir(), 'Library', 'WebKit', identifier, 'WebsiteDataStore', dataStoreUuid(taskId));
+}
+
+function nativeStateTargets(taskId, manifest, bundle) {
+  const suffix = taskIdentifierSuffix(taskId);
+  const uuid = dataStoreUuid(taskId);
+  const dirs = manifest && manifest.dirs && typeof manifest.dirs === 'object' ? manifest.dirs : {};
+  const seen = new Set();
+  const targets = [];
+  const refused = [];
+  for (const [name, value] of Object.entries(dirs)) {
+    if (typeof value !== 'string' || !path.isAbsolute(value)) {
+      refused.push({ name, value, reason: 'not an absolute path' });
+      continue;
+    }
+    const dir = path.resolve(value);
+    if (!path.basename(dir).endsWith(suffix)) {
+      refused.push({ name, value: dir, reason: `does not carry this task's identifier suffix ${suffix}` });
+      continue;
+    }
+    if (seen.has(dir)) continue;
+    seen.add(dir);
+    targets.push({ name, dir });
+  }
+  const store = webkitStoreDir(bundle, taskId);
+  // Exact name match, so this can only ever address this task's own store.
+  if (store && path.basename(store) === uuid && !seen.has(store)) targets.push({ name: 'webkitStore', dir: store });
+  return { targets, refused };
+}
+
+function releaseNativeState(taskId, manifest, bundle) {
+  const { targets, refused } = nativeStateTargets(taskId, manifest, bundle);
+  const removed = [];
+  for (const target of targets) {
+    if (!exists(target.dir)) { removed.push({ ...target, removed: false, reason: 'already absent' }); continue; }
+    try { fs.rmSync(target.dir, { recursive: true, force: true }); removed.push({ ...target, removed: true }); }
+    catch (err) { removed.push({ ...target, removed: false, reason: err.message }); }
+  }
+  return { removed, refused };
+}
+
 // Source and build identity of the checkout, plus what the app itself
 // disclosed. `ok` requires all three: owner, unchanged source/build, and a
 // live app manifest that names this task.
@@ -247,11 +323,13 @@ function nativeHandshake(taskId, ownerToken) {
 async function runNativeLauncher(taskId, options = {}, emit = () => {}) {
   const config = nativeLaunchConfig(taskId, options);
   let startupBuild;
+  // A start that fails must NOT call isolation.releaseTask: task ids are reused
+  // across restarts (that is what makes an instance's state survive a stop), and
+  // releasing here deleted the roots of a previous, legitimately stopped
+  // instance that this launch never owned. Found by running it — a refused
+  // reservation wiped the earlier run's records.
   try { startupBuild = identity.buildIdentity(); }
-  catch (err) {
-    isolation.releaseTask(taskId);
-    throw new Error(`build identity unavailable: ${err.message}`);
-  }
+  catch (err) { throw new Error(`build identity unavailable: ${err.message}`); }
   // Shared exclusive resources are reserved BEFORE the app starts and only when
   // asked for. Two isolated instances are meant to run at the same time; it is
   // driving the one keyboard/mouse, or measuring the one GPU, that has to be
@@ -261,7 +339,6 @@ async function runNativeLauncher(taskId, options = {}, emit = () => {}) {
     const acquired = isolation.acquireExclusiveSlot(slot, taskId, { pid: process.pid });
     if (!acquired.acquired) {
       for (const held of reservations) held.release();
-      isolation.releaseTask(taskId);
       throw new Error(`exclusive resource "${slot}" unavailable: ${acquired.reason}`);
     }
     reservations.push(acquired);
@@ -406,6 +483,11 @@ module.exports = {
   APP_MANIFEST_SCHEMA,
   assertNativePlatform,
   bundleExecutable,
+  bundleIdentifier,
+  taskIdentifierSuffix,
+  dataStoreUuid,
+  nativeStateTargets,
+  releaseNativeState,
   resolveApp,
   nativeLaunchConfig,
   readNativeStatus,

--- a/scripts/nemo/native-runtime.test.cjs
+++ b/scripts/nemo/native-runtime.test.cjs
@@ -23,7 +23,7 @@ const appStub = path.join(scratch, 'app-stub');
 fs.writeFileSync(appStub, '#!/usr/bin/env node\n' + String.raw`
 const fs = require('node:fs');
 const path = require('node:path');
-const [capture, mode = 'manifest'] = process.argv.slice(2);
+const [capture, mode = 'manifest', appDirBase = ''] = process.argv.slice(2);
 const seen = {
   pid: process.pid,
   taskId: process.env.NEMO_TASK_ID,
@@ -37,8 +37,21 @@ const seen = {
 fs.writeFileSync(capture, JSON.stringify(seen));
 if (mode !== 'no-manifest') {
   const key = String(seen.taskKey || '');
+  let dirs = {};
+  if (appDirBase) {
+    const suffix = '.nemo-task-' + key.slice(0, 16);
+    const mine = path.join(appDirBase, 'AppSupport', 'com.strokemotion.app' + suffix);
+    const production = path.join(appDirBase, 'AppSupport', 'com.strokemotion.app');
+    const other = path.join(appDirBase, 'AppSupport', 'com.strokemotion.app.nemo-task-0123456789abcdef');
+    for (const d of [mine, production, other]) {
+      fs.mkdirSync(d, { recursive: true });
+      fs.writeFileSync(path.join(d, 'history.json'), '{}');
+    }
+    dirs = { appData: mine, appLocalData: mine, appLog: production, appCache: other, appConfig: 'relative/path' };
+  }
   const manifest = {
     schema: 'nemo.native-runtime/1',
+    dirs,
     isolated: true,
     state: 'active',
     taskId: mode === 'foreign-manifest' ? 'another-task' : seen.taskId,
@@ -73,10 +86,10 @@ function firstLine(child) {
   });
 }
 
-async function launch(task, capture, { mode = 'manifest', reserve = null } = {}) {
+async function launch(task, capture, { mode = 'manifest', reserve = null, appDirBase = '' } = {}) {
   const args = [cli, 'start', '--task', task, '--executable', appStub];
   if (reserve) args.push('--reserve', reserve);
-  args.push('--manifest-timeout-ms', '5000', '--', capture, mode);
+  args.push('--manifest-timeout-ms', '5000', '--', capture, mode, appDirBase);
   const child = spawn(process.execPath, args, {
     cwd: repoRoot,
     env: { ...process.env },
@@ -255,4 +268,75 @@ test('a missing build is a named blocker, and a bundle names its own executable'
   fs.writeFileSync(path.join(bundle, 'Contents', 'MacOS', 'ffmpeg'), '#!/bin/sh\n', { mode: 0o700 });
   assert.equal(runtime.bundleExecutable(bundle), path.join(bundle, 'Contents', 'MacOS', 'renamed-binary'));
   assert.throws(() => runtime.bundleExecutable(path.join(scratch, 'Nope.app')), /no Contents\/Info\.plist/);
+});
+
+test('stopping removes the isolated app directories and refuses everything else', async () => {
+  // The isolated app directories are `<platform dir>/<identifier>`, so they sit
+  // OUTSIDE the task root and isolation.releaseTask never sees them. Found by
+  // running two real instances: both left their Application Support, Caches and
+  // Logs directories behind after a clean stop.
+  const base = fs.mkdtempSync(path.join(scratch, 'appdirs-'));
+  const task = `native-appstate-${process.pid}`;
+  const instance = await launch(task, path.join(scratch, 'capture-appstate.json'), { appDirBase: base });
+  const suffix = runtime.taskIdentifierSuffix(task);
+  const mine = path.join(base, 'AppSupport', `com.strokemotion.app${suffix}`);
+  const production = path.join(base, 'AppSupport', 'com.strokemotion.app');
+  const other = path.join(base, 'AppSupport', 'com.strokemotion.app.nemo-task-0123456789abcdef');
+  await waitFor(() => fs.existsSync(mine), 'app directories');
+
+  const stopped = await command(['stop', '--task', task, '--owner', instance.info.ownerToken]);
+  assert.equal(stopped.code, 0, stopped.stderr || stopped.stdout);
+  await exited(instance.child);
+  const result = JSON.parse(stopped.stdout.trim().split('\n').pop());
+
+  assert.equal(fs.existsSync(mine), false, 'this task\'s own directory is removed');
+  assert.equal(fs.existsSync(production), true, 'the shared production directory is never touched');
+  assert.equal(fs.existsSync(other), true, "another task's directory is never touched");
+  const refusedNames = result.appState.refused.map((entry) => entry.name).sort();
+  assert.deepEqual(refusedNames, ['appCache', 'appConfig', 'appLog']);
+  assert.ok(result.appState.removed.some((entry) => entry.dir === mine && entry.removed === true));
+});
+
+test('cleanup eligibility is bound to the task derivation, not to what a manifest claims', () => {
+  const task = `native-targets-${process.pid}`;
+  const suffix = runtime.taskIdentifierSuffix(task);
+  const { targets, refused } = runtime.nativeStateTargets(task, {
+    dirs: {
+      appData: `/tmp/Application Support/com.strokemotion.app${suffix}`,
+      appLocalData: `/tmp/Application Support/com.strokemotion.app${suffix}`,
+      appLog: '/tmp/Application Support/com.strokemotion.app',
+      appCache: '/tmp/Application Support/com.strokemotion.app.nemo-task-0123456789abcdef',
+      appConfig: 'not/absolute',
+      appTray: 42,
+    },
+  }, null);
+  assert.deepEqual(targets.map((t) => t.name), ['appData']);
+  assert.deepEqual(refused.map((r) => r.name).sort(), ['appCache', 'appConfig', 'appLog', 'appTray']);
+  assert.match(runtime.dataStoreUuid(task), /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+});
+
+test('a refused start leaves an existing task instance state intact', async () => {
+  // Task ids are reused across restarts — that is what makes an instance's
+  // state survive a stop. A start that never took ownership must not release
+  // the roots of the run before it; releasing here destroyed a stopped
+  // instance's records during the live paired run.
+  const slot = `desktop-input-retain-${process.pid}`;
+  const task = `native-retain-${process.pid}`;
+  const roots = isolation.taskRoots(task);
+  const keepsake = path.join(roots.tauriDataDir, 'retained.json');
+  fs.writeFileSync(keepsake, '{"kept":true}');
+  const holder = isolation.acquireExclusiveSlot(slot, `native-retain-holder-${process.pid}`);
+  assert.equal(holder.acquired, true, holder.reason);
+  try {
+    const refused = await command([
+      'start', '--task', task, '--executable', appStub, '--reserve', slot,
+      '--', path.join(scratch, 'capture-retain.json'), 'manifest', '',
+    ]);
+    assert.equal(refused.code, 1);
+    assert.match(refused.stderr, /exclusive resource/);
+    assert.equal(fs.existsSync(keepsake), true, 'the earlier instance state survives a refused start');
+  } finally {
+    isolation.releaseExclusiveSlot(slot, holder.ownerToken);
+    fs.rmSync(roots.root, { recursive: true, force: true });
+  }
 });

--- a/scripts/nemo/native-runtime.test.cjs
+++ b/scripts/nemo/native-runtime.test.cjs
@@ -247,5 +247,12 @@ test('a missing build is a named blocker, and a bundle names its own executable'
   assert.throws(() => runtime.bundleExecutable(bundle), /bundle executable missing/);
   fs.writeFileSync(path.join(bundle, 'Contents', 'MacOS', 'renamed-binary'), '#!/bin/sh\n', { mode: 0o700 });
   assert.equal(runtime.bundleExecutable(bundle), path.join(bundle, 'Contents', 'MacOS', 'renamed-binary'));
+  // The real R04 package ships the ffmpeg sidecar next to the app binary, and
+  // readdir returns it FIRST there (observed: ['ffmpeg', 'nemo'] — and 'ffmpeg'
+  // also sorts before 'nemo', so sorting the scan would not save it either).
+  // Picking any executable found in Contents/MacOS therefore launches ffmpeg,
+  // not the app; only the declared CFBundleExecutable is right.
+  fs.writeFileSync(path.join(bundle, 'Contents', 'MacOS', 'ffmpeg'), '#!/bin/sh\n', { mode: 0o700 });
+  assert.equal(runtime.bundleExecutable(bundle), path.join(bundle, 'Contents', 'MacOS', 'renamed-binary'));
   assert.throws(() => runtime.bundleExecutable(path.join(scratch, 'Nope.app')), /no Contents\/Info\.plist/);
 });

--- a/scripts/nemo/native-runtime.test.cjs
+++ b/scripts/nemo/native-runtime.test.cjs
@@ -1,0 +1,251 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { after, test } = require('node:test');
+
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-native-runtime-test-'));
+process.env.NEMO_ISOLATION_ROOT = path.join(scratch, 'runtime');
+const isolation = require('./lib/isolation.cjs');
+const runtime = require('./lib/native-runtime.cjs');
+const cli = path.join(__dirname, 'native.cjs');
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+// Stands in for a built Nemo. It reproduces only the app's OBSERVABLE contract
+// — the environment it is handed and the manifest it writes into that task's
+// tauri-data root — so these tests exercise the launcher without a desktop,
+// a GPU or a window. The identifier/data-store derivation itself is proved on
+// the native side (src-tauri/src/task_runtime.rs unit tests).
+const appStub = path.join(scratch, 'app-stub');
+fs.writeFileSync(appStub, '#!/usr/bin/env node\n' + String.raw`
+const fs = require('node:fs');
+const path = require('node:path');
+const [capture, mode = 'manifest'] = process.argv.slice(2);
+const seen = {
+  pid: process.pid,
+  taskId: process.env.NEMO_TASK_ID,
+  taskKey: process.env.NEMO_TASK_KEY,
+  dataDir: process.env.NEMO_TAURI_DATA_DIR,
+  ownerTokenPresent: !!process.env.NEMO_TASK_OWNER_TOKEN,
+  reports: process.env.NEMO_REPORT_DIR,
+  temp: process.env.TMPDIR,
+  cache: process.env.XDG_CACHE_HOME,
+};
+fs.writeFileSync(capture, JSON.stringify(seen));
+if (mode !== 'no-manifest') {
+  const key = String(seen.taskKey || '');
+  const manifest = {
+    schema: 'nemo.native-runtime/1',
+    isolated: true,
+    state: 'active',
+    taskId: mode === 'foreign-manifest' ? 'another-task' : seen.taskId,
+    taskKey: key,
+    identifier: 'com.strokemotion.app.nemo-task-' + key.slice(0, 16),
+    dataStoreIdentifier: key.slice(0, 32),
+    dataDir: seen.dataDir,
+    pid: process.pid,
+  };
+  fs.mkdirSync(seen.dataDir, { recursive: true });
+  fs.writeFileSync(path.join(seen.dataDir, 'native-runtime.json'), JSON.stringify(manifest, null, 2));
+  console.log(JSON.stringify(manifest));
+}
+process.on('SIGTERM', () => process.exit(0));
+setInterval(() => {}, 1000);
+`, { mode: 0o700 });
+
+after(() => fs.rmSync(scratch, { recursive: true, force: true }));
+
+function exited(child) {
+  if (child.exitCode != null || child.signalCode != null) return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  return new Promise((resolve) => child.once('exit', (code, signal) => resolve({ code, signal })));
+}
+
+function firstLine(child) {
+  return new Promise((resolve, reject) => {
+    let data = ''; const timer = setTimeout(() => done(new Error('launcher readiness timed out')), 10_000);
+    function done(error, value) { clearTimeout(timer); child.stdout.off('data', read); child.off('exit', early); error ? reject(error) : resolve(value); }
+    function read(chunk) { data += chunk; const newline = data.indexOf('\n'); if (newline !== -1) done(null, data.slice(0, newline)); }
+    function early(code) { done(new Error(`launcher exited before readiness (${code}): ${data}`)); }
+    child.stdout.on('data', read); child.once('exit', early);
+  });
+}
+
+async function launch(task, capture, { mode = 'manifest', reserve = null } = {}) {
+  const args = [cli, 'start', '--task', task, '--executable', appStub];
+  if (reserve) args.push('--reserve', reserve);
+  args.push('--manifest-timeout-ms', '5000', '--', capture, mode);
+  const child = spawn(process.execPath, args, {
+    cwd: repoRoot,
+    env: { ...process.env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return { child, info: JSON.parse(await firstLine(child)) };
+}
+
+function command(args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [cli, ...args], { cwd: repoRoot, env: { ...process.env }, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = ''; let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.once('exit', (code, signal) => resolve({ code, signal, stdout, stderr }));
+  });
+}
+
+async function waitFor(check, what, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  let value = null;
+  while (Date.now() < deadline) {
+    value = check();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`timed out waiting for ${what}`);
+}
+
+async function stopOwned(instance) {
+  if (!instance || !isolation.pidAlive(instance.child.pid)) return;
+  await command(['stop', '--task', instance.info.taskId, '--owner', instance.info.ownerToken]);
+  await exited(instance.child);
+}
+
+test('the launcher and the native module name the same environment contract', () => {
+  // The activation switch and its three companions are read in Rust and
+  // written here. A rename on one side only would silently return the app to
+  // the shared production identifier, which is the failure R06 exists to stop.
+  const native = fs.readFileSync(path.join(repoRoot, 'src-tauri', 'src', 'task_runtime.rs'), 'utf8');
+  const config = runtime.nativeLaunchConfig('env-contract', { executable: appStub });
+  for (const name of ['NEMO_TAURI_DATA_DIR', 'NEMO_TASK_ID', 'NEMO_TASK_KEY', 'NEMO_TASK_OWNER_TOKEN']) {
+    assert.match(native, new RegExp(`"${name}"`), `${name} must be read by src-tauri/src/task_runtime.rs`);
+    assert.ok(config.env[name], `${name} must be exported to the app`);
+  }
+  assert.match(native, new RegExp(`"${runtime.APP_MANIFEST_SCHEMA}"`));
+  assert.match(native, new RegExp(`"${runtime.APP_MANIFEST_FILE}"`));
+  assert.equal(config.env.NEMO_TASK_KEY, isolation.idKey('env-contract'));
+  assert.equal(config.env.NEMO_TAURI_DATA_DIR, config.roots.tauriDataDir);
+  assert.equal(config.env.NEMO_TASK_OWNER_TOKEN, config.ownerToken);
+  assert.throws(() => runtime.assertNativePlatform('win32'), /supports macOS only/);
+});
+
+test('two instances run concurrently on disjoint native state', async () => {
+  const captureA = path.join(scratch, 'capture-a.json');
+  const captureB = path.join(scratch, 'capture-b.json');
+  let a; let b;
+  try {
+    a = await launch(`native-a-${process.pid}`, captureA);
+    b = await launch(`native-b-${process.pid}`, captureB);
+    const seenA = JSON.parse(await waitFor(() => fs.existsSync(captureA) && fs.readFileSync(captureA, 'utf8'), 'instance A environment'));
+    const seenB = JSON.parse(await waitFor(() => fs.existsSync(captureB) && fs.readFileSync(captureB, 'utf8'), 'instance B environment'));
+
+    assert.ok(isolation.pidAlive(a.child.pid) && isolation.pidAlive(b.child.pid), 'both launchers stay live');
+    for (const field of ['taskId', 'taskKey', 'dataDir', 'reports', 'temp', 'cache']) {
+      assert.notEqual(seenA[field], seenB[field], `${field} must differ between instances`);
+    }
+    assert.equal(seenA.taskKey, isolation.idKey(seenA.taskId));
+    assert.equal(seenB.taskKey, isolation.idKey(seenB.taskId));
+    assert.ok(seenA.ownerTokenPresent && seenB.ownerTokenPresent);
+    // Distinct keys are what the identifier and WebKit data store are derived
+    // from on the native side, so distinct keys are the isolation claim here.
+    assert.notEqual(seenA.taskKey.slice(0, 16), seenB.taskKey.slice(0, 16));
+
+    const handshakeA = runtime.nativeHandshake(a.info.taskId, a.info.ownerToken);
+    assert.equal(handshakeA.ok, true, handshakeA.reason);
+    assert.equal(handshakeA.app.taskId, a.info.taskId);
+    assert.notEqual(handshakeA.app.identifier, runtime.nativeHandshake(b.info.taskId, b.info.ownerToken).app.identifier);
+  } finally {
+    await stopOwned(a);
+    await stopOwned(b);
+  }
+});
+
+test('an instance is only accepted when the app itself disclosed this task', async () => {
+  const silent = path.join(scratch, 'capture-silent.json');
+  const foreign = path.join(scratch, 'capture-foreign.json');
+  let a; let b;
+  try {
+    a = await launch(`native-silent-${process.pid}`, silent, { mode: 'no-manifest' });
+    const quiet = runtime.nativeHandshake(a.info.taskId, a.info.ownerToken);
+    assert.equal(quiet.ok, false);
+    assert.match(quiet.reason, /runtime manifest/);
+
+    b = await launch(`native-foreign-${process.pid}`, foreign, { mode: 'foreign-manifest' });
+    const mismatched = runtime.nativeHandshake(b.info.taskId, b.info.ownerToken);
+    assert.equal(mismatched.ok, false);
+    assert.match(mismatched.reason, /belongs to task another-task/);
+
+    const wrongOwner = runtime.nativeHandshake(b.info.taskId, 'not-the-owner');
+    assert.equal(wrongOwner.ok, false);
+    assert.match(wrongOwner.reason, /owner token mismatch/);
+  } finally {
+    await stopOwned(a);
+    await stopOwned(b);
+  }
+});
+
+test('only the owner stops an instance, and stopping removes its native state', async () => {
+  const capture = path.join(scratch, 'capture-stop.json');
+  const instance = await launch(`native-stop-${process.pid}`, capture);
+  try {
+    const dataDir = isolation.taskRoots(instance.info.taskId).tauriDataDir;
+    await waitFor(() => fs.existsSync(path.join(dataDir, runtime.APP_MANIFEST_FILE)), 'app manifest');
+
+    const refused = await command(['stop', '--task', instance.info.taskId, '--owner', 'not-the-owner']);
+    assert.equal(refused.code, 1);
+    assert.match(refused.stdout, /not the task owner/);
+    assert.ok(isolation.pidAlive(instance.child.pid), 'a refused stop leaves the instance running');
+
+    const stopped = await command(['stop', '--task', instance.info.taskId, '--owner', instance.info.ownerToken]);
+    assert.equal(stopped.code, 0, stopped.stderr || stopped.stdout);
+    await exited(instance.child);
+    assert.equal(fs.existsSync(dataDir), false, 'the task tauri-data root is removed on release');
+  } finally {
+    await stopOwned(instance);
+  }
+});
+
+test('a shared desktop resource is reserved explicitly and refused to a second holder', async () => {
+  const capture = path.join(scratch, 'capture-reserve.json');
+  const slot = `desktop-input-test-${process.pid}`;
+  const instance = await launch(`native-reserve-a-${process.pid}`, capture, { reserve: slot });
+  try {
+    const held = await waitFor(() => runtime.readNativeStatus(instance.info.taskId), 'launcher status');
+    assert.deepEqual(held.reservations, [slot]);
+
+    const refused = await command([
+      'start', '--task', `native-reserve-b-${process.pid}`, '--executable', appStub,
+      '--reserve', slot, '--', path.join(scratch, 'capture-reserve-b.json'), 'manifest',
+    ]);
+    assert.equal(refused.code, 1);
+    assert.match(refused.stderr, /exclusive resource "[^"]+" unavailable/);
+
+    // Concurrency itself is not what the slot restricts: a second instance
+    // that does not ask for the shared resource still starts.
+    const free = await launch(`native-reserve-c-${process.pid}`, path.join(scratch, 'capture-reserve-c.json'));
+    await stopOwned(free);
+  } finally {
+    await stopOwned(instance);
+  }
+  const after = isolation.acquireExclusiveSlot(slot, `native-reserve-after-${process.pid}`);
+  assert.equal(after.acquired, true, `slot must be free after the owner stopped: ${after.reason}`);
+  isolation.releaseExclusiveSlot(slot, after.ownerToken);
+});
+
+test('a missing build is a named blocker, and a bundle names its own executable', () => {
+  const missing = path.join(scratch, 'no-such-target');
+  assert.throws(
+    () => runtime.resolveApp(`native-missing-${process.pid}`, { hostTriple: 'aarch64-test-host' }),
+    (err) => err.code === 'ENOAPP' && /Looked in: .*aarch64-test-host/.test(err.message),
+  );
+  assert.equal(fs.existsSync(missing), false);
+
+  const bundle = path.join(scratch, 'Fake.app');
+  fs.mkdirSync(path.join(bundle, 'Contents', 'MacOS'), { recursive: true });
+  fs.writeFileSync(path.join(bundle, 'Contents', 'Info.plist'), '<plist><dict><key>CFBundleExecutable</key><string>renamed-binary</string></dict></plist>');
+  assert.throws(() => runtime.bundleExecutable(bundle), /bundle executable missing/);
+  fs.writeFileSync(path.join(bundle, 'Contents', 'MacOS', 'renamed-binary'), '#!/bin/sh\n', { mode: 0o700 });
+  assert.equal(runtime.bundleExecutable(bundle), path.join(bundle, 'Contents', 'MacOS', 'renamed-binary'));
+  assert.throws(() => runtime.bundleExecutable(path.join(scratch, 'Nope.app')), /no Contents\/Info\.plist/);
+});

--- a/scripts/nemo/native.cjs
+++ b/scripts/nemo/native.cjs
@@ -8,7 +8,9 @@
 const isolation = require('./lib/isolation.cjs');
 const {
   nativeHandshake,
+  readAppManifest,
   readNativeStatus,
+  releaseNativeState,
   runNativeLauncher,
 } = require('./lib/native-runtime.cjs');
 
@@ -55,12 +57,27 @@ function status(args) {
 
 async function stop(args) {
   if (!args.task || !args.owner) throw new Error('stop requires --task ID and --owner TOKEN');
+  // Read the app's own manifest BEFORE stopping: it names the directories the
+  // instance actually resolved, and it lives in the tauri-data root that the
+  // release below removes.
+  const disclosed = readAppManifest(args.task);
+  const statusBeforeStop = readNativeStatus(args.task);
   const stopped = await isolation.requestStop(args.task, args.owner, {
     timeoutMs: args['timeout-ms'] == null ? 10_000 : Number(args['timeout-ms']),
   });
-  const statusBeforeRelease = readNativeStatus(args.task);
+  const statusBeforeRelease = readNativeStatus(args.task) || statusBeforeStop;
+  // The isolated app directories are outside the task root, so releaseTask
+  // alone would leave them behind on every run. Ownership was proved by the
+  // stop above; eligibility is bound to this task's own derivation.
+  const appState = stopped.stopped
+    ? releaseNativeState(
+      args.task,
+      disclosed && disclosed.valid ? disclosed.manifest : null,
+      statusBeforeRelease && statusBeforeRelease.app ? statusBeforeRelease.app.bundle : null,
+    )
+    : null;
   const released = stopped.stopped ? isolation.releaseTask(args.task, args.owner) : null;
-  output({ ...stopped, runtime: statusBeforeRelease, released });
+  output({ ...stopped, runtime: statusBeforeRelease, appState, released });
   process.exit(stopped.stopped && released && released.released ? 0 : 1);
 }
 

--- a/scripts/nemo/native.cjs
+++ b/scripts/nemo/native.cjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+'use strict';
+// One-shot CLI for the native (Tauri) task-instance launcher — R06, #902.
+// Same shape as build.cjs: `start` is long-lived and prints one JSON line
+// containing the owner token; `status` and `stop` are run by the controlling
+// process that kept that token.
+
+const isolation = require('./lib/isolation.cjs');
+const {
+  nativeHandshake,
+  readNativeStatus,
+  runNativeLauncher,
+} = require('./lib/native-runtime.cjs');
+
+function parse(argv) {
+  const out = { _: [], passthrough: [] };
+  let passthrough = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (passthrough) { out.passthrough.push(arg); continue; }
+    if (arg === '--') { passthrough = true; continue; }
+    if (!arg.startsWith('--')) { out._.push(arg); continue; }
+    const key = arg.slice(2); const next = argv[i + 1];
+    if (next == null || next.startsWith('--')) out[key] = true;
+    else { out[key] = next; i += 1; }
+  }
+  return out;
+}
+
+function output(value) { process.stdout.write(JSON.stringify(value) + '\n'); }
+
+function reservations(value) {
+  if (value == null || value === true) return [];
+  return String(value).split(',').map((slot) => slot.trim()).filter(Boolean);
+}
+
+async function start(args) {
+  const taskId = isolation.resolveTaskId(args.task);
+  await runNativeLauncher(taskId, {
+    app: args.app === true ? undefined : args.app,
+    executable: args.executable === true ? undefined : args.executable,
+    args: args.passthrough,
+    hostTriple: args['host-triple'],
+    reserve: reservations(args.reserve),
+    manifestTimeoutMs: args['manifest-timeout-ms'] == null ? undefined : Number(args['manifest-timeout-ms']),
+  }, output);
+}
+
+function status(args) {
+  if (!args.task || !args.owner) throw new Error('status requires --task ID and --owner TOKEN');
+  const result = nativeHandshake(args.task, args.owner);
+  output(result);
+  process.exit(result.ok ? 0 : 1);
+}
+
+async function stop(args) {
+  if (!args.task || !args.owner) throw new Error('stop requires --task ID and --owner TOKEN');
+  const stopped = await isolation.requestStop(args.task, args.owner, {
+    timeoutMs: args['timeout-ms'] == null ? 10_000 : Number(args['timeout-ms']),
+  });
+  const statusBeforeRelease = readNativeStatus(args.task);
+  const released = stopped.stopped ? isolation.releaseTask(args.task, args.owner) : null;
+  output({ ...stopped, runtime: statusBeforeRelease, released });
+  process.exit(stopped.stopped && released && released.released ? 0 : 1);
+}
+
+async function main() {
+  const args = parse(process.argv.slice(2));
+  const command = args._[0] || 'start';
+  if (command === 'start') return start(args);
+  if (command === 'status') return status(args);
+  if (command === 'stop') return stop(args);
+  throw new Error('usage: native.cjs start [--task ID] [--app /path/Nemo.app | --executable /absolute/path] [--reserve desktop-input,gpu-reference] [--manifest-timeout-ms N] [-- args...] | status --task ID --owner TOKEN | stop --task ID --owner TOKEN [--timeout-ms N]');
+}
+
+main().catch((err) => { process.stderr.write((err.stack || String(err)) + '\n'); process.exit(1); });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,8 @@ use tauri_plugin_shell::ShellExt;
 // EXPERIMENTAL (experimental/native-video-decode) — see the module header.
 mod video_decode;
 mod vectorize;
+// Per-task isolation of the app's native mutable state (R06, #902).
+mod task_runtime;
 
 #[tauri::command]
 async fn run_ffmpeg(app: tauri::AppHandle, window: tauri::Window, args: Vec<String>) -> Result<i32, String> {
@@ -173,6 +175,21 @@ fn start_tablet_pressure_monitor(app: tauri::AppHandle) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let mut ctx = tauri::generate_context!();
+    // R06 (#902): opt-in per-task isolation of every mutable native root.
+    // Without NEMO_TAURI_DATA_DIR this is None and not one resolved path below
+    // changes; with it, an invalid request aborts instead of quietly falling
+    // back to the shared production identifier. See src/task_runtime.rs.
+    let task_runtime = match task_runtime::TaskRuntime::from_env() {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            eprintln!("nemo: refusing to start an isolated task runtime: {err}");
+            std::process::exit(2);
+        }
+    };
+    if let Some(runtime) = &task_runtime {
+        runtime.apply_to_config(ctx.config_mut());
+    }
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         // The update channel is the public `nemo` repo's GitHub Releases —
@@ -204,7 +221,9 @@ pub fn run() {
             video_decode::autobench_report,
             video_decode::optimized_media_target,
             video_decode::create_optimized_media,
-            vectorize::vectorize_image
+            vectorize::vectorize_image,
+            task_runtime::nemo_task_runtime,
+            task_runtime::nemo_task_runtime_release
         ])
         // "Vérifier les mises à jour…" in the app (StrokeMotion) menu — same
         // check the Réglages button and the silent startup check already
@@ -221,7 +240,11 @@ pub fn run() {
                 let _ = app.emit("menu-check-update", ());
             }
         })
-        .setup(|app| {
+        .setup(move |app| {
+            // First: in the isolated path the configured windows are created
+            // here (with their own WebKit data store) instead of by Tauri, so
+            // this has to run before anything resolves the "main" window.
+            task_runtime::start(app, task_runtime)?;
             #[cfg(debug_assertions)]
             {
                 let window = app.get_webview_window("main").unwrap();
@@ -249,6 +272,6 @@ pub fn run() {
             let _ = app;
             Ok(())
         })
-        .run(tauri::generate_context!())
+        .run(ctx)
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/task_runtime.rs
+++ b/src-tauri/src/task_runtime.rs
@@ -1,0 +1,552 @@
+// Task-runtime isolation for the native app (R06, https://github.com/mysteropodes/nemo/issues/902).
+//
+// `scripts/nemo/lib/isolation.cjs` already allocates a `tauri-data` root per
+// task, and `engineering/runtime-isolation.md` says in as many words why that is
+// not enough on its own: "Merely creating a `tauri-data` directory does not make
+// the app use it." This module is the native half — it makes a running Nemo
+// actually resolve its mutable state per task, so two task instances can run at
+// once without one overwriting the other's settings, history, feedback,
+// autosave or WebKit storage.
+//
+// Two mechanisms, because macOS keeps those two kinds of state in two different
+// places:
+//
+//   * every `app_*_dir()` in Tauri resolves as `<platform dir>/<config
+//     identifier>` (tauri 2.11.3, `src/path/desktop.rs`), so a per-task
+//     identifier moves Application Support / Caches / Logs / config in one step,
+//     and every consumer that goes through the path resolver — the fs plugin
+//     scope, `appDataDir()` in JS, the feedback and history folders — follows
+//     without knowing this module exists;
+//   * WKWebView's localStorage/IndexedDB do NOT live under those directories;
+//     they follow the webview's data store, so an isolated window is built with
+//     an explicit `data_store_identifier` (macOS >= 14 / iOS >= 17).
+//
+// Isolation is OFF unless `NEMO_TAURI_DATA_DIR` is set: with that variable
+// absent nothing here changes a single resolved path, and the production app
+// keeps using `com.strokemotion.app` exactly as before. When it IS set,
+// everything else this module needs must be present and valid or startup fails
+// loudly — silently falling back to the shared production identifier would let
+// an isolated run scribble on the user's real app data, which is the exact
+// failure this work package exists to prevent.
+//
+// The task key is supplied by the launcher instead of being recomputed here on
+// purpose: `isolation.cjs` already derives it (`idKey`, SHA-256 of the exact
+// task id, which is what keeps case variants distinct on a case-insensitive
+// filesystem). A second implementation on this side would be one more pair of
+// functions that has to stay identical by hand — the maintenance trap CLAUDE.md
+// §3 is about — and it would need a hashing dependency this crate does not have.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{json, Value};
+use tauri::{Manager, Runtime};
+
+/// Manifest schema written into the task's `tauri-data` root.
+pub const SCHEMA: &str = "nemo.native-runtime/1";
+/// File name of that manifest, inside `NEMO_TAURI_DATA_DIR`.
+pub const MANIFEST_FILE: &str = "native-runtime.json";
+
+/// Presence of this variable is what turns isolation on. Nothing else in the
+/// repository sets it, unlike `NEMO_TASK_ID`, which the R06 build launcher
+/// already exports for every desktop build.
+const ENV_DATA_DIR: &str = "NEMO_TAURI_DATA_DIR";
+const ENV_TASK_ID: &str = "NEMO_TASK_ID";
+const ENV_TASK_KEY: &str = "NEMO_TASK_KEY";
+const ENV_OWNER_TOKEN: &str = "NEMO_TASK_OWNER_TOKEN";
+
+/// A resolved isolated-runtime request. Construction is fallible and total:
+/// either every field is valid, or the process must not start.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskRuntime {
+    pub task_id: String,
+    pub task_key: String,
+    pub data_dir: PathBuf,
+    owner_token: Option<String>,
+}
+
+/// Managed state for the two commands. Present even when the app is NOT
+/// isolated, so `nemo_task_runtime` can answer "isolated: false" instead of
+/// failing in a way a caller could mistake for "isolation is working".
+pub struct TaskRuntimeState {
+    manifest: Mutex<Value>,
+    owner_token: Option<String>,
+    manifest_file: Option<PathBuf>,
+}
+
+// ---- validation (pure, unit-tested) ---------------------------------------
+
+/// Mirror of the task-id rule in `scripts/nemo/lib/isolation.cjs`: 1-120 ASCII
+/// letters, digits, dot, underscore or hyphen, starting with a letter or digit.
+/// Rejected, never normalized — two ids that differ must stay two ids.
+pub fn valid_task_id(id: &str) -> bool {
+    let mut chars = id.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii_alphanumeric() => {}
+        _ => return false,
+    }
+    id.len() <= 120
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_' || c == '-')
+}
+
+/// `idKey` from `isolation.cjs`: SHA-256 of the exact task id, lowercase hex.
+pub fn valid_task_key(key: &str) -> bool {
+    key.len() == 64 && key.chars().all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
+}
+
+fn valid_owner_token(token: &str) -> bool {
+    (16..=128).contains(&token.len())
+        && token
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// `<base>.nemo-task-<16 hex>`. Stays a legal bundle-style identifier
+/// (alphanumerics, dots and hyphens only) because it becomes a real directory
+/// name under Application Support / Caches / Logs.
+pub fn isolated_identifier(base_identifier: &str, task_key: &str) -> String {
+    format!("{base_identifier}.nemo-task-{}", &task_key[..16])
+}
+
+/// First 16 bytes of the task key. Same input as the identifier, so one task id
+/// always addresses one WebKit data store.
+pub fn data_store_identifier(task_key: &str) -> [u8; 16] {
+    let mut out = [0u8; 16];
+    for (i, byte) in out.iter_mut().enumerate() {
+        // Safe: `valid_task_key` proved 64 hex characters before we get here.
+        *byte = u8::from_str_radix(&task_key[i * 2..i * 2 + 2], 16).unwrap_or(0);
+    }
+    out
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn epoch_millis() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+impl TaskRuntime {
+    /// Resolve an isolation request from an arbitrary environment lookup.
+    /// Taking the lookup as a parameter is what makes every branch below
+    /// testable without mutating the real process environment (and without the
+    /// cross-test interference that `std::env::set_var` causes under
+    /// `cargo test`'s thread-per-test model).
+    ///
+    /// `Ok(None)` = not isolated, run exactly as before.
+    /// `Err(_)`   = isolation was requested but cannot be honored; the caller
+    ///              must abort rather than fall back to the shared identifier.
+    pub fn resolve<F>(get: F) -> Result<Option<Self>, String>
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        let Some(raw_dir) = get(ENV_DATA_DIR).filter(|v| !v.trim().is_empty()) else {
+            return Ok(None);
+        };
+        let data_dir = PathBuf::from(raw_dir.trim());
+        if !data_dir.is_absolute() {
+            return Err(format!("{ENV_DATA_DIR} must be an absolute path"));
+        }
+        let task_id = get(ENV_TASK_ID)
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .ok_or_else(|| format!("{ENV_DATA_DIR} is set but {ENV_TASK_ID} is missing"))?;
+        if !valid_task_id(&task_id) {
+            return Err(format!(
+                "{ENV_TASK_ID} must be 1-120 ASCII letters, digits, dot, underscore or hyphen, starting with a letter or digit"
+            ));
+        }
+        let task_key = get(ENV_TASK_KEY)
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+            .ok_or_else(|| format!("{ENV_DATA_DIR} is set but {ENV_TASK_KEY} is missing"))?;
+        if !valid_task_key(&task_key) {
+            return Err(format!(
+                "{ENV_TASK_KEY} must be the 64 lowercase hex characters of the task id digest produced by scripts/nemo/lib/isolation.cjs"
+            ));
+        }
+        // Optional: without it this instance simply refuses every release
+        // request. A missing token must not silently authorize one.
+        let owner_token = match get(ENV_OWNER_TOKEN).map(|v| v.trim().to_string()) {
+            Some(token) if token.is_empty() => None,
+            Some(token) if !valid_owner_token(&token) => {
+                return Err(format!("{ENV_OWNER_TOKEN} is not a valid owner token"))
+            }
+            Some(token) => Some(token),
+            None => None,
+        };
+        Ok(Some(Self {
+            task_id,
+            task_key,
+            data_dir,
+            owner_token,
+        }))
+    }
+
+    /// Read the real process environment.
+    pub fn from_env() -> Result<Option<Self>, String> {
+        Self::resolve(|key| std::env::var(key).ok())
+    }
+
+    pub fn identifier(&self, base_identifier: &str) -> String {
+        isolated_identifier(base_identifier, &self.task_key)
+    }
+
+    pub fn data_store_identifier(&self) -> [u8; 16] {
+        data_store_identifier(&self.task_key)
+    }
+
+    pub fn manifest_file(&self) -> PathBuf {
+        self.data_dir.join(MANIFEST_FILE)
+    }
+
+    /// The only mutation of the generated context. Two edits:
+    ///
+    /// 1. the identifier, which is what every `app_*_dir()` is built from;
+    /// 2. `create = false` on each configured window, so the window is rebuilt
+    ///    in `setup` with a data store identifier instead of being created by
+    ///    Tauri before we can attach one. This is the documented use of that
+    ///    field (see `WindowConfig::create` in tauri-utils). Labels are left
+    ///    untouched, so `capabilities/default.json`'s `"windows": ["main"]`
+    ///    keeps applying to exactly the same window.
+    pub fn apply_to_config(&self, config: &mut tauri::utils::config::Config) -> String {
+        let identifier = self.identifier(&config.identifier);
+        config.identifier = identifier.clone();
+        for window in config.app.windows.iter_mut() {
+            window.create = false;
+        }
+        identifier
+    }
+}
+
+/// Resolve the app directories this instance will actually write to. Reported
+/// rather than assumed: the whole claim of this module is "these paths differ
+/// per task", and a manifest that echoed the intended value instead of the
+/// resolved one could not prove it.
+fn resolved_dirs<R: Runtime>(app: &tauri::AppHandle<R>) -> Value {
+    let path = app.path();
+    let one = |result: tauri::Result<PathBuf>| match result {
+        Ok(dir) => json!(dir.to_string_lossy()),
+        Err(err) => json!({ "error": err.to_string() }),
+    };
+    json!({
+        "appData": one(path.app_data_dir()),
+        "appLocalData": one(path.app_local_data_dir()),
+        "appConfig": one(path.app_config_dir()),
+        "appCache": one(path.app_cache_dir()),
+        "appLog": one(path.app_log_dir()),
+    })
+}
+
+fn write_manifest(file: &Path, manifest: &Value) -> std::io::Result<()> {
+    if let Some(parent) = file.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let temporary = file.with_extension(format!("json.{}.tmp", std::process::id()));
+    std::fs::write(&temporary, format!("{}\n", serde_json::to_string_pretty(manifest)?))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&temporary, std::fs::Permissions::from_mode(0o600))?;
+    }
+    std::fs::rename(&temporary, file)
+}
+
+/// Bootstrap hook, called first inside `setup` so the isolated window exists
+/// before anything else resolves `"main"`.
+pub fn start<R: Runtime>(
+    app: &tauri::App<R>,
+    runtime: Option<TaskRuntime>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let handle = app.handle().clone();
+    let Some(runtime) = runtime else {
+        app.manage(TaskRuntimeState {
+            manifest: Mutex::new(json!({
+                "schema": SCHEMA,
+                "isolated": false,
+                "identifier": handle.config().identifier,
+                "pid": std::process::id(),
+                "reason": "NEMO_TAURI_DATA_DIR is not set; this instance uses the shared application state",
+            })),
+            owner_token: None,
+            manifest_file: None,
+        });
+        return Ok(());
+    };
+
+    // The config was already rewritten before the builder ran; read back what
+    // Tauri will actually use rather than recomputing it.
+    let identifier = handle.config().identifier.clone();
+    let store = runtime.data_store_identifier();
+    let windows = handle.config().app.windows.clone();
+    let mut labels = Vec::with_capacity(windows.len());
+    for window in &windows {
+        tauri::WebviewWindowBuilder::from_config(&handle, window)?
+            .data_store_identifier(store)
+            .build()?;
+        labels.push(window.label.clone());
+    }
+
+    let manifest_file = runtime.manifest_file();
+    let manifest = json!({
+        "schema": SCHEMA,
+        "isolated": true,
+        "state": "active",
+        "taskId": runtime.task_id,
+        "taskKey": runtime.task_key,
+        "identifier": identifier,
+        "dataStoreIdentifier": hex(&store),
+        "dataDir": runtime.data_dir.to_string_lossy(),
+        "manifestFile": manifest_file.to_string_lossy(),
+        "pid": std::process::id(),
+        "executable": std::env::current_exe().map(|p| p.to_string_lossy().into_owned()).unwrap_or_default(),
+        "appVersion": handle.package_info().version.to_string(),
+        "windows": labels,
+        "ownerTokenConfigured": runtime.owner_token.is_some(),
+        "startedAtEpochMs": epoch_millis(),
+        "dirs": resolved_dirs(&handle),
+    });
+    write_manifest(&manifest_file, &manifest)?;
+    // One machine-readable line for a launcher that captured stdout, matching
+    // the existing browser/build launchers' "first line is JSON" convention.
+    // Never includes the owner token.
+    println!("{}", serde_json::to_string(&manifest)?);
+
+    app.manage(TaskRuntimeState {
+        manifest: Mutex::new(manifest),
+        owner_token: runtime.owner_token.clone(),
+        manifest_file: Some(manifest_file),
+    });
+    Ok(())
+}
+
+// ---- commands -------------------------------------------------------------
+
+/// Source/build handshake for the running instance. Readable from the page so
+/// an automated UI check can assert which task's state it is looking at before
+/// it writes anything. Contains no owner token.
+#[tauri::command]
+pub fn nemo_task_runtime(state: tauri::State<'_, TaskRuntimeState>) -> Result<Value, String> {
+    state
+        .manifest
+        .lock()
+        .map(|manifest| manifest.clone())
+        .map_err(|_| "task runtime manifest lock poisoned".to_string())
+}
+
+/// Owner-authorized release: mark the manifest released and exit.
+///
+/// This exists because process-group termination is not always available to the
+/// owner — an instance started through macOS `open` is reparented by launchd —
+/// and because "only its owner can stop it" has to be enforced by the instance
+/// itself in that case. Refuses when no owner token was configured, so a
+/// missing token can never be read as "no check required".
+#[tauri::command]
+pub fn nemo_task_runtime_release<R: Runtime>(
+    app: tauri::AppHandle<R>,
+    state: tauri::State<'_, TaskRuntimeState>,
+    owner_token: String,
+) -> Result<Value, String> {
+    let Some(expected) = state.owner_token.as_ref() else {
+        return Err("refused: this instance has no configured owner token".into());
+    };
+    if owner_token != *expected {
+        return Err("refused: caller is not the task owner".into());
+    }
+    let manifest = {
+        let mut manifest = state
+            .manifest
+            .lock()
+            .map_err(|_| "task runtime manifest lock poisoned".to_string())?;
+        manifest["state"] = json!("released");
+        manifest["releasedAtEpochMs"] = json!(epoch_millis());
+        manifest.clone()
+    };
+    if let Some(file) = state.manifest_file.as_ref() {
+        write_manifest(file, &manifest).map_err(|err| err.to_string())?;
+    }
+    app.exit(0);
+    Ok(manifest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |key: &str| map.get(key).cloned()
+    }
+
+    const KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn full() -> Vec<(&'static str, &'static str)> {
+        vec![
+            (ENV_DATA_DIR, "/tmp/nemo-runtime/tasks/abc/tauri-data"),
+            (ENV_TASK_ID, "task-a"),
+            (ENV_TASK_KEY, KEY),
+        ]
+    }
+
+    #[test]
+    fn absent_activation_variable_is_not_isolated() {
+        // The production path: NEMO_TASK_ID alone (which the R06 build launcher
+        // already exports) must NOT be enough to move the app's data roots.
+        let resolved = TaskRuntime::resolve(env(&[(ENV_TASK_ID, "task-a"), (ENV_TASK_KEY, KEY)]));
+        assert_eq!(resolved, Ok(None));
+    }
+
+    #[test]
+    fn empty_activation_variable_is_not_isolated() {
+        assert_eq!(TaskRuntime::resolve(env(&[(ENV_DATA_DIR, "   ")])), Ok(None));
+    }
+
+    #[test]
+    fn complete_request_resolves() {
+        let runtime = TaskRuntime::resolve(env(&full())).unwrap().unwrap();
+        assert_eq!(runtime.task_id, "task-a");
+        assert_eq!(runtime.task_key, KEY);
+        assert_eq!(
+            runtime.data_dir,
+            PathBuf::from("/tmp/nemo-runtime/tasks/abc/tauri-data")
+        );
+        assert_eq!(runtime.owner_token, None);
+    }
+
+    #[test]
+    fn incomplete_or_invalid_requests_fail_closed() {
+        // Each of these once meant "fall back to com.strokemotion.app", i.e.
+        // write an isolated run's state into the user's real app data.
+        for (pairs, needle) in [
+            (vec![(ENV_DATA_DIR, "/tmp/x")], ENV_TASK_ID),
+            (
+                vec![(ENV_DATA_DIR, "/tmp/x"), (ENV_TASK_ID, "task-a")],
+                ENV_TASK_KEY,
+            ),
+            (
+                vec![
+                    (ENV_DATA_DIR, "relative/path"),
+                    (ENV_TASK_ID, "task-a"),
+                    (ENV_TASK_KEY, KEY),
+                ],
+                ENV_DATA_DIR,
+            ),
+            (
+                vec![
+                    (ENV_DATA_DIR, "/tmp/x"),
+                    (ENV_TASK_ID, "-leading-hyphen"),
+                    (ENV_TASK_KEY, KEY),
+                ],
+                ENV_TASK_ID,
+            ),
+            (
+                vec![
+                    (ENV_DATA_DIR, "/tmp/x"),
+                    (ENV_TASK_ID, "task a"),
+                    (ENV_TASK_KEY, KEY),
+                ],
+                ENV_TASK_ID,
+            ),
+            (
+                vec![
+                    (ENV_DATA_DIR, "/tmp/x"),
+                    (ENV_TASK_ID, "task-a"),
+                    (ENV_TASK_KEY, "ABCDEF"),
+                ],
+                ENV_TASK_KEY,
+            ),
+            (
+                vec![
+                    (ENV_DATA_DIR, "/tmp/x"),
+                    (ENV_TASK_ID, "task-a"),
+                    (ENV_TASK_KEY, KEY),
+                    (ENV_OWNER_TOKEN, "no"),
+                ],
+                ENV_OWNER_TOKEN,
+            ),
+        ] {
+            let err = TaskRuntime::resolve(env(&pairs)).expect_err("must refuse");
+            assert!(err.contains(needle), "{err} should name {needle}");
+        }
+    }
+
+    #[test]
+    fn uppercase_task_key_is_refused_rather_than_lowercased() {
+        // isolation.cjs emits lowercase hex; accepting a normalized variant
+        // would let two spellings of one task address two different stores.
+        let mut pairs = full();
+        pairs[2] = (ENV_TASK_KEY, "0123456789ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef");
+        assert!(TaskRuntime::resolve(env(&pairs)).is_err());
+    }
+
+    #[test]
+    fn owner_token_is_optional_and_kept_out_of_the_identifier() {
+        let mut pairs = full();
+        pairs.push((ENV_OWNER_TOKEN, "0123456789abcdef0123"));
+        let runtime = TaskRuntime::resolve(env(&pairs)).unwrap().unwrap();
+        assert_eq!(runtime.owner_token.as_deref(), Some("0123456789abcdef0123"));
+        assert!(!runtime.identifier("com.strokemotion.app").contains("0123456789abcdef0123"));
+    }
+
+    #[test]
+    fn identifier_is_per_task_and_bundle_safe() {
+        let a = isolated_identifier("com.strokemotion.app", KEY);
+        let b = isolated_identifier(
+            "com.strokemotion.app",
+            "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210",
+        );
+        assert_eq!(a, "com.strokemotion.app.nemo-task-0123456789abcdef");
+        assert_ne!(a, b);
+        assert!(a
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-'));
+    }
+
+    #[test]
+    fn data_store_identifier_is_the_first_sixteen_key_bytes() {
+        assert_eq!(
+            data_store_identifier(KEY),
+            [
+                0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab,
+                0xcd, 0xef
+            ]
+        );
+        // Distinct tasks must not share a WebKit store.
+        assert_ne!(
+            data_store_identifier(KEY),
+            data_store_identifier(
+                "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+            )
+        );
+    }
+
+    #[test]
+    fn task_id_rule_matches_the_node_library() {
+        for ok in ["a", "task-a", "Task.A_1", "0", &"a".repeat(120)] {
+            assert!(valid_task_id(ok), "{ok} should be accepted");
+        }
+        for bad in ["", "-a", ".a", "_a", "a b", "a/b", "a\u{e9}", &"a".repeat(121)] {
+            assert!(!valid_task_id(bad), "{bad} should be rejected");
+        }
+    }
+
+    #[test]
+    fn manifest_file_lives_inside_the_task_data_root() {
+        let runtime = TaskRuntime::resolve(env(&full())).unwrap().unwrap();
+        assert_eq!(
+            runtime.manifest_file(),
+            PathBuf::from("/tmp/nemo-runtime/tasks/abc/tauri-data/native-runtime.json")
+        );
+    }
+}

--- a/tests/nemo-native-runtime.test.cjs
+++ b/tests/nemo-native-runtime.test.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+// Keep this process-isolated: the suite sets NEMO_ISOLATION_ROOT before the
+// isolation module captures it at import time.
+require('../scripts/nemo/native-runtime.test.cjs');


### PR DESCRIPTION
Closes half of the remaining R06 work in #902: the native side of task-runtime isolation.

`scripts/nemo/lib/isolation.cjs` already allocated a `tauri-data` root per task, and `engineering/runtime-isolation.md` named the gap in as many words — *"Merely creating a `tauri-data` directory does not make the app use it."* Nothing consumed the root, so two concurrent instances of the packaged app shared one identifier, one set of app directories and one WebKit store.

## Native side — `src-tauri/src/task_runtime.rs` + bootstrap hunks in `lib.rs`

Two mechanisms, because macOS keeps the two kinds of state in two different places:

| State | Mechanism |
|---|---|
| App data / config / cache / logs | every `app_*_dir()` resolves as `<platform dir>/<config identifier>` (tauri 2.11.3 `src/path/desktop.rs`), so the identifier becomes `com.strokemotion.app.nemo-task-<16 hex>` before the builder runs. The fs plugin scope, `appDataDir()` in JS, feedback and history folders all follow without knowing this exists. |
| WebKit `localStorage` / IndexedDB | not under those directories at all — the configured windows are created in `setup` with an explicit `data_store_identifier` (macOS ≥ 14), using the documented `WindowConfig.create = false` path. Labels are untouched, so `capabilities/default.json`'s `"windows": ["main"]` still applies. |

Activation is `NEMO_TAURI_DATA_DIR`. Absent, **not one resolved path changes**. Present with anything else missing or invalid, the app exits 2 naming the variable — a silent fallback to the shared identifier would write an isolated run's state into the user's real app data. `NEMO_TASK_ID` alone is deliberately not enough, since the build launcher already exports it for every desktop build.

The task key (`idKey`, SHA-256 of the exact task id) is supplied by the launcher instead of recomputed in Rust, so there is one derivation rather than two that must stay identical by hand.

## Launcher side — `scripts/nemo/lib/native-runtime.cjs`, `scripts/nemo/native.cjs`

Starts a built Nemo with that environment, owns its process group, and reports the manifest the instance writes for itself (`native-runtime.json`, schema `nemo.native-runtime/1`, also the app's first stdout line, never containing the owner token). `status` is `ok` only when the owner token, the complete R02 source/build identity, and a live manifest naming *this* task all agree. `stop` is owner-only and removes the task's roots including `tauri-data`.

`--reserve desktop-input,gpu-reference` gives the shared desktop resources an explicit exclusive reservation with a real consumer. Running two isolated instances at once is *not* what a slot restricts.

`nemo_task_runtime` returns the manifest to the page; `nemo_task_runtime_release` takes the owner token and exits — the stop path that stays available when process-group termination does not (an instance started through macOS `open` is reparented by launchd).

## Validation

- `cargo test task_runtime` — 10/10: activation, six fail-closed refusals, uppercase-key refusal, identifier and data-store derivation, task-id rule mirrored from the Node library.
- `node --test scripts/nemo/native-runtime.test.cjs` — 6/6: two concurrent instances on disjoint roots with per-task keys, handshake refusal for a silent or foreign manifest, owner-only stop with root removal, reservation refusal and release, missing-build blocker, and the environment contract asserted against `task_runtime.rs` so renaming a variable on one side only fails the suite.
- `npm test` — 191/191, reaching the new suite through `tests/nemo-native-runtime.test.cjs` (existing `tests/*.test.cjs` discovery, no harness change).
- Real packaged release build via `node scripts/nemo/build.cjs start --task r06-native-build` (isolated `CARGO_TARGET_DIR`, `--no-sign`, `completed`, exit 0). That binary refuses all six invalid isolated environments with exit 2 **before any window is created**.

## Not covered here

Two live Nemo windows saving and reloading side by side. That needs the exclusive desktop input/GPU slot, currently held for R04 packaged UI export; the doc's remaining-integration list states this explicitly rather than implying the acceptance bullet is closed.

`src-tauri/gen/schemas/capabilities.json` is left dirty on purpose: it is build-regenerated drift (the committed copy is missing `dialog:allow-ask`/`dialog:allow-confirm` that `capabilities/default.json` already lists), pre-existing and shared with other worktrees.

Refs #902