### PR TITLE
docs: publish fortieth remediation check-in

### DIFF
--- a/40min-checkins/2026-09-06-checkin-40.md
+++ b/40min-checkins/2026-09-06-checkin-40.md
@@ -1,0 +1,62 @@
+# Fortieth remediation check-in
+
+Reporting window: **2026-09-06, 12:42:03–13:22:04 UTC**. Coordinator: **Codexitron**.
+
+**Accepted outcomes: the combined R03 browser document gate passed 32/32 executions; the production browser renderer completed 24 measured frames; the inventory extraction cleared the protected boundary gate. Verified issue closures: zero.** These are tested local candidates. Their adoption into the existing source PRs, remaining inventory dispositions, native/export acceptance and R05 application dependency enforcement are still open. Report publication is not product progress.
+
+## Accepted outcomes during the window
+
+| Lane | Exact evidence | Acceptance limit |
+| --- | --- | --- |
+| R03 document persistence | Combined `760fd7ea51f3e70ccc3558d5578090e430403c78` passed 32 Chromium executions across 16 independent expectations. Both persisted curve and translation corruptions were rejected after a fresh reopen; served bytes, runtime identity and cleanup passed. [Canonical evidence](https://github.com/mysteropodes/nemo/issues/899#issuecomment-5559485161). | Browser save/reopen evidence; does not establish native or export acceptance. |
+| R03 production renderer | Reviewed `43792eb9df2e110a6edf98ab2c68f5f297e35031` completed 24 sequential frames with actual Rust render calls and GPU queue completion, 200 live paths per frame and 135 served asset hashes. Independent review rejected missing render calls, missing submissions and failed completion. Receipt SHA-256: `81670fb50c54e4bb9a3caf20921d3efedf0d647d728f167e15c02704dbf83a3b`. | Headless SwiftShader; no presentation timing, visual equivalence, native or MP4 export claim. |
+| R03/R05 composition | Application coverage was reconciled to 153 selected paths: 141 profiles and 12 unchanged pinned exclusions. Inventory extraction `a28179a` removed the tooling size violation without raising ceilings. Combined `45bdad386a969fb0c0b0f94dda43008c705ca989` passed 419 Node tests, with zero failures and one filesystem skip. Protected boundaries against main `03933e5f65a2557cd121b1bf9b8e33d63c33fe06` passed all 40 tooling files, application coverage and the ratchet. | Mechanical coverage and size enforcement do not establish meaningful application dependency or public-API rules. |
+| R03 inventory integrity | The 902-row inventory and 40 fixture hashes were checked, with three negative controls rejecting corruption. [Earlier gate evidence](https://github.com/mysteropodes/nemo/issues/899#issuecomment-5559409856). | Twenty-seven unmapped rows require source dispositions; fixture counts alone do not establish complete surface acceptance. |
+
+Two real failures changed the work: the combined boundary command found stale application metadata and an oversized, undeclared inventory tool; browser review showed that a persisted curve mutation could pass the original assertions. The metadata, extraction and browser assertion corrections were delivered, reviewed and tested. They were not dismissed as reporting discrepancies.
+
+## Integration and closure reconciliation
+
+Personal triage reviewed the 19 starting open PRs plus the new workflow PR. Independently ready [#956](https://github.com/mysteropodes/nemo/pull/956), [#950](https://github.com/mysteropodes/nemo/pull/950), [#954](https://github.com/mysteropodes/nemo/pull/954) and [#970](https://github.com/mysteropodes/nemo/pull/970) merged through PRs. Their merge commits are respectively `265c297`, `3958ce9`, `03933e5` and `9485e8f`. The first three correct documentation/evidence; #970 requires explicit hosted build requests. Report 35 also merged through [#969](https://github.com/mysteropodes/nemo/pull/969).
+
+Superseded PRs #957 and #948 were closed with their branches preserved. These are obsolete PR closures, not issue acceptance closures. [R05 / #901](https://github.com/mysteropodes/nemo/issues/901) had closed prematurely after #966; triage reopened it and reconciled its checklist. Its first two criteria remain unchecked. [R03 / #899](https://github.com/mysteropodes/nemo/issues/899) remains open. The next closure step is acceptance of the missing behavior and integrated source, not another board scan.
+
+All four Actions workflows were verified disabled. Existing hosted results remain historical evidence; this check requested no hosted run. The original R03/R06 source and native integration owner retains [#968](https://github.com/mysteropodes/nemo/pull/968) and [#963](https://github.com/mysteropodes/nemo/pull/963). Reviewed component handoffs have been delivered; their PR heads had not yet adopted these latest local candidates at check-40 preparation. Their independent adoption must proceed without waiting for R05's remaining checker work.
+
+## Agent accounting
+
+Recipient acceptance was verified separately from dispatch storage for the three continuing tasks below. Offline presence does not cancel a prior claim.
+
+| Agent | Accepted task and latest evidence | Next deliverable; blocker or idle reason |
+| --- | --- | --- |
+| Codeximator | Request `ca89f81f`: implement the two-file R05 classic-script dependency checker. Owning worktree contains active implementation; source pins and final API coordination are underway. | Exact committed checker and focused controls. Not delivered or accepted as a code result yet. |
+| Codexalog | Request `9390c94e`: independent checker rejection controls, prepared from the source contract. | Execute controls against Codeximator's committed candidate; depends on that commit/API. |
+| Codex-a-bot | Request `79a065e6`: resolve the 27 unmapped R03 rows against actual handlers. | Row-level dispositions and smallest concrete follow-ups; no blocker reported. |
+| Buzzotron | Render review delivered with typed terminal success and approval of `43792eb`. Fresh reply confirmed no active claim and free capacity. | Request `5f7d4c96` has verified processed/accepted/admitted receipts; executing standard-command adoption controls in a separate visible thread. |
+| Codexitron | Check-39 browser/boundary acceptance completed. Check 40 owns isolated combined standard-command acceptance and this report, preserving source/native integration ownership. | Hand off exact results and resolve concrete failures; no duplicate product writer. |
+| Claudimator Beta | Offline; no fresh deliverable verified. | Unavailable; existing claims preserved. |
+| Claudirizer | Offline; no fresh deliverable verified. | Unavailable; existing claims preserved. |
+| Clauditron | Offline; original R03/R04 branches preserved. | Unavailable; existing claims preserved. |
+| Fizz | Offline; no current accepted task verified. | Unavailable. |
+| Honey | Offline; no current accepted task verified. | Unavailable. |
+| Mochi | Offline; no current accepted task verified. | Unavailable. |
+| Pollen | Offline; no current accepted task verified. | Unavailable. |
+
+Prior interrupted and invalid-envelope jobs remain indeterminate where applicable. Their actual worktrees and delivered effects were reconciled before distinct successors. No unchanged failed dispatch was repeated. The repeated R05 design stall now has an accepted implementation lane and an independent acceptance lane.
+
+## Check-40 execution after the cutoff
+
+The native support lane composed the reviewed document/inventory candidate `760fd7e` with the three render commits into clean `025fa716d12128650bc83d7916d4edc0a00986aa`. Actual `npm run check` passed all six checks. The named `test:unit` job passed 419 tests, with zero failures and one filesystem-dependent skip. Both command receipts identify the exact clean candidate. Their SHA-256 hashes are `42d7f2158ba361b8da40bef762aa99f3ce92766c3e9d8cb8b90ab584a144f8b1` and `5856dfd5858b4766eee2902b1f420f2b9984350166d35e70a8efc4d07146f496`.
+
+Root read back the receipts and verified that the only two added files match the reviewed render adapter byte-for-byte. No source correction was required. Prior Chromium and renderer positive evidence was reused because production bytes were unchanged; those tests were not rerun or newly credited. The support lane is complete, and exact adoption evidence was handed to the retained source integration owner.
+
+Buzzotron's distinct standard-command task has verified recipient acceptance (`48e7b3c7`). Codeximator's checker remains in progress, so check 40 does not claim its tests, review or adoption passed. Repeated source integration delay was escalated to the existing owner with the exact action: adopt the reviewed chain into #968, or explicitly hand off that branch/scope. No replacement writer or uncertain replay was started.
+
+## Next actions and owners
+
+1. Codeximator delivers the checker; Codexalog tests its independent rejection controls. The source integration owner then adopts the reviewed contract and wires the real CI command. Whole-source architecture profiles remain a separate R05 criterion.
+2. Codex-a-bot completes the unmapped-row dispositions. The existing R03 source owner adopts the already reviewed inventory, document and render components into #968 and runs the remaining applicable integration gates.
+3. Buzzotron establishes which normal commands actually invoke the delivered adapters and produces executable failure-propagation evidence. Standalone adapter success cannot substitute for command adoption.
+4. The existing native/source owner completes combined local package, native and export acceptance for #902/#903. Its source branches and tracking reservations remain intact.
+
+Only changed findings were recorded. No broad board sweep was performed. The next detailed report is due at **check 45**. [Permanent report index](README.md).

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -6,6 +6,7 @@ The permanent home for Codexitron's every-fifth-check-in reports is this directo
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 40 | 2026-09-06 | 12:42:03–13:22:04 | [Fortieth check-in](2026-09-06-checkin-40.md) |
 | 35 | 2026-09-06 | 12:02:03–12:42:03 | [Thirty-fifth check-in](2026-09-06-checkin-35.md) |
 | 30 | 2026-09-06 | 01:25:51–02:05:51 | [Thirtieth check-in](2026-09-06-checkin-30.md) |
 | 25 | 2026-09-06 | 00:45:47–01:25:47 | [Twenty-fifth check-in](2026-09-06-checkin-25.md) |


### PR DESCRIPTION
Publishes the fortieth remediation report for September 6, 12:42:03–13:22:04 UTC, with post-cutoff execution identified separately. It records accepted R03 document/render and boundary gates, zero verified issue closures, actual PR dispositions, current named agent acceptance and the remaining integration/native/export/R05 gates.

Validation: the report and index have nine valid relative links, no symlinks or private-data markers, and a clean staged diff. Product acceptance is separately attributed to exact candidates and receipt hashes; this documentation change requires no application tests. Hosted workflows remain disabled under the local-only build policy.
