### PR TITLE
docs: publish fifteenth 40-minute remediation report

### DIFF
--- a/40min-checkins/2026-09-06-checkin-15.md
+++ b/40min-checkins/2026-09-06-checkin-15.md
@@ -1,0 +1,90 @@
+# Remediation check-in 15 — 2026-09-06
+
+Reporting window: **September 5, 23:21:07–September 6, 00:01:07 UTC** (September 5, 19:21:07–20:01:07 EDT).
+
+**New remediation tasks completed: 0. Product-source PRs merged: 0. Documentation PRs merged: 1.** The five closed remediation issues remain #895, #896, #897, #898 and #900; each closed before this window. The period produced approved corrections and stronger validation, but those results have not yet become integrated task acceptance.
+
+The next closure priority remains **R06 / #902**: reconcile the native candidates, finish shared launcher/profile wiring, and validate the integrated native workflow. Codexitron's existing source/native integration lane retains that work.
+
+## Accomplishments during the 40 minutes
+
+### R03: inventory correction approved
+
+Local successor `f68fe1916a0ce332d14cce34b86ae00088d38c66` received approval at **23:22:01**. It corrects false ownership bindings for legal multiline declarations. The author's **51 tests** passed; all **eight independent VM comparisons** passed, including six that fail the parent revision. The generated 902-row inventory remained unchanged.
+
+This closes the bounded source defect found in the preceding report. Integration with the inventory/fixture candidates and full [R03 acceptance](https://github.com/mysteropodes/nemo/issues/899) remain open.
+
+### R05: piped CLI output repaired
+
+Local `73062b358090a67629653211d484a6860c717c99` completed at **23:22:37**. It preserves complete piped JSON, text and diagnostics while retaining exit statuses 0, 1 and 2; the old implementation could truncate output at 65,536 bytes. **Nine real subprocess tests** passed on Node 24.19 and 25.9. The lead independently inspected the change and reran all nine tests.
+
+The correction is ready for integration. It was not merged during this window.
+
+### R05: coverage helper delivered, reviewed and corrected
+
+The initial helper `ee526434` made undeclared source additions and invalid exclusions observable. Independent review then found that distinct hard-linked paths to the same physical file could evade its alias check.
+
+Successor `ad88e76122e09340e10fd746e24c2015efba5b44` received independent approval at **23:49:53**. Validation passed **176 checks**, real base/candidate hard-link controls and **36 ordering permutations per revision**. This is an approved local helper, not application-wide enforcement.
+
+### R05: provisional policy and independent source discovery approved
+
+The one-file policy `b26967af316d76208d73f0a384cbda41e4c27a1b` received independent approval at **23:43:08**. All **152 selected files** have exactly one disposition: **140 retained and 12 exact exclusions**. Review checked membership, load sites and 21 provenance pins. Policy adoption, protected-baseline trust and global ownership remain separate gates.
+
+Discovery helper `3f860acf79213c48d1e4624127dbe44935acb4d7` scans the working tree independently of declarations, including untracked and ignored additions. Independent approval at **23:55:50** recorded **37 passing tests**, one fixture skipped because macOS rejects its invalid-UTF-8 filename, and **nine independent controls**. The scan assumes a stable source tree.
+
+An overlapping second review also passed. It is counted as one delivered prerequisite, not another completed task. The original interrupted discovery operation was reconciled before a separate remaining-work assignment; its historical indeterminate outcome was preserved.
+
+### R05: HTML parser prerequisite verified
+
+The parser feasibility task completed at **23:55:45**. Scratch tests of parse5 8.0.1 passed **24 controls on each of Node 20.19, 24.19 and 25.9**, and classified **132 script records** in Nemo's current startup HTML.
+
+The result supports a standards-based inventory implementation. No dependency or production wiring was adopted. Codeximator accepted the bounded helper/test implementation using a caller-supplied parser; shared manifests, lockfiles, CLI and CI remain with the integration owner.
+
+### Reports published in one permanent location
+
+[PR #960](https://github.com/mysteropodes/nemo/pull/960) merged at **23:48:05** as `a5ef39453682dae7074116ff888219e42c0bcf66`. Reports 5 and 10 and their index were verified on `main`.
+
+The [permanent report index](https://github.com/mysteropodes/nemo/tree/main/40min-checkins) is now the review location. The underlying accomplishments described in those earlier reports belong to their original windows.
+
+### Tracking and workspace reconciliation
+
+R03/R09 issue bodies and four source/mirror References fields were corrected around **23:34**. R05's earlier checkpoint and two References fields were verified at **23:42:59**. Statuses, validation, acceptance boxes and existing ownership were preserved.
+
+The latest R05 approval/discovery delta was **not complete at the cutoff**. A late partial update retained stale review wording and omitted three prior URLs; its subsequent correction is recorded below.
+
+The cleanup result reported removal of **28 worktrees and 72 reproducible cache directories**, with a **19.44 GiB reduction in measured allocation** and passing Git metadata checks. That is not a measurement of immediately free disk space. An active board-worker checkout was subsequently found removed and was restored clean at its original revision at **23:57**. Active-work preservation therefore failed during that cleanup; restoration and actual-effect reconciliation were required before further board updates.
+
+## Board position and remaining acceptance
+
+The reconciled population is **43 remediation items**, not all legacy roadmap rows. Source Project 8 and mirror Project 2 agree: **5 Done, 2 Review, 5 Blocked, 2 In progress and 29 Inbox**, with zero remediation-status mismatches in the latest count audit. Some legacy roadmap status fields intentionally use different vocabulary.
+
+| Task | Current disposition | Exact remaining step |
+| --- | --- | --- |
+| [R06 / #902](https://github.com/mysteropodes/nemo/issues/902) | Blocked / Needs validation | Reconcile #952 and #953 with #958, complete launcher/profile wiring and validate the integrated native candidate. |
+| [R03 / #899](https://github.com/mysteropodes/nemo/issues/899) | Review / Needs validation | Integrate approved inventory/fixture corrections and complete the remaining fixture, benchmark and combined-runtime gates. |
+| [R05 / #901](https://github.com/mysteropodes/nemo/issues/901) | Review / Needs validation | Adopt reviewed profiles and helpers; establish trusted baselines, global/order ownership and standard-command/CI enforcement. |
+| [R07 / #903](https://github.com/mysteropodes/nemo/issues/903) | Blocked / Needs validation | Finish the application/runtime coverage that depends on R05/R06 and verify the full acceptance contract. |
+| [R08 / #904](https://github.com/mysteropodes/nemo/issues/904) | Blocked / Needs validation | Complete dependency integration and native acceptance for the animation extraction. |
+| [R09 / #905](https://github.com/mysteropodes/nemo/issues/905) | Blocked / Planned | Integrate reviewed contract preparation only when prerequisite implementation and consumer evidence support adoption. |
+
+Boards: [Nemo Foundation Remediation](https://github.com/users/ivg-design/projects/8) · [Nemo Feature Roadmap mirror](https://github.com/users/mysteropodes/projects/2).
+
+## Follow-through after the cutoff
+
+- **00:01:50:** R05 composition evidence arrived. All **13 scratch tests** passed; fresh discovery and coverage reconcile **152 = 140 declared + 12 excluded**. No functional helper-composition blocker was found. Policy provenance, exclusion hashes and membership checks remain caller responsibilities. This does not establish production adoption.
+- **00:02:48:** The original board coordinator completed the final R05 correction. Exact issue and paired References readbacks passed, the three prior URLs were restored, and stale review/receipt wording was corrected. The original interrupted operation remains indeterminate; the reconciled correction is a distinct result.
+- R07 acceptance execution subsequently completed: **26 focused checks**, the quick lane with **194 Node tests and 15 Rust tests**, protected-base boundary checks and hosted failure/metadata controls passed. Acceptance criterion 1 remains partial/blocked; criteria 2 and 3 are evidenced for the current CI contract. **R07 is not Done.**
+- Codex-a-bot accepted the new, bounded R05/R07 issue-and-board evidence update after the earlier writer released ownership. This later delta is tracked separately from the completed 00:02:48 correction.
+
+## Assignments at report preparation
+
+All four online peers have accepted work in separate visible threads:
+
+- **Codexalog:** reconcile the R06 candidate choice across #952, #953 and #958.
+- **Buzzotron:** verify native artifact provenance and fixture readiness for the existing integration owner.
+- **Codeximator:** implement the two-file HTML script inventory/order prerequisite.
+- **Codex-a-bot:** record the completed R05 composition and R07 acceptance evidence in the two issues and both boards.
+
+Three Claude peers remain provider-limited/offline; Fizz, Honey, Mochi and Pollen are offline. They are not counted as busy, and unchanged failed operations have not been retried. Codexitron retains source/native integration ownership and this report's publication.
+
+Next detailed report: **check-in 20**. The next progress measure is accepted task closure on an identified integrated candidate, with the specific remaining check and its owner stated at each check-in.

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -6,6 +6,7 @@ The permanent home for Codexitron's every-fifth-check-in reports is this directo
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 15 | 2026-09-06 | Sep 5 23:21:07–Sep 6 00:01:07 | [Fifteenth check-in](2026-09-06-checkin-15.md) |
 | 10 | 2026-09-05 | 22:41:06–23:21:06 | [Tenth check-in](2026-09-05-checkin-10.md) |
 | 05 | 2026-09-05 | 22:01:15–22:41:15 | [Fifth check-in](2026-09-05-checkin-05.md) |
 


### PR DESCRIPTION
Publishes the fifteenth 40-minute remediation report for September 5 23:21:07–September 6 00:01:07 UTC and adds it to the permanent index. It separates approved local work from integrated acceptance, records zero new remediation closures, and identifies results arriving after the cutoff.

Validation: checked the reporting window against signed handoffs and GitHub timestamps; relative links resolve, both files are ordinary Markdown, private-data marker checks and staged diff checks passed. Documentation only; no application behavior changed. Publication to main is covered by the existing report-publication instruction.

Hosted run [34000490079](https://github.com/mysteropodes/nemo/actions/runs/34000490079): local quick and boundaries passed. Affected-surfaces failed because `40min-checkins/*.md` is not in the current explicit documentation allowlist, selecting all runtime surfaces for these two Markdown files. The receipt records missing browser/build/desktop prerequisites and native Rust failures (7 pass, 30 fail); these are unresolved runtime evidence, not a green validation claim. No product, test or CI source differs from the base. The aggregate correctly reports the failed lane.

Publication uses the existing authorized maintainer exemption for the documentation-only report, retaining repository protection settings. The documentation applicability gap is handed to the existing R07 integration owner; this PR does not alter CI selection or weaken its failure semantics.
