### PR TITLE
docs: publish remediation check-in 55

### DIFF
--- a/40min-checkins/2026-09-06-checkin-55.md
+++ b/40min-checkins/2026-09-06-checkin-55.md
@@ -1,0 +1,67 @@
+# Remediation check-in 55 — September 6, 2026
+
+**Accepted outcomes:** the exclusion-pin correction now has a permanent regression, and its combined nine-file adoption package passed the normal Node suite, six static checks and protected-base boundaries in check 54. Check 55 executes the newly proposed per-file size policy for 50 previously omitted source files and confirms its six hard-limit failures and eight warnings without waivers. **Issues closed: 0. Product merges: 0.** Full R05 acceptance remains open because source-policy/caller adoption and architecture ownership are not complete. Report publication is documentation delivery, not product progress.
+
+This report covers checks 51–55, from the previous checkpoint at **14:41:56 UTC to the scheduled check-55 prompt at 15:29:57 UTC** (48 minutes of observed time). Subsequent review completion and publication are recorded below. The verified product base is `c9027a7e708a4d20776ef3e1f3831a4a8e2ca7b4`.
+
+## Accepted gates and remaining limits
+
+Check 51 verified 72 size controls on 36 actual non-JS text sources, nine discovery/coverage/size/ratchet composition controls, and the new helpers' normal command/test registration. Its two hard-coded tooling-count assertions were corrected from 34 to 38. Those results support helper composition, not application-wide ownership. [Canonical check-51 receipt](https://github.com/mysteropodes/nemo/issues/901#issuecomment-5560089931).
+
+Check 53 verified seven real protected-base boundary-command outcomes, including the nested exclusion-path bypass and its correction, and passed the full combined Node suite: 367 passed, zero failed, one existing invalid-UTF8 filesystem skip. [Canonical check-53 receipt](https://github.com/mysteropodes/nemo/issues/901#issuecomment-5560201643).
+
+Check 54 accepted Codex-a-bot's DCO commit `2a03cee99fc05d1f02784d170bb722e57ad297b7`, adding one normally discovered regression file. The vulnerable helper produces 5 passes and 3 intended failures; the corrected helper passes all 8 cases. The nine-file combination passes **375 of 376 Node tests, zero failures, one existing filesystem skip**, all six standard checks, and the actual protected-base boundary command with **38/38 tooling paths**. All candidate source hashes remained unchanged. These results are reused here; no duplicate full-suite run is counted. [Canonical check-54 receipt](https://github.com/mysteropodes/nemo/issues/901#issuecomment-5560246076).
+
+The adoption patch SHA-256 is `b9508f66c3c64561ee6b1831539e597dce65e962c6e92e53b7b096985c245240`. Its regression must accompany the helper correction: the test-only commit deliberately fails against the vulnerable helper. [Repository discovery draft #973](https://github.com/mysteropodes/nemo/pull/973) and [language-neutral size draft #975](https://github.com/mysteropodes/nemo/pull/975) remain delivered, reviewed increments awaiting adoption.
+
+## Check-55 source-policy execution
+
+Check 52's authors delivered 22 Rust and 28 non-Rust source dispositions. Check 55 independently verified all 50 unique Git blobs, SHA-256 hashes and nonblank counts, confirmed that their source bytes still match current main, and built a scratch-only profile using each proposed existing label and unchanged ceiling. The real size helper's complete violation/warning output matches independent expectations, with zero exceptions applied.
+
+| Source | Proposed existing profile | Nonblank lines / hard limit |
+| --- | --- | --- |
+| `geometry-wasm/src/engine.rs` | Rust production module | 4,151 / 500 |
+| `geometry-wasm/src/fill.rs` | Rust production module | 998 / 500 |
+| `geometry-wasm/src/tweenmatch.rs` | Rust production module | 1,074 / 500 |
+| `src-tauri/src/video_decode.rs` | Rust production module | 2,205 / 500 |
+| `src/css/style.css` | Stylesheet | 2,797 / 350 |
+| `src/index.html` | Handwritten config/bootstrap | 2,434 / 250 |
+
+Eight further paths produce warnings. The exact acceptance receipt is SHA-256 `e1cab748424b0b4ba287f606e02ebc2c9d090ab85d883e7121b73dacd70ddd48`. This verifies the proposed policy's executable size behavior. It does not approve profile semantics, assign human owners, grant exceptions, enforce dependency graphs or connect production callsites. Check 52 retains final semantic policy acceptance.
+
+The independent Rust review covered all 22 rows and returned seven concrete corrections before semantic acceptance: frontend rebuild invalidation in `build.rs`; the real shader-library dependency and `serde_json`; the substep-count cap versus an unconditional timestep bound; four transform seeds versus a full matching matrix; opaque screen background versus transparent export; legacy selection/transform API and `pathRef` limits; and incorrect size-table citations. Lead checked the findings against the pinned source. Review SHA-256: `f887d34730cee55ed06ef44f3684128a66c90be246a0113333bef2a0603daa20`.
+
+Codexalog has recipient-accepted the bounded correction task and is preparing a separate corrected copy. The original source-disposition artifact remains preserved. Correction delivery and final semantic acceptance are pending at this publication checkpoint.
+
+Buzzotron has recipient-accepted the independent 28-row non-Rust review and is checking source identities, cited ranges and cross-boundary contracts. Its verdict is pending at this publication checkpoint. These live tasks continue after report publication.
+
+## Agent accounting
+
+All four online peers answered fresh capacity questions. Those replies establish session-local availability; the typed recipient receipts below establish actual task acceptance.
+
+| Agent | Accepted task and latest evidence | Next deliverable or idle reason |
+| --- | --- | --- |
+| Codex-a-bot | Check-54 regression request `277449f0`, acceptance `80fa8d29`, terminal success `980d0e9e`; independently tested and accepted. New check-55 Rust review `71367d75` processed `84c83ef6`, accepted `4e0db6cb`, admitted `4c49ad6a`. | Review delivered under typed terminal success `23723f83`; lead verified all seven findings. Awaiting adoption of the separate corrected handoff by check 52. |
+| Buzzotron | Check-52 Rust dispositions `e5d5c5fa`, acceptance `f9829bbc`, terminal success `3d0917cf`; final policy acceptance remains with check 52. New check-55 non-Rust review `e3e66937` processed `9726709c`, accepted `e0a43e1d`, admitted `95f0dde4`. | NONReview delivered under typed terminal success `23723f83`; lead verified all seven findings. Awaiting adoption of the separate corrected handoff by check 52. |
+| Codexalog | New correction request `b3681805` processed `5802cc67`, accepted `8992f48a`, admitted `6baa5181`; owns only a new scratch copy addressing the seven Rust findings. | Active: deliver corrected artifact, seven-finding change map and unchanged source/profile invariants. |
+| Codeximator | Check-53 actual-command review delivered and accepted; fresh capacity reply confirms no newer known accepted job or unreconciled effects. | Idle: no additional independent ready scope; repeating completed controls would not advance acceptance. |
+| Codexitron, check 55 | Completed the 50-file proposed-policy execution; native `integration_handoff` completed read-only branch/effect reconciliation. | Review new peer findings, return them to check 52, publish this report. |
+| Codexitron, check 52 | Retains final semantic acceptance of the delivered source-disposition package. | Reconcile independent findings and prepare complete reviewed source-policy handoff. |
+| Codexitron, retained source session `ac6d2343` | Owns source/CI/PR adoption. R05, R03 and both R06 worktrees are clean; no verified adoption or handoff is present. | Adopt the tested R05 package independently of R03/native blockers, or explicitly transfer precise scopes. |
+| Claudimator Beta | Offline; no fresh deliverable verified. | Unavailable; prior claims preserved. |
+| Claudirizer | Offline; no fresh deliverable verified. | Unavailable; prior claims preserved. |
+| Clauditron | Offline; existing source branches preserved. | Unavailable; prior claims preserved. |
+| Fizz | Offline; no current accepted task verified. | Unavailable. |
+| Honey | Offline; no current accepted task verified. | Unavailable. |
+| Mochi | Offline; no current accepted task verified. | Unavailable. |
+| Pollen | Offline; no current accepted task verified. | Unavailable. |
+
+## Repeated stall and exact owner action
+
+The source-integration stall has survived multiple checks. This check changed approach by advancing the delivered policy's actual per-file execution and independently reviewing its source claims. It did not retry the previously rejected self-address dispatch or replace an uncertain owner.
+
+Read-only reconciliation confirms clean R05 integration at `4c16e32cf653d000c832584e8f33f0f7cd0306e8`, R03 at published `1053aa59ec6eb34b60234abeb79bbad606e9192e`, and R06 integration at `f6fb2cfae0813c68d470117a337ecdbfe16007ba`. The latter already contains nine commits beyond draft #963's `6a976614` head; those changes must not be cherry-picked again. The prerequisite branch remains `67164ec58901bd52d148ce404f2466af66d3a3c5`. Older stack checks do not validate the unpublished combined R06 candidate. [R06 integration triage](https://github.com/mysteropodes/nemo/pull/967#issuecomment-5559325069).
+
+**Required action:** Ilya/operator resumes retained session `ac6d2343`, or explicitly transfers its exact source/CI/PR scopes. That owner checks the complete nine-file patch against the existing R05 candidate, reconciles overlapping registrations, adopts correction and regression together, and runs the remaining checks on the resulting exact candidate before the protected PR route. This R05 integration step need not wait for R03 or native acceptance. R06 separately needs exact-candidate local surface checks and packaged Open/Resume replay; R03 retains its inventory/caller acceptance.
+
+No full-board sweep, issue closure, acceptance-checkbox promotion or hosted/native run was performed. All four Actions workflows were verified disabled and preserved. Only changed canonical facts are updated. Next detailed report: **check 60**. [Permanent report index](README.md).

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -6,6 +6,7 @@ The permanent home for Codexitron's every-fifth-check-in reports is this directo
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 55 | 2026-09-06 | 14:41:56–15:29:57 | [Fifty-fifth check-in](2026-09-06-checkin-55.md) |
 | 50 | 2026-09-06 | 14:02:05–14:41:56 | [Fiftieth check-in](2026-09-06-checkin-50.md) |
 | 45 | 2026-09-06 | 13:22:04–14:02:05 | [Forty-fifth check-in](2026-09-06-checkin-45.md) |
 | 40 | 2026-09-06 | 12:42:03–13:22:04 | [Fortieth check-in](2026-09-06-checkin-40.md) |


### PR DESCRIPTION
Publishes the scheduled check-55 report and updates the permanent index. It records accepted R05 regression and composition results, the new 50-file proposed-policy execution, seven verified Rust disposition findings, live review/correction ownership, and the exact retained integration blocker. Zero issue closures and zero product merges are stated explicitly.

Validation: two-file staged scope; 12 relative links resolve; regular files and private-data marker checks pass; staged bytes match the validated artifacts. Existing product checks are cited and were not repeated for this documentation change. Active source reviews continue after the publication checkpoint.
