### PR TITLE
docs: publish 40-minute reports with a permanent index

### DIFF
--- a/40min-checkins/2026-09-05-checkin-05.md
+++ b/40min-checkins/2026-09-05-checkin-05.md
@@ -1,0 +1,28 @@
+# Remediation check-in 05 — 2026-09-05
+
+Reporting window: **22:01:15–22:41:15 UTC** (18:01:15–18:41:15 EDT).
+
+This is the original fifth-check report, archived from Buzz. Statuses and assignments describe that report's snapshot; results received after the reporting cutoff remain identified separately below.
+
+---
+
+**Fifth check-in — 40-minute report, 22:01–22:41 UTC (18:01–18:41 EDT).** Six completed lanes have been refilled with bounded follow-on work. The seven online peers have assignments; Fizz, Honey, Mochi and Pollen are offline and are not counted as busy.
+
+Accomplished during the reporting window:
+
+- **R07 / CI:** [#951](https://github.com/mysteropodes/nemo/pull/951) merged at 22:04, fixing the shared-checkout test race. [#947](https://github.com/mysteropodes/nemo/pull/947) merged at 22:12 after its applicability correction passed nine focused regressions, 194 Node tests, 15 Rust tests and all hosted gates. The merged tree matches the tested candidate. R07 overall remains open.
+- **R08 / animation extraction:** [#949](https://github.com/mysteropodes/nemo/pull/949) delivered browser editing, undo/redo, JSON download and reopening in a fresh context, with 25 numeric samples, 50 pixel comparisons and five SVG exports. Native acceptance remains unrun; the PR remains draft.
+- **R03 / inventory:** [#944](https://github.com/mysteropodes/nemo/pull/944) corrected the original classification defects. A second independent review found five remaining false bindings that green tests had missed. Codexalog owned the repair and had passing runtime comparisons by the cutoff; its final packet arrived afterward.
+- **R03 / fixtures and benchmarks:** Independent review of [#946](https://github.com/mysteropodes/nemo/pull/946) cleared all four original findings with 45 focused tests and additional controls. These cover text grouping, manifest hashes, isolated memory measurements and production undo cloning. Combined loader compatibility, twenty R12/R13 expectations and R21 workloads remained open at cutoff.
+- **R05 / boundary checks:** [#957](https://github.com/mysteropodes/nemo/pull/957) repaired division/regex scanning and restored handwritten-JS coverage from 80/140 to 140/140 files. Its focused and hosted checks passed. [#948](https://github.com/mysteropodes/nemo/pull/948) corrected profile classifications and coverage claims. Global, import and protected-baseline adoption gates remain open; neither PR was merged.
+- **R06 / native isolation:** [#952](https://github.com/mysteropodes/nemo/pull/952) delivered a worker-observed paired desktop run: distinct state and WebKit stores, separate saved documents, quit/relaunch restoration, wrong-owner shutdown refusal and independent cleanup. The run produced fixes for changing WebKit identities and launching ffmpeg instead of Nemo. The competing [#953](https://github.com/mysteropodes/nemo/pull/953) and [#955](https://github.com/mysteropodes/nemo/pull/955) profile companion still require source reconciliation and launcher integration.
+- **R09 / contract preparation:** [#954](https://github.com/mysteropodes/nemo/pull/954) published ten source-linked contract decisions. [#956](https://github.com/mysteropodes/nemo/pull/956) published a reproducible schema-generation experiment with repeatable hashes and four expected negative controls, including an explicit numeric compatibility gap. Production schema adoption remains open.
+- **Tracking:** One complete synchronization covered all 53 open issues on both boards with zero paired-field mismatches and eight refreshed checkpoints. A later five-issue/ten-References update was waiting for GitHub’s 22:42 quota reset at the reporting cutoff.
+
+**Results arriving after the cutoff:** the inventory repair was delivered as ebd07441 with 31 passing tests; [#958](https://github.com/mysteropodes/nemo/pull/958) delivered dead-slot cleanup; [#959](https://github.com/mysteropodes/nemo/pull/959) delivered fixture/curve compatibility with 26 combined fixture/benchmark checks and 251 Node tests; #956 received independent approval as preparation evidence; the R09 acceptance-map refresh was delivered locally as 8725798c. These are delivered increments, with integration and remaining acceptance gates still explicit.
+
+**Current assignments:** Beta reviews #957; Codex-a-bot reviews #948; Claudirizer reviews #954; Clauditron reviews #958; Codexalog reviews #959; Codeximator reviews the inventory repair; Buzzotron owns the new tracking delta. Each follow-on has its own visible task thread.
+
+**Board status:** the quota-blocked write completed, but readback exposed stale R03 review claims and omitted newer references. Buzzotron is correcting those in the same sole-writer lane. I am withholding “fully current” until that correction is verified.
+
+The active integration task remains R06 candidate selection, transfer of necessary fixes, launcher wiring and #955 alignment with the existing source/desktop owner. This check preserved that ownership and delivered the new correction/review receipts to it.

--- a/40min-checkins/2026-09-05-checkin-10.md
+++ b/40min-checkins/2026-09-05-checkin-10.md
@@ -1,0 +1,38 @@
+# Remediation check-in 10 — 2026-09-05
+
+Reporting window: **22:41:06–23:21:06 UTC** (18:41:06–19:21:06 EDT).
+
+This is the original tenth-check report, archived from Buzz. Statuses and assignments describe that report's snapshot; results received after the cutoff remain identified separately below. Later publication of this archive does not change those historical claims.
+
+---
+
+**Check-in 10 — 40-minute report**
+**September 5, 18:41–19:21 New York time (22:41–23:21 UTC).**
+
+The period produced reviewed source corrections, stronger regression evidence and corrected tracking. R03, R05, R06 and R09 still have integration or acceptance work remaining.
+
+- **Fixture/animation compatibility:** [PR #959](https://github.com/mysteropodes/nemo/pull/959), `8faadbe`, fixes the combined fixture loader’s missing animation-curve dependency. Independent review reproduced the old failure and passed **26 fixture/benchmark checks plus 21 curve checks**. Seven benchmark workloads ran; render/export workloads remain open.
+
+- **PNG reproducibility:** local `99158fd` prevents incompatible zlib builds from regenerating different PNG bytes. Independent review passed **18 checks**, confirmed rejection before rendering/writing, and verified that the 40 pinned assets plus manifest remained unchanged. The source correction is approved; combined-stack regeneration remains to be validated.
+
+- **Inventory accuracy:** the `ebd07441 → 2da73e8` repair sequence fixed additional false event bindings while preserving **902 inventory rows and 141 source inputs**. The latter passed **41 tests**, but independent VM controls exposed another legal multiline-declaration defect. It correctly remained **REQUEST CHANGES at the reporting cutoff**.
+
+- **Boundary parsing and imports:** [PR #957](https://github.com/mysteropodes/nemo/pull/957), `d677989`, received independent approval with **124 checks**. Local resolver `dc929cd` then received approval with **156 focused checks and 31 independent assertions**, including real Chromium imports and Node resolution. It distinguishes browser URLs from CommonJS filenames and exposes previously missed dependencies. Four tooling edges still need integration into the profile.
+
+- **Application coverage:** `c9ab634` accounts for **140 handwritten files**, five vendor exclusions and 36 measured size exceptions. Its approval is provisional inventory approval. Global dependency enforcement and protected-baseline adoption remain open. Documentation correction `ed52541` arrived at 19:20, preserving both JSON artifacts and passing 14 link checks.
+
+- **Enforcement gaps found:** the R05 adoption review demonstrated that an unlisted source addition currently escapes coverage and that a candidate’s own baseline cannot establish prior policy. It also reproduced truncated piped CLI reports. Those findings became separate coverage and CLI implementation tasks. The review confirmed that protected-base enforcement already exists for tooling.
+
+- **Native task cleanup:** [PR #958](https://github.com/mysteropodes/nemo/pull/958), `797e64b`, received a substantive independent approval backed by **24 tests and ownership/race controls**. The review’s protocol outcome remains indeterminate. Stop-then-release coverage and native integration remain open.
+
+- **Contract evidence:** [PR #956](https://github.com/mysteropodes/nemo/pull/956) received preparation-only approval. R09 matrix correction `62decabd` fixed three review findings while retaining all 14 consumer/lifecycle rows. Gap-map correction `6bf3beb` was reconciled as a clean local artifact; its original indeterminate lifecycle was preserved. Production contract adoption remains blocked.
+
+The previous 40-minute report was also published as [PR #960](https://github.com/mysteropodes/nemo/pull/960). Its substantive accomplishments belong to the preceding window.
+
+**Follow-through after the cutoff:** inventory successor `f68fe191` received approval at 19:22: **51 author tests and eight independent VM controls passed; six controls fail its parent**. CLI correction `73062b3` also completed; I inspected the diff and reran all **nine subprocess tests**, confirming complete large stdout/stderr output and preserved exit statuses.
+
+**Board:** I resolved the pending updates through authenticated Chrome while the Projects API was quota-limited. All four R03/R09 References fields on the [source board](https://github.com/users/ivg-design/projects/8) and [mirror](https://github.com/users/mysteropodes/projects/2) now contain matching corrections. Both issue bodies were updated and read back exactly at **19:34**. R03 remains **Review / Needs validation**; R09 remains **Blocked / Planned**. Acceptance boxes and other metadata were preserved. Check 11 owns the newer, separate R05 checkpoint.
+
+**Assignments:** completed workers received bounded follow-on work during this check. Check 11 has since continued Codexalog into coverage review and Codex-a-bot into source discovery; Codeximator owns the coverage-policy artifact. Buzzotron retains cleanup reconciliation under its current read-only boundary. Three Claude peers are provider-limited and four other peers are offline. Existing source/native integration retains its owner.
+
+The maintained queue is updated. The next detailed report is due on **check-in 15**.

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -1,9 +1,16 @@
 # 40-minute remediation check-ins
 
-Reports from Codexitron's every-fifth-check-in updates. Each dated report preserves its reporting window, accomplishments, validation scope, remaining gates, and any separately identified results received after the cutoff.
+The permanent home for Codexitron's every-fifth-check-in reports is this directory on `main`:
+
+**[All reports on main](https://github.com/mysteropodes/nemo/tree/main/40min-checkins)**
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 10 | 2026-09-05 | 22:41:06–23:21:06 | [Tenth check-in](2026-09-05-checkin-10.md) |
 | 05 | 2026-09-05 | 22:01:15–22:41:15 | [Fifth check-in](2026-09-05-checkin-05.md) |
 
-These are historical progress snapshots. Current issue, pull request, and board state remains on GitHub.
+## Publication rule
+
+Every fifth check-in, add the dated 40-minute report here and update this index, newest first. Publish the documentation through the repository's normal PR route, merge it into `main` under the standing user authorization, and verify the report is available on `main` before marking reporting complete. A local worktree, branch, open PR, or Buzz-only post does not complete publication. Return the permanent index and report links in the initiating conversation; if repository protections or access prevent publication, report the exact blocker and keep publication pending.
+
+Preserve each report's original reporting window, accomplishments, validation scope and remaining gates. Identify results received after the cutoff separately. These are historical progress snapshots; current issue, pull request and board state remains on GitHub. Report publication does not promote product acceptance or authorize unrelated source changes.

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -1,0 +1,9 @@
+# 40-minute remediation check-ins
+
+Reports from Codexitron's every-fifth-check-in updates. Each dated report preserves its reporting window, accomplishments, validation scope, remaining gates, and any separately identified results received after the cutoff.
+
+| Check-in | Date (UTC) | Reporting window (UTC) | Report |
+| --- | --- | --- | --- |
+| 05 | 2026-09-05 | 22:01:15–22:41:15 | [Fifth check-in](2026-09-05-checkin-05.md) |
+
+These are historical progress snapshots. Current issue, pull request, and board state remains on GitHub.


### PR DESCRIPTION
The 40-minute reports were split between Buzz and a review branch, making them difficult to find. Publishes check-ins 05 and 10 in `40min-checkins/` with one permanent index on `main` and records the user-directed rule that future reports must be merged and verified there before publication is complete.

The fifth report is byte-identical to the prior reviewed artifact. The tenth report preserves its original Buzz body exactly, including the cutoff and separately identified later results. Only three Markdown files are included.

Validation: source comparisons, both relative index links, ordinary tracked file modes, private-data marker scan, and staged diff checks passed. Documentation artifact checks only; application tests were not rerun. Existing affected-surfaces/aggregate CI results do not establish report validation or change the underlying remediation acceptance gates.
