### PR TITLE
Stop automatic GitHub builds; require explicit manual runs

### DIFF
--- a/.github/workflows/deploy-feedback-worker.yml
+++ b/.github/workflows/deploy-feedback-worker.yml
@@ -20,18 +20,20 @@ name: Deploy feedback Worker to Cloudflare
 # FEEDBACK_WORKER_URL are both checked in (wrangler.jsonc `vars`, and the
 # bridge source respectively) — no manual dashboard step needed anymore.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'worker-feedback/**'
-      - '.github/workflows/deploy-feedback-worker.yml'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      allow_hosted_build:
+        description: 'Explicitly approve this requested hosted Worker build and deployment (normally local)'
+        type: boolean
+        required: true
+        default: false
 
 permissions:
   contents: read
 
 jobs:
   deploy:
+    if: github.event_name == 'workflow_dispatch' && inputs.allow_hosted_build == true
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -21,15 +21,20 @@ name: Deploy web beta to Cloudflare Workers
 #      the dashboard (Workers & Pages > nemo-editor > Settings > Domains &
 #      Routes > Add > Custom Domain).
 on:
-  push:
-    branches: [main]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      allow_hosted_build:
+        description: 'Explicitly approve this requested hosted build and deployment (normally local)'
+        type: boolean
+        required: true
+        default: false
 
 permissions:
   contents: read
 
 jobs:
   deploy:
+    if: github.event_name == 'workflow_dispatch' && inputs.allow_hosted_build == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,8 +61,8 @@ jobs:
         with:
           node-version: 20
 
-      # Production (push to main) deploys as "nemo-editor" (wrangler.jsonc's
-      # name); anything else (manual dispatch from a non-main ref) deploys
+      # An explicitly requested manual run from main deploys as "nemo-editor"
+      # (wrangler.jsonc's name); a manual run from a non-main ref deploys
       # under "nemo-dev" via --name override — same stable/dev split
       # Graphite uses for editor.graphite.art/dev.graphite.art, just on
       # Worker names instead of Pages project names.

--- a/.github/workflows/nemo-validation.yml
+++ b/.github/workflows/nemo-validation.yml
@@ -1,23 +1,34 @@
 name: Nemo validation
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
+    inputs:
+      allow_hosted_build:
+        description: 'Explicitly approve this requested GitHub-hosted run (builds normally run locally)'
+        type: boolean
+        required: true
+        default: false
+      base_sha:
+        description: 'Full 40-character reviewed main/base SHA to compare against the selected ref'
+        type: string
+        required: true
 
-# Untrusted PR code runs only on disposable GitHub-hosted runners.
+# Local checks are the default. Hosted runs require an explicit human request.
+# Untrusted candidate code runs only on disposable GitHub-hosted runners.
 permissions:
   contents: read
 
 concurrency:
-  group: nemo-validation-${{ github.event.pull_request.number }}
+  group: nemo-validation-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  NEMO_CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+  NEMO_CI_BASE_SHA: ${{ inputs.base_sha }}
 
 jobs:
   quick:
     name: Nemo / local quick
+    if: github.event_name == 'workflow_dispatch' && inputs.allow_hosted_build == true
     runs-on: macos-14
     timeout-minutes: 30
     steps:
@@ -37,6 +48,7 @@ jobs:
 
   boundaries:
     name: Nemo / boundaries
+    if: github.event_name == 'workflow_dispatch' && inputs.allow_hosted_build == true
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -57,6 +69,7 @@ jobs:
 
   surfaces:
     name: Nemo / affected surfaces
+    if: github.event_name == 'workflow_dispatch' && inputs.allow_hosted_build == true
     runs-on: macos-14
     timeout-minutes: 60
     steps:
@@ -77,7 +90,7 @@ jobs:
 
   aggregate:
     name: Nemo / required
-    if: always()
+    if: always() && github.event_name == 'workflow_dispatch' && inputs.allow_hosted_build == true
     needs: [quick, boundaries, surfaces]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 
