### PR TITLE
Check text source sizes without JavaScript analysis

### DIFF
--- a/scripts/nemo/boundaries-size.test.cjs
+++ b/scripts/nemo/boundaries-size.test.cjs
@@ -1,0 +1,179 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { checkApplicationSize } = require('./lib/boundaries-application.cjs');
+const { checkSourceSizes } = require('./lib/boundaries-size.cjs');
+const { compareSizeBaseline } = require('./lib/boundaries-ratchet.cjs');
+const ROOT = path.resolve(__dirname, '../..');
+const now = new Date('2026-09-06T12:00:00Z');
+function fixture(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-source-size-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+function write(root, file, source) {
+  const target = path.join(root, file);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, source);
+}
+function profile(file, hardMax = 2, warn = Math.min(1, hardMax)) {
+  return { modules: [{ id: 'sample', layer: 'domain', dir: path.posix.dirname(file),
+    files: [path.posix.basename(file)], publicApi: [], sizeProfile: 'bounded' }],
+  sizeProfiles: { bounded: { warn, hardMax } }, exceptions: [] };
+}
+function exception(file, rule = 'size') {
+  return { path: file, rule, ...(rule === 'size' ? { ceiling: 3 } : {}),
+    owner: 'maintainer', issue: '901', expires: '2026-09-07', reason: 'Regression fixture' };
+}
+const cases = [
+  ['css', 'a { background: url(/x); }\n', 'src/css/style.css'],
+  ['py', "# user's note\npass\n", 'scripts/dev_server.py'],
+  ['sh', "# user's note\n:\n", 'scripts/rebuild-ffmpeg-lgpl.sh'],
+  ['html', '<p>x</p>\n', 'src/index.html'],
+];
+for (const [language, minimal, real] of cases) {
+  for (const [kind, file, source] of [
+    ['minimal', `sample.${language}`, minimal],
+    ['real', real, fs.readFileSync(path.join(ROOT, real), 'utf8')],
+  ]) test(`${language}/${kind}: source at ceiling and +1 growth`, (t) => {
+    const root = fixture(t);
+    const count = source.split(/\r?\n/).filter((line) => line.trim()).length;
+    const policy = profile(file, count);
+    write(root, file, source);
+    const report = checkSourceSizes(policy, { root, now });
+    assert.equal(report.ok, true);
+    assert.equal(report.warnings[0]?.detail.lines, count > 1 ? count : undefined);
+    write(root, file, source + '\ncounted extra line\n');
+    const grown = checkSourceSizes(policy, { root, now });
+    assert.equal(grown.ok, false);
+    assert.deepEqual(grown.violations[0].detail, { lines: count + 1, hardMax: count });
+  });
+}
+for (const [language, source] of [
+  ['rs', "fn borrow<'a>(s: &'a str) -> &'a str { s }\n// user's note\n"],
+  ['wgsl', '@fragment fn main() -> @location(0) vec4f { return vec4f(1.0); }\n// counted\n'],
+  ...cases.map(([language, source]) => [language, source]),
+]) for (const eol of ['\n', '\r\n']) test(`${language}: ${JSON.stringify(eol)} text counting`, (t) => {
+  const root = fixture(t), file = `sample.${language}`;
+  const sourceLines = source.trimEnd().split('\n');
+  write(root, file, [' \t', ...sourceLines, '', ''].join(eol));
+  assert.equal(checkSourceSizes(profile(file, sourceLines.length), { root, now }).ok, true);
+});
+
+test('supported JS reports preserve warnings, ceilings, expiry and exception metadata', (t) => {
+  const root = fixture(t), file = 'sample.cjs';
+  for (const count of [0, 1, 2, 3, 4]) for (const mode of ['none', 'active', 'expired', 'graph']) {
+    write(root, file, 'const value = 1;\n'.repeat(count));
+    const policy = profile(file);
+    if (mode !== 'none') policy.exceptions.push(exception(file, mode === 'graph' ? 'cycle' : 'size'));
+    if (mode === 'expired') policy.exceptions[0].expires = '2026-09-06';
+    assert.deepEqual(checkSourceSizes(policy, { root, now }), checkApplicationSize(policy, { root, now }));
+  }
+  const policy = profile(file);
+  policy.exceptions = [exception(file, 'cycle'), exception(file)];
+  policy.exceptions[0].expires = '2026-09-06';
+  assert.deepEqual(checkSourceSizes(policy, { root, now }), checkApplicationSize(policy, { root, now }));
+  const exactExpiry = new Date('2026-09-07T00:00:00Z');
+  assert.equal(checkSourceSizes(policy, { root, now: exactExpiry }).violations.filter(v => v.rule === 'expired-exception').length, 2);
+});
+
+test('real app profile has exact wrapper report parity', () => {
+  const policy = JSON.parse(fs.readFileSync(path.join(ROOT, 'engineering/boundaries/profiles/app-js.profile.json')));
+  assert.deepEqual(checkSourceSizes(policy, { root: ROOT, now }), checkApplicationSize(policy, { root: ROOT, now }));
+});
+
+test('size acceptance and independent baseline ratchet remain separate', (t) => {
+  const root = fixture(t), file = 'sample.py';
+  write(root, file, "# user's note\npass\n");
+  const baseline = profile(file, 3);
+  for (const ceiling of [1, 2, 4]) {
+    const candidate = profile(file, ceiling);
+    const size = checkSourceSizes(candidate, { root, now });
+    const ratchet = compareSizeBaseline(baseline, candidate, { root });
+    assert.equal(size.ok, ceiling >= 2);
+    assert.equal(ratchet.ok, ceiling <= 3);
+    if (ceiling < 3) assert.equal(ratchet.reductions[0].candidateCeiling, ceiling);
+  }
+  baseline.exceptions = [exception(file)];
+  const candidate = structuredClone(baseline);
+  candidate.exceptions[0].ceiling++;
+  assert.equal(checkSourceSizes(candidate, { root, now }).ok, true);
+  assert.equal(compareSizeBaseline(baseline, candidate, { root }).ok, false);
+});
+
+test('exact-path exception cannot shield a sibling and never reports graph waivers', (t) => {
+  const root = fixture(t), policy = profile('a.py', 1);
+  policy.modules[0].files.push('b.py');
+  for (const file of policy.modules[0].files) write(root, file, "# user's note\npass\n");
+  policy.exceptions = [exception('a.py'), exception('b.py', 'cycle')];
+  const report = checkSourceSizes(policy, { root, now });
+  assert.deepEqual(report.violations.map(v => v.file), ['b.py']);
+  assert.deepEqual(report.exceptionsApplied, [{ ...policy.exceptions[0], actualLines: 2 }]);
+});
+
+test('malformed profile, exception metadata and clocks fail closed', (t) => {
+  const root = fixture(t), file = 'a.py';
+  write(root, file, 'pass\n');
+  for (const key of ['owner', 'issue', 'reason', 'expires']) {
+    const policy = profile(file); policy.exceptions = [exception(file)];
+    delete policy.exceptions[0][key];
+    assert.throws(() => checkSourceSizes(policy, { root, now }), /invalid profile/);
+  }
+  for (const expires of ['2026-02-30', 'tomorrow']) {
+    const policy = profile(file); policy.exceptions = [{ ...exception(file), expires }];
+    assert.throws(() => checkSourceSizes(policy, { root, now }), /invalid exception expiry/);
+  }
+  const policy = profile(file); policy.modules.push({ ...policy.modules[0], id: 'other' });
+  assert.throws(() => checkSourceSizes(policy, { root, now }), /multiple modules/);
+  for (const clock of [new Date(NaN), '2026-09-06', null, 0]) {
+    assert.throws(() => checkSourceSizes(profile(file), { root, now: clock }), /invalid check clock/);
+  }
+});
+
+test('unsafe paths, missing sources, directories, aliases and invalid UTF-8 fail closed', (t) => {
+  const root = fixture(t), outside = fixture(t);
+  write(root, 'a.py', 'pass\n'); write(outside, 'external.py', 'pass\n');
+  for (const file of ['../external.py', '/absolute.py', 'C:/drive.py', 'bad\u0000.py', 'a\\b.py']) {
+    assert.throws(() => checkSourceSizes(profile(file), { root, now }));
+  }
+  assert.throws(() => checkSourceSizes(profile('missing.py'), { root, now }));
+  fs.mkdirSync(path.join(root, 'directory'));
+  assert.throws(() => checkSourceSizes(profile('directory'), { root, now }), /regular file/);
+  fs.symlinkSync(path.join(outside, 'external.py'), path.join(root, 'external.py'));
+  fs.symlinkSync(outside, path.join(root, 'linked'));
+  fs.symlinkSync(path.join(root, 'a.py'), path.join(root, 'alias.py'));
+  for (const file of ['external.py', 'linked/external.py', 'alias.py']) {
+    assert.throws(() => checkSourceSizes(profile(file), { root, now }), /symlink/);
+  }
+  fs.linkSync(path.join(root, 'a.py'), path.join(root, 'hard.py'));
+  const policy = profile('a.py'); policy.modules[0].files.push('hard.py');
+  assert.throws(() => checkSourceSizes(policy, { root, now }), /physical source/);
+  write(root, 'invalid.py', Buffer.from([0xff]));
+  assert.throws(() => checkSourceSizes(profile('invalid.py'), { root, now }), /utf-8/i);
+  for (const invalidRoot of ['', null, 42, path.join(root, 'a.py')]) {
+    assert.throws(() => checkSourceSizes(profile('a.py'), { root: invalidRoot, now }));
+  }
+});
+
+test('preflight rejects an unsafe later path before any source read', (t) => {
+  const root = fixture(t), outside = fixture(t);
+  write(root, 'a.py', 'pass\n');
+  fs.symlinkSync(outside, path.join(root, 'escape'));
+  const policy = profile('a.py'); policy.modules[0].files.push('escape/external.py');
+  const original = fs.readFileSync;
+  let reads = 0;
+  fs.readFileSync = () => { reads++; throw new Error('unexpected content read'); };
+  try { assert.throws(() => checkSourceSizes(policy, { root, now }), /symlink/); }
+  finally { fs.readFileSync = original; }
+  assert.equal(reads, 0);
+});
+
+test('source remains opaque, with no evaluation or import resolution', (t) => {
+  const root = fixture(t), file = 'opaque.sh';
+  write(root, file, "require('/outside/never-read');\nwindow.SMState = import(dynamic);\n'\n");
+  assert.equal(checkSourceSizes(profile(file, 3), { root, now }).ok, true);
+  assert.equal(fs.readdirSync(root).length, 1);
+});

