### PR TITLE
docs: publish thirtieth remediation check-in

### DIFF
--- a/40min-checkins/2026-09-06-checkin-30.md
+++ b/40min-checkins/2026-09-06-checkin-30.md
@@ -1,0 +1,86 @@
+# Thirtieth remediation check-in
+
+Reporting window: **2026-09-06, 01:25:51–02:05:51 UTC**. Coordinator: **Codexitron**.
+
+**Zero remediation tasks newly reached Done; five remain Done overall.** The final R06 packaged pipeline completed successfully, the hosted CI failures were diagnosed, and current evidence updates were prepared. Final native Open/Resume acceptance and worker admission remain blocked. No product-source PR merged during this window.
+
+## Delivered and verified
+
+| Time (UTC) | Accomplishment | Acceptance limit |
+| --- | --- | --- |
+| 01:26:57 | The standard desktop build/test pipeline passed on clean R06 candidate `6a976614b031cd2e3e46201957ddc9c09d18af1e`. | Packaged isolation evidence; final native repaint acceptance remains outstanding. |
+| 01:29:44 | Final-head hosted validation completed, providing exact failure evidence for diagnosis. | Quick and boundaries passed; affected surfaces and the required aggregate failed. |
+| 01:32:04 | [PR #964](https://github.com/mysteropodes/nemo/pull/964) published report 25 and the permanent index on main as `181f7f4a8f5c9a50090dfe1fa9fe37ba86b04e4c`. Both files were verified byte-for-byte. | Documentation publication; this was the only main merge in the window. |
+| Check-in 27 | Completed a bounded CI diagnosis and refreshed guarded R06/R07 issue and board evidence updates. | Updates are prepared, not applied; original tracking cancellations remain unresolved. |
+| Checks 26–29 | Reconciled complete board snapshots and the four original assignment chains. | No new closures, board changes or worker acceptance receipts. |
+
+The final watchdog correction was committed at **01:25:45**, immediately before this report's window. Its implementation was recorded in [report 25](2026-09-06-checkin-25.md); the completed pipeline below is the new validation result in this window.
+
+## R06 packaged result and remaining native gate
+
+[Draft PR #963](https://github.com/mysteropodes/nemo/pull/963) remains OPEN on `6a97661`. The clean standard `build:desktop` → `test:desktop` run completed with **two passing jobs, zero failures, zero blocked jobs and zero jobs not run**:
+
+- Fresh isolated desktop build: **64.967 seconds**.
+- Packaged native isolation test: **1/1 passed, no skips**, in **6.474 seconds**.
+- Owned build cleanup stopped the task and released its reservations.
+- Executable SHA-256: `3d4e310ae75aa399c6a171b5c2b416111c6c34f6c6da385e728bdd31d4b3b617`.
+
+This is an unsigned local verification package. It does not establish release acceptance. The final source correction also has **21/21 focused build/desktop controls** passing; the protected 30-module boundary comparison reports **zero violations and six warnings**, with no raised ceilings.
+
+Native inspection remained unavailable during checks 26 and 28: application inventory succeeded, but supported app/window lookup returned `-10005 cgWindowNotFound`, including for Finder or the installed Buzz application. Final Open/Resume repaint acceptance therefore remains **Blocked**. The later checks reused this concrete failure instead of rerunning unchanged builds or treating the earlier native workflow as final acceptance.
+
+The existing source/native owner retains the exact next test: launch the preserved verified A/B packages in distinct task stores, Open their saved autosave fixtures, verify immediate geometry, retain-stop/relaunch/Resume both, then Open the original saved fixtures and verify cleanup. Shared desktop/GPU input remains serialized. [R06 / #902](https://github.com/mysteropodes/nemo/issues/902) remains **OPEN / Blocked / Needs validation**.
+
+## Hosted CI diagnosis completed
+
+[Run 34003911855](https://github.com/mysteropodes/nemo/actions/runs/34003911855) tests PR head `6a97661` through merge candidate `930842397f073fdb235125015d32efc585ba39d4`. Quick verification and boundaries passed; affected surfaces and the required aggregate failed.
+
+The diagnosis established that all **10 task-runtime tests** and **seven video probe parsing tests** passed. All **30 Rust failures** occurred while generating video fixtures. The bundled FFmpeg could not load `libvmaf.3.dylib`; the loader also identified a macOS 26 build running on macOS 14.8.9. The missing library is an observed failure; fixing it alone has not been shown sufficient for compatibility.
+
+Fixture generation selects the bundled executable directly. Installing FFmpeg on PATH alone would not change that selection. Other selected surfaces still lack the integration suite, Playwright, wasm-pack, Tauri CLI or a packaged application. The required aggregate propagates these failures. No new actionable R06 regression was identified by this inspection.
+
+[R07 / #903](https://github.com/mysteropodes/nemo/issues/903) remains **OPEN / Blocked / Needs validation**. Its existing owner retains integration of the compatible FFmpeg proposals and hosted prerequisite validation. Local controls and packaged success do not clear these hosted gates.
+
+## Agent capacity
+
+Four peers are online; seven are offline. The four online peers still have the original assignments from check-in 21:
+
+| Agent | Assigned outcome | Verified disposition |
+| --- | --- | --- |
+| Codex-a-bot | Combined R06 failure/cleanup interaction controls | Request stored; no recipient acceptance |
+| Buzzotron | Initial-import repaint diagnosis | Request stored; no recipient acceptance; source already contains a repaint correction |
+| Codexalog | R06 issue and paired References update | Cancellation requested; no terminal settlement |
+| Codeximator | R07 issue and paired References update | Cancellation requested; no terminal settlement |
+
+Checks 26–29 found no new processed, accepted, progress or terminal receipts for these operations. Earlier signed peer replies established no execution in their responding sessions, without proving activity elsewhere. **These peers cannot be counted as busy.** No enrolled-peer task newly completed in this window; the bounded CI diagnosis was completed by native support.
+
+The original operations remain preserved. Replacement dispatches and competing tracking writes await runtime reconciliation. The available trusted tools expose no repair operation for this admission/cancellation failure. Offline peers are unavailable, rather than assigned fictional work.
+
+## Board consistency and stale checkpoints
+
+The latest in-window reads, at **01:59:51–01:59:55 UTC**, fully paginated [Nemo Foundation Remediation](https://github.com/users/ivg-design/projects/8), **58 items**, and [Nemo Feature Roadmap](https://github.com/users/mysteropodes/projects/2), **220 items**. All **43 remediation rows**, **831 field comparisons** and **43 native Status mappings** agreed, with no changes since the prior check.
+
+| Status | Count |
+| --- | ---: |
+| Done | 5 |
+| Review | 2 |
+| In progress | 2 |
+| Blocked | 5 |
+| Inbox | 29 |
+
+The Done issues remain #895–#898 and #900. R03 and R05 remain in Review. No acceptance checkbox or closure was changed.
+
+The boards are consistent but **not fully current**: R06's checkpoint remains dated **00:42:29 UTC**, and R07's **00:51:11 UTC**. At check-in 27, both guarded update plans were refreshed to include draft PR #963, the final packaged pass, the exact hosted failure and the outstanding Open/Resume gate. They preserve existing acceptance text and evidence URLs, and their issue/paired References baselines remained unchanged through check-in 29. They remain **PREPARED_NOT_APPLIED** until the original tracking cancellations settle.
+
+## Readback after the cutoff
+
+At **02:07:23–02:07:28 UTC**, check-in 30 reconfirmed complete 58/220-item boards, all 43 remediation rows, 831 field comparisons and 43 active Status mappings, with zero mismatches or changes since check-in 29. Five items remain Done. The two issue snapshots and all 84 reserved board fields still match the prepared update baselines. No tracking write was performed. The prepared R06 References value preserves its existing URLs and points to the issue checkpoint; its prepared issue body carries the current PR, candidate and CI evidence.
+
+## Next acceptance steps
+
+1. Buzz runtime/operator reconciliation must settle the four original admissions and two tracking cancellations. Then the coordinator can verify fresh baselines, apply the prepared R06/R07 evidence updates, read them back and refill released peer capacity.
+2. The existing R06 source/native owner completes the preserved final Open/Resume replay when desktop inspection recovers. PR #963 remains draft pending its remaining acceptance.
+3. The existing R07 owner completes hosted prerequisites and integrated FFmpeg validation; the recorded failure must be corrected before another run can establish success.
+4. R05 composition remains queued after R06. This report does not transfer existing source ownership.
+
+The next detailed report is due at **check-in 35**. [Permanent report index](README.md).

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -6,6 +6,7 @@ The permanent home for Codexitron's every-fifth-check-in reports is this directo
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 30 | 2026-09-06 | 01:25:51–02:05:51 | [Thirtieth check-in](2026-09-06-checkin-30.md) |
 | 25 | 2026-09-06 | 00:45:47–01:25:47 | [Twenty-fifth check-in](2026-09-06-checkin-25.md) |
 | 20 | 2026-09-06 | 00:05:48–00:45:48 | [Twentieth check-in](2026-09-06-checkin-20.md) |
 | 15 | 2026-09-06 | Sep 5 23:21:07–Sep 6 00:01:07 | [Fifteenth check-in](2026-09-06-checkin-15.md) |


### PR DESCRIPTION
Publishes Codexitron's thirtieth check-in for 01:25:51–02:05:51 UTC and adds it to the permanent report index. Records the final R06 packaged pass, completed hosted CI diagnosis, zero new remediation closures, stale R06/R07 checkpoints, and unresolved worker admission/cancellation and native acceptance gates.

Validation: checked the report against source receipts, live PR/CI state and complete paired-board snapshots; verified ordinary files, relative links, private-data markers and the scoped staged diff. Report-only change; no application tests rerun. Publication follows the standing authorization recorded in the report index. After merge, verify the report and index byte-for-byte on main. No product acceptance is implied.
