### PR TITLE
Fix boundary scanning of division and control-header regex literals

### DIFF
--- a/scripts/nemo/boundaries.test.cjs
+++ b/scripts/nemo/boundaries.test.cjs
@@ -10,6 +10,7 @@ const test = require('node:test');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { Script } = require('node:vm');
 const { checkProfile, extractImports, countNonBlankLines, validateProfile } = require('./lib/boundaries.cjs');
 
 const roots = new Set();
@@ -299,6 +300,7 @@ test('non-size exceptions apply only to their exact rule and file', () => {
 test('legal JS spelling variants enforce the same private import and layer edge', async (t) => {
   const variants = [
     "require ('../adapter/private.cjs');", "require /* comment */ ('../adapter/private.cjs');", "require?.('../adapter/private.cjs');",
+    "(left + right) / require('../adapter/private.cjs') / 2;", "ratio /= import('../adapter/private.cjs');",
     "const marker = '.'\nrequire('../adapter/private.cjs');",
     "import ('../adapter/private.cjs');", "import/*comment*/('../adapter/private.cjs');",
     "import{default as x}from '../adapter/private.cjs';", "export{default}from '../adapter/private.cjs';",
@@ -390,12 +392,98 @@ test('CLI rejects malformed profiles and unknown/trailing/missing arguments with
 });
 
 
-test('ambiguous lexical forms fail closed and computed globals are explicit', () => {
+test('unsupported lexical forms fail closed and computed globals are explicit', () => {
   const root = makeRoot(), p = fixtureProfile();
-  write(root, 'domain/a.cjs', 'if (ok) /pattern/.test(value);');
-  assert.throws(() => checkProfile(p, { root }), /ambiguous slash/);
   write(root, 'domain/a.cjs', 'window[member].run();');
   assert.equal(checkProfile(p, { root }).violations[0].rule, 'unsupported-global');
   write(root, 'domain/a.cjs', "require('\\056/hidden.cjs');");
   assert.throws(() => checkProfile(p, { root }), /numeric string escapes/);
+});
+
+test('real application division preserves following imports and global diagnostics', async (t) => {
+  // Exact counterexamples from the R05 application review at d499521.
+  const cases = {
+    'camera.js:59': 'u = (lo + hi) / 2;',
+    'app.js:599': 'function _r3(v){return isFinite(v)?Math.round(v*1000)/1000:0;}',
+    'motion.js:1182': 'var tx = (next.x - prev.x) / 2;',
+    'timeline.js:104': 'var steps=Math.floor((now-playClock)/frameMs);',
+    'tools.js:13': 'var step=Math.PI/4,angle=Math.round(Math.atan2(dy,dx)/step)*step;',
+  };
+  for (const [location, source] of Object.entries(cases)) await t.test(location, () => {
+    new Script(source); // Syntax validation only; never execute application code.
+    const root = makeRoot();
+    write(root, 'domain/a.cjs', `${source}\nwindow.SMReal.run();\nrequire(target);\nimport('./real.js');`);
+    assert.deepEqual(extractImports(fs.readFileSync(path.join(root, 'domain/a.cjs'), 'utf8')), [{ specifier: './real.js', line: 4 }]);
+    assert.deepEqual(checkProfile(fixtureProfile(), { root }).violations.map(v => [v.rule, v.line]), [
+      ['unsupported-import', 3], ['global-state', 2],
+    ]);
+  });
+});
+
+test('division and regex lexical goals retain real findings and keep regex text opaque', async (t) => {
+  const cases = [
+    '(a + b) / window.SMReal / 2;',
+    'fn() / window.SMReal / 2;',
+    'obj.if(value) / window.SMReal / 2;',
+    'obj.return / window.SMReal / 2;',
+    'value++ / window.SMReal / 2;',
+    '({ value: 1 }) / window.SMReal / 2;',
+    'if (ok) "value" / window.SMReal / 2;',
+    '"}" / window.SMReal / 2;',
+    '(function () {}) / window.SMReal / 2;',
+    '(class {}) / window.SMReal / 2;',
+    'const s = `${(a + b) / window.SMReal / 2}`;',
+    'const s = `${/window.SMPhantom/.source}`; window.SMReal;',
+    'if (ok) /window.SMPhantom/.test(value); window.SMReal;',
+    'if (ok) /require\\("phantom"\\)|window.SMPhantom/.test(value); window.SMReal;',
+    'while (ok) /window.SMPhantom/.test(value); window.SMReal;',
+    'for (; ok;) /window.SMPhantom/.test(value); window.SMReal;',
+    'async function f() { for await (const value of values) /window.SMPhantom/.test(value); } window.SMReal;',
+    'const f = () => /window.SMPhantom/; window.SMReal;',
+    'const r = /[\\/]/g; const value = 4 / /window.SMPhantom/.source.length; window.SMReal;',
+    'value /= /window.SMPhantom/.source.length; window.SMReal;',
+    'function f() { return ({}) / window.SMReal / 2; }',
+  ];
+  for (const source of cases) await t.test(source, () => {
+    new Script(source);
+    const root = makeRoot();
+    write(root, 'domain/a.cjs', `${source}\nimport('./real.js');`);
+    assert.deepEqual(extractImports(source + "\nimport('./real.js');").map(x => x.specifier), ['./real.js']);
+    const report = checkProfile(fixtureProfile(), { root });
+    assert.deepEqual(report.violations.map(v => [v.rule, v.detail?.global]), [['global-state', 'window.SMReal']]);
+  });
+});
+
+test('slash directly after a brace remains an explicit scope limitation', () => {
+  // These need block/object/function context beyond this control-parenthesis fix.
+  // Keep rejecting them rather than hiding real findings inside a guessed regex.
+  for (const source of [
+    'if (ok) {} /window.SMPhantom/.test(value);',
+    'function f() {} /window.SMPhantom/.test(value);',
+    'const f = function () {} / window.SMReal / 2;',
+    'const C = class {} / window.SMReal / 2;',
+    'function f() { return {} / window.SMReal / 2; }',
+  ]) {
+    new Script(source);
+    assert.throws(() => extractImports(source), /ambiguous slash after } at line/);
+  }
+});
+
+test('malformed slash literals and delimiter contexts remain rejected', async (t) => {
+  for (const source of [
+    'if (ok) /unterminated', 'const r = /[abc/;', 'const r = /(/;', 'const r = /x/gg;',
+    'const r = /x\\\n/;', 'const ratio = (a + b) /;', 'const ratio = (a + b) /',
+    'const ratio = (a + b] / 2;', 'const ratio = (a + b / 2;', 'const s = `value ${(a + b) / 2`;',
+  ]) await t.test(source, () => {
+    assert.throws(() => new Script(source), SyntaxError);
+    assert.throws(() => extractImports(source));
+  });
+});
+
+test('the actual application JS corpus scans, including previously omitted large files', () => {
+  const sourceRoot = path.resolve(__dirname, '../../src/js');
+  const files = fs.readdirSync(sourceRoot, { recursive: true }).filter(file => /\.m?js$/.test(file)).sort();
+  assert.ok(files.includes('camera.js') && files.includes('motion.js'));
+  // Include vendor files in this lexical regression too; scanning is not policy adoption.
+  for (const file of files) assert.doesNotThrow(() => extractImports(fs.readFileSync(path.join(sourceRoot, file), 'utf8')), file);
 });

--- a/scripts/nemo/lib/boundaries.cjs
+++ b/scripts/nemo/lib/boundaries.cjs
@@ -106,16 +106,18 @@ function validateProfile(profile) {
   }
 }
 
-function lineAt(text, index) {
-  return text.slice(0, index).split('\n').length;
-}
-
 /** Small lexical scanner, not an AST/binding analyzer. Comments and literal text are opaque;
  * template substitutions are scanned recursively so imports inside them stay in the graph. */
 function tokenize(source) {
   const tokens = [];
-  let i = 0;
-  const add = (type, value, start) => tokens.push({ type, value, line: lineAt(source, start) });
+  let i = 0, line = 1, lineOffset = 0;
+  // Token starts advance monotonically, including template substitutions. Avoid
+  // repeatedly splitting whole prefixes of the large application source files.
+  const lineAt = (index) => {
+    while (lineOffset < index) if (source[lineOffset++] === '\n') line++;
+    return line;
+  };
+  const add = (type, value, start) => tokens.push({ type, value, line: lineAt(start) });
   function escape() {
     const ch = source[i++];
     const simple = { n: '\n', r: '\r', t: '\t', b: '\b', f: '\f', v: '\v', '0': '\0', '\n': '', '\r': '' };
@@ -132,11 +134,11 @@ function tokenize(source) {
   }
   function literal(quote, start) {
     let value = '', interpolated = false;
-    const token = { type: 'string', value: '', line: lineAt(source, start) };
+    const token = { type: 'string', value: '', line: lineAt(start) };
     tokens.push(token);
     while (i < source.length) {
       const ch = source[i++];
-      if (ch === quote) { token.value = value; return; }
+      if (ch === quote) { token.value = value; if (interpolated) add('template-end', '', i - 1); return; }
       if (ch === '\\') value += escape();
       else if (quote === '`' && ch === '$' && source[i] === '{') {
         i++; interpolated = true; token.type = 'template';
@@ -146,7 +148,8 @@ function tokenize(source) {
     throw new Error(`unterminated ${interpolated ? 'template' : 'string'} literal at line ${token.line}`);
   }
   function scan(substitution = false) {
-    let braces = 0;
+    const firstToken = tokens.length, contexts = [];
+    let closedControl = false;
     while (i < source.length) {
       const start = i, ch = source[i];
       if (/\s/.test(ch)) { i++; continue; }
@@ -156,38 +159,51 @@ function tokenize(source) {
         if (end < 0) throw new Error('unterminated block comment');
         i = end + 2; continue;
       }
-      if (ch === '"' || ch === "'" || ch === '`') { i++; literal(ch, start); continue; }
-      const previous = tokens.at(-1);
-      // A slash after these tokens needs statement/expression AST context.
-      // Refuse that ambiguity instead of potentially swallowing a real import as regex text.
-      if (ch === '/' && previous?.type === 'punct' && [')', '}'].includes(previous.value)) throw new Error(`ambiguous slash after ${previous.value} at line ${lineAt(source, start)}; requires an AST inventory`);
-      const expressionStart = !previous || (previous.type === 'name' && /^(return|throw|yield|case|delete|void|typeof|new|else|do)$/.test(previous.value)) || (previous.type === 'punct' && ![')', ']', '}', '++', '--'].includes(previous.value));
+      if (ch === '"' || ch === "'" || ch === '`') { i++; literal(ch, start); closedControl = false; continue; }
+      const previous = tokens.length === firstToken ? null : tokens.at(-1);
+      // A control header starts a statement; a call/group closes an expression.
+      // Brace endings still need block/object/function context: do not guess.
+      if (ch === '/' && previous?.type === 'punct' && previous.value === '}') throw new Error(`ambiguous slash after } at line ${lineAt(start)}; requires an AST inventory`);
+      if (previous?.type === 'punct' && ['/', '/='].includes(previous.value) && ')}];,*%=&|<>?:'.includes(ch)) throw new Error(`missing division operand at line ${lineAt(start)}`);
+      const keyword = previous?.type === 'name' && !['.', '?.'].includes(tokens.at(-2)?.value);
+      const expressionStart = !previous || closedControl || (keyword && /^(return|throw|yield|await|case|delete|void|typeof|new|else|do|in|instanceof)$/.test(previous.value)) || (previous.type === 'punct' && ![')', ']', '}', '++', '--', '.', '?.'].includes(previous.value));
+      closedControl = false;
       if (ch === '/' && expressionStart) {
         i++; let bracket = false, closed = false;
         while (i < source.length) {
           const c = source[i++];
+          if (/[\n\r\u2028\u2029]/.test(c) || (c === '\\' && /[\n\r\u2028\u2029]/.test(source[i] || ''))) break;
           if (c === '\\') { i++; continue; }
           if (c === '[') bracket = true;
           if (c === ']') bracket = false;
           if (c === '/' && !bracket) { closed = true; break; }
-          if (c === '\n') break;
         }
-        if (!closed) throw new Error(`unsupported or unterminated regex at line ${lineAt(source, start)}`);
+        if (!closed) throw new Error(`unsupported or unterminated regex at line ${lineAt(start)}`);
+        const patternEnd = i - 1;
         while (/[a-z]/i.test(source[i] || '') && i < source.length) i++;
+        try { new RegExp(source.slice(start + 1, patternEnd), source.slice(patternEnd + 1, i)); }
+        catch { throw new Error(`invalid or unsupported regex at line ${lineAt(start)}`); }
         add('regex', '', start); continue;
       }
       if (/[A-Za-z_$]/.test(ch)) {
         i++; while (i < source.length && /[A-Za-z0-9_$]/.test(source[i])) i++;
         add('name', source.slice(start, i), start); continue;
       }
-      if (ch === '\\') throw new Error(`escaped identifiers are unsupported at line ${lineAt(source, start)}`);
+      if (ch === '\\') throw new Error(`escaped identifiers are unsupported at line ${lineAt(start)}`);
       if (/\d/.test(ch)) { i++; while (i < source.length && /[\w.]/.test(source[i])) i++; add('number', source.slice(start, i), start); continue; }
-      if (ch === '{') braces++;
-      if (ch === '}' && substitution && braces-- === 0) { i++; return; }
-      if (['?.', '++', '--'].includes(source.slice(i, i + 2))) i += 2;
+      if (ch === '}' && substitution && !contexts.length) { i++; return; }
+      if ('({['.includes(ch)) contexts.push({ open: ch, control: ch === '(' && keyword && (/^(if|while|for|with|switch|catch)$/.test(previous.value) || (previous.value === 'await' && tokens.at(-2)?.value === 'for')) });
+      if (')}]'.includes(ch)) {
+        const context = contexts.pop();
+        if (!context || context.open !== { ')': '(', '}': '{', ']': '[' }[ch]) throw new Error(`unmatched ${ch} at line ${lineAt(start)}`);
+        closedControl = context.control;
+      }
+      if (['?.', '++', '--', '/='].includes(source.slice(i, i + 2))) i += 2;
       else i++;
       add('punct', source.slice(start, i), start);
     }
+    if (tokens.at(-1)?.type === 'punct' && ['/', '/='].includes(tokens.at(-1).value)) throw new Error('missing division operand at end of source');
+    if (contexts.length) throw new Error('unterminated delimiter context');
     if (substitution) throw new Error('unterminated template substitution');
   }
   scan();


### PR DESCRIPTION
The boundary scanner rejected valid division such as `u = (lo + hi) / 2;` in `camera.js:59`, excluding most application source from the candidate measurements in #948. This correction distinguishes control-statement parentheses from calls/grouped expressions, preserves regex literal opacity and real imports/globals following division, and validates malformed regex/delimiter cases. Template substitutions retain their own lexical context. Line tracking advances through the source once so the large-file census stays practical.

Part of #901. Only the checker and its focused tests change. Base: `d4995210e8142cf6c13a3fa5dab865aca263410f`.

### Coverage and diagnostics

Measured against unchanged `src/js/**` at the base above. “Scanned” means lexical coverage, not full grammar/binding or architecture acceptance.

| Population | Before | After | Newly covered nonblank lines |
| --- | ---: | ---: | ---: |
| Handwritten `.js` | 80/140 | 140/140 | 79,952 of 104,855 total |
| All `.js`, including 3 vendor files | 80/143 | 143/143 | 80,688 of 105,591 total |
| Two vendor `.mjs` files | 1/2 | 2/2 | 12 of 24 total |

The original 80-module profile from #948 at `33e248795a0b94b4c93dde210c1d29f3fdab5039` produces identical before/after report values: 161 deduplicated global diagnostics, 2 unsupported imports, 7 size warnings, and a failing result.

A scratch-only expansion to all 140 handwritten files, retaining the same policy and existing ceilings, reports 437 deduplicated global diagnostics, 2 unsupported imports, 4 unsupported computed-global diagnostics, 25 size violations and 18 warnings. This still fails. No profile, baseline, exception, dependency manifest, application file, job or CI configuration changes are included.

### Validation

- Five exact division counterexamples from `camera.js:59`, `app.js:599`, `motion.js:1182`, `timeline.js:104`, and `tools.js:13` fail with the base scanner and pass with this change; following imports and globals remain visible.
- `node --test tests/nemo-boundaries.test.cjs tests/nemo-boundaries-ratchet.test.cjs`: **124 passed**, including the real 145-file corpus, regex/division distinctions, private/layer controls, malformed input and remaining explicit scope failures. The prior suites passed 81 tests before the new regressions.
- `npm run verify`: **PASS** — doctor, all 6 check gates, 237 Node tests, 15 Rust tests. Receipt: `reports/20260905T222846Z-d499521-dirty/receipt.json`, source digest `4a9739dad14f` before committing this exact diff.
- Existing tooling profile: 23 modules, 0 violations, 3 warnings; ratchet passes against the baseline extracted from protected main `d499521` (blob `44973979933163cc50fdd6064d8e7c6ab695d21b`). Checker remains at 472 nonblank lines, under its unchanged 500-line maximum.

### Remaining gates

A slash immediately after `}` still fails explicitly because block/object/function distinctions need more context; no current corpus file hits this case. Escaped identifiers and legacy numeric string escapes remain unsupported. This remains a lexical scanner; independent syntax checking and binding analysis are still required.

Global binding/legacy dependency modeling, query-bearing or unclassified import resolution, and protected-baseline/coverage enforcement remain separate R05 gaps. The existing candidate profile and baseline remain inactive and provisional. Beta retains the three #948 profile/docs paths and will sequence any expansion against the reviewed checker revision. The bounded fix does not establish R05 adoption or authorize issue closure.

DCO: commit signed off with `git commit -s`.