--- a/scripts/nemo/lib/boundaries-size.cjs
+++ b/scripts/nemo/lib/boundaries-size.cjs
@@ -1,0 +1,85 @@
+'use strict';
+// Temporary adoption seam: size-only checks over explicitly declared UTF-8 text.
+// No lexical/dependency analysis, content execution, or scanner-derived waivers.
+// Callers MUST separately require complete coverage, provenance, compareSizeBaseline,
+// and graph/language checks where applicable. This API cannot adopt policy, replace
+// aggregation, or establish language-independent dependency acceptance. No CI wiring.
+const fs = require('node:fs');
+const path = require('node:path');
+const { TextDecoder } = require('node:util');
+const { validateProfile, countNonBlankLines } = require('./boundaries.cjs');
+
+// Resolve the caller's root once (including macOS /tmp aliases). Below that root,
+// reject every symlink, even internal ones: exact-path ownership must be unambiguous.
+// Preflight ALL paths before reading contents; directories/devices/FIFOs are not text.
+// The caller must provide a stable checkout; this is not a concurrent filesystem sandbox.
+function sourceFiles(profile, root) {
+  const files = [], physical = new Set();
+  for (const module of profile.modules) for (const file of module.files) {
+    const relative = path.posix.join(module.dir, file);
+    if (/[\x00-\x1f\x7f:]/.test(relative)) throw new Error('invalid profile: unsafe source path');
+    let absolute = root, stat;
+    const components = relative.split('/');
+    for (const [index, component] of components.entries()) {
+      absolute = path.join(absolute, component);
+      stat = fs.lstatSync(absolute);
+      if (stat.isSymbolicLink()) throw new Error('invalid profile: symlink source paths are unsupported');
+      if (index < components.length - 1 && !stat.isDirectory()) throw new Error('invalid profile: source parent must be a directory');
+    }
+    if (!stat.isFile()) throw new Error('invalid profile: source must be a regular file');
+    const identity = `${stat.dev}:${stat.ino}`;
+    if (physical.has(identity)) throw new Error('invalid profile: multiple files refer to the same physical source');
+    physical.add(identity);
+    files.push({ module, relative, absolute });
+  }
+  return files;
+}
+
+/** Same size/expired-exception report shape as checkApplicationSize, without its
+ * JS scanner. Expired exceptions of ALL rules remain violations; only size
+ * exceptions are applied. Counts include nonblank comments, with LF/CRLF parity.
+ * @param {object} profile - engineering/boundaries/profile.schema.json
+ * @param {object} [opts]
+ * @param {string} [opts.root] - existing source root (default cwd)
+ * @param {Date} [opts.now] - exception clock (default current date)
+ */
+function checkSourceSizes(profile, opts = {}) {
+  validateProfile(profile);
+  const now = opts.now === undefined ? new Date() : opts.now;
+  if (!(now instanceof Date) || !Number.isFinite(now.getTime())) throw new Error('invalid check clock');
+  const requestedRoot = opts.root === undefined ? process.cwd() : opts.root;
+  if (typeof requestedRoot !== 'string' || !requestedRoot.trim()) throw new Error('invalid source root');
+  const root = fs.realpathSync(requestedRoot);
+  if (!fs.statSync(root).isDirectory()) throw new Error('invalid source root: must be a directory');
+  const files = sourceFiles(profile, root);
+  const violations = [], warnings = [], exceptionsApplied = [], active = new Map();
+  for (const exception of profile.exceptions || []) {
+    if (new Date(exception.expires) <= now) {
+      violations.push({ rule: 'expired-exception', module: null, file: exception.path, line: null,
+        message: `Exception for "${exception.rule}" on ${exception.path} expired ${exception.expires}`,
+        detail: { exception } });
+    } else if (exception.rule === 'size') active.set(exception.path, exception);
+  }
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+  for (const { module, relative, absolute } of files) {
+    const lines = countNonBlankLines(decoder.decode(fs.readFileSync(absolute)));
+    const limits = profile.sizeProfiles[module.sizeProfile], exception = active.get(relative);
+    const location = { rule: 'size', module: module.id, file: relative, line: null };
+    if (exception) {
+      exceptionsApplied.push({ ...exception, actualLines: lines });
+      if (lines > exception.ceiling) violations.push({ ...location,
+        message: `${lines} nonblank lines exceeds excepted ceiling ${exception.ceiling}`,
+        detail: { lines, ceiling: exception.ceiling, exception: true } });
+    } else if (lines > limits.hardMax) {
+      violations.push({ ...location,
+        message: `${lines} nonblank lines exceeds hard maximum ${limits.hardMax} for profile "${module.sizeProfile}"`,
+        detail: { lines, hardMax: limits.hardMax } });
+    } else if (lines > limits.warn) {
+      warnings.push({ ...location,
+        message: `${lines} nonblank lines exceeds warn threshold ${limits.warn} for profile "${module.sizeProfile}"`,
+        detail: { lines, warn: limits.warn } });
+    }
+  }
+  return { ok: violations.length === 0, violations, warnings, exceptionsApplied };
+}
+module.exports = { checkSourceSizes };


### PR DESCRIPTION
The current size wrapper invokes the JavaScript scanner before filtering its results, so valid CSS, Python, shell and HTML can throw before producing a size report. Add an isolated `checkSourceSizes` helper that counts declared UTF-8 text without lexical analysis and preserves size, warning and exception behavior. Refs #901.

Validation at `024da8bcd63540bb165cfc93a0915ff492abb0a9`: 28 focused tests pass with zero skips; all six `npm run check` jobs pass; the 140-file application result matches exactly, including 18 warnings and 36 applied exceptions. The eight confirmed real/minimal language failures are covered, with above-ceiling rejection retained. Independent review accepted the exact candidate: 14/14 additional controls pass, reproduced by the lead after verifying all eight pinned helper/test blobs. Instrumentation confirms no full JavaScript checker call, with a working positive control on the old wrapper.

Draft for adoption by the existing integration owner. The actual protected-base boundary command rejects only the two new, unregistered files (36 discovered, 34 declared); current tooling/application profiles and ratchets pass. Profile registration, normal test discovery and caller wiring remain in the retained integration scope. Complete coverage, provenance, baseline ratchets and applicable dependency/language checks must still be required together. This PR does not close R05.
