### PR TITLE
R06: reconcile a released task's dead exclusive slots (#902)

### DIFF
--- a/scripts/nemo/isolation.cjs
+++ b/scripts/nemo/isolation.cjs
@@ -37,7 +37,9 @@ function usage() {
     '  roots     --task ID                                       print the root paths for an existing/new task id',
     '  handshake --task ID --owner TOKEN [--check-source]      verify a launcher is alive and matches',
     '  stop      --task ID --owner TOKEN [--signal SIG] [--timeout-ms N] stop a task; refused unless --owner matches',
-    '  release   --task ID [--owner TOKEN]                       remove task roots only after exit; existing records require their owner',
+    '  release   --task ID [--owner TOKEN]                       remove task roots only after exit; existing records require their owner.',
+    '                                                            An owner-verified release also reports `slots`: this task\'s verifiably-dead',
+    '                                                            slot reservations reconciled, and every record left as found with the reason.',
     '  slot-acquire --slot NAME --task ID [--pid N]              acquire a named exclusive slot (desktop input, GPU bench, ...)',
     '  slot-release --slot NAME --owner TOKEN                    release a named exclusive slot',
   ].join('\n'));

--- a/scripts/nemo/isolation.test.cjs
+++ b/scripts/nemo/isolation.test.cjs
@@ -412,6 +412,115 @@ test('simultaneous launcher registrations have exactly one persistent owner', as
   }
 });
 
