### PR TITLE
boundaries: classify #952's native-runtime.cjs/test.cjs in scripts-nemo profile

### DIFF
--- a/engineering/boundaries/profiles/scripts-nemo.baseline.json
+++ b/engineering/boundaries/profiles/scripts-nemo.baseline.json
@@ -15,6 +15,8 @@
       "files": ["build-runtime.cjs"], "publicApi": ["build-runtime.cjs"], "sizeProfile": "Platform/engine adapter" },
     { "id": "nemo.lib.boundariesChecker", "layer": "tooling-adapters", "dir": "scripts/nemo/lib",
       "files": ["boundaries.cjs"], "publicApi": ["boundaries.cjs"], "sizeProfile": "Platform/engine adapter" },
+    { "id": "nemo.cli.nativeRuntime", "layer": "tooling-adapters", "dir": "scripts/nemo",
+      "files": ["native-runtime.cjs"], "publicApi": ["native-runtime.cjs"], "sizeProfile": "Platform/engine adapter" },
 
     { "id": "nemo.lib.jobs", "layer": "tooling-application", "dir": "scripts/nemo/lib",
       "files": ["jobs.cjs"], "publicApi": ["jobs.cjs"], "sizeProfile": "Domain/application JS or TS" },
@@ -49,7 +51,9 @@
     { "id": "nemo.test.buildRuntime", "layer": "tooling-test", "dir": "scripts/nemo",
       "files": ["build-runtime.test.cjs"], "publicApi": ["build-runtime.test.cjs"], "sizeProfile": "Test file" },
     { "id": "nemo.test.isolation", "layer": "tooling-test", "dir": "scripts/nemo",
-      "files": ["isolation.test.cjs"], "publicApi": ["isolation.test.cjs"], "sizeProfile": "Test file" }
+      "files": ["isolation.test.cjs"], "publicApi": ["isolation.test.cjs"], "sizeProfile": "Test file" },
+    { "id": "nemo.test.nativeRuntime", "layer": "tooling-test", "dir": "scripts/nemo",
+      "files": ["native-runtime.test.cjs"], "publicApi": ["native-runtime.test.cjs"], "sizeProfile": "Test file" }
   ],
   "layerRules": {
     "tooling-shared": { "allowedLayers": [] },

--- a/engineering/boundaries/profiles/scripts-nemo.profile.json
+++ b/engineering/boundaries/profiles/scripts-nemo.profile.json
@@ -15,6 +15,8 @@
       "files": ["build-runtime.cjs"], "publicApi": ["build-runtime.cjs"], "sizeProfile": "Platform/engine adapter" },
     { "id": "nemo.lib.boundariesChecker", "layer": "tooling-adapters", "dir": "scripts/nemo/lib",
       "files": ["boundaries.cjs"], "publicApi": ["boundaries.cjs"], "sizeProfile": "Platform/engine adapter" },
+    { "id": "nemo.cli.nativeRuntime", "layer": "tooling-adapters", "dir": "scripts/nemo",
+      "files": ["native-runtime.cjs"], "publicApi": ["native-runtime.cjs"], "sizeProfile": "Platform/engine adapter" },
 
     { "id": "nemo.lib.jobs", "layer": "tooling-application", "dir": "scripts/nemo/lib",
       "files": ["jobs.cjs"], "publicApi": ["jobs.cjs"], "sizeProfile": "Domain/application JS or TS" },
