### PR TITLE
Inventory all Git candidates for repository coverage

### DIFF
--- a/scripts/nemo/boundaries-repository.test.cjs
+++ b/scripts/nemo/boundaries-repository.test.cjs
@@ -1,0 +1,254 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { createHash } = require('node:crypto');
+const { discoverRepositoryFiles } = require('./lib/boundaries-repository.cjs');
+
+function command(root, args, input) {
+  const result = spawnSync('git', ['-C', root, ...args], { input, encoding: 'utf8',
+    env: Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_'))) });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+function fixture(t) {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-repository-')));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  command(root, ['init', '-q']);
+  command(root, ['config', 'user.name', 'Fixture']);
+  command(root, ['config', 'user.email', 'fixture@example.invalid']);
+  command(root, ['-c', 'commit.gpgsign=false', 'commit', '--allow-empty', '-qm', 'fixture']);
+  return root;
+}
+function write(root, name, bytes = name) {
+  fs.mkdirSync(path.dirname(path.join(root, name)), { recursive: true });
+  fs.writeFileSync(path.join(root, name), bytes);
+}
+const sha = (bytes) => createHash('sha256').update(bytes).digest('hex');
+const scan = (root) => discoverRepositoryFiles({ root });
+const codes = (report, name) => report.diagnostics.filter((item) => item.path === name).map((item) => item.code);
+
+test('all roots and suffixes, hidden/vendor/generated names, ignored distinctions and current bytes', (t) => {
+  const root = fixture(t);
+  write(root, '.gitignore', '*.ignored\ncache/\n');
+  const tracked = ['elsewhere/a.rs', 'skins/theme.css', 'novel/file.unheard', '.hidden', 'vendor/a.bin', 'generated/a', 'keep.ignored'];
+  for (const name of tracked) write(root, name, 'indexed');
+  command(root, ['add', '-f', '--', '.gitignore', ...tracked]);
+  write(root, 'skip.ignored');
+  write(root, 'cache/excluded');
+  write(root, 'new/location.no-known-suffix', Buffer.from([0, 255, 10]));
+  write(root, 'elsewhere/a.rs', 'current');
+  const result = scan(root);
+  assert.equal(result.ok, true, JSON.stringify(result));
+  assert.equal(result.head, command(root, ['rev-parse', 'HEAD']));
+  assert.deepEqual(result.entries.map((e) => e.path), [...tracked, '.gitignore', 'new/location.no-known-suffix'].sort());
+  const entry = result.entries.find((e) => e.path === 'elsewhere/a.rs');
+  assert.equal(entry.sha256, sha('current'));
+  assert.deepEqual(entry.index, [{ mode: '100644', oid: command(root, ['hash-object', '--stdin'], 'indexed'), stage: 0 }]);
+  assert.equal(entry.workingTree.kind, 'file');
+  const untracked = result.entries.find((e) => !e.tracked);
+  assert.deepEqual(untracked.index, []);
+  assert.equal(untracked.sha256, sha(Buffer.from([0, 255, 10])));
+  assert.deepEqual(scan(root), result);
+  assert.ok(!JSON.stringify(result).includes(root));
+});
+
+test('NUL parsing preserves tabs, newlines, quotes, unicode, spaces and option-like names', (t) => {
+  const root = fixture(t);
+  const names = ['-dash', 'tab\there', 'line\nbreak', 'quote"file', ' spaced ', '雪.unknown'];
+  if (process.platform !== 'win32') names.push('back\\slash');
+  for (const name of names) write(root, name);
+  command(root, ['add', '--', ...names.slice(0, 3)]);
+  const result = scan(root);
+  assert.equal(result.ok, true, JSON.stringify(result));
+  assert.deepEqual(result.entries.map((e) => e.path), names.sort((a, b) => Buffer.compare(Buffer.from(a), Buffer.from(b))));
+  for (const entry of result.entries) assert.equal(entry.sha256, sha(entry.path));
+});
+
+test('requires explicit top-level Git worktree, rejects policy options and absent HEAD', (t) => {
+  const root = fixture(t);
+  fs.mkdirSync(path.join(root, 'subtree'));
+  for (const options of [undefined, {}, { root, extensions: ['.js'] }, { root, sourceRoots: ['.'] }]) {
+    assert.equal(discoverRepositoryFiles(options).ok, false);
+  }
+  assert.ok(codes(scan(path.join(root, 'subtree')), null).includes('root-not-worktree-top'));
+  assert.equal(scan(path.join(root, 'absent')).ok, false);
+  const empty = path.join(root, 'empty');
+  fs.mkdirSync(empty);
+  command(empty, ['init', '-q']);
+  assert.equal(scan(empty).ok, false);
+  const plain = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-not-git-'));
+  t.after(() => fs.rmSync(plain, { recursive: true, force: true }));
+  assert.equal(scan(plain).ok, false);
+  command(plain, ['init', '--bare', '-q']);
+  assert.equal(scan(plain).ok, false);
+});
+
+test('missing indexed files remain candidates, including skip-worktree and assume-unchanged', (t) => {
+  const root = fixture(t);
+  for (const name of ['missing', 'sparse', 'assumed']) write(root, name);
+  command(root, ['add', '--', 'missing', 'sparse', 'assumed']);
+  command(root, ['update-index', '--skip-worktree', 'sparse']);
+  command(root, ['update-index', '--assume-unchanged', 'assumed']);
+  for (const name of ['missing', 'sparse', 'assumed']) fs.unlinkSync(path.join(root, name));
+  const result = scan(root);
+  assert.equal(result.ok, false);
+  assert.equal(result.entries.length, 3);
+  for (const entry of result.entries) {
+    assert.ok(codes(result, entry.path).includes('missing-indexed-path'));
+    assert.equal(entry.workingTree.kind, 'missing');
+    assert.equal(entry.sha256, undefined);
+  }
+});
+
+test('working-tree permissions are separate from index mode', { skip: process.platform === 'win32' }, (t) => {
+  const root = fixture(t);
+  write(root, 'mode');
+  command(root, ['add', 'mode']);
+  fs.chmodSync(path.join(root, 'mode'), 0o755);
+  const result = scan(root);
+  assert.equal(result.ok, true);
+  assert.equal(result.entries[0].index[0].mode, '100644');
+  assert.equal(result.entries[0].workingTree.mode, '0755');
+});
+
+test('unmerged index stages are retained and fail explicitly without hashing', (t) => {
+  const root = fixture(t);
+  write(root, 'conflict', 'working');
+  const oids = ['base', 'ours', 'theirs'].map((text) => command(root, ['hash-object', '-w', '--stdin'], text));
+  command(root, ['update-index', '--index-info'], oids.map((oid, i) => `100644 ${oid} ${i + 1}\tconflict\n`).join(''));
+  const result = scan(root);
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.entries[0].index.map((s) => s.stage), [1, 2, 3]);
+  assert.deepEqual(result.entries[0].index.map((s) => s.oid), oids);
+  assert.ok(codes(result, 'conflict').includes('unmerged-index'));
+  assert.equal(result.entries[0].sha256, undefined);
+});
+
+test('symlink leaves, ancestors, indexed symlinks and gitlinks never read target bytes', { skip: process.platform === 'win32' }, (t) => {
+  const root = fixture(t);
+  const outside = fixture(t);
+  write(outside, 'secret', 'outside sentinel');
+  write(root, 'ancestor/secret');
+  command(root, ['add', '--', 'ancestor/secret']);
+  fs.rmSync(path.join(root, 'ancestor'), { recursive: true });
+  fs.symlinkSync(outside, path.join(root, 'ancestor'));
+  fs.symlinkSync(path.join(outside, 'secret'), path.join(root, 'leaf'));
+  fs.symlinkSync('absent', path.join(root, 'dangling'));
+  fs.symlinkSync(path.join(outside, 'secret'), path.join(root, 'indexed'));
+  command(root, ['add', '--', 'indexed']);
+  fs.unlinkSync(path.join(root, 'indexed'));
+  write(root, 'indexed', 'now regular');
+  const head = command(root, ['rev-parse', 'HEAD']);
+  command(root, ['update-index', '--add', '--cacheinfo', `160000,${head},submodule`]);
+  write(root, 'submodule', 'replacement regular');
+  const original = fs.readSync;
+  const reads = [];
+  t.mock.method(fs, 'readSync', function (fd, ...args) {
+    reads.push(fs.fstatSync(fd).ino);
+    return original.call(fs, fd, ...args);
+  });
+  const result = scan(root);
+  assert.equal(result.ok, false);
+  for (const [name, code] of [['ancestor/secret', 'symlink-ancestor'], ['leaf', 'symlink'], ['dangling', 'symlink'], ['indexed', 'indexed-symlink'], ['submodule', 'gitlink']]) {
+    assert.ok(codes(result, name).includes(code), JSON.stringify(result));
+    assert.equal(result.entries.find((e) => e.path === name).sha256, undefined);
+  }
+  assert.ok(!reads.includes(fs.statSync(path.join(outside, 'secret')).ino));
+  assert.equal(reads.length, 0);
+});
+
+test('indexed directory and FIFO replacements fail without blocking', { skip: process.platform === 'win32' }, (t) => {
+  const root = fixture(t);
+  for (const name of ['directory', 'fifo']) write(root, name);
+  command(root, ['add', '--', 'directory', 'fifo']);
+  fs.unlinkSync(path.join(root, 'directory'));
+  fs.mkdirSync(path.join(root, 'directory'));
+  fs.unlinkSync(path.join(root, 'fifo'));
+  assert.equal(spawnSync('mkfifo', [path.join(root, 'fifo')]).status, 0);
+  const result = scan(root);
+  assert.equal(result.ok, false);
+  for (const name of ['directory', 'fifo']) assert.ok(codes(result, name).includes('unsupported-type'));
+});
+
+test('non-UTF8 Git paths fail explicitly without aliasing a valid replacement character', { skip: process.platform === 'win32' }, (t) => {
+  const root = fixture(t);
+  const oid = command(root, ['hash-object', '-w', '--stdin'], 'bad name');
+  command(root, ['update-index', '-z', '--index-info'], Buffer.concat([Buffer.from(`100644 ${oid}\t`), Buffer.from([255, 0])]));
+  write(root, '\uFFFD', 'valid name');
+  const result = scan(root);
+  assert.equal(result.ok, false);
+  assert.ok(result.diagnostics.some((d) => d.code === 'non-utf8-path' && d.pathBytesHex === 'ff'));
+  assert.equal(result.entries[0].sha256, sha('valid name'));
+});
+
+test('ambient Git directory/index overrides do not redirect discovery; linked worktree works', (t) => {
+  const root = fixture(t);
+  const other = fixture(t);
+  write(root, 'wanted');
+  write(other, 'unwanted');
+  const overrides = { GIT_DIR: path.join(other, '.git'), GIT_WORK_TREE: other, GIT_INDEX_FILE: path.join(other, '.git/index') };
+  for (const [key, value] of Object.entries(overrides)) {
+    const previous = process.env[key];
+    t.after(() => { if (previous === undefined) delete process.env[key]; else process.env[key] = previous; });
+    process.env[key] = value;
+  }
+  assert.deepEqual(scan(root).entries.map((e) => e.path), ['wanted']);
+  const linked = path.join(other, 'linked');
+  command(root, ['worktree', 'add', '--detach', linked, 'HEAD']);
+  assert.equal(scan(linked).ok, true);
+});
+
+test('read errors and concurrent content changes fail without publishing a digest', (t) => {
+  const root = fixture(t);
+  write(root, 'candidate', 'before');
+  const original = fs.readSync;
+  let changed = false;
+  const mock = t.mock.method(fs, 'readSync', function (...args) {
+    const count = original.apply(fs, args);
+    if (!changed) { changed = true; write(root, 'candidate', 'changed and longer'); }
+    return count;
+  });
+  let result = scan(root);
+  assert.ok(codes(result, 'candidate').includes('working-tree-changed'));
+  assert.equal(result.entries[0].sha256, undefined);
+  mock.mock.restore();
+  t.mock.method(fs, 'readSync', () => { throw Object.assign(new Error('private host path must not leak'), { code: 'EACCES' }); });
+  result = scan(root);
+  assert.equal(result.ok, false);
+  assert.ok(codes(result, 'candidate').includes('EACCES'));
+  assert.equal(result.entries[0].sha256, undefined);
+  assert.ok(!JSON.stringify(result).includes('private host'));
+});
+
+test('leaf swapped to outside symlink immediately before open is not read', { skip: process.platform === 'win32' }, (t) => {
+  const root = fixture(t);
+  const outside = fixture(t);
+  write(outside, 'secret');
+  write(root, 'candidate');
+  const original = fs.openSync;
+  t.mock.method(fs, 'openSync', function (file, ...args) {
+    if (file === path.join(root, 'candidate')) {
+      fs.unlinkSync(file);
+      fs.symlinkSync(path.join(outside, 'secret'), file);
+    }
+    return original.call(fs, file, ...args);
+  });
+  const read = t.mock.method(fs, 'readSync', () => assert.fail('must not read outside bytes'));
+  const result = scan(root);
+  assert.equal(result.ok, false);
+  assert.equal(result.entries[0].sha256, undefined);
+  assert.equal(read.mock.callCount(), 0);
+});
+
+test('repository exclude rules apply only to untracked candidates', (t) => {
+  const root = fixture(t);
+  write(root, 'retained');
+  command(root, ['add', 'retained']);
+  fs.appendFileSync(path.join(root, '.git/info/exclude'), '\nretained\nexcluded\n');
+  write(root, 'excluded');
+  assert.deepEqual(scan(root).entries.map((e) => e.path), ['retained']);
+});