+// ---- dead-task slot residue (slot records live outside every task root) ----
+
+// SIGKILL and wait until the pid is really gone, so a record naming it is
+// unambiguously dead rather than merely unresponsive.
+async function reap(child) {
+  child.kill('SIGKILL');
+  await waitForExit(child, 5000);
+  const deadline = Date.now() + 2000;
+  while (iso.pidAlive(child.pid) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(iso.pidAlive(child.pid), false);
+}
+
+// Take the slot legitimately (acquire refuses a dead pid, by design), then kill
+// the holder: the residue an interrupted run actually leaves behind.
+async function slotHeldByDeadPid(slot, task) {
+  const child = spawnDummyProcess();
+  const held = iso.acquireExclusiveSlot(slot, task, { pid: child.pid });
+  assert.equal(held.acquired, true);
+  await reap(child);
+  return held;
+}
+
+// A launcher registered against a process that is then killed: the "killed
+// launcher" state an authorized release has to clean up after.
+async function killedLauncher(task) {
+  const child = spawnDummyProcess();
+  const launcher = iso.registerLauncher(task, { pid: child.pid, label: 'killed-launcher' });
+  await reap(child);
+  return launcher;
+}
+
+test('killed launcher: the rightful owner reclaims its own dead slots and no one else\'s', async () => {
+  const task = 'slot-residue-own';
+  const launcher = await killedLauncher(task);
+  const mine = await slotHeldByDeadPid('residue-mine', task);
+  const theirs = await slotHeldByDeadPid('residue-theirs', 'slot-residue-other');
+
+  const released = iso.releaseTask(task, launcher.ownerToken);
+  assert.equal(released.released, true);
+  assert.deepEqual(released.slots.reconciled, ['residue-mine']);
+  assert.deepEqual(released.slots.retained, []);
+  assert.ok(released.slots.otherTasks >= 1, 'the other task\'s record must be counted, never inspected further');
+  assert.equal(fs.existsSync(mine.file), false, 'the dead task\'s own slot record must be gone');
+  assert.equal(fs.existsSync(theirs.file), true, 'another task\'s record must survive untouched');
+  assert.equal(JSON.parse(fs.readFileSync(theirs.file, 'utf8')).taskId, 'slot-residue-other');
+});
+
+test('release leaves live, malformed and self-inconsistent slot records exactly as found', async () => {
+  const task = 'slot-residue-retain';
+  const launcher = await killedLauncher(task);
+  const live = spawnDummyProcess();
+  try {
+    const held = iso.acquireExclusiveSlot('retain-live', task, { pid: live.pid });
+    const bad = await slotHeldByDeadPid('retain-malformed', task);
+    const wrongName = await slotHeldByDeadPid('retain-mismatch', task);
+    fs.writeFileSync(bad.file, JSON.stringify({ ...JSON.parse(fs.readFileSync(bad.file, 'utf8')), pid: 'not-a-pid' }));
+    fs.writeFileSync(wrongName.file, JSON.stringify({ ...JSON.parse(fs.readFileSync(wrongName.file, 'utf8')), slot: 'some-other-slot' }));
+
+    const released = iso.releaseTask(task, launcher.ownerToken);
+    assert.equal(released.released, true);
+    assert.deepEqual(released.slots.reconciled, []);
+    assert.equal(released.slots.retained.length, 3);
+    assert.match(released.slots.retained.map((r) => r.reason).join('|'), /holder still running/);
+    assert.match(released.slots.retained.map((r) => r.reason).join('|'), /malformed holder pid/);
+    assert.match(released.slots.retained.map((r) => r.reason).join('|'), /does not match its own filename/);
+    for (const file of [held.file, bad.file, wrongName.file]) assert.equal(fs.existsSync(file), true);
+    assert.equal(iso.acquireExclusiveSlot('retain-live', 'someone-else').acquired, false, 'a live holder keeps its slot');
+  } finally { live.kill('SIGKILL'); await waitForExit(live, 5000); }
+});
+
+test('a refused release reconciles nothing', async () => {
+  const task = 'slot-residue-refused';
+  const launcher = await killedLauncher(task);
+  const slot = await slotHeldByDeadPid('refused-slot', task);
+
+  const nonOwner = iso.releaseTask(task, 'not-the-owner-token');
+  assert.equal(nonOwner.released, false);
+  assert.equal(nonOwner.slots, undefined);
+  assert.equal(fs.existsSync(slot.file), true, 'a non-owner must not reclaim the task\'s slots');
+
+  assert.deepEqual(iso.releaseTask(task, launcher.ownerToken).slots.reconciled, ['refused-slot']);
+});
+
+test('reconciliation never bypasses an interrupted slot mutation guard', async () => {
+  const task = 'slot-residue-guarded';
+  const launcher = await killedLauncher(task);
+  const slot = await slotHeldByDeadPid('guarded-slot', task);
+
+  // Leave that one slot's guard behind exactly as a crashed mutation would.
+  const code = String.raw`
+    const fs = require('node:fs'); const write = fs.writeFileSync;
+    fs.writeFileSync = function(file, ...args) {
+      const result = write.call(this, file, ...args);
+      if (String(file).endsWith('owner.json')) { process.send('guard-held'); Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 4000); }
+      return result;
+    };
+    require(process.argv[1]).acquireExclusiveSlot('guarded-slot', 'contender');
+  `;
+  const child = worker(code, [require.resolve('./lib/isolation.cjs')]);
+  try { assert.equal(await message(child), 'guard-held'); }
+  finally { child.kill('SIGKILL'); await waitForExit(child, 5000); }
+
+  const released = iso.releaseTask(task, launcher.ownerToken);
+  assert.equal(released.released, true, 'a wedged slot guard must not block releasing the task itself');
+  assert.deepEqual(released.slots.reconciled, []);
+  assert.deepEqual(released.slots.retained, [{ slot: 'guarded-slot', reason: 'slot mutation busy or interrupted; left for explicit reconciliation' }]);
+  assert.equal(fs.existsSync(slot.file), true);
+});
+
 test('an interrupted mutation stays closed until explicit reconciliation', async () => {
   const code = String.raw`
     const fs = require('node:fs'); const write = fs.writeFileSync;

--- a/scripts/nemo/lib/isolation.cjs
+++ b/scripts/nemo/lib/isolation.cjs
@@ -267,8 +267,16 @@ function releaseTask(taskId, ownerToken) {
     if (exists(file) && !rec) return { released: false, reason: 'unreadable launcher record; reconcile before release' };
     if (rec && (!ownerToken || ownerToken !== rec.ownerToken)) return { released: false, reason: 'refused: caller is not the task owner' };
     if (rec && pidAlive(rec.pid)) return { released: false, reason: 'launcher still running; stop it before release' };
+    // Slot records live in SLOTS_DIR, outside every task root, so the rmSync
+    // below cannot reach them. Reconcile first: reconcileTaskSlots never throws,
+    // and doing it before the tree is gone keeps a retried release idempotent.
+    // Only a release that matched a real launcher record has proven ownership;
+    // an ownerless release (no record to check against) reclaims nothing beyond
+    // this task's own tree.
+    const slots = rec ? reconcileTaskSlots(taskId)
+      : { scanned: 0, reconciled: [], retained: [{ reason: 'no launcher record to prove ownership; slot records left untouched' }], otherTasks: 0, truncated: false };
     fs.rmSync(taskRoot(taskId), { recursive: true, force: true });
-    return { released: true, taskId };
+    return { released: true, taskId, slots };
   });
 }
 
@@ -313,6 +321,69 @@ function releaseExclusiveSlot(slot, ownerToken) {
     if (err.code === 'EBUSY') return { released: false, reason: err.message };
     throw err;
   }
+}
+
+// A slot record survives its owning task's release because it lives outside the
+// task tree. acquireExclusiveSlot already reclaims a dead holder, so the residue
+// never wedges a slot — but the dead task's name and pid stay on disk until some
+// other task happens to want that exact slot.
+//
+// An authorized release reconciles only what the record itself proves: it names
+// THIS task, it is complete, its declared slot name is the one this filename
+// encodes (so the guard taken below is the right guard), and its holder pid is
+// verifiably not running. Nothing here can grant more than the existing acquire
+// path already grants — a dead holder's record is reclaimable by any task today
+// — so removing one is strictly narrower than reclaiming it. Anything live,
+// foreign, malformed, self-inconsistent, or under an interrupted guard is
+// reported and left exactly as found. Not exported: the ownership proof is the
+// caller's verified launcher token inside releaseTask, not a standalone verb.
+const SLOT_SCAN_LIMIT = 4096;
+
+function ownSlotClaim(file, taskId) {
+  const name = path.basename(file);
+  const rec = safeReadJson(file);
+  if (!rec || typeof rec !== 'object') return { retain: { file: name, reason: 'unreadable slot record; left for explicit reconciliation' } };
+  if (rec.taskId !== taskId) return { foreign: true };
+  if (typeof rec.slot !== 'string' || typeof rec.ownerToken !== 'string') return { retain: { file: name, reason: 'incomplete slot record; left for explicit reconciliation' } };
+  let expected;
+  try { expected = slotFile(rec.slot); } catch { return { retain: { file: name, reason: 'invalid slot name in record; left for explicit reconciliation' } }; }
+  if (expected !== file) return { retain: { file: name, reason: 'slot record does not match its own filename; left for explicit reconciliation' } };
+  if (!Number.isSafeInteger(rec.pid) || rec.pid <= 0) return { retain: { slot: rec.slot, reason: 'malformed holder pid; left for explicit reconciliation' } };
+  if (pidAlive(rec.pid)) return { retain: { slot: rec.slot, reason: 'holder still running; left held' } };
+  return { slot: rec.slot };
+}
+
+function reconcileTaskSlots(taskId) {
+  const out = { scanned: 0, reconciled: [], retained: [], otherTasks: 0, truncated: false };
+  let entries;
+  try { entries = fs.readdirSync(SLOTS_DIR); }
+  catch (err) {
+    if (err.code !== 'ENOENT') out.retained.push({ reason: `slot directory unreadable (${err.code}); left for explicit reconciliation` });
+    return out;
+  }
+  if (entries.length > SLOT_SCAN_LIMIT) { out.truncated = true; entries = entries.slice(0, SLOT_SCAN_LIMIT); }
+  for (const entry of entries) {
+    out.scanned += 1;
+    const file = path.join(SLOTS_DIR, entry);
+    const claim = ownSlotClaim(file, taskId);
+    if (claim.foreign) { out.otherTasks += 1; continue; }
+    if (claim.retain) { out.retained.push(claim.retain); continue; }
+    try {
+      // Re-read under the same guard every acquire/release takes: a contender
+      // may have reclaimed this record between the scan above and this point.
+      const blocked = mutate('slot', claim.slot, () => {
+        const now = ownSlotClaim(file, taskId);
+        if (now.slot !== claim.slot) return { slot: claim.slot, reason: (now.retain && now.retain.reason) || 'record changed during reconciliation; left as found' };
+        fs.unlinkSync(file);
+        return null;
+      });
+      if (blocked) out.retained.push(blocked);
+      else out.reconciled.push(claim.slot);
+    } catch (err) {
+      out.retained.push({ slot: claim.slot, reason: err.code === 'EBUSY' ? 'slot mutation busy or interrupted; left for explicit reconciliation' : err.message });
+    }
+  }
+  return out;
 }
 
 module.exports = {


### PR DESCRIPTION
Refs #902 (R06 task-runtime isolation).

## The residue

Exclusive slot records live in `<runtime>/slots/`, deliberately outside every task root, so `releaseTask`'s `rmSync` of the task tree could never reach them. Reproduced against `origin/main` (d499521) with a disposable `NEMO_ISOLATION_ROOT`: register a launcher, acquire a slot, SIGKILL the launcher, then call `releaseTask` with the correct owner token.

```
releaseTask -> {"released":true,"taskId":"repro-task-59925"}
task root removed: true
RESIDUE slot files after authorized release: 1
  record: { "slot": "repro-slot-59925", "taskId": "repro-task-59925",
            "pid": 59926, "ownerToken": "...", "acquiredAt": "..." }
holder pid alive: false
```

`acquireExclusiveSlot` already reclaims a dead holder, so this never wedged a slot — the record just outlived the task that owned it, naming a released task and a dead pid until some other task happened to want that exact slot.

## The correction

An owner-verified release now reconciles only what the record itself proves:

- it names **this** task (`rec.taskId === taskId`),
- it is complete (`slot` and `ownerToken` present, `pid` a positive safe integer),
- its declared slot name is the one its filename encodes — so the per-slot guard taken below is the right guard, and a crashed `writeRecord` `.tmp` leftover is rejected rather than reclaimed,
- its holder pid is verifiably not running.

Every removal happens inside the same `mutate('slot', ...)` guard that `acquireExclusiveSlot`/`releaseExclusiveSlot` already take, and **re-reads the record under that guard**, so a contender that reclaimed it between the scan and the removal is never overwritten.

This cannot grant more than the existing acquire path already grants: a dead holder's record is reclaimable by any task today, so deleting one is strictly narrower than reclaiming it.

Anything live, foreign, malformed, self-inconsistent or under an interrupted guard is reported in the new `slots` result and **left exactly as found**. A release with no launcher record to check against has no ownership proof and touches nothing beyond its own tree — which keeps the existing ownerless `isolation.releaseTask(taskId)` calls in `lib/build-runtime.cjs` fail-closed.

The helper is **not exported**: the authority is the caller's verified launcher token inside `releaseTask`, not a standalone verb. The module's public API is unchanged, so the `nemo.lib.isolation` boundary profile needs no edit.

## Result shape

```json
{ "released": true, "taskId": "cli-probe",
  "slots": { "scanned": 1, "reconciled": ["cli-slot"],
             "retained": [], "otherTasks": 0, "truncated": false } }
```

Bounded at 4096 scanned entries with a truthful `truncated` flag.

## Validation

- `node --test scripts/nemo/isolation.test.cjs` — **24/24 pass**, including the pre-existing concurrent stale-reclaim and interrupted-mutation guarantees, which are untouched.
- `node scripts/nemo/ci.cjs quick` on this exact commit (head `797e64b`, base `d499521`) — `ok: true`, `problems: []`; doctor / check / test:unit / test:rust all pass.
- `node scripts/nemo/ci.cjs boundaries` — exit 0, ratchet `ok: true`, no violations.
- Repro re-run against the patched library: `RESIDUE slot files after authorized release: 0`, `slots.reconciled: ["repro-slot-..."]`.
- CLI end-to-end: `isolation.cjs release` prints the `slots` block; a live launcher is still refused with `launcher still running; stop it before release`.

New tests: killed-child + rightful-owner reclaim with a foreign task's dead slot left intact; live, malformed and filename-mismatched records retained with reasons; non-owner release reconciling nothing; interrupted slot guard blocking reconciliation without blocking the task release.

## Known limitations (both outside this branch's owned paths)

- `engineering/runtime-isolation.md` line 22 says release "removes only that validated task's roots after exit". That is now incomplete — it also reconciles that same validated task's verifiably-dead slot records. Left for that file's owner.
- `scripts/nemo/isolation.test.cjs` is now 479 nonblank lines, crossing the advisory `warn` threshold of 450 for the "Test file" profile (hard maximum 600). Advisory only; the boundaries lane passes, and several modules already sit above their warn thresholds on `main`.

All probes used disposable runtime roots. No native candidate, `task_runtime.rs`, native-runtime, package/jobs, profile, user Library, real slot or desktop state was touched.