@@ -49,7 +51,9 @@
     { "id": "nemo.test.buildRuntime", "layer": "tooling-test", "dir": "scripts/nemo",
       "files": ["build-runtime.test.cjs"], "publicApi": ["build-runtime.test.cjs"], "sizeProfile": "Test file" },
     { "id": "nemo.test.isolation", "layer": "tooling-test", "dir": "scripts/nemo",
-      "files": ["isolation.test.cjs"], "publicApi": ["isolation.test.cjs"], "sizeProfile": "Test file" }
+      "files": ["isolation.test.cjs"], "publicApi": ["isolation.test.cjs"], "sizeProfile": "Test file" },
+    { "id": "nemo.test.nativeRuntime", "layer": "tooling-test", "dir": "scripts/nemo",
+      "files": ["native-runtime.test.cjs"], "publicApi": ["native-runtime.test.cjs"], "sizeProfile": "Test file" }
   ],
   "layerRules": {
     "tooling-shared": { "allowedLayers": [] },


### PR DESCRIPTION
## Scope

Bounded companion to #952 (R06 isolated native launcher), scoped only to the two assigned
paths: `engineering/boundaries/profiles/scripts-nemo.profile.json` and
`scripts-nemo.baseline.json`. Pinned to #952's head commit
`38fd3f70f079403ae217da80fa9da141d2d25628`. No checker (`scripts/nemo/lib/boundaries.cjs`),
`lib/jobs.cjs`, `package.json`, or source file is touched — those remain owned by root/#952's
own branch.

## What this adds

#952 adds two files directly under `scripts/nemo/**` that the 23-module
`scripts-nemo.profile.json`/`.baseline.json` on `main` does not yet declare:

- `scripts/nemo/native-runtime.cjs` (333 nonblank lines) → new module `nemo.cli.nativeRuntime`,
  layer `tooling-adapters`, sizeProfile `"Platform/engine adapter"`, `publicApi:
  ["native-runtime.cjs"]`.
- `scripts/nemo/native-runtime.test.cjs` (266 nonblank lines) → new module
  `nemo.test.nativeRuntime`, layer `tooling-test`, sizeProfile `"Test file"`, `publicApi:
  ["native-runtime.test.cjs"]`.

## Why `tooling-adapters`, not the default `tooling-bootstrap`

Every other top-level `scripts/nemo/*.cjs` (build.cjs, browser.cjs, check.cjs, …) is a thin
shim delegating to `lib/*` and is classified `tooling-bootstrap`. `native-runtime.cjs` is
different by its own author's design ("both a module and a CLI on purpose" per its header
comment) — it keeps its launch/handshake logic and real `fs`/`child_process`/`crypto` I/O in
this one file rather than a `lib/` counterpart, matching this profile's own documented
`tooling-adapters` role ("Direct OS/fs/process/network/subprocess I/O"), not
`tooling-bootstrap`'s ("thin CLI entry points that wire lib pieces together").

Verified this is load-bearing, not stylistic, using a disposable tree composed from current
`origin/main`'s `scripts/nemo/**` plus #952's two candidate files copied in read-only (nothing
from #952 merged into source or the checker):

- The naive `tooling-bootstrap` classification (matching every sibling CLI) produces two real
  findings against the actual files: a `size` violation (333 > hardMax 250) and a
  `layer-violation` (`native-runtime.test.cjs`, `tooling-test`, may not depend on
  `tooling-bootstrap` per this profile's own `layerRules`). `tooling-adapters` +
  `"Platform/engine adapter"` (warn 300/hardMax 500) has neither problem.
- `publicApi: ["native-runtime.cjs"]` is load-bearing: `native-runtime.test.cjs` really does
  `require('./native-runtime.cjs')` and calls several exported functions. Stripping
  `publicApi` to `[]` on a scratch copy reproduces exactly one `private-import` violation
  naming that edge; restoring it passes again.
- `node scripts/nemo/boundaries.cjs …profile.json --root <composed-tree> --json`: exit 0,
  `ok:true`, 25 modules, 0 violations, 4 size warnings (the 3 pre-existing warn-zone files
  plus `native-runtime.cjs` itself at 333/300 — a warning, not a violation).
- `--baseline <main's committed baseline>` against the same composed tree: `ratchet.ok: true`,
  `baselinePathCount: 23`, `candidatePathCount: 25`, 0 violations/reductions/removals — no
  `sizeProfile` hardMax was raised and no size exception was added, so this is coverage
  growth, not baseline inflation.
- `node --test scripts/nemo/boundaries.test.cjs scripts/nemo/boundaries-ratchet.test.cjs`:
  81/81 passing, unmodified.

## Real dependency on #952 (not just procedural)

Running this same checker against the actual unmodified working tree today (#952 not merged,
files absent) fails closed exactly as expected:
`ENOENT: no such file or directory, open '.../scripts/nemo/native-runtime.cjs'`, exit 2 — a
profile's `files` list is unconditionally read (no filesystem walking). **This PR must not be
merged before #952**; it will not pass standalone until then.

No global suppression, no blanket exception, no baseline ceiling inflation: both new modules
reuse existing `sizeProfiles`/`layerRules` verbatim, and no `exceptions[]` entry was added.

Refs #952. Depends on #952.