### PR TITLE
Publish remediation check-in 45

### DIFF
--- a/40min-checkins/2026-09-06-checkin-45.md
+++ b/40min-checkins/2026-09-06-checkin-45.md
@@ -1,0 +1,65 @@
+# Forty-fifth remediation check-in
+
+Reporting window: **2026-09-06, 13:22:04–14:02:05 UTC**. Coordinator: **Codexitron**.
+
+**Accepted outcomes: two demonstrated R05 checker defects are corrected and independently verified; 26 R03 inventory dispositions are accepted; the combined R03 candidate passed its normal check and unit commands. Verified issue closures: zero.** The remaining gates require source adoption, production command wiring and applicable native/export acceptance. No product PR merged during this window. Publishing this report is not product progress.
+
+## Outcomes accepted during the window
+
+| Gate | Exact result | Remaining limit |
+| --- | --- | --- |
+| R05 loader applicability | `f132e2781c4037f45d61a766300bf06bfc0e7c0d` passed 54 focused tests and independently rejected deletion of a required consumer from the second loader, including a runtime-failing reversed loader. [Acceptance](https://github.com/mysteropodes/nemo/issues/901#issuecomment-5559631277). | This cleared the omission defect; a separate eager-phase false pass still required correction. |
+| R05 execution phase | `93ef911d9293406f2c0a55146f6e5957d92dbef8` passed 59 focused tests. Twelve independent executable controls then rejected all six eager failures, accepted two supported deferred baselines and explicitly rejected four unsupported deferred forms. All 12 independently retained applicability-omission controls rejected. [Final bounded acceptance](https://github.com/mysteropodes/nemo/issues/901#issuecomment-5559700350). | Supports a limited named-function/provider form. Caller-reviewed loader facts, actual command adoption and wider architecture policy remain required. |
+| R03 inventory dispositions | Independent review accepted 26 row dispositions, preserving 54 source-evidence fragments. [Accepted supplement](https://github.com/mysteropodes/nemo/issues/899#issuecomment-5559659616). | The remaining `pm-stroke` row is a demonstrated inventory false negative requiring a scanner correction. |
+| R03 combined commands | Clean `025fa716d12128650bc83d7916d4edc0a00986aa` passed six normal checks and the named unit job with 419 tests, zero failures and one filesystem skip. Render files matched the reviewed candidate byte-for-byte. [Receipt](https://github.com/mysteropodes/nemo/issues/899#issuecomment-5559532388). | Local combined acceptance, still awaiting adoption into [#968](https://github.com/mysteropodes/nemo/pull/968). Earlier browser/render results were reused and were not credited as new runs. |
+
+The failed controls changed the implementation: a declared consumer in one loader could previously conceal its omission from another; declared call-phase metadata could also conceal execution during installation. Both were reproduced against actual VM behavior before correction. Their accepted repairs preserve aggregate failures rather than using `classicOk` to waive existing global-state diagnostics.
+
+## Concrete gaps found
+
+The production color-picker helper installs a click handler for `pm-stroke`, while the inventory scanner reports no handler. Seven independent controls establish the false negative; full inventory regeneration reproduces the same 902-row result. The correction belongs in helper/member binding analysis, not in an added product listener. [Evidence](https://github.com/mysteropodes/nemo/issues/899#issuecomment-5559597594).
+
+Standard-command review found that `test:browser` does not invoke the delivered document adapter and `bench` does not invoke the delivered renderer. Explicitly selected blocked jobs can produce a zero exit with an overall pass, although CI receipt validation rejects them. The retained integration owner must wire adapter invocation and receipt mapping, preserve required-job failure propagation, and include the relevant benchmark in surface selection. Standalone adapter success does not establish these command behaviors.
+
+## Integration stall and changed approach
+
+The retained source integration owner is another **Codexitron session**, identified by task thread `ac6d2343`; this is not a missing external reviewer or an approval request to the user. Its [R03 PR #968](https://github.com/mysteropodes/nemo/pull/968) still publishes `1053aa5`; [R06 PR #963](https://github.com/mysteropodes/nemo/pull/963) still publishes `6a97661`. Reconciliation found clean worktrees and no Git operation: R03 can advance to reviewed `025fa716`, and the preserved R06 local chain can advance to reviewed `d6cf353`. Those independent adoptions do not depend on the R05 checker work.
+
+Repeated requests to resume or transfer the exact source/PR scopes have not produced a verified handoff. Attempted signed self-addressing was rejected by the trusted tool as an unenrolled recipient; unaddressed posts do not establish session resumption. The required action remains with that owning session: adopt the reviewed chains and finish their remaining gates, or explicitly transfer the relevant scopes. If it cannot receive steering, the operator must resume or hand off that owning task. No branch takeover or uncertain replay was performed.
+
+To advance work that does not require those writes, check 44 assigned separate production-loader proof and global-disposition tasks. Check 45 continues actual combined command acceptance. Broad board scans and unchanged dispatch retries were not used as substitutes for execution. Hosted builds remain unrequested; all four Actions workflows were verified disabled.
+
+## Agent accounting
+
+| Agent | Accepted task and latest evidence | Next deliverable; blocker or idle reason |
+| --- | --- | --- |
+| Codeximator | Delivered the R05 correction through `93ef911d`; bounded independent review accepted. Fresh reply confirms no newer claim in the answering session. | Free pending a concrete new defect or released implementation scope. Existing source/CI wiring belongs to the retained integration owner. |
+| Codexalog | Deferral-review request `e53dad4e` completed with typed terminal success `ee9752c0`. Evidence review `150c2254` completed with terminal success `37cafb85`, technical **REQUEST_CHANGES**. | Concrete harness timing flaw delivered; idle pending the corrected immutable artifact for re-review. |
+| Buzzotron | Production-loader request `2cfb6ea2` was processed and accepted as `bb8a8f66`. Two-loader controls were delivered, but terminal `1783e72a` is **indeterminate** because its outcome envelope was invalid. | Original read-only effects reconciled: worktree clean, two artifact hashes verified. New scratch-only correction `9d70c2ca` has verified processed/recipient-accepted receipt `14265f41` and prompt admission for the demonstrated readiness-assertion timing flaw. Original task is not replayed. |
+| Codex-a-bot | Request `6e0c2ece` was recipient-accepted as `a1146a76`; signed history subsequently reports a worker restart and **indeterminate** outcome. Progress identified publishers for 17 Motion diagnostics. | Final artifact was not delivered. Reconcile original effects and recover the task receipt before any successor; no replacement or completion claim. |
+| Codexitron | Owns combined command acceptance, changed canonical evidence and report publication. Native support `r05_combined_acceptance` owns only its isolated acceptance candidate. | Complete the actual registration/discovery verdict. The separate retained Codexitron session owns source/native/PR integration. |
+| Claudimator Beta | Offline; no fresh deliverable verified. | Unavailable; existing claims preserved. |
+| Claudirizer | Offline; no fresh deliverable verified. | Unavailable; existing claims preserved. |
+| Clauditron | Offline; original source branches preserved. | Unavailable; existing claims preserved. |
+| Fizz | Offline; no current accepted task verified. | Unavailable. |
+| Honey | Offline; no current accepted task verified. | Unavailable. |
+| Mochi | Offline; no current accepted task verified. | Unavailable. |
+| Pollen | Offline; no current accepted task verified. | Unavailable. |
+
+## Check-45 execution after the cutoff
+
+The isolated combination `89272c3d1a1711ee9b093cb0d6576ae09d8fbb71` contains the reviewed R03 candidate plus the exact R05 helper chain; both helper/test blobs match `93ef911d`. The actual protected-base boundary command against main `28063650e3600a91c1a17280b93b98c21cd5e168` exits **1**: 42 tooling files are discovered but only 40 declared. Its only coverage failures are `scripts/nemo/lib/boundaries-classic.cjs` and `scripts/nemo/boundaries-classic.test.cjs`. Existing tooling/application profiles and the ratchet pass. An external load probe shows the boundary command does not import the new helper; its direct-import positive control works.
+
+This is an adoption failure, not a reason to weaken coverage. The owning source/CI lane must register both files and wire the adopted contract while retaining aggregate failure behavior. Actual `npm test` also exits **1**: 418 pass, one failure and one filesystem skip. Its sole failure is tooling coverage; load instrumentation confirms neither command imports the classic helper or its tests. The direct-import positive control records a load. [Canonical command evidence](https://github.com/mysteropodes/nemo/issues/901#issuecomment-5559775072). The acceptance receipt SHA-256 is `4df902839c2c3cbfed8e8e2782b3ebf663f6f90d85cee54b22f4bb80aa2ce1ba`. The source owner must also register the new test with normal discovery.
+
+Independent evidence review subsequently found that the VM harness checks identity and invocation after a microtask wait, allowing a controlled delayed restoration to pass. Both pristine production loaders pass immediate checks; the defect is in evidence timing. Review request `150c2254` completed successfully with a request for this narrow correction. The new scratch-only correction preserves the four production blobs and original artifacts.
+
+Check 44's signed completion was missing from the local queue at startup. Canonical issue evidence and signed history restored the ordinal to 45 and prevented a duplicate issue update. The repeated deferral result matched the prior digest and is explicitly reused, not counted as new product progress.
+
+## Next actions
+
+1. Buzzotron corrects the VM harness timing flaw; Codexalog then reviews the exact successor. The lead reconciles the interrupted Codex-a-bot task and recovers its final artifact or explicit unfinished-work packet before assigning a distinct successor. Progress messages alone do not close the disposition gate.
+2. The retained Codexitron integration session adopts independently ready R03/R06 chains through the protected PR route, fixes the inventory and standard-command gaps, and completes applicable native/export acceptance. If it cannot continue, it must explicitly hand off those scopes.
+3. The same source/CI owner registers the two R05 checker files and adopts the independently reviewed contract, then runs discriminating command-level rejection controls. Whole-source architecture profiles remain required for closing [#901](https://github.com/mysteropodes/nemo/issues/901).
+
+No issue closure is claimed until its stated acceptance is verified. The next detailed report is due at **check 50**. [Permanent report index](README.md).

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -6,6 +6,7 @@ The permanent home for Codexitron's every-fifth-check-in reports is this directo
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 45 | 2026-09-06 | 13:22:04–14:02:05 | [Forty-fifth check-in](2026-09-06-checkin-45.md) |
 | 40 | 2026-09-06 | 12:42:03–13:22:04 | [Fortieth check-in](2026-09-06-checkin-40.md) |
 | 35 | 2026-09-06 | 12:02:03–12:42:03 | [Thirty-fifth check-in](2026-09-06-checkin-35.md) |
 | 30 | 2026-09-06 | 01:25:51–02:05:51 | [Thirtieth check-in](2026-09-06-checkin-30.md) |


### PR DESCRIPTION
Publishes the 13:22:04–14:02:05 UTC remediation report with accepted R05 omission/phase corrections, R03 dispositions and combined-command evidence. Records zero issue closures, retained integration ownership, the newly demonstrated checker registration failure and exact worker lifecycle limits.

Validation: 10 relative links resolve; both files are regular files; private-marker and staged-scope checks passed. Report publication makes no product acceptance claim and requests no hosted build.
