### PR TITLE
R03: fixture VM and bench loader follow the R08 curve extraction (stacked on #946)

### DIFF
--- a/tests/bench/README.md
+++ b/tests/bench/README.md
@@ -15,7 +15,7 @@ are R19's job and must be derived from receipts like these, not invented.
 
 | Workload | Backend | What is measured |
 |---|---|---|
-| `evaluation.valueAtFrame` | the real `motion.js`, loaded whole in a vm sandbox (`tests/fixtures/lib/sandbox.cjs`) | ns per property evaluation over the `keyed-props` fixture plus a 200-key synthetic track |
+| `evaluation.valueAtFrame` | the real `motion.js`, loaded whole in a vm sandbox (`tests/fixtures/lib/sandbox.cjs`) after the production modules `src/index.html` loads before it (`src/js/animation/curve.js`, the R08 easing kernel, when the tree has it); the `backend` string names every module that ran and `workload.evaluator` names the ease evaluator | ns per property evaluation over the `keyed-props` fixture plus a 200-key synthetic track |
 | `evaluation.evalCurvePoints` | same | ns per ease-curve evaluation on `DEFAULT_CURVE` |
 | `evaluation.expression` | same, with the shipped expression compiler | ns per evaluation of `frame * 3` and `[value[0] + frame * 2, value[1]]` over the `expression-props` fixture |
 | `copy.undoClone.<workload>` | the production `_cloneLayersForUndo` (`src/js/tweens.js`, lifted with `_walkStrokes` and app.js `_HEAVY_STROKE_FIELDS`) | ms for the real undo snapshot of the document's layers (heavy string fields detached, native clone, reattached — CLAUDE.md §5bis) |

--- a/tests/bench/run.cjs
+++ b/tests/bench/run.cjs
@@ -8,9 +8,14 @@
 // worthless (CLAUDE.md §5bis on why rAF-based probes mislead).
 //
 //   evaluation.*   the real motion.js, loaded whole in a vm sandbox
-//                  (tests/fixtures/lib/sandbox.cjs): valueAtFrame over the
-//                  keyed-props fixture, evalCurvePoints, expression evaluation
-//                  over the expression-props fixture
+//                  (tests/fixtures/lib/sandbox.cjs, which first installs the
+//                  production modules src/index.html loads before it — the
+//                  R08 easing kernel src/js/animation/curve.js when the tree
+//                  has it): valueAtFrame over the keyed-props fixture,
+//                  evalCurvePoints, expression evaluation over the
+//                  expression-props fixture. The backend string names every
+//                  module that ran, so receipts from before and after the
+//                  extraction are distinguishable.
 //   copy.undoClone the PRODUCTION undo snapshot (tweens.js _cloneLayersForUndo,
 //                  lifted) of a workload document's layers; copy.jsonClone is
 //                  the plain JSON round trip it is built on, copy.serialize the
@@ -104,6 +109,14 @@ function measureMemoryHere(id) {
   return { id, gcAvailable, before, after, delta: Math.max(0, after - before), identity: built.identity };
 }
 
+// The evaluation backend names every production module the sandbox ran, in
+// load order (sandbox.cjs MOTION_PRELUDE + motion.js), so a receipt taken
+// before the R08 extraction ('src/js/motion.js') and one taken after
+// ('src/js/animation/curve.js + src/js/motion.js') are never confused.
+function evaluationBackend(motion) {
+  return 'node:' + motion.modules.map((f) => 'src/js/' + f).join(' + ') + ' (whole modules in a vm sandbox, tests/fixtures/lib/sandbox.cjs)';
+}
+
 function loadProject(id) {
   const project = readJson(path.join(FIXTURES, id, 'project.json'));
   const state = sandbox.defaultState();
@@ -117,13 +130,15 @@ function runBench(opts) {
   const iterations = opts.iterations || (quick ? 2 : 5);
   const docIds = opts.workloads || (quick ? [QUICK_WORKLOAD] : Object.keys(gen.WORKLOAD_DOCS));
   const workloads = [];
-  const EVAL_BACKEND = 'node:motion.js (whole module in a vm sandbox, tests/fixtures/lib/sandbox.cjs)';
+  let EVAL_BACKEND = null;
   const UNDO_BACKEND = 'node:tweens.js _cloneLayersForUndo (lifted, tests/fixtures/lib/sandbox.cjs)';
 
   // ---- evaluation ---------------------------------------------------------
   {
     const { state, motion } = loadProject('keyed-props');
     const { SMMotion } = motion;
+    EVAL_BACKEND = evaluationBackend(motion);
+    const evaluator = motion.SMAnimationCurve ? 'SMAnimationCurve.evalCurvePoints (src/js/animation/curve.js)' : 'evalCurvePoints declared in src/js/motion.js';
     const ld = state.layers[0]; // "Default ease": position, rotation, scale and opacity keyed
     const synthetic = corpus.helpers.layer('ly_bench_synthetic', 'Synthetic 200 keys', corpus.helpers.frames(state.totalFrames), {
       motion: { position: corpus.helpers.keys(Array.from({ length: 200 }, (_, i) => ({ frame: i * 3, v: [i * 7, (i % 5) * 11] }))) },
@@ -138,15 +153,16 @@ function runBench(opts) {
         evaluations += 5;
       }
     }, iterations);
-    workloads.push({ id: 'evaluation.valueAtFrame', kind: 'evaluation', status: 'ran', fixture: 'keyed-props', backend: EVAL_BACKEND, workload: { framesPerIteration: framesPer, propertiesPerFrame: 5, keysInSyntheticTrack: 200, evaluations }, stats: stats(samples.map((ms) => (ms * 1e6) / (framesPer * 5)), 'ns/evaluation') });
+    workloads.push({ id: 'evaluation.valueAtFrame', kind: 'evaluation', status: 'ran', fixture: 'keyed-props', backend: EVAL_BACKEND, workload: { framesPerIteration: framesPer, propertiesPerFrame: 5, keysInSyntheticTrack: 200, evaluations, evaluator }, stats: stats(samples.map((ms) => (ms * 1e6) / (framesPer * 5)), 'ns/evaluation') });
 
     const curve = SMMotion.DEFAULT_CURVE();
     const n = quick ? 5000 : 100000;
     const curveSamples = timed(() => { let acc = 0; for (let i = 0; i < n; i++) acc += SMMotion.evalCurvePoints(curve, i / n); if (acc < 0) throw new Error('unreachable'); }, iterations);
-    workloads.push({ id: 'evaluation.evalCurvePoints', kind: 'evaluation', status: 'ran', fixture: null, backend: EVAL_BACKEND, workload: { evaluationsPerIteration: n, curve: 'DEFAULT_CURVE' }, stats: stats(curveSamples.map((ms) => (ms * 1e6) / n), 'ns/evaluation') });
+    workloads.push({ id: 'evaluation.evalCurvePoints', kind: 'evaluation', status: 'ran', fixture: null, backend: EVAL_BACKEND, workload: { evaluationsPerIteration: n, curve: 'DEFAULT_CURVE', evaluator }, stats: stats(curveSamples.map((ms) => (ms * 1e6) / n), 'ns/evaluation') });
   }
   {
     const { project, state, motion } = loadProject('expression-props');
+    if (evaluationBackend(motion) !== EVAL_BACKEND) throw new Error('the sandbox loaded different modules for two projects: ' + evaluationBackend(motion) + ' vs ' + EVAL_BACKEND);
     const le = state.layers[project.layers.findIndex((l) => l.layerUid === 'ly_expr_e')];
     const framesPer = quick ? 48 : 600;
     const samples = timed(() => { for (let f = 0; f < framesPer; f++) { motion.SMMotion.valueAtFrame(le, 'rotation', f); motion.SMMotion.valueAtFrame(le, 'position', f); } }, iterations);
@@ -196,4 +212,4 @@ function main() {
 }
 
 if (require.main === module) main();
-module.exports = { runBench, measureMemory, verifyWorkloadJson, buildWorkload, SCHEMA, QUICK_WORKLOAD };
+module.exports = { runBench, measureMemory, verifyWorkloadJson, buildWorkload, evaluationBackend, SCHEMA, QUICK_WORKLOAD };

--- a/tests/fixtures/lib/sandbox.cjs
+++ b/tests/fixtures/lib/sandbox.cjs
@@ -6,10 +6,13 @@
 //
 // motion.js runs whole: its IIFE only touches the DOM lazily, so a stub
 // `document` whose lookups return null is enough for the evaluator, the
-// expression compiler and the migrations. app.js does not (Paper.js bound at
-// load), so the few pure functions the fixtures need are lifted out of it by
-// brace matching — the same technique tests/performance-regressions.test.cjs
-// uses — and run against a minimal `state`. Nothing here modifies src/.
+// expression compiler and the migrations. It is preceded by the production
+// modules src/index.html loads before it (MOTION_PRELUDE below), because
+// motion.js binds to globals they install at load time. app.js does not run
+// whole (Paper.js bound at load), so the few pure functions the fixtures need
+// are lifted out of it by brace matching — the same technique
+// tests/performance-regressions.test.cjs uses — and run against a minimal
+// `state`. Nothing here modifies src/.
 const fs = require('node:fs');
 const path = require('node:path');
 const vm = require('node:vm');
@@ -72,13 +75,49 @@ function defaultState() {
   return { layers: [], symbols: {}, fps: 24, totalFrames: 24, frame: 0, mode: 'motion', canvasW: 1920, canvasH: 1080, imageMeshes: {}, trackRoles: {}, cameraKeys: [] };
 }
 
-// motion.js: returns { SMMotion, state, sandbox }. `state.layers` and
-// `state.fps` are read by the evaluator and the expression engine.
-function loadMotion(state = defaultState()) {
+// Production modules that src/index.html loads BEFORE motion.js and that
+// motion.js binds to at load time, in that order. animation/curve.js (R08,
+// #949) installs the pure easing kernel `SMAnimationCurve`, which motion.js
+// reads once (`var evalCurvePoints = SMAnimationCurve.evalCurvePoints`) as
+// its IIFE runs — so a sandbox that ran motion.js alone died on that line
+// (ReferenceError) and took every fixture check and bench evaluation workload
+// with it. A prelude file is skipped only when the tree does not have it
+// (a motion.js that still declares the evaluator itself needs nothing); a
+// motion.js that needs the kernel without the file fails loudly, never silently.
+const MOTION_PRELUDE = ['animation/curve.js'];
+
+// motion.js: returns { SMMotion, SMAnimationCurve, modules, state, sandbox }.
+// `state.layers` and `state.fps` are read by the evaluator and the expression
+// engine. `modules` lists the production files that ran, in order, so a
+// receipt can name its backend exactly; `SMAnimationCurve` is the installed
+// kernel, or null on a tree from before the extraction.
+// Two test seams: `hooks.prelude` replaces MOTION_PRELUDE (an empty list runs
+// motion.js alone, which is how a regression reproduces the original failure;
+// a `var` a vm script declared cannot be deleted from the context afterwards),
+// and `hooks.beforeMotion(sb)` runs after the prelude and before motion.js so a
+// regression can observe or wrap what motion.js binds at load.
+function loadMotion(state = defaultState(), hooks = {}) {
   const sb = baseSandbox(state);
-  vm.runInNewContext(read('motion.js'), sb, { filename: 'src/js/motion.js' });
+  const modules = [];
+  for (const file of Array.isArray(hooks.prelude) ? hooks.prelude : MOTION_PRELUDE) {
+    if (!fs.existsSync(path.join(SRC, file))) continue;
+    vm.runInNewContext(read(file), sb, { filename: 'src/js/' + file });
+    modules.push(file);
+  }
+  if (typeof hooks.beforeMotion === 'function') hooks.beforeMotion(sb);
+  try {
+    vm.runInNewContext(read('motion.js'), sb, { filename: 'src/js/motion.js' });
+  } catch (e) {
+    // Errors thrown inside the vm belong to another realm: match by name, not instanceof.
+    if (e && e.name === 'ReferenceError' && /SMAnimationCurve/.test(String(e.message))) {
+      throw new Error('motion.js binds to SMAnimationCurve at load, which src/js/animation/curve.js installs; the sandbox mirrors the src/index.html loader order (' + MOTION_PRELUDE.join(', ') + ' before motion.js) and that module is missing or was not installed: ' + e.message);
+    }
+    throw e;
+  }
+  modules.push('motion.js');
   if (!sb.SMMotion || typeof sb.SMMotion.valueAtFrame !== 'function') throw new Error('motion.js did not expose SMMotion.valueAtFrame');
-  return { SMMotion: sb.SMMotion, state, sandbox: sb };
+  if (typeof sb.SMMotion.evalCurvePoints !== 'function') throw new Error('motion.js did not expose SMMotion.evalCurvePoints');
+  return { SMMotion: sb.SMMotion, SMAnimationCurve: sb.SMAnimationCurve || null, modules, state, sandbox: sb };
 }
 
 // Pure document-resolution helpers lifted from app.js (read-only over the
@@ -133,4 +172,4 @@ function loadVectorTextGroup() {
   return { vectorTextGroupMembers: sb.__api.vectorTextGroupMembers, sandbox: sb };
 }
 
-module.exports = { ROOT, extractFunction, loadMotion, loadAppHelpers, loadImageMesh, loadTextSelector, loadUndoClone, loadVectorTextGroup, defaultState };
+module.exports = { ROOT, MOTION_PRELUDE, extractFunction, loadMotion, loadAppHelpers, loadImageMesh, loadTextSelector, loadUndoClone, loadVectorTextGroup, defaultState };

--- a/tests/fixtures/lib/sandbox.test.cjs
+++ b/tests/fixtures/lib/sandbox.test.cjs
@@ -1,0 +1,118 @@
+'use strict';
+// The fixture VM (sandbox.cjs) must install production modules in the order
+// src/index.html does. R08 (#949) moved Motion's easing kernel to
+// src/js/animation/curve.js and motion.js now binds `evalCurvePoints` to the
+// installed `SMAnimationCurve` as its IIFE runs; a sandbox that ran motion.js
+// alone died on that line (ReferenceError: SMAnimationCurve is not defined),
+// which took 12 of 17 fixture checks and both bench evaluation tests with it
+// on the combined #946+#949 candidate. These tests pin the loader contract on
+// BOTH sides of the extraction, so the R03 harness holds whichever PR lands
+// first: the prelude is installed when the tree has it, the facade member is
+// the extracted kernel (not a copy), a keyed track really invokes it, and the
+// values it produces match the independent expectations of reference.cjs.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const sandbox = require('./sandbox.cjs');
+const ref = require('./reference.cjs');
+const corpus = require('./corpus.cjs');
+
+const SRC = path.join(sandbox.ROOT, 'src', 'js');
+const CURVE_MODULE = path.join(SRC, 'animation', 'curve.js');
+const extracted = fs.existsSync(CURVE_MODULE);
+const motionSource = fs.readFileSync(path.join(SRC, 'motion.js'), 'utf8');
+const clone = (x) => JSON.parse(JSON.stringify(x));
+function near(actual, expect, tol, msg) {
+  assert.equal(actual.length, expect.length, msg + ': dimension');
+  for (let i = 0; i < expect.length; i++) assert.ok(Math.abs(actual[i] - expect[i]) <= tol, `${msg}: [${i}] got ${actual[i]}, expected ${expect[i]} (±${tol})`);
+}
+
+// Position keyed with the default ease (no curvePoints on the key): frames 2,
+// 4 and 6 sit on the default curve's on-curve waypoints (t = 0.25, 0.5, 0.75),
+// where the eased fraction is known without evaluating any spline.
+const KEYS = [{ frame: 0, v: [0, 0] }, { frame: 8, v: [80, 40] }];
+function keyedLayer() {
+  return corpus.helpers.layer('ly_sandbox_keyed', 'Sandbox keyed', corpus.helpers.frames(24), { motion: { position: corpus.helpers.keys(KEYS) } });
+}
+// Manual tangents (1, 0) at both ends make the segment the smoothstep
+// polynomial 3t² − 2t³: an independent closed form for any evaluator.
+const SMOOTH = [{ x: 0, y: 0, tx: 1, ty: 0 }, { x: 1, y: 1, tx: 1, ty: 0 }];
+
+test('sandbox: the production prelude precedes motion.js exactly as src/index.html loads it', () => {
+  const html = fs.readFileSync(path.join(sandbox.ROOT, 'src', 'index.html'), 'utf8');
+  const scripts = Array.from(html.matchAll(/<script src="js\/([^"]+)"><\/script>/g), (m) => m[1]);
+  const motionAt = scripts.indexOf('motion.js');
+  assert.ok(motionAt >= 0, 'index.html loads js/motion.js');
+  for (const file of sandbox.MOTION_PRELUDE) {
+    const onDisk = fs.existsSync(path.join(SRC, file));
+    const at = scripts.indexOf(file);
+    assert.equal(at >= 0, onDisk, `${file}: script tag present iff the module exists`);
+    if (onDisk) assert.ok(at < motionAt, `${file} is loaded before motion.js (index.html position ${at} vs ${motionAt})`);
+  }
+  const m = sandbox.loadMotion();
+  assert.equal(typeof m.SMMotion.evalCurvePoints, 'function');
+  assert.equal(m.modules[m.modules.length - 1], 'motion.js');
+  if (extracted) {
+    assert.deepEqual(m.modules, ['animation/curve.js', 'motion.js']);
+    assert.equal(typeof m.SMAnimationCurve.evalCurvePoints, 'function', 'the kernel is installed in the VM');
+    assert.equal(m.SMMotion.evalCurvePoints, m.SMAnimationCurve.evalCurvePoints, 'the facade member is the extracted kernel itself, not a copy');
+    assert.doesNotMatch(motionSource, /function evalCurvePoints\(/, 'after the extraction motion.js no longer declares the evaluator');
+  } else {
+    assert.deepEqual(m.modules, ['motion.js']);
+    assert.equal(m.SMAnimationCurve, null);
+    assert.match(motionSource, /function evalCurvePoints\(/, 'before the extraction motion.js declares the evaluator itself');
+  }
+});
+
+test('sandbox: the evaluator the facade exposes matches the independent expectations, before or after the extraction', () => {
+  const { SMMotion } = sandbox.loadMotion();
+  const curve = SMMotion.DEFAULT_CURVE();
+  for (const t of Object.keys(ref.DEFAULT_EASE_WAYPOINTS).map(Number)) assert.ok(Math.abs(SMMotion.evalCurvePoints(curve, t) - ref.defaultEaseAt(t)) <= 1e-9, `default ease at ${t}`);
+  for (let i = 0; i <= 64; i++) { const t = i / 64; assert.ok(Math.abs(SMMotion.evalCurvePoints(SMOOTH, t) - t * t * (3 - 2 * t)) <= 1e-9, `smoothstep at ${t}`); }
+  // Two waypoints without tangents still go through the Newton solve: equal to 1e-9, not bit-exact.
+  for (const t of [0.1, 0.3, 0.5, 0.9]) assert.ok(Math.abs(SMMotion.evalCurvePoints(ref.LINEAR_CURVE, t) - ref.linearEaseAt(t)) <= 1e-9, `linear at ${t}`);
+});
+
+test('sandbox: the kernel installed in the VM is the same production file Node imports', { skip: !extracted && 'src/js/animation/curve.js is absent (before the R08 extraction)' }, () => {
+  const direct = require(CURVE_MODULE).evalCurvePoints;
+  const { SMAnimationCurve } = sandbox.loadMotion();
+  const curves = { default: corpus.DEFAULT_CURVE, smooth: SMOOTH, peak: [{ x: 0, y: 0 }, { x: 0.5, y: 1 }, { x: 1, y: 0 }] };
+  for (const [name, pts] of Object.entries(curves)) {
+    for (let i = 0; i <= 64; i++) { const x = i / 64; assert.equal(SMAnimationCurve.evalCurvePoints(clone(pts), x), direct(pts, x), `${name} at ${x}`); }
+  }
+});
+
+test('sandbox: valueAtFrame on a keyed track invokes the extracted evaluator with the key curve and the segment fraction', { skip: !extracted && 'src/js/animation/curve.js is absent (before the R08 extraction)' }, () => {
+  const calls = [];
+  const m = sandbox.loadMotion(undefined, {
+    beforeMotion(sb) {
+      // Wrap the kernel BEFORE motion.js binds to it: whatever motion.js
+      // captures at load is what its track evaluation calls at run time.
+      const kernel = sb.SMAnimationCurve.evalCurvePoints;
+      sb.SMAnimationCurve.evalCurvePoints = function (pts, x) { calls.push({ pts: clone(pts), x }); return kernel(pts, x); };
+    },
+  });
+  const ld = keyedLayer();
+  m.state.layers.push(ld);
+  near(Array.from(m.SMMotion.valueAtFrame(ld, 'position', 0)), KEYS[0].v, 0, 'on the first key');
+  near(Array.from(m.SMMotion.valueAtFrame(ld, 'position', 8)), KEYS[1].v, 0, 'on the last key');
+  assert.equal(calls.length, 0, 'a frame on a key does not consult the curve');
+  for (const frame of [2, 4, 6]) {
+    const got = Array.from(m.SMMotion.valueAtFrame(ld, 'position', frame));
+    near(got, ref.trackValueAt(KEYS, frame, ref.defaultEaseAt), 1e-9, `position@${frame} (independent: default-ease waypoint)`);
+  }
+  assert.deepEqual(calls.map((c) => c.x), [0.25, 0.5, 0.75], 'one kernel call per evaluated frame, at the segment fraction');
+  for (const c of calls) assert.deepEqual(c.pts, corpus.DEFAULT_CURVE, 'a key without curvePoints evaluates DEFAULT_CURVE');
+  ld.motion.position.keys[0].curvePoints = clone(SMOOTH);
+  calls.length = 0;
+  const got = Array.from(m.SMMotion.valueAtFrame(ld, 'position', 2));
+  near(got, ref.lerpVec(KEYS[0].v, KEYS[1].v, 0.25 * 0.25 * (3 - 2 * 0.25)), 1e-9, 'position@2 with manual tangents (independent: smoothstep)');
+  assert.deepEqual(calls, [{ pts: SMOOTH, x: 0.25 }], 'the edited key curve reaches the kernel unchanged');
+});
+
+test('sandbox: motion.js run alone on an extracted tree (the original failure) fails loudly with the loader-order explanation', { skip: !extracted && 'src/js/animation/curve.js is absent (before the R08 extraction)' }, () => {
+  assert.throws(() => sandbox.loadMotion(undefined, { prelude: [] }), (e) => /animation\/curve\.js/.test(e.message) && /SMAnimationCurve is not defined/.test(e.message) && /src\/index\.html loader order/.test(e.message));
+  assert.deepEqual(sandbox.loadMotion(undefined, { prelude: sandbox.MOTION_PRELUDE }).modules, ['animation/curve.js', 'motion.js']);
+});

--- a/tests/nemo-bench.test.cjs
+++ b/tests/nemo-bench.test.cjs
@@ -29,6 +29,16 @@ test('a quick run yields a receipt bound to source and hardware, with measured a
     if (w.status === 'ran') { assert.ok(Number.isFinite(w.stats.median) && w.stats.median >= 0 && w.stats.unit, w.id); assert.ok(w.backend, w.id); }
     else { assert.equal(w.status, 'not-run'); assert.match(w.reason, /WebGPU/); assert.equal(w.fixture, 'export'); }
   }
+  // The evaluation backend names the production modules the sandbox ran, in
+  // src/index.html order: the R08 easing kernel first when the tree has it.
+  const kernel = fs.existsSync(path.join(ROOT, 'src', 'js', 'animation', 'curve.js'));
+  const expectedBackend = bench.evaluationBackend({ modules: kernel ? ['animation/curve.js', 'motion.js'] : ['motion.js'] });
+  assert.equal(r.backends.evaluation, expectedBackend);
+  for (const w of r.workloads.filter((x) => x.kind === 'evaluation')) assert.equal(w.backend, expectedBackend, w.id);
+  for (const id of ['evaluation.valueAtFrame', 'evaluation.evalCurvePoints']) {
+    const w = r.workloads.find((x) => x.id === id);
+    assert.match(w.workload.evaluator, kernel ? /^SMAnimationCurve\.evalCurvePoints \(src\/js\/animation\/curve\.js\)$/ : /^evalCurvePoints declared in src\/js\/motion\.js$/, id);
+  }
   const undo = r.workloads.find((w) => w.id === 'copy.undoClone.' + Q);
   assert.match(undo.backend, /_cloneLayersForUndo/, 'the undo clone is the production function, not a JSON round trip');
   assert.deepEqual(undo.workload.heavyFieldsDetached, ['src', 'bitmapPressureProfile']);

--- a/tests/nemo-fixtures.test.cjs
+++ b/tests/nemo-fixtures.test.cjs
@@ -1,5 +1,8 @@
 'use strict';
 
 // Normal-discovery entry (tests/*.test.cjs) for the R03 fixture corpus
-// verification, which lives next to the corpus.
+// verification, which lives next to the corpus, and for the loader contract
+// of the fixture VM it runs against (production modules in src/index.html
+// order, the R08 easing kernel included).
 require('./fixtures/fixtures.test.cjs');
+require('./fixtures/lib/sandbox.test.cjs');


### PR DESCRIPTION
Stacked on #946 (`6d49921`); reconciles R03 with #949 (R08). One commit, `8faadbe`, touching only R03-owned harness files: `tests/fixtures/lib/sandbox.cjs`, `tests/fixtures/lib/sandbox.test.cjs` (new), `tests/nemo-fixtures.test.cjs`, `tests/bench/run.cjs`, `tests/bench/README.md`, `tests/nemo-bench.test.cjs`. No production, package, jobs, index or inventory change.

## Failure reproduced

#949 moves Motion's easing kernel to `src/js/animation/curve.js`; `motion.js` now binds `var evalCurvePoints = SMAnimationCurve.evalCurvePoints` as its IIFE runs. The R03 sandbox ran `motion.js` alone. On a temporary combined candidate (#946 `6d49921` + #949 `f489203`, merge `1891ba9`, local only):

- `node --test tests/nemo-fixtures.test.cjs`: 12 of 17 fail, all `ReferenceError: SMAnimationCurve is not defined` at `src/js/motion.js:1173` via `sandbox.cjs loadMotion`.
- `node --test tests/nemo-bench.test.cjs`: 2 of 4 fail, same error; `node --expose-gc tests/bench/run.cjs --quick` crashes before measuring.

## Fix

`sandbox.cjs` installs the production modules `src/index.html` loads before `motion.js` (`MOTION_PRELUDE = ['animation/curve.js']`) in the same vm context, skipping a prelude file only when the tree does not have it, so the harness holds whichever PR lands first. A `motion.js` that needs the kernel without the module fails loudly with the loader-order explanation. `loadMotion()` returns the modules it ran and the installed `SMAnimationCurve` (null before the extraction) and takes two test seams (`prelude`, `beforeMotion`).

`tests/bench/run.cjs` names every module that ran in the evaluation backend string (`node:src/js/animation/curve.js + src/js/motion.js (...)` after the extraction, `node:src/js/motion.js (...)` before) and records `workload.evaluator` on the `valueAtFrame`/`evalCurvePoints` workloads, so receipts from both sides of the extraction are never confused.

## Regression (`tests/fixtures/lib/sandbox.test.cjs`, via `tests/nemo-fixtures.test.cjs`)

1. Prelude order matches `src/index.html` (script tag present iff the module exists, and before `motion.js`).
2. `SMMotion.evalCurvePoints` is the extracted kernel itself (identity), and `motion.js` no longer declares the evaluator.
3. The kernel in the VM evaluates identically to the CommonJS import of the same file (3 curves, 65 samples each).
4. `valueAtFrame` on a keyed track invokes the wrapped kernel once per evaluated frame with `DEFAULT_CURVE` and t = 0.25/0.5/0.75, returning the independent waypoint expectations of `reference.cjs`; with manual tangents it returns the smoothstep closed form and passes the edited curve unchanged.
5. `motion.js` run alone on an extracted tree (the original failure) throws the explained error.
6. Default/linear/smoothstep expectations through the facade hold on both sides of the extraction.

Cases 2–5 skip with their reason on a tree without `src/js/animation/curve.js`.

## Validation

- This branch alone (before #949): `npm test` 235 pass, 3 skipped (the extraction-only cases), 0 fail; `npm run check` pass; `inventory --check` up to date.
- Combined candidate with this commit cherry-picked (`a2a8b64` on the local merge): fixtures+bench 26/26 with 0 skips; `npm test` 251/251 (includes the R08 `tests/animation` suites); `npm run check` pass; bench CLI measures 7 workloads with backend `node:src/js/animation/curve.js + src/js/motion.js (...)`.
- Not run: `cargo test` (no Rust or production change in this delta).

## Application order and lead-owned integration items

Apply after #946, before or after #949 (both verified). Integrating #946 and #949 together needs two shared-wiring items outside R03 ownership, resolved in the temporary candidate and reported, not owned here:

- `package.json` and `scripts/nemo/README.md` conflict (adjacent additive hunks): keep #946's `inventory`/`fixtures` scripts and `npm run inventory` row, take #949's `test` script scope and `npm test` row. `scripts/nemo/lib/jobs.cjs` auto-merges.
- `npm run inventory` must be re-run on the combined tree: #949 shifts `motion.js` handler line numbers (330 changed lines across the three inventory files), so the `inventory` job fails as stale until regenerated.

Part of #899 (R03). Draft until the lead decides the integration order; no merge, issue closure or release requested.
