### PR TITLE
Require worktree cleanup at task boundaries and sparse report checkouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,11 @@ in its issue, pull request, or lead-designated queue; do not create a competing 
   See [the CI policy](engineering/ci/README.md); preserve normal PR review protections.
 - Read `CONTRIBUTING.md`, inspect current source, related branches and existing ownership,
   then use a dedicated branch and isolated worktree for tracked changes.
+- Reuse a suitable owned checkout within a task; use sparse checkout for narrow report or
+  documentation work. At publication, review, integration, handoff, cancellation and completion,
+  remove the worktree as soon as it is unneeded, after preserving its work and settling ownership.
+  Record removal or a concrete retention reason and next cleanup trigger in the receipt. Follow
+  [the worktree lifecycle](engineering/remediation/07_GITHUB_PROJECT_AND_PARALLEL_WORK.md#worktree-lifetime-and-disk-use).
 - Record the outcome, scope, dependencies, base, branch/worktree, acceptance checks,
   reviewer, and publication authority before writing. Repository-relative paths coordinate
   ownership; they are not a user-maintained filesystem permission list.

--- a/engineering/remediation/07_GITHUB_PROJECT_AND_PARALLEL_WORK.md
+++ b/engineering/remediation/07_GITHUB_PROJECT_AND_PARALLEL_WORK.md
@@ -91,6 +91,60 @@ to that owner.
 
 A separate worktree does not isolate browser storage, app data, GPU load or desktop input.
 
+## Worktree lifetime and disk use
+
+**Current user-directed policy (2026-09-06): remove a temporary worktree as soon as it is
+unneeded.** Each worktree has an owner, a concrete purpose and a cleanup trigger in its task
+packet. Reuse a suitable owned checkout for successive steps of the same task. Pushing a
+commit, opening a PR or publishing another report does not itself require a new checkout.
+
+Reassess the checkout at every boundary:
+
+| Boundary | Cleanup decision |
+|---|---|
+| Commit, push, PR creation or report publication | Verify the required preservation/publication result; remove the checkout if no remaining local step needs it. An open PR can keep its branch without keeping a checkout. |
+| Review, validation or integration finishes | Preserve the relevant evidence, stop owned processes and remove the checkout when its local purpose is complete. |
+| Pause or handoff | Preserve the checkpoint and settle ownership. Retain only for an identified next action or an accepted transfer of the same checkout. |
+| Cancellation or interruption | Wait for the worker to stop; reconcile indeterminate effects before deciding whether the checkout is disposable. |
+| Completion, supersession or abandonment | Remove the obsolete checkout before the final receipt, or record the exact remaining dependency, owner and next cleanup trigger. |
+
+Before removal, inspect tracked changes, untracked **and ignored** files, local commits,
+worktree locks and processes still using the checkout. Preserve required source, fixtures and
+evidence at a verified durable destination. A clean status, merged HEAD, empty Git journal or
+silent worker alone does not prove that a checkout is obsolete. Unresolved ownership or
+unique data requires a specific retention reason, not a guessed deletion.
+
+Run `git worktree remove <path>` from outside the checkout and verify that its directory and
+entry in `git worktree list` are gone. Do not force-remove unknown state. Branch retention
+is a separate decision: removing a checkout does not delete its named branch or the PR.
+`git worktree prune` only removes stale registration metadata; it does not reclaim existing
+checkout directories. Record removal or retention in the existing task receipt, not a new ledger.
+
+For report and documentation jobs, materialize only the required paths with sparse checkout.
+For example, after selecting unused task-specific branch and path values:
+
+```sh
+git worktree add --no-checkout -b <task-branch> <worktree-path> origin/main
+git -C <worktree-path> sparse-checkout set --cone 40min-checkins
+git -C <worktree-path> checkout <task-branch>
+```
+
+Cone mode also includes top-level files and files in ancestor directories. Read relevant
+guidance outside the selected paths with `git show HEAD:<path>`, or add the needed directories
+with `git sparse-checkout add`. Expand the checkout when a build or validation needs more
+source; missing paths are not a reason to omit an applicable check. Do not shrink an active
+worker's checkout or share writable source/build outputs through hard links or symlinks.
+
+Git worktrees share repository objects/history but normally materialize separate working
+files. Sparse checkout selects paths; it is not a diff overlay that reads missing files from
+main. APFS copy-on-write clones can share file storage while keeping writes independent, but
+ordinary Git worktree creation does not establish clone sharing. Any clone-based setup needs
+separate implementation and validation and does not replace lifecycle cleanup.
+
+References: [Git worktrees](https://git-scm.com/docs/git-worktree),
+[sparse checkout](https://git-scm.com/docs/git-sparse-checkout),
+[Apple APFS cloning](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/APFS_Guide/FAQ/FAQ.html).
+
 ## Commit hygiene
 
 1. Fetch and inspect main, relevant branches/PRs and current claims before diagnosis.

--- a/engineering/remediation/templates/HANDOFF_RECEIPT.md
+++ b/engineering/remediation/templates/HANDOFF_RECEIPT.md
@@ -40,6 +40,8 @@
 ## Ownership
 
 - Working state preserved at:
+- Worktree disposition: removed / retained (owner, concrete reason and next cleanup trigger):
+- Cleanup evidence: preserved commit/artifacts; worker/process settlement; directory and registration removal verified:
 - Grant disposition requested:
 - Handoff recipient, if any:
 - Exact next action:

--- a/engineering/remediation/templates/TASK_PACKET.md
+++ b/engineering/remediation/templates/TASK_PACKET.md
@@ -20,6 +20,7 @@
 - Base SHA:
 - Branch:
 - Worktree ID:
+- Worktree owner, purpose, checkout paths (sparse/full) and cleanup trigger:
 - Repository-relative writable paths:
 - Read-only context paths:
 - Public contract/schema versions:


### PR DESCRIPTION
Published report jobs left full worktrees behind after their local work was finished. Require a cleanup decision at commit/push/PR publication, review, integration, pause, handoff, cancellation and completion; record removal or a concrete retention reason in the task receipt.

Use sparse checkout for narrow report/documentation jobs, preserve task ownership and unique data before removal, and retain branches independently of checkouts. Add a tested creation example and explain the limits of sparse checkout versus APFS copy-on-write storage.

Validation: four changed Markdown files; 12 relative links/anchors, symlink/private-marker checks and staged diff checks passed. A temporary Git fixture exercised sparse creation, an isolated report-only commit, and checkout removal while preserving the branch and main files. No application code changed or hosted Actions run was requested. The historical local knowledge checker reports pre-existing baseline drift.

Operational cleanup: the eight report commits were verified merged into main; seven checkouts were removed and the eighth reused sparsely for this change. Its checkout is removed after publication verification. Other agents' worktrees remain subject to ownership and lifecycle reconciliation.
