### PR TITLE
docs: publish twenty-fifth remediation check-in

### DIFF
--- a/40min-checkins/2026-09-06-checkin-25.md
+++ b/40min-checkins/2026-09-06-checkin-25.md
@@ -1,0 +1,101 @@
+# Twenty-fifth remediation check-in
+
+Reporting window: **September 6, 2026, 00:45:47–01:25:47 UTC**. Coordinator: Codexitron.
+Results verified after the cutoff are identified separately below.
+
+**R06 gained integrated safety fixes, a passing clean packaged build and native harness, and draft PR #963. No remediation task became Done; five remain Done overall.** Four support tasks completed, but their successor assignments stalled before recipient acceptance. The boards remain consistent with each other while their newest R06/R07 checkpoints await cancellation reconciliation.
+
+## Delivered to main
+
+[PR #962](https://github.com/mysteropodes/nemo/pull/962) merged the twentieth report and permanent index at **00:54:20 UTC**, as `84d33bdfd69aaf8289f08fa0765846a6422a8e14`. Both files were verified byte-for-byte from GitHub main. This was the only main merge in the reporting window; no product-source PR merged. [Previous report](2026-09-06-checkin-20.md).
+
+## R06: corrections integrated and packaged validation advanced
+
+The existing source owner continued the native acceptance branch and opened [draft PR #963](https://github.com/mysteropodes/nemo/pull/963) at **01:20:05 UTC**. Its scope combines task isolation, standard desktop build/test entry points, owned cleanup, retained restart, and native Open/Resume repaint.
+
+| Integrated change | Result |
+| --- | --- |
+| `73ae7f3` | Missing desktop prerequisites and an empty/comment-only suite produce nonpassing required-job results; six focused controls passed. |
+| `28623a5` | Adopted the completed helper-cleanup and retained-manifest/current-child handshake patches; 52 focused controls passed. |
+| `40f33d7` | Wired the standard desktop build through isolated task ownership. |
+| `0297909` | Added immediate repaint after native Open/Resume. Final native visual acceptance remains outstanding. |
+| `0a0987a` | Updated command documentation and coverage for 30 protected modules, with zero boundary violations. |
+| `b9178ce` | Reconciled standard-build startup failure cleanup; 19 focused build/desktop controls passed. |
+| `6a97661` | Committed the later watchdog/finalization cleanup correction at **01:25:45 UTC**. Its full packaged result arrived after the cutoff. |
+
+At **01:06:20 UTC**, the clean integration quick gate on `1ef1af3b47a248775d7e55acc73b391b9717fc1c` passed **242/242 Node tests, 15/15 core Rust tests, and all six structural checks**.
+
+The standard `build:desktop` → `test:desktop` pipeline on clean candidate `b9178cec48881e38316e56db67eb63f33d82ffff` completed at **01:15:38 UTC**:
+
+- A real isolated desktop build passed in **64.468 seconds**.
+- The packaged native isolation test passed **1/1, with no skips**, in **6.426 seconds**.
+- Owned build cleanup and reservation release passed.
+- The executable SHA-256 was `3d4e310ae75aa399c6a171b5c2b416111c6c34f6c6da385e728bdd31d4b3b617`.
+
+The source owner also started two final native instances with valid current handshakes and distinct stores, reserving shared desktop/GPU input. Final Open/Resume replay could not proceed: desktop inspection returned `cgWindowNotFound` for both native app paths and Finder, including after a tool-session reset. The final UI receipt therefore records **Blocked**, with owned process/state/reservation cleanup completed at **01:19:02 UTC**. Earlier save/open/resume evidence does not establish immediate repaint on the final candidate.
+
+A subsequent integration review found that an outer watchdog could terminate the build controller during package preservation/finalization and bypass its cleanup receipt. The existing bounded source lane corrected that defect in `6a976614b031cd2e3e46201957ddc9c09d18af1e`; it remains part of the same R06 acceptance task. [R06 / #902](https://github.com/mysteropodes/nemo/issues/902) stays **OPEN / Blocked / Needs validation**. PR #963 remains a draft.
+
+## Completed support work
+
+These are completed bounded tasks, with their validation limits preserved:
+
+| Agent and terminal time | Delivered result | Validation |
+| --- | --- | --- |
+| Codexalog, **00:48:53** | Retained-manifest invalidation before readiness; handshake requires the current live app child. | **45/45** focused controls; reproduced false readiness on the original candidate. Patch `f771f48b…`, subsequently adopted into R06. |
+| Codex-a-bot, **00:49:31** | Track helper processes until exit; escalate resistant helpers and sweep cleanup-created helpers. | **13/13** controls; four new regressions failed on the original harness. Patch `379e5c2b…`, subsequently adopted into R06. |
+| Buzzotron, **00:51:56** | Hosted macOS FFmpeg provisioning proposal, including codec/filter/pipe smoke checks before exporting the test executable. | Nine CI-contract checks, YAML/Bash validation and local codec controls. Workflow diff `c3b02220…`; no hosted acceptance. |
+| Codeximator, **00:57:30** | Align named-job preflight with the explicit FFmpeg selector, including package-relative paths and rejected invalid overrides. | **16/16** controls; three new controls fail against the old proposal. Patch `50d247bd…`; fake executables, no native/hosted acceptance. |
+
+The two FFmpeg proposals were delivered for controlled owner integration. Their completion does not repair the shipped sidecar or establish macOS 14 compatibility. The previously completed selector remains a prerequisite, rather than a new completion in this window.
+
+## Hosted CI remains a separate failure
+
+[PR #963 run 34003624728](https://github.com/mysteropodes/nemo/actions/runs/34003624728) finished at **01:22:35 UTC** on the `b9178ce` proposal. Quick verification and boundaries passed; affected surfaces and the required aggregate failed.
+
+On tested merge `de3a96bdbd5db9e1bc029c920c89ea5e3400dcf5`, the hosted quick job passed **245/245 Node and 15/15 core Rust tests**. Boundaries covered **30 modules with zero violations and six warnings**; the protected-baseline check passed.
+
+The surface receipt records missing Playwright, wasm-pack, Tauri CLI/application prerequisites, and an undefined integration suite. Native Rust recorded **17 passing and 30 failing tests**; the video-fixture failures still expose missing `libvmaf.3.dylib` and the newer-macOS FFmpeg artifact. They do not establish 30 independent decoder defects. A local packaged pass does not clear these hosted failures.
+
+[R07 / #903](https://github.com/mysteropodes/nemo/issues/903) therefore remains **OPEN / Blocked / Needs validation**. Its compatible provisioning, selector and preflight candidates still need integrated hosted proof.
+
+## Capacity and tracking
+
+Four peers are online: Codex-a-bot, Codexalog, Codeximator and Buzzotron. Seven peers are offline. After the completed tasks, four successors were assigned in separate visible threads:
+
+| Agent | Successor assignment | Verified lifecycle |
+| --- | --- | --- |
+| Codex-a-bot | Combined R06 failure/cleanup interaction controls | Request stored; no recipient acceptance |
+| Buzzotron | Initial-import repaint diagnosis | Request stored; no recipient acceptance; later source already contains a repaint correction |
+| Codexalog | R06 issue and paired References update | Cancellation requested; no terminal cancellation |
+| Codeximator | R07 issue and paired References update | Cancellation requested; no terminal cancellation |
+
+Checks 21–25 found no recipient processed, accepted, progress or terminal receipts for those successors. Earlier signed peer replies confirm no execution in the responding sessions, without proving activity elsewhere or the cause of the admission failure. **The four online peers cannot be reported as busy.** The original operations remain preserved; no duplicate dispatch or competing tracking writer was introduced.
+
+Both boards were fully read during checks 21–24: [Nemo Foundation Remediation](https://github.com/users/ivg-design/projects/8), 58 items, and [Nemo Feature Roadmap](https://github.com/users/mysteropodes/projects/2), 220 items. All **43 remediation rows** agreed, with **831 field comparisons and zero mismatches** in the latest in-window read.
+
+| Status | Count |
+| --- | ---: |
+| Done | 5 |
+| Review | 2 |
+| In progress | 2 |
+| Blocked | 5 |
+| Inbox | 29 |
+
+The five Done issues remain #895–#898 and #900. R03 and R05 remain in Review; R06–R09 retain their existing blocking/validation states. All active lane issues retain accountable human `ivg-design`.
+
+Consistency is not freshness: #902 still has its **00:42:29 UTC** checkpoint, and #903 its **00:51:11 UTC** checkpoint. The new PR #963 and completed-candidate evidence are absent from those checkpoints and paired References. Prepared updates remain unapplied while their original cancellation requests are unsettled. They must be refreshed against current source evidence before application; the older prepared wording is now stale.
+
+## Evidence received after the cutoff
+
+- The clean `6a97661` standard pipeline started at **01:25:46 UTC** and completed at **01:26:57 UTC**. Its two jobs passed, including packaged-native **1/1 with no skips**. This extends packaged evidence after the window; final Open/Resume visual acceptance remains outstanding.
+- At **01:28:26 UTC**, the check-in 25 read reconfirmed both complete boards, all 43 rows, 831 comparisons, zero mismatches and no changes since check-in 24. This also confirmed the two stale checkpoints and unchanged assignments.
+
+## Exact next actions
+
+1. The existing R06 source owner completes final Open/Resume repaint acceptance on the identified current package when desktop inspection is available, and retains the latest cleanup evidence in PR #963.
+2. The R07 owner integrates the compatible FFmpeg proposals and passes the required hosted surfaces/aggregate; local controls do not substitute for this run.
+3. Buzz operator/runtime reconciliation must settle the four original admissions and two tracking cancellations. Then the coordinator can refresh and apply the guarded #902/#903 issue/paired References updates and reassign available peers without overlapping delayed work.
+4. R05 composition remains the next dependency-ordered source task after R06 closure. No existing source ownership changes through this report.
+
+The next detailed report is due at **check-in 30**. [Permanent report index](README.md).

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -6,6 +6,7 @@ The permanent home for Codexitron's every-fifth-check-in reports is this directo
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 25 | 2026-09-06 | 00:45:47–01:25:47 | [Twenty-fifth check-in](2026-09-06-checkin-25.md) |
 | 20 | 2026-09-06 | 00:05:48–00:45:48 | [Twentieth check-in](2026-09-06-checkin-20.md) |
 | 15 | 2026-09-06 | Sep 5 23:21:07–Sep 6 00:01:07 | [Fifteenth check-in](2026-09-06-checkin-15.md) |
 | 10 | 2026-09-05 | 22:41:06–23:21:06 | [Tenth check-in](2026-09-05-checkin-10.md) |


### PR DESCRIPTION
Publishes the check-in 25 report for September 6, 00:45:47–01:25:47 UTC, and adds it to the permanent index. It records R06's integrated repairs, packaged validation and draft PR #963, completed support patches, hosted failures, stale board checkpoints and stalled worker admission. Results received after the cutoff are labeled separately.

Validation: both staged files match the reviewed artifacts; relative links, regular-file/symlink checks, private-data markers and diff whitespace checks pass. Documentation only; no application acceptance or issue closure is claimed. Publication follows the standing every-fifth-check-in authorization and existing maintainer route.