--- a/scripts/nemo/lib/boundaries-repository.cjs
+++ b/scripts/nemo/lib/boundaries-repository.cjs
@@ -1,0 +1,157 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { createHash } = require('node:crypto');
+
+function fault(code) { return Object.assign(new Error(code), { code }); }
+function git(root, args) {
+  // Ambient Git overrides must not redirect this explicit repository/index.
+  const env = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')));
+  const result = spawnSync('git', ['--no-optional-locks', '-C', root, ...args], {
+    env, encoding: 'buffer', maxBuffer: 128 * 1024 * 1024,
+  });
+  if (result.error || result.status !== 0) throw fault('git-command-failed');
+  return result.stdout;
+}
+function records(bytes) {
+  if (!bytes.length) return [];
+  if (bytes.at(-1) !== 0) throw fault('invalid-git-output');
+  const result = [];
+  let start = 0;
+  for (let i = 0; i < bytes.length; i++) {
+    if (bytes[i] === 0) { result.push(bytes.subarray(start, i)); start = i + 1; }
+  }
+  return result;
+}
+function filename(bytes) {
+  const name = bytes.toString('utf8');
+  if (!Buffer.from(name).equals(bytes)) throw fault('non-utf8-path');
+  if (!name || path.isAbsolute(name) || name.split('/').some((part) => !part || part === '.' || part === '..')
+    || (process.platform === 'win32' && /[\\:]/.test(name))) throw fault('unsafe-git-path');
+  return name;
+}
+function candidates(root, diagnose) {
+  const found = new Map();
+  const add = (bytes, index) => {
+    let name;
+    try { name = filename(bytes); } catch (error) {
+      diagnose(error.code, null, { pathBytesHex: bytes.toString('hex') }); return;
+    }
+    if (!found.has(name)) found.set(name, { path: name, tracked: false, index: [] });
+    const entry = found.get(name);
+    if (index) { entry.tracked = true; entry.index.push(index); }
+  };
+  for (const record of records(git(root, ['ls-files', '--cached', '--stage', '-z']))) {
+    const tab = record.indexOf(9);
+    const match = record.subarray(0, tab).toString('ascii').match(/^([0-7]{6}) ([a-f0-9]{40}|[a-f0-9]{64}) ([0-3])$/);
+    if (tab < 0 || !match) throw fault('invalid-index-record');
+    add(record.subarray(tab + 1), { mode: match[1], oid: match[2], stage: Number(match[3]) });
+  }
+  for (const record of records(git(root, ['ls-files', '--others', '--exclude-standard', '-z']))) add(record);
+  return [...found.values()].sort((a, b) => Buffer.compare(Buffer.from(a.path), Buffer.from(b.path)));
+}
+function inspect(root, relative) {
+  let current = root;
+  const parts = relative.split('/');
+  for (let i = 0; i < parts.length; i++) {
+    current = path.join(current, parts[i]);
+    const stat = fs.lstatSync(current, { bigint: true });
+    if (stat.isSymbolicLink()) {
+      if (i < parts.length - 1) throw fault('symlink-ancestor');
+      return { stat, absolute: current, kind: 'symlink' };
+    }
+    if (i < parts.length - 1 && !stat.isDirectory()) throw fault('unsupported-ancestor');
+    if (i === parts.length - 1) return {
+      stat, absolute: current, kind: stat.isFile() ? 'file' : stat.isDirectory() ? 'directory' : 'unsupported',
+    };
+  }
+}
+function same(a, b) {
+  return ['dev', 'ino', 'mode', 'size', 'mtimeNs', 'ctimeNs'].every((key) => a[key] === b[key]);
+}
+function digest(root, entry, state) {
+  if (fs.constants.O_NOFOLLOW === undefined) throw fault('nofollow-unavailable');
+  const fd = fs.openSync(state.absolute, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW | fs.constants.O_NONBLOCK);
+  try {
+    const before = fs.fstatSync(fd, { bigint: true });
+    if (!before.isFile() || !same(state.stat, before) || !same(inspect(root, entry.path).stat, before)) {
+      throw fault('working-tree-changed');
+    }
+    const hash = createHash('sha256');
+    const buffer = Buffer.allocUnsafe(64 * 1024);
+    let length;
+    while ((length = fs.readSync(fd, buffer, 0, buffer.length, null))) hash.update(buffer.subarray(0, length));
+    if (!same(before, fs.fstatSync(fd, { bigint: true })) || !same(before, inspect(root, entry.path).stat)) {
+      throw fault('working-tree-changed');
+    }
+    return hash.digest('hex');
+  } finally { fs.closeSync(fd); }
+}
+
+/**
+ * Synchronous Git candidate inventory: discoverRepositoryFiles({root}).
+ * Returns {head, entries, diagnostics, ok}; entries have {path, tracked, index,
+ * workingTree: {kind, mode}, sha256?}. Index mode/OID/stage describe the index,
+ * never the current bytes. SHA256 hashes current regular-file bytes only.
+ * All tracked paths (including tracked ignored files) and nonignored untracked
+ * paths are candidates, with no root/suffix/profile/vendor/generated policy.
+ * Untracked ignored files and empty directories are not Git candidates.
+ * Paths are repository-relative, byte-order sorted UTF-8; unrepresentable names
+ * fail explicitly with hex bytes. No absolute host paths or raw Git stderr leak.
+ * Missing paths, conflicts, symlinks/ancestors, gitlinks and unsupported types
+ * make ok=false. Unsafe candidates are not read; symlink targets are not read.
+ * A root alias is canonicalized; a subtree, bare repo, or absent HEAD fails.
+ *
+ * This is NOT an atomic snapshot: keep the repository/index stable during use.
+ * Descriptor identity/change checks and O_NOFOLLOW protect ordinary replacements;
+ * concurrent hostile ancestor swaps require OS sandboxing/openat-style traversal,
+ * which this portable Node API does not provide. HEAD does not identify dirty bytes.
+ *
+ * Handoff only an ok report to existing coverage with independently reviewed
+ * classification/exclusions. Coverage currently rejects some legal Git filenames;
+ * do not silently drop/normalize those names or treat inventory as coverage/adoption.
+ * The existing filesystem discovery helper and all policy consumers are unchanged.
+ */
+function discoverRepositoryFiles(options) {
+  const report = { head: null, entries: [], diagnostics: [], ok: false };
+  const diagnose = (code, file = null, extra = {}) => report.diagnostics.push({ code, path: file, ...extra });
+  try {
+    if (!options || typeof options !== 'object' || Array.isArray(options)
+      || Object.keys(options).some((key) => key !== 'root')
+      || typeof options.root !== 'string' || !options.root || options.root.includes('\0')) throw fault('invalid-options');
+    const root = fs.realpathSync(options.root);
+    if (!fs.statSync(root).isDirectory()) throw fault('invalid-root');
+    // --show-prefix is empty only at the worktree root (no newline-sensitive paths).
+    if (git(root, ['rev-parse', '--is-inside-work-tree']).toString() !== 'true\n'
+      || git(root, ['rev-parse', '--show-prefix']).toString() !== '\n') throw fault('root-not-worktree-top');
+    const head = git(root, ['rev-parse', '--verify', 'HEAD']).toString().trim();
+    if (!/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/.test(head)) throw fault('invalid-head');
+    report.head = head;
+    report.entries = candidates(root, diagnose);
+    for (const entry of report.entries) {
+      entry.workingTree = { kind: 'unknown', mode: null };
+      const conflict = entry.index.some((item) => item.stage !== 0);
+      const gitlink = entry.index.some((item) => item.mode === '160000');
+      const indexedSymlink = entry.index.some((item) => item.mode === '120000');
+      if (conflict) diagnose('unmerged-index', entry.path);
+      if (gitlink) diagnose('gitlink', entry.path);
+      if (indexedSymlink) diagnose('indexed-symlink', entry.path);
+      try {
+        const state = inspect(root, entry.path);
+        entry.workingTree = { kind: state.kind, mode: Number(state.stat.mode & 0o7777n).toString(8).padStart(4, '0') };
+        if (state.kind !== 'file') diagnose(state.kind === 'symlink' ? 'symlink' : 'unsupported-type', entry.path);
+        if (state.kind === 'file' && !conflict && !gitlink && !indexedSymlink) entry.sha256 = digest(root, entry, state);
+      } catch (error) {
+        const missing = error.code === 'ENOENT';
+        if (missing) entry.workingTree.kind = 'missing';
+        diagnose(missing ? (entry.tracked ? 'missing-indexed-path' : 'working-tree-changed') : error.code || 'filesystem-error', entry.path);
+      }
+    }
+  } catch (error) { diagnose(error.code || 'repository-error'); }
+  report.ok = report.diagnostics.length === 0;
+  return report;
+}
+
+module.exports = { discoverRepositoryFiles };


