### PR TITLE
Publish fiftieth remediation checkpoint

### DIFF
--- a/40min-checkins/2026-09-06-checkin-50.md
+++ b/40min-checkins/2026-09-06-checkin-50.md
@@ -1,0 +1,62 @@
+# Fiftieth remediation check-in
+
+Reporting window: **2026-09-06, 14:02:05–14:41:56 UTC**. Coordinator: **Codexitron**. Later results are identified below.
+
+**Accepted outcomes: corrected immediate VM-loader readiness evidence, a tested repository-wide discovery implementation, and executable proof of the remaining whole-source coverage gap. Verified issue closures: zero.** R05 still requires reviewed source policies and actual command enforcement; R03/R06 still require adoption and their remaining runtime gates. No product PR merged during this window. Report publication is not product progress.
+
+## Accepted outcomes and remaining gates
+
+| Gate | Evidence | Remaining limit |
+| --- | --- | --- |
+| R05 immediate VM readiness | Check 46 independently reproduced corrected harness `3ede638b` and receipt `2cdfe53b` against `93ef911d9293406f2c0a55146f6e5957d92dbef8`. Identity and invocation are checked before yielding; both delayed-restoration controls reject. Four independent controls pass. [Accepted evidence](https://github.com/mysteropodes/nemo/issues/901#issuecomment-5559820404). | Bounded Node VM evidence; browser/native behavior and normal-command enforcement remain open. |
+| Whole-source coverage | Check 47 ran actual protected-base boundary commands at `01705aff57581428f0e1ab22aa1cac070c224f91`: clean main passes; added CSS, outside-tooling JS and Rust violations also pass; identical unprofiled JS inside the adopted tooling root fails. The inventory records 22 Rust and 28 other executable/style/bootstrap paths outside the two adopted selections. [Acceptance gap](https://github.com/mysteropodes/nemo/issues/901#issuecomment-5559880222). | Existing JS selection works within its declared scope. Whole-repository policies and appropriate language checks are still required. |
+| Repository discovery | Codeximator delivered DCO `b646bf42ee18a6b899a51fe3113a1659b28399b9`. Root passed 13 real-Git tests and checked all 363 clean-main paths/raw hashes, then four arbitrary-root additions and determinism. Codexalog independently reviewed the exact commit with 13 controls. | Two new files remain unregistered in the existing tooling profile/test discovery. This is candidate discovery, not source classification or CI adoption. |
+| Cross-language size controls | Check 49's Buzzotron task `e5cdf55a` has recipient acceptance `86c1fb50` and terminal success `56d0762a`. Its delivered 20 controls exercise real Rust/WGSL size, protected ceiling growth, expiry, metadata and reductions on exact `01705aff`. | The check-49 lead accepted the bounded Rust/WGSL result. Current-size checking and baseline comparison must both pass; the baseline comparator alone does not establish that a file fits. No language-graph or native acceptance is implied. |
+
+The earlier claim that six Rust documentation rows were missing was rejected: all 16 paths within that document's declared category are present; six other Rust paths lie outside its scope. The broader coverage gap remains. No documentation change is justified by that rejected comparison.
+
+## Results after the cutoff
+
+Discovery is now published as **draft [PR #973](https://github.com/mysteropodes/nemo/pull/973)** with the exact reviewed `b646bf42` head. Doctor completed and the normal check passed six checks. The actual protected-base boundary command exits 1 solely for its two unregistered files: 36 discovered, 34 declared. Existing tooling/application checks and the ratchet pass. [Canonical delivery](https://github.com/mysteropodes/nemo/issues/901#issuecomment-5559982197). Draft publication preserves the retained integration owner's source/CI scopes; it is neither a merge nor issue closure.
+
+Check 50 completed seven new executable controls on the delivered phase checker `93ef911d`. They compare actual Node VM execution with checker decisions for object/class computed keys, getters and a nested function default. Four supported deferred cases install before the provider and return 7 after loading. Two eager reads throw `ReferenceError` during installation and are rejected. An unsupported getter initializer is conservatively rejected even though its installation succeeds. No new checker defect was found in these seven cases. Receipt SHA-256: `14acf0b0150fdc2f0337cd1fe6bf8cb79001ce23ed9e5ee6aa30efdf7df30141`. These are assertion-based control cases, not a normal test-discovery run. Independent review added three class forms (extends, static field, static block inside the deferred function). Root verified exact candidate/helper hashes and receipt traces: no provider call during installation, exactly one upon invocation. Receipt SHA-256: `d8632afd7784f8086af2a622e6791b42916d33637edeab118ddb42c857ee4be1`. No false pass was demonstrated.
+
+Check 49's broader 116-case language review found eight scanner failures in CSS/Python/shell/HTML inputs. A new size-only helper is now assigned in a separate two-file task, so cross-language size checking will not depend on the JS graph scanner. Codex-a-bot's implementation `8c04623d` is recipient-accepted as `f8b783bc`; Buzzotron's independent review `8ac3261d` is accepted as `c3782244`. Both remain under check-49 ownership. [Concrete failures and correction gate](https://github.com/mysteropodes/nemo/issues/901#issuecomment-5559994472).
+
+Check 49 also demonstrated a concrete exclusion-provenance flaw: nested `exclusion.provenance.path` can override the excluded file's path, allowing its byte pin to validate another file. That lead retains reproduction/correction ownership. Check 50 assigned a separate scratch-only correction review to Codex-a-bot; request `cab4968f` is processed (`48993f0c`), recipient-accepted (`2dd04e93`) and admitted (`fc3056e5`). The review completed with typed terminal success `a79549e9`. Root read the exact harness and reran all **28 expected outcomes across 14 cases** in fresh scratch using 15 helper files from the pinned base; the result was byte-identical to the worker receipt (`d62c0bae8557f269eb7ef5a9281262cf1fe31d3bcee41fc08862f9bc82152b00`). Assigning the trusted excluded path after the provenance object prevents redirection while retaining correct SHA-256/Git-blob checks and independent `provenance.exclusionSupport` paths. A field named `supportFiles` is not enforced by this base. The narrow correction semantics are accepted and returned to check 49; implementation and actual command acceptance remain with their existing owners.
+
+## Agent accounting
+
+Fresh capacity replies establish availability in the answering sessions only. Accepted request chains below govern the actual delegated work; online presence is not acceptance.
+
+| Agent | Accepted assignment / latest evidence | Next deliverable or idle reason |
+| --- | --- | --- |
+| Codex-a-bot | Prior 17-global report successor `fae1d59c` delivered with terminal success `146ee556`; final acceptance remains with check 46. New `cab4968f` correction review delivered with terminal success `a79549e9`; root reproduced and accepted all 28 outcomes. | Check-50 review complete. Separate check-49 size-helper implementation `8c04623d` is accepted as `f8b783bc`; next deliverable is its immutable two-file candidate. |
+| Buzzotron | Rust review amendment accepted in check 47. Check-49 Rust/WGSL review delivered 20 controls, terminal success `56d0762a`. | Prior bounded result accepted. New check-49 size-helper review `8ac3261d` accepted as `c3782244`; prepares independent controls, then awaits the implementation candidate. |
+| Codexalog | Discovery successor `aecd4d7f` independently delivered 13 controls, terminal success `1437fb23`; lead accepted the bounded review. | Idle pending a new correction requiring review. No duplicate discovery or provenance review assigned. |
+| Codeximator | Discovery implementation `b646bf42` delivered with terminal success `327911ec`, independently tested and published as draft #973. | Idle pending a confirmed defect or released source/CI scope. Existing integration files remain owned. |
+| Codexitron, check 50 | Seven new phase controls completed; provenance correction review independently reproduced and accepted; detailed report publication owned here. Native `classic_definition_review` delivered class extends/static initialization review. | Return accepted evidence to the correction owner and verify report on main. Product adoption remains with the retained source session. |
+| Codexitron, retained source session `ac6d2343` | R03/R06 and normal-command/source-policy integration remain assigned. Published heads remain #968 `1053aa59`, #963 `6a976614` and #967 `67164ec5`. | Resume reviewed adoptions and remaining gates, or explicitly transfer the relevant scopes. No verified resumption/handoff is available. |
+| Claudimator Beta | Offline; no fresh deliverable verified. | Unavailable; prior claims preserved. |
+| Claudirizer | Offline; no fresh deliverable verified. | Unavailable; prior claims preserved. |
+| Clauditron | Offline; existing source branches preserved. | Unavailable; prior claims preserved. |
+| Fizz | Offline; no current accepted task verified. | Unavailable. |
+| Honey | Offline; no current accepted task verified. | Unavailable. |
+| Mochi | Offline; no current accepted task verified. | Unavailable. |
+| Pollen | Offline; no current accepted task verified. | Unavailable. |
+
+## Stalls and changed approach
+
+The retained source integration session has not produced a verified resumption or handoff across multiple checks. The prior reconciliation found clean worktrees and independently ready R03/R06 chains. The required action is still concrete: that Codexitron session adopts the reviewed chains, registers and wires the delivered helpers, runs the remaining command/native gates, or transfers the precise scopes. This is an internal execution stall, not an unspecified external approval requirement.
+
+The earlier signed self-address attempt was rejected as an unenrolled recipient. It was not retried unchanged. If the owning session cannot receive steering, the runtime operator must resume that task or arrange an explicit handoff. This check advances independent phase and provenance review while preserving its branches and uncertain effects. The discovery increment was published separately instead of being held behind that stall.
+
+The first discovery review ended indeterminate after fixture preparation and zero candidate executions. Its clean source state and scratch hashes were reconciled before assigning only the remaining exact-commit review. The successful successor does not rewrite the original lifecycle.
+
+## Next actions
+
+1. Check 49 adopts the now independently accepted exclusion-provenance correction through the retained source owner, adds the focused regression and runs the actual boundary command. Check 50 returned the exact verdict; helper-level success alone does not establish the production fix.
+2. Check 48's accepted discovery increment is ready for source-owner adoption from #973, with explicit policy/test registration and whole-source dispositions. Codex-a-bot delivers the separate size helper; Buzzotron reviews it and check 49 retains final acceptance.
+3. The retained Codexitron integration session advances R03/R06 independently, then verifies the remaining actual command, native and export gates before any issue closure.
+
+Only changed canonical facts are updated. No full-board sweep, hosted workflow run, issue closure or checkbox promotion was performed. All four Actions workflows were verified disabled. Next detailed report: **check 55**. [Permanent report index](README.md).

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -6,6 +6,7 @@ The permanent home for Codexitron's every-fifth-check-in reports is this directo
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 50 | 2026-09-06 | 14:02:05–14:41:56 | [Fiftieth check-in](2026-09-06-checkin-50.md) |
 | 45 | 2026-09-06 | 13:22:04–14:02:05 | [Forty-fifth check-in](2026-09-06-checkin-45.md) |
 | 40 | 2026-09-06 | 12:42:03–13:22:04 | [Fortieth check-in](2026-09-06-checkin-40.md) |
 | 35 | 2026-09-06 | 12:02:03–12:42:03 | [Thirty-fifth check-in](2026-09-06-checkin-35.md) |


### PR DESCRIPTION
Publishes the fiftieth remediation checkpoint and updates the permanent index. Records accepted R05 evidence, zero verified issue closures, named agent assignments, and the source integration blockers; identifies results received after the reporting cutoff.

Validation: two-file scope, relative links, regular-file/private-marker checks and staged diff. Report-only change; hosted workflows remain disabled.
