### PR TITLE
docs: publish twentieth remediation check-in

### DIFF
--- a/40min-checkins/2026-09-06-checkin-20.md
+++ b/40min-checkins/2026-09-06-checkin-20.md
@@ -1,0 +1,97 @@
+# Twentieth remediation check-in
+
+Reporting window: **September 6, 2026, 00:05:48–00:45:48 UTC**. Coordinator: Codexitron.
+This is the 40-minute snapshot requested at check-in 20. Later check-in actions are identified separately below.
+
+**No remediation tasks became Done during this window. Five are Done overall. One documentation PR merged; no product-source PR merged.** R06 advanced to a substantial local integration candidate, but independent reviews found defects that still block native acceptance. R07's hosted native failures now have a concrete prerequisite diagnosis and bounded correction candidates.
+
+## Board and completion state
+
+The fully paginated check-in 19 read covered all 58 source-project items and all 220 roadmap items. Both contain the same 43 remediation issues, #888–#930, with matching remediation status, validation, References and native status mappings.
+
+| Remediation status | Items |
+| --- | ---: |
+| Done | 5 |
+| Review | 2 |
+| In progress | 2 |
+| Blocked | 5 |
+| Inbox | 29 |
+
+Validation remains 5 Accepted, 7 Needs validation and 31 Planned. The five closed/Done issues are #895, #896, #897, #898 and #900; 38 remain open. No issue was promoted because a worker finished a review or prepared a patch.
+
+Canonical boards: [Nemo Foundation Remediation](https://github.com/users/ivg-design/projects/8) and [Nemo Feature Roadmap](https://github.com/users/mysteropodes/projects/2). The roadmap's native Status maps Review to In progress, Blocked to Needs work and Done to Already there. Its separate legacy Board Status field is not the active status field.
+
+## Delivered to main
+
+[PR #961](https://github.com/mysteropodes/nemo/pull/961) merged the fifteenth report and permanent index update at **00:11:36 UTC**, as `bf2020c76a0e1abba6da7ba0bae99dcb0b408954`. Both files were read back byte-for-byte from GitHub main. The report candidate was `bcdc331e439711f4c7618c80d6c964e8337a7ce2`.
+
+This was the only main merge in the reporting window. It published historical evidence; it did not change product behavior or close a runtime gate. [Previous report](2026-09-06-checkin-15.md).
+
+## R06: integrated locally, with four blocking review findings
+
+The existing source owner selected [PR #953](https://github.com/mysteropodes/nemo/pull/953) plus the dead-slot reconciliation from [PR #958](https://github.com/mysteropodes/nemo/pull/958), then assembled the native acceptance branch:
+
+| Local candidate | Resulting increment |
+| --- | --- |
+| `eec1424` / `e7a3924` | Selected native state isolation plus dead-slot reconciliation |
+| `323a430` | Native command entry points and packaged desktop job wiring |
+| `8971069` | Packaged native isolation acceptance harness |
+| `3c9277b` | Verify native exit before releasing ownership; retain data for restart |
+| `f4f3475` | Complete profile coverage and native test integration |
+| `3d87860` | Clean candidate with generated capability ordering preserved |
+
+Relative to main, the final local candidate spans 24 files, 2,760 additions and 30 deletions. Recorded implementation checks include a protected boundary baseline moving from 23 to 27 modules with zero violations, 56 focused Node controls, and 10 native task-runtime Rust tests. These results are retained implementation evidence; report preparation did not rerun them.
+
+Independent reviews then reproduced four defects:
+
+1. Missing package or harness prerequisites could return CLI exit 0.
+2. A comment-only test file could satisfy the nonempty-suite check.
+3. Timed-out command helpers could outlive successful harness cleanup.
+4. Failed retained-manifest deletion could leave a stale handshake accepted, including after launcher failure without a current child PID.
+
+The reviews completed successfully as review tasks, with **changes required** verdicts. Existing green tests did not cover all these failure cases. An older review's missing retain-data finding was reconciled against `3c9277b`, which already implements that option; it was not carried forward as an unresolved absence.
+
+Before the cutoff, Codex-a-bot accepted the isolated harness-cleanup correction and Codexalog accepted the retained-manifest/current-app handshake correction. Both supply scratch patches to the existing integration owner. [R06 / #902](https://github.com/mysteropodes/nemo/issues/902) remains **OPEN / Blocked / Needs validation**. No rebuilt-artifact, paired native-instance or UI save/reload acceptance was established.
+
+## R07: native CI failure isolated; corrections prepared
+
+[Hosted run 34000490079](https://github.com/mysteropodes/nemo/actions/runs/34000490079), on merge candidate `4217a283adc3241bcbfe46292c6561fabd43f1a4`, compiled Rust but recorded **7 passing and 30 failing native tests**. The 30 failures occurred while generating video fixtures, before the affected decoder assertions: the bundled FFmpeg could not load `libvmaf.3.dylib`. Its Mach-O metadata targets macOS 26.0, while the runner was macOS 14.8.9. The failures do not establish 30 decoder regressions.
+
+The earlier green run selected no required runtime surfaces and skipped native execution. It is not a passing native baseline.
+
+Work completed during this window:
+
+- **Dependency inventory:** the checked-in arm64 executable has 26 direct Homebrew dependencies; the inspected packaging closure contains 37 dylibs. The current host's closure itself requires macOS 15 or 26, so copying it does not establish macOS 14 compatibility. Raw Cargo testing does not perform the app's dependency bundling.
+- **Test executable selection:** Codeximator delivered a scratch patch against main `bf2020c`, with 15 focused controls passing. It shares one immutable preflighted executable across fixtures and probe/decode, honors an explicit `NEMO_TEST_FFMPEG_PATH`, retains the bundled default, isolates process caches and serializes indexed fixture initialization. Eight controls deliberately make Rust tests fail on bad prerequisites or encoding. Whole-file Rust parsing and patch application passed; full native crate compilation and hosted acceptance were not run. Patch SHA-256: `a18eef75307003d04936afc4c0f89aa44d2ba45f67697810c67be2d2e46f2aad`.
+- **Named-job preflight:** a separate scratch proposal passed eight controls covering missing executable, permission/loader failure, timeout, successful launch and later Cargo failure. Blocked prerequisites prevent Cargo and remain nonpassing in required CI receipts. Its older bundled-path assumption must be aligned with the explicit selector before adoption.
+- **Report-path CI correction:** the report Markdown was not classified as documentation and unnecessarily selected runtime surfaces. The recovered two-file patch adds the narrow Markdown exemption, with 10 tests passing and mixed application/CJS/JSON inputs still selecting runtime gates. The original worker operation remains indeterminate; its actual scratch effects were reconciled and inspected, without replay. Production adoption remains pending.
+
+Buzzotron's separate compatible hosted-FFmpeg provisioning proposal was still active at cutoff. Substituting a test executable does not repair or establish compatibility of the checked-in product sidecar. [R07 / #903](https://github.com/mysteropodes/nemo/issues/903) remains **OPEN / Blocked / Needs validation**, with its existing two of three acceptance criteria checked.
+
+## R03, R05 and tracking
+
+The R03 combined fixture-regeneration check, R05 HTML-helper review and scratch R06 profile adaptation reached verified terminal success. They supplied bounded evidence to the integration owner; no production adoption or task closure followed from those receipts alone. The HTML helper at `c53e351` is approved within its reviewed scope.
+
+During checks 16–19, issue checkpoints and paired project References for [#899](https://github.com/mysteropodes/nemo/issues/899), [#901](https://github.com/mysteropodes/nemo/issues/901), [#902](https://github.com/mysteropodes/nemo/issues/902) and [#903](https://github.com/mysteropodes/nemo/issues/903) were updated and independently read back. The latest #902 update records the clean candidate and changes-required reviews while preserving all 17 reference URLs, acceptance boxes and metadata. #901's paired References now identify the approved HTML helper, preserving all 11 URLs.
+
+## Capacity and actions after the cutoff
+
+Four peers were online and seven were offline. Offline peers are unavailable, not counted as busy. Finished online workers were reassigned to dependency-relevant tasks with visible assignment threads and recipient acceptance receipts.
+
+At check-in 20, the completed selector worker received a new, accepted scratch task to align the named-job preflight with that selector. The resulting active allocation is:
+
+| Agent | Accepted work |
+| --- | --- |
+| Codex-a-bot | R06 timed-out helper cleanup correction |
+| Codexalog | R06 retained-manifest and current-app handshake correction |
+| Codeximator | R07 explicit-selector / named-job preflight alignment |
+| Buzzotron | R07 compatible hosted FFmpeg provisioning |
+| Codexitron | R06 source integration in its existing session; check-in coordination, tracking and report publication in the reporting session |
+
+At **00:48:27 UTC**, a fresh fully paginated board read reconfirmed all 43 items, zero status/validation/reference mismatches and five Done overall. At **00:51:11 UTC**, #903 received the new selector result and preflight-alignment checkpoint; both References fields were read back equal at 966 characters, with all seven existing URLs retained. Issue state, acceptance boxes, forecasts and other metadata remained unchanged.
+
+## Next acceptance step
+
+The priority remains **R06 closure**: integrate the bounded corrections and remaining desktop-job guards in the existing owned branch, build from an identified clean commit, then exercise paired packaged instances, owned stop, retained relaunch and actual UI document save/reload under the required reservations. R07 needs compatible provisioning, aligned preflight/selector behavior and a real hosted native rerun. Neither gate is satisfied by scratch tests or this report's publication.
+
+The next detailed report is due at **check-in 25**. [Permanent report index](README.md).

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -6,6 +6,7 @@ The permanent home for Codexitron's every-fifth-check-in reports is this directo
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 20 | 2026-09-06 | 00:05:48–00:45:48 | [Twentieth check-in](2026-09-06-checkin-20.md) |
 | 15 | 2026-09-06 | Sep 5 23:21:07–Sep 6 00:01:07 | [Fifteenth check-in](2026-09-06-checkin-15.md) |
 | 10 | 2026-09-05 | 22:41:06–23:21:06 | [Tenth check-in](2026-09-05-checkin-10.md) |
 | 05 | 2026-09-05 | 22:01:15–22:41:15 | [Fifth check-in](2026-09-05-checkin-05.md) |


### PR DESCRIPTION
Publishes check-in 20 for September 6, 00:05:48–00:45:48 UTC and adds it to the permanent report index. The snapshot distinguishes the local R06 integration, blocking review findings, R07 prerequisite corrections and unchanged five-Done board total; actions after cutoff are identified separately.

Validation: both files are ordinary Markdown; relative links, private-data markers, scoped diff and whitespace checks passed. Both boards were fully read and the new R07 issue/References delta was verified. This change contains no application code and does not promote runtime acceptance.

The existing report-Markdown CI selector defect is tracked in #903 with its recovered two-file correction pending the source owner; the preceding report run selected unavailable runtime surfaces. Repository protections remain unchanged. Publication follows the standing every-fifth-check report instruction.
