### PR TITLE
Record check 60 R03 acceptance and restart

### DIFF
--- a/40min-checkins/2026-09-06-checkin-60.md
+++ b/40min-checkins/2026-09-06-checkin-60.md
@@ -1,0 +1,61 @@
+# Remediation check-in 60 — September 6, 2026
+
+**Accepted outcomes:** the R03 restart now has accepted browser document-contract evidence and a measured production software-render workload on one identified R03-only candidate. The inventory swatch correction has been delivered for integration. **Issues closed: 0. Product merges: 0 in this check.** R03/#899 and F0/#888 remain open because final inventory regeneration, combined-candidate review and integration are unfinished; full fixture/render/export requirements remain explicit. Report publication is documentation delivery, not product progress.
+
+This is the fifth-check report following check 55. The scheduled checkpoint is **20:51:15 UTC**, September 6. The interval since check 55 at 15:29:57 includes the execution stop, audit and approved restart; it is not forty minutes of continuous implementation. Review and delivery results obtained after the scheduled cutoff are identified below. GitHub main was verified at `b86c69dda2a061ef551fc522dd96327a5b9a4f66`.
+
+The approved restart established one R03 integration owner and stopped periodic report PRs. The subsequently delivered check-60 prompt explicitly requests this fifth-check publication. This documentation task leaves the active implementation session, its workers and manual-only workflow policy intact.
+
+## Accepted R03 evidence
+
+The active integration session assembled candidate `ad20a824efacbd7d439d21645c00a798f4695faa` from current main and retained R03 commits. Application source remains unchanged from main; R08 extraction is separate. Its checkpoint records byte-identical regeneration of the twelve-fixture corpus, including all 41 files; 34/34 focused fixture/benchmark/CI checks; and 40/40 tooling coverage. These are the integration owner's receipts, reused here rather than rerun.
+
+Codex-a-bot's browser task `8f387b11` has verified processed receipt `f90fdea6`, recipient acceptance `cdb3b0f6` and terminal success `f36a2f11`. Its completed artifacts were independently reviewed in this check after the scheduled cutoff:
+
+- Nine document-source/harness pins and 138 render-source/harness/generator pins match exact candidate Git blobs. All six document artifacts match their reported byte lengths and SHA-256 hashes.
+- Sixteen independent migration/text expectations pass on original application import and fresh-context reopen: **32 executions**. Application `exportJSON()` supplies the reopened document; browser Save/download UI is outside this test.
+- Curve-handle and one-pixel translation controls retain their serialized corruption after reopen. The actual geometry assertion rejects both. The same checks cannot accept an unrelated exception as a successful control.
+- Eight document contexts, browser and owned runtime report successful cleanup. Before/after source and build identities match.
+- The production Rust/vello WASM renderer completes **24 serial frames**, each with 200 materialized paths and observed queue submissions. Completion is measured with the actual render queues' `GPUQueue.onSubmittedWorkDone()`.
+- All five metric families were independently recomputed from raw samples. Frame navigation through queue completion is p50 **42.5 ms**, p95 **46.8 ms**, p99 **305.1 ms**. The measured backend is Chrome 152.0.7977.76, Playwright 1.61.0 and a SwiftShader fallback adapter on an Apple M3 Ultra host.
+
+Document receipt SHA-256: `3168c78afbdfa88a9c4ca979cc0395d8c15b657eb170bff38f586f00a9290a5f`.
+Render receipt SHA-256: `716d68af8d842b7e9170c0cba97f8485ca3db00453887f775e8c4ce906f73d29`.
+
+**Disposition: accepted for document-contract behavior and software-render measurement.** These results do not prove visual equivalence, compositor presentation, realtime playback, hardware-GPU performance, native export, Tauri or packaged-app acceptance. No budgets were invented. Final integration must match the unchanged application, harness and fixture bytes before reusing this evidence.
+
+## Delivered correction and remaining gate
+
+After the scheduled cutoff, Codeximator delivered DCO commit `2584444dfc3fc4bc4d36a1cf44cb55ee23ea3728`, based on `e1e7adaca32f43d009df76777bf2195c68eee952`. Request `b06a3cbb` has processed `9457a996`, recipient acceptance `352493c7` and terminal success `126a4a73`.
+
+The two-file correction follows exported record-array helpers: `pm-stroke` resolves to the `ColorPicker.wireColorSwatches()` click registration, while `pm-stroke-c` retains its input handler. The author reports **8/8 immutable swatch regressions** and **51/52 inventory tests**; the remaining failure is committed-output freshness because generated inventory artifacts belong to the integration owner. These are delivered author results, not final independent correction approval.
+
+Next: the existing Codexitron integration session adopts the correction, regenerates its inventory, resolves applicable profile registration, obtains Codexalog's exact-candidate review, and completes the revision-specific F0 baseline through the protected PR route. [R03 acceptance](https://github.com/mysteropodes/nemo/issues/899) and [F0 acceptance](https://github.com/mysteropodes/nemo/issues/888) remain open. No acceptance checkbox or board status is promoted here.
+
+## Retained prior work and changed approach
+
+Checks 57–59 produced useful but unintegrated increments. The notice-generator regression and proposed metadata correction passed bounded controls; the test must accompany the correction. Check 58 established browser isolation and a conflict-free R06/current-main composition, while exposing four Node failures, stale provenance, a project.js size-ceiling violation and a spaced-Node fixture defect. Those prior results are historical, not reruns. [R06 check-58 evidence](https://github.com/mysteropodes/nemo/issues/902#issuecomment-5560468982).
+
+Check 59 reproduced orphaned native reservation acquisition and delivered regression `16d756e05d0fb04c6eed6be0fdecf179ffef5549`, which still requires review corrections. Original request `af81f46f` has processed/accepted and commit progress; cancellation `a702f581` still has no terminal disposition on the fresh typed read. Its legacy recipient identity differs from the current Buzzotron roster entry. Current online presence cannot settle that original signed operation. The managing runtime/operator must reconcile the original recipient and terminal cancellation or indeterminate disposition before that claimed test is replaced. The original commit and ownership remain preserved. [R06 check-59 evidence](https://github.com/mysteropodes/nemo/issues/902#issuecomment-5560470074).
+
+The restart changes the response to these stalls: integrate the R03-only baseline now, keep the uncertain reservation claim confined to its actual scope, then advance the declared R05/R06 prerequisites and existing R08/shared-property/MCP sequence. No unchanged dispatch is retried and no uncertain source work is overwritten.
+
+## Named agent accounting
+
+| Agent | Latest accepted/delivered evidence | Next deliverable or idle reason |
+| --- | --- | --- |
+| Codexitron, active integration session | R03 candidate `ad20a824`; existing scoped composition and baseline checks. | Adopt swatch fix, regenerate, obtain final review and integrate. Ownership remains in the approved restart thread. |
+| Codexitron, this timed check | Independently accepted the delivered browser artifacts and recomputed the render metrics; result returned to the integration owner. | Complete this requested documentation publication; no competing implementation assignment. |
+| Codeximator | Swatch request `b06a3cbb`, accepted `352493c7`, terminal `126a4a73`; delivered `2584444d`. | Bounded author task delivered. Await combined-candidate review or a concrete correction from its integration owner. |
+| Codex-a-bot | Browser request `8f387b11`, accepted `cdb3b0f6`, terminal `f36a2f11`; bounded result independently accepted. | Established-check task complete; next source-dependent baseline assignment remains with the integration owner. No duplicate check assigned here. |
+| Codexalog | Prior audit task terminal success; reserved by the restart owner for independent final-candidate review. | Await the regenerated combined candidate; no new recipient acceptance is claimed. |
+| Buzzotron | Current roster online, workload unknown. Legacy `af81f46f` accepted/committed; cancellation remains unsettled under a different recipient identity. | Runtime/identity reconciliation before reassigning the held regression. No replacement or second job issued here. |
+| Claudimator Beta | Offline; prior source claims preserved. | Unavailable; no fresh delivery verified. |
+| Claudirizer | Offline; prior source claims preserved. | Unavailable; no fresh delivery verified. |
+| Clauditron | Offline; retained R03 source branches preserved. | Unavailable; no source overwrite or ownership inference. |
+| Fizz | Offline; no current accepted task verified. | Unavailable. |
+| Honey | Offline; no current accepted task verified. | Unavailable. |
+| Mochi | Offline; no current accepted task verified. | Unavailable. |
+| Pollen | Offline; no current accepted task verified. | Unavailable. |
+
+No helper agents or new worker assignments were created by this check. The existing restart already supplies the independent author, browser-validation and final-review lanes. Missing usage counters are unknown, not zero; this report makes no cumulative-token claim. No hosted workflow, native build/app launch, release, board sweep or issue closure was performed by this check.

--- a/40min-checkins/2026-09-06-checkin-60.md
+++ b/40min-checkins/2026-09-06-checkin-60.md
@@ -59,3 +59,11 @@ The restart changes the response to these stalls: integrate the R03-only baselin
 | Pollen | Offline; no current accepted task verified. | Unavailable. |
 
 No helper agents or new worker assignments were created by this check. The existing restart already supplies the independent author, browser-validation and final-review lanes. Missing usage counters are unknown, not zero; this report makes no cumulative-token claim. No hosted workflow, native build/app launch, release, board sweep or issue closure was performed by this check.
+
+## Post-preparation update
+
+The active integration owner subsequently rejected the first swatch delivery's size: **468 nonblank lines against the existing 400-line module ceiling**. Codeximator's bounded helper extraction now has signed received/started/admitted receipts in its separate correction thread; Codexalog's independent exported-helper review likewise has signed received/started/admitted receipts. These replace the earlier waiting dispositions above; neither successor is called delivered or approved. The original correction is preserved, and no ceiling was waived.
+
+The owner also records separate native results on `ad20a824`: 36 passes and one indexed-seek timing failure, p95 36.2 ms; integration not run; desktop blocked by the missing app/harness. These are owner-reported native results, not browser evidence or a fresh native run by this check. The nearest next action remains the owner's corrected-candidate composition and review.
+
+Report PR publication itself is pending the repository's required approving review. The normal merge route was rejected by main's review policy, and automatic merge is disabled. No protection bypass or main-publication claim is made.

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -6,6 +6,7 @@ The permanent home for Codexitron's every-fifth-check-in reports is this directo
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 60 | 2026-09-06 | 15:29:57–20:51:15 (stop/restart interval) | [Sixtieth check-in](2026-09-06-checkin-60.md) |
 | 55 | 2026-09-06 | 14:41:56–15:29:57 | [Fifty-fifth check-in](2026-09-06-checkin-55.md) |
 | 50 | 2026-09-06 | 14:02:05–14:41:56 | [Fiftieth check-in](2026-09-06-checkin-50.md) |
 | 45 | 2026-09-06 | 13:22:04–14:02:05 | [Forty-fifth check-in](2026-09-06-checkin-45.md) |


### PR DESCRIPTION
Records the R03-only restart's accepted browser document checks and software-render measurements, the delivered swatch correction, and the remaining integration and ownership gates. Fulfills the delivered fifth-check publication request; no product acceptance or issue closure is inferred.

Validation: source/artifact hashes and raw render statistics independently checked; report relative links, private-data markers, symlinks and scoped diff checked. Documentation only; no application tests or workflow runs added.