-# Builds the desktop app on a tag and publishes it as a GitHub Release,
-# updater manifest included.
+# Builds the desktop app for an existing tag only on an explicitly requested
+# manual run, then creates a draft GitHub Release with its updater manifest.
+# Tag pushes do not trigger builds. Local builds are the default.
 #
 # It produces the public binaries and, via includeUpdaterJson, the latest.json
 # the auto-updater will read. Pointing the app AT it is a deliberate follow-up:
@@ -28,12 +29,16 @@ name: Release
 # a choice -- see the `matrix` comment below before adding a platform.
 
 on:
-  push:
-    tags: ['v*']
   workflow_dispatch:
     inputs:
+      allow_hosted_build:
+        description: 'Explicitly approve this requested hosted release build (normally local)'
+        type: boolean
+        required: true
+        default: false
       tag:
         description: 'Tag to build (must already exist)'
+        type: string
         required: true
 
 permissions:
@@ -41,6 +46,7 @@ permissions:
 
 jobs:
   release:
+    if: github.event_name == 'workflow_dispatch' && inputs.allow_hosted_build == true
     strategy:
       fail-fast: false
       matrix:
@@ -69,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          ref: refs/tags/${{ inputs.tag }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -139,7 +145,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
-          tagName: ${{ github.event.inputs.tag || github.ref_name }}
+          tagName: ${{ inputs.tag }}
           releaseName: 'Nemo __VERSION__'
           releaseBody: |
             Nemo __VERSION__ — early alpha.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,10 @@ in its issue, pull request, or lead-designated queue; do not create a competing 
 
 ## Work safely
 
+- Run builds and validation locally. Do not enable, dispatch, rerun, or add automatic
+  GitHub Actions builds without an explicit human request for that specific hosted run.
+  Commits, pushes, PRs, merges, tags, and routine acceptance work are not that request.
+  See [the CI policy](engineering/ci/README.md); preserve normal PR review protections.
 - Read `CONTRIBUTING.md`, inspect current source, related branches and existing ownership,
   then use a dedicated branch and isolated worktree for tracked changes.
 - Record the outcome, scope, dependencies, base, branch/worktree, acceptance checks,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -458,6 +458,11 @@ silencieusement.
 
 ## 7. Avant chaque build : synchroniser le numéro de version partout
 
+**Builds et validation en local par défaut.** Aucun commit, push, PR, merge ou tag ne
+doit lancer un build GitHub Actions. Ne pas activer, déclencher ni relancer un workflow
+hébergé sans demande humaine explicite pour cette exécution précise. Voir la
+[politique CI](engineering/ci/README.md) ; conserver les protections de revue des PR.
+
 Trois fichiers portent le numéro de version et doivent rester identiques à chaque bump :
 `package.json`, `src-tauri/tauri.conf.json`. L'affichage à l'écran (titre de fenêtre, barre
 de statut en bas, Réglages → "Mises à jour de l'app") est lu dynamiquement via
@@ -509,9 +514,10 @@ Checklist avant `npm run build` :
    l'instant — réimplémentation clean-room de RDD-36 (spec SMPTE publiée), aucun pool de
    brevets public connu contrairement à AVC/HEVC, risque plus faible mais pas fermé ;
    `prores_videotoolbox` (ci-dessus) le fermerait si besoin un jour.
-4. Si c'est un vrai changement fonctionnel (pas juste un patch de bug) : pousser un tag
-   `v<version>` déclenche `.github/workflows/release.yml`, qui build, signe et publie une
-   Release GitHub en **draft** (le vrai verrou manuel : rien n'est visible tant qu'elle n'est
+4. Un tag `v<version>` ne déclenche plus de build. Construire en local par défaut.
+   Seulement sur demande humaine explicite, `.github/workflows/release.yml` peut être
+   lancé manuellement pour un tag existant avec `allow_hosted_build: true` ; il build,
+   signe et crée une Release GitHub en **draft** (rien n'est visible tant qu'elle n'est
    pas publiée à la main sur GitHub) — la publier la rend visible à l'updater intégré, qui lit
    `releases/latest/download/latest.json` sur le repo public `mysteropodes/nemo` (aucun token,
    endpoint dans `tauri.conf.json`). L'ancien script `publish-update.sh` (repo privé

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,12 @@ say so in the PR before it's merged, not after.
 
 ## Building locally
 
+Builds and validation run locally by default. Commits, pushes, pull requests, merges,
+and version tags must not start GitHub Actions builds. Hosted validation, web/Worker
+deployment, and release builds are manual exceptions requiring an explicit human request
+for that specific run; do not automatically dispatch or rerun them to satisfy a PR check.
+Keep local receipts with the PR. See [the CI policy](engineering/ci/README.md).
+
 ```bash
 npm install
 npm run dev      # tauri dev — desktop build with hot reload

--- a/engineering/ci/README.md
+++ b/engineering/ci/README.md
@@ -6,33 +6,58 @@
 3. **Match agents and effort to the work.** Use the least costly capable model and reasoning effort for each bounded task; delegate independent work when useful and escalate when complexity, uncertainty or risk warrants it.
 <!-- nemo-golden-rules:end -->
 
-# PR validation
+# Local validation and explicitly requested hosted runs
 
-This first R07 increment runs the existing local checks on pull requests into `main`.
-It does not close [R07](https://github.com/mysteropodes/nemo/issues/903) or configure
-repository protection. The proposed stable required check name is **`Nemo / required`**.
-An authorized owner must first validate its real check-run name and failure behavior,
-then configure required-check/review policy separately.
+**Current policy (2026-09-06): all builds and validation run locally by default.**
+Commits, pushes, PR updates, merges, and version tags must not trigger GitHub Actions
+builds. A routine request to implement, test, open a PR, merge, deploy, or release does
+not authorize a hosted build. Agents must not enable, dispatch, rerun, or introduce
+automatic build workflows without an explicit human request for that specific hosted run.
 
-| Always-required workflow lane | Local invocation | Success criterion |
+All four workflows (`nemo-validation`, `deploy-web`, `deploy-feedback-worker`, and
+`release`) expose only `workflow_dispatch`. Every job also requires the boolean input
+`allow_hosted_build: true`, which defaults to false. This is an execution guard; the
+human's request must already exist before an agent sets it. No scheduled, push, PR,
+tag, or chained workflow trigger is permitted. Build and publish locally unless the
+requested exception explicitly covers hosted execution and any deployment/release effect.
+
+The workflows were disabled in repository settings as immediate containment. Keep them
+disabled until the manual-only definitions are merged and a specific hosted run is
+requested. Before enabling one, verify both the default branch and the selected ref
+contain the manual-only definition; older branches/tags can retain automatic triggers.
+Enable only the needed workflow for the authorized run, then disable it again afterward.
+Never dispatch a hosted run simply to test these trigger changes.
+
+Attach local command receipts and exact source/base SHAs to PRs. Preserve required PR
+review; do not add an unattended hosted-build requirement to branch protection or bypass
+existing protection to compensate for a disabled check. This changes execution policy,
+not [R07](https://github.com/mysteropodes/nemo/issues/903)'s remaining runtime acceptance.
+The optional workflow's aggregate retains the name **`Nemo / required`** for compatibility.
+
+| Lane in an explicitly requested validation run | Local invocation | Success criterion |
 |---|---|---|
 | `quick` / Nemo / local quick | `node scripts/nemo/ci.cjs quick` | Existing `verify.cjs --jobs doctor,check,test:unit,test:rust --json`; every selected job passes |
 | `boundaries` / Nemo / boundaries | `node scripts/nemo/ci.cjs boundaries` | Existing boundary CLI and its protected-base ratchet both pass |
 | `surfaces` / Nemo / affected surfaces | `node scripts/nemo/ci.cjs surfaces` | Explicit applicability decision, then every applicable runtime job passes |
 | `aggregate` / Nemo / required | `node scripts/nemo/ci.cjs aggregate` | All three named workflow lanes return exactly `success` |
 
-`boundaries` and `surfaces` require `NEMO_CI_BASE_SHA`, the full 40-character commit SHA
-from the pull request event's base. The workflow checks out the candidate merge commit,
-with full history where base content is needed. Locally, fetch the protected branch,
-select its reviewed SHA and set that variable; do not substitute an arbitrary contributor
-revision. Local uncommitted edits are included by quick/boundary source checks, but surface
+`boundaries` and `surfaces` require `NEMO_CI_BASE_SHA`, the full 40-character reviewed
+protected-base commit SHA. Locally, fetch the protected branch, select its reviewed SHA
+and set that variable; do not substitute an arbitrary contributor revision. For an
+explicitly requested hosted run, provide the same SHA as the required `base_sha` input.
+The workflow checks out the selected dispatch ref, with full history where base content
+is needed; it does not synthesize a PR merge candidate. Use a reviewed integration ref
+when merge-result validation is required. Concurrency is scoped to the selected ref.
+Local uncommitted edits are included by quick/boundary source checks, but surface
 selection compares **committed** base and HEAD, just as the workflow does.
 
 `aggregate` consumes GitHub's `toJSON(needs)` through `NEMO_CI_NEEDS`. The expected lane
 list is fixed in the runner, not inferred from the received results. Missing, cancelled,
 failed, skipped, blocked, unavailable and unknown results all fail. The job uses
 [`if: always()` with explicit dependencies](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idneeds)
-so a failed prerequisite does not silently skip aggregation. Cancelling the aggregate
+plus the manual-event/approval guard, so a failed prerequisite does not silently skip
+an authorized aggregation. Without approval, every job including the aggregate is skipped.
+Cancelling the aggregate
 itself cannot produce success. No workflow path filters or `continue-on-error` are used.
 
 The existing local registry permits some optional jobs to return `blocked`/`not-run`
@@ -43,7 +68,8 @@ runner or killed process cannot pass. This does not change local optional-job se
 
 ## Applicability and remaining acceptance
 
-Quick and the adopted boundary profile run on every PR, including documentation changes.
+Quick and the adopted boundary profile run whenever the validation lanes are explicitly
+invoked, including for documentation changes; opening or updating a PR runs no workflow.
 Only explicit Markdown documentation paths (including `scripts/nemo/README.md`), boundary
 policy JSON, the isolated `engineering/boundaries/profiles/scripts-nemo.fixture/` subtree,
 the CI workflow/runner, and boundary checker/tests are exempt from runtime jobs. See `applicability()` in
@@ -78,18 +104,19 @@ receipts on their supported environments; CPU tests cannot supply that evidence.
 
 The runner materializes
 `engineering/boundaries/profiles/scripts-nemo.profile.json` directly with `git show`
-from the event base SHA into a unique temporary directory. It passes that absolute file
+from the reviewed base SHA into a unique temporary directory. It passes that absolute file
 to the existing `boundaries.cjs --baseline` CLI against the candidate profile/root.
 It records the base SHA, source path and content SHA-256. Missing commit/profile or
 malformed baseline fails closed. Candidate `scripts-nemo.baseline.json` is never used
 as the trusted prior policy. Temporary materialization is removed after the checker runs.
 
-The workflow uses `pull_request`, a read-only contents token, nonpersistent checkout
+The optional workflow uses `workflow_dispatch`, a read-only contents token, nonpersistent checkout
 credentials and disposable GitHub-hosted runners. No personal/self-hosted runner,
 `pull_request_target`, settings API, privileged follow-up workflow, cache reuse, or
 secret injection is involved. macOS arm64 matches the only committed FFmpeg sidecar;
-Linux runs the pure boundary/aggregate checks. Existing release/deploy workflows are
-outside this increment. PR workflow/checker changes remain reviewable candidate code;
+Linux runs the pure boundary/aggregate checks. Release/deploy workflows follow the same
+manual-only execution rule and require authority for their publishing effects.
+Workflow/checker changes remain reviewable candidate code;
 base provenance does not make that code immutable or replace required maintainer review.
 
 ## Evidence

--- a/engineering/remediation/03_TESTING_AND_DEBUGGING.md
+++ b/engineering/remediation/03_TESTING_AND_DEBUGGING.md
@@ -116,7 +116,11 @@ where applicable. Stale responses cannot update a later document.
 
 ## CI design
 
-Run static architecture, fast CPU, document-contract, browser and required native/build jobs
+**Current execution policy (2026-09-06): builds and validation run locally.** Hosted
+Actions builds require an explicit human request for the specific run; commits, pushes,
+PRs, merges and tags do not authorize one. See [the CI policy](../ci/README.md).
+
+Run static architecture, fast CPU, document-contract, browser and required native/build jobs locally
 according to changed modules and reverse dependencies. Until global coupling is retired,
 selection stays conservative. Required aggregate checks fail if a required child fails,
 cancels or is missing. Expensive GPU/native checks use trusted runners or an explicit

--- a/scripts/nemo/ci.test.cjs
+++ b/scripts/nemo/ci.test.cjs
@@ -216,13 +216,38 @@ console.log(${JSON.stringify(JSON.stringify(receipt([{ name: 'test:browser', sta
   assert.equal(ci.verify(['test:browser'], root).ok, false);
 });
 
-test('workflow invokes each CLI lane and always aggregates exact dependencies without PR privileges', (t) => {
+test('all hosted workflows require manual dispatch and explicit build approval before allocating a runner', () => {
+  const directory = path.join(ROOT, '.github/workflows');
+  const files = fs.readdirSync(directory).filter((file) => /\.ya?ml$/.test(file));
+  assert.ok(files.length > 0);
+  for (const file of files) {
+    const workflow = fs.readFileSync(path.join(directory, file), 'utf8');
+    const triggerBlock = workflow.match(/^on:\n((?:[ \t].*\n|#.*\n|\n)*)/m)?.[1];
+    assert.ok(triggerBlock, `${file}: expected a block-form trigger declaration`);
+    assert.deepEqual([...triggerBlock.matchAll(/^  ([\w]+):/gm)].map((match) => match[1]),
+      ['workflow_dispatch'], `${file}: automatic triggers are forbidden`);
+    assert.match(triggerBlock, /allow_hosted_build:\n\s+description: [^\n]+\n\s+type: boolean\n\s+required: true\n\s+default: false/);
+    const jobs = workflow.split(/^jobs:\n/m)[1];
+    assert.ok(jobs, `${file}: expected jobs`);
+    const jobCount = [...jobs.matchAll(/^  [\w-]+:\s*$/gm)].length;
+    const guards = [...jobs.matchAll(/^    if: (.+)$/gm)].map((match) => match[1]);
+    assert.ok(jobCount > 0);
+    assert.equal(guards.length, jobCount, `${file}: every job needs an approval guard`);
+    for (const guard of guards) assert.match(guard,
+      /^(?:always\(\) && )?github\.event_name == 'workflow_dispatch' && inputs\.allow_hosted_build == true$/);
+  }
+});
+
+test('manual validation invokes each CLI lane and aggregates exact dependencies without PR privileges', (t) => {
   const workflow = fs.readFileSync(path.join(ROOT, '.github/workflows/nemo-validation.yml'), 'utf8');
   const invocations = [...workflow.matchAll(/^\s+- run: node scripts\/nemo\/ci.cjs (\w+)$/gm)].map((m) => m[1]);
   assert.deepEqual(invocations, [...ci.LANES, 'aggregate']);
-  assert.match(workflow, /aggregate:\n\s+name: Nemo \/ required\n\s+if: always\(\)\n\s+needs: \[quick, boundaries, surfaces\]/);
+  assert.match(workflow, /aggregate:\n\s+name: Nemo \/ required\n\s+if: always\(\) && github.event_name == 'workflow_dispatch' && inputs.allow_hosted_build == true\n\s+needs: \[quick, boundaries, surfaces\]/);
   assert.match(workflow, /NEMO_CI_NEEDS: \$\{\{ toJSON\(needs\) \}\}/);
-  assert.match(workflow, /NEMO_CI_BASE_SHA: \$\{\{ github.event.pull_request.base.sha \}\}/);
+  assert.match(workflow, /NEMO_CI_BASE_SHA: \$\{\{ inputs.base_sha \}\}/);
+  assert.match(workflow, /base_sha:\n\s+description: [^\n]+\n\s+type: string\n\s+required: true/);
+  assert.match(workflow, /group: nemo-validation-\$\{\{ github.ref \}\}/);
+  assert.doesNotMatch(workflow, /github.event.pull_request/);
   assert.doesNotMatch(workflow, /pull_request_target|secrets\.|self-hosted|contents: write|continue-on-error|paths-ignore:|paths:/);
   assert.equal((workflow.match(/uses: actions\/checkout@/g) || []).length,
     (workflow.match(/persist-credentials: false/g) || []).length);


### PR DESCRIPTION
PR updates and main/tag pushes were starting hosted validation, WASM deployment builds, and desktop release builds automatically. This change makes all four workflows manual-only and requires `allow_hosted_build: true` on every job, with the input defaulting to false. Builds and validation run locally unless a human explicitly requests the specific hosted run.

Validation now takes a required reviewed `base_sha` and checks the selected dispatch ref; release builds take an existing tag. Contributor and agent guidance records the local-build policy. Normal PR review protection stays in place.

Immediate containment is already applied on GitHub: Nemo validation, web deployment, feedback Worker deployment, and Release are all `disabled_manually`. No queued or in-progress runs remained at readback. Keep these workflows disabled until this source change is merged and a specific hosted run is requested; do not dispatch Actions to validate this PR.

### Validation

- `node --test tests/nemo-ci.test.cjs`: 12/12 passed locally.
- PyYAML parsed all four workflows; each has only `workflow_dispatch`, a false-default boolean approval input, and approval guards on every job. Checked base-history fetch and exact release-tag checkout.
- Regression negative controls rejected an added push trigger, a true approval default, and a removed job guard; restored the original workflow afterward.
- Changed documentation relative links and `git diff --check` passed.
- Independent read-only review found no blocker. No hosted build, deployment, or release was dispatched.

### Task and remaining queue

- Priority P0; requested by Ilya on 2026-09-06; coordinator/writer Codexitron.
- Base: `f79cdedfcfac20c9414a8c673c99182ecdbbd99b`; candidate: `41081aa`.
- Branch/worktree ID: `codex/manual-only-actions-20260906` / `manual-only-actions-20260906`.
- Scope: four workflow definitions, CI regression test, CI/contributor/agent policy docs. Application code and other contributors' branches are untouched.
- Acceptance completed: immediate remote disablement, local trigger/approval regression checks, source publication for protected review.
- Remaining: required approving review and merge. This PR is the canonical queue for the source-policy change; immediate containment remains effective while review is pending.
- Integration dependency: PR #967 also changes `nemo-validation.yml`; preserve its useful prerequisite setup while retaining this manual-only trigger/input/job-guard policy when resolving overlap.
- No branch-protection changes or review bypass. Existing product/runtime acceptance gates remain open and require their appropriate local receipts.


Lead acceptance, exact `41081aa3383f2cc8c76c7805f531f43057f33534`:

- [x] Personally reviewed all four workflow trigger/job-guard changes and the local execution policy.
- [x] Independent isolated run: `node --test scripts/nemo/ci.test.cjs` passed 12/12, zero skips; scoped diff check passed.
- [x] All four live workflows are disabled. No hosted run was dispatched or enabled for this review.

Accepted for integration through the user-authorized protected PR override. Workflows remain disabled after merge; a future hosted run still requires an explicit human request.
