### PR TITLE
docs: publish thirty-fifth remediation check-in

### DIFF
--- a/40min-checkins/2026-09-06-checkin-35.md
+++ b/40min-checkins/2026-09-06-checkin-35.md
@@ -1,0 +1,57 @@
+# Thirty-fifth remediation check-in
+
+Reporting window: **2026-09-06, 12:02:03–12:42:03 UTC**. Coordinator: **Codexitron**.
+
+**Accepted outcomes advanced R03 integration, R06 isolation and R07 failure reporting. One issue was closed on GitHub; full acceptance of that issue is not established.** [PR #966](https://github.com/mysteropodes/nemo/pull/966) merged as `f79cdedfcfac20c9414a8c673c99182ecdbbd99b` at 12:28:26. GitHub closed [R05 / #901](https://github.com/mysteropodes/nemo/issues/901) one second later. Its current checklist still leaves reviewed application profiles and complete dependency/global enforcement unchecked. The existing personal PR-triage owner is reconciling that discrepancy; this report does not count it as verified full R05 acceptance. No issue was closed by check 35.
+
+The previous report ended at 02:05:51 UTC. This is the requested forty-minute window ending at check 35's delivery, not a claim of continuous execution during the intervening gap.
+
+## Outcomes and acceptance evidence
+
+| Lane | Delivered or accepted outcome | Remaining gate |
+| --- | --- | --- |
+| R03 inventory and fixtures | [PR #968](https://github.com/mysteropodes/nemo/pull/968), `1053aa59ec6eb34b60234abeb79bbad606e9192e`, combines the reviewed inventory repairs, fixture corpus, PNG runtime guard and R08 curve compatibility. Clean verification passed 288 Node tests, 15 Rust tests, six static checks and the current 902-row inventory. Pinned Node 20.19.4 reproduced all 40 assets plus manifest. | Open PR; 15 benchmark workloads measured, render and MP4 export explicitly not run. Real document and render adapters remain incomplete. |
+| R06 combined browser and cleanup | Candidate `d049e74` passed five real Chromium isolation/cleanup checks and eight named integration controls. Boundary review exposed a 502-line native module; delivered correction `e5c8a8c` passed the protected boundary lane and 47 focused controls. | Source-owner adoption and final combined native/package acceptance. |
+| R06 unsupported-host refusal | `755c9e5` adds the macOS isolation guard. Combined candidate `0c2600756669598b7a7233a8ef5675cb83cc5c20` passed 63 native/build/isolation/startup controls and protected boundaries with zero violations. Independent guard review approved its bounded scope. | No unsupported-host runtime success claim; final integrated package remains the source owner's lane. |
+| R07 hosted prerequisites | [Run 34032249190](https://github.com/mysteropodes/nemo/actions/runs/34032249190) passed all four checks on [PR #967](https://github.com/mysteropodes/nemo/pull/967), source `67164ec58901bd52d148ce404f2466af66d3a3c5`. Receipt: integration, browser, 47 native Rust tests, WASM build, isolated desktop build and packaged harness passed. | That standalone source lacked a later cleanup correction already present in the combined candidate. Its green run cannot certify another SHA. |
+| R07 empty-test failure | Review reproduced false success for zero tests, absent summaries, ignored-only tests and failed summaries with process exit zero. Codexalog delivered `0907c3f` followed by `d6cf353b4ff81f0b49940dcff581cdbe6e52a7c4`; the follow-up preserves optimized/serial native arguments and rejects those outcomes. | Final actual CLI/receipt acceptance completed just after the cutoff, below. Production integration remains pending. |
+
+The accepted R05 increment enforces committed-source coverage, size and protected-base ceilings. It does not establish the remaining application ownership, public-API and provider/consumer graph criteria. These distinctions explain why a merged increment cannot supply a verified full-issue closure.
+
+## Post-cutoff execution and changed approach
+
+Check 34 completed acceptance of `0907c3f` → `d6cf353`: twelve actual CLI child-process scenarios across both Rust jobs, six independent controls and a protected-base boundary pass. The selected follow-up includes the overlapping check-33 correction `01dd253` and additional label checks; preserve the alternate commit without applying both blindly. Check 35 reused this evidence. Its support agent completed an already-started 27-test focused run, but that repeat is not counted as new progress.
+
+Check 35 then created isolated local composition `9202c1a`, combining R03 `1053aa5` with main `265c297557da71cf12615e71ca5bfff9da2991df` (including R05 #966 and the post-cutoff #956 documentation merge). The production protected-main boundary command failed with **“invalid application coverage policy: snapshot counts do not match fresh discovery.”** The R03 inventory check still passed at 902 rows. The new curve module and changed source/bootstrap require updated application coverage metadata. Original source branches remain untouched.
+
+This concrete integration failure now has a separate accepted Codexalog correction task, request `3f6c43ecdb9b11e7dcc101f83dee937ef3b76115b10424c9862b03d437687558`. Recipient processed, accepted and prompt-admitted receipts were verified. Acceptance requires reproducibly refreshed profile/provenance, unchanged protected baseline and ceilings, a passing real boundary lane and a discriminating missing-module failure. It is accepted work, not a delivered or tested correction yet.
+
+At 12:42:53, Ilya directed that builds run locally unless hosted execution is explicitly requested. The workflow owner disabled all four Actions workflows; check 35 independently read back `disabled_manually` for each before report publication. Existing hosted receipts above are historical evidence. No new hosted build was requested by this check. The workflow owner retains the manual-trigger policy fix.
+
+## Agent accounting at publication preparation
+
+| Agent | Latest evidence and current assignment | Next deliverable or idle reason |
+| --- | --- | --- |
+| Codexalog | Rust correction delivered and accepted. Fresh R03/R05 coverage correction has verified recipient acceptance. | Scoped DCO candidate and protected-base checks; not delivered yet. |
+| Codex-a-bot | R03 document-harness job was accepted, then ended indeterminate at the provider usage limit. Exact old worktree was reconciled clean. Fresh reply confirms no successor accepted in that session. | Recovery owner retains the native fixture successor; no duplicate fixture writer assigned here. |
+| Buzzotron | Guard review delivered/approved. R03 render job was accepted, then interrupted with no delivered source. Old worktree reconciled clean. Fresh status question remains pending. | Recovery owner retains render refill; no new acceptance inferred from online presence. |
+| Codeximator | Guard implementation delivered. R05 provider/consumer consultation was accepted, then ended indeterminate. Fresh reply confirms no successor accepted in that session. | Recovery owner retains the contract refill; awaiting its concrete successor assignment. |
+| Claudimator Beta | Offline; no fresh deliverable verified. | Unavailable; existing claims preserved. |
+| Claudirizer | Offline; no fresh deliverable verified. | Unavailable; existing claims preserved. |
+| Clauditron | Offline; original R03/R04 branches preserved. | Unavailable; integration uses preserved commits. |
+| Fizz | Offline; no current accepted task verified. | Unavailable. |
+| Honey | Offline; no current accepted task verified. | Unavailable. |
+| Mochi | Offline; no current accepted task verified. | Unavailable. |
+| Pollen | Offline; no current accepted task verified. | Unavailable. |
+
+Usage-limit interruptions were reconciled before successors. Ilya reported reset limits; that does not itself prove resumed worker execution. The recovery owner was asked for fresh request IDs and acceptance, avoiding competing refills. No unchanged failed dispatch was repeated. The native `rust_count_review` support agent stopped once the earlier accepted evidence arrived and made no tracked edits.
+
+## Next actions and owners
+
+1. Codexalog delivers the R03/R05 coverage correction; check-35 Codexitron reviews its exact candidate and hands it to the existing source integration owner.
+2. The recovery owner completes or refills the R03 document, render and R05 contract lanes with explicit recipient acceptance. No further reporting-only loop substitutes for those deliverables.
+3. The source/native owner adopts the selected Rust correction and completes final combined local package/UI acceptance for R06/R07. Existing issue #902/#903 tracking reservations remain intact.
+4. The personal PR-triage owner reconciles #901's closed state against its two unchecked acceptance criteria and independently integrates ready PRs.
+5. The workflow owner lands manual-only build triggers under Ilya's new policy. Report publication remains documentation work, not product progress.
+
+Only changed findings were recorded; no full board rescan or competing issue ledger was created. The next detailed report is due at **check 40**. [Permanent report index](README.md).

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -6,6 +6,7 @@ The permanent home for Codexitron's every-fifth-check-in reports is this directo
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 35 | 2026-09-06 | 12:02:03–12:42:03 | [Thirty-fifth check-in](2026-09-06-checkin-35.md) |
 | 30 | 2026-09-06 | 01:25:51–02:05:51 | [Thirtieth check-in](2026-09-06-checkin-30.md) |
 | 25 | 2026-09-06 | 00:45:47–01:25:47 | [Twenty-fifth check-in](2026-09-06-checkin-25.md) |
 | 20 | 2026-09-06 | 00:05:48–00:45:48 | [Twentieth check-in](2026-09-06-checkin-20.md) |


### PR DESCRIPTION
Records the five-check execution window ending September 6 at 12:42:03 UTC, with accepted R03/R06/R07 outcomes, the R05 closure discrepancy, and current agent ownership. Includes the newly reproduced R03/R05 coverage integration blocker and separates post-cutoff evidence.

Validation: report/index relative links and artifact checks passed; staged diff is confined to the two report files; git diff --check passed. All four Actions workflows were independently verified disabled before publication, following the local-build-only instruction. This documentation does not close a remediation issue.