### PR DESCRIPTION
The current boundary selector covers application JavaScript and `scripts/nemo`, leaving other candidate source paths outside discovery. This adds `discoverRepositoryFiles({root})`, which inventories every tracked and nonignored untracked Git candidate with raw working-byte hashes, separate index metadata, and explicit diagnostics for missing, conflicted, linked or unsupported paths.

Refs #901. This draft is ready for the retained integration owner to adopt. It requires tooling-profile registration, normal test discovery and connection to independently reviewed source dispositions before merge. The existing source/CI ownership remains unchanged.

Validation at `b646bf42ee18a6b899a51fe3113a1659b28399b9`:

- 13 new real-Git tests passed independently; author combined discovery/coverage run: 53 passed, one existing filesystem skip.
- Independent review passed 13 controls, including a positively validated descriptor-read guard, exact index metadata, ignored-file distinctions, unusual filenames, conflicts, symlinks and Git failures.
- Clean main: all 363 candidate paths and raw hashes matched an independent tree inventory. Four new Rust/CSS/unknown-binary/hidden paths were detected; repeatability and cleanup passed. Committed helper bytes match the tested snapshot.
- `npm run doctor` completed; `npm run check` passed all six checks. Syntax, DCO and diff checks passed.
- The actual protected-base boundary command exits 1 solely because the two new files are not yet registered: 36 discovered, 34 declared. Existing tooling rules, application checks and ratchets pass. This is the concrete draft adoption gate.

The inventory is not an atomic snapshot and requires stable repository/index state. It supplies discovery evidence; reviewed classification, CI adoption and whole-R05 acceptance remain open. No hosted workflows were run.
