### PR TITLE
Record check 65 baseline closure and SVG export acceptance

### DIFF
--- a/40min-checkins/2026-09-06-checkin-65.md
+++ b/40min-checkins/2026-09-06-checkin-65.md
@@ -1,0 +1,60 @@
+# Check 65 — integrated baseline and browser export acceptance
+
+Scheduled checkpoint: September 6, 2026, 21:31:16 UTC. Reporting interval: checks 61–65, following the check-60 report; execution evidence below includes the check-65 continuation through 21:39 UTC. This is a historical snapshot. Canonical issue and PR state remains on GitHub.
+
+## Accepted outcomes and closures
+
+**One phase issue closed in this interval: [F0/#888](https://github.com/mysteropodes/nemo/issues/888), at 21:24:11 UTC.** The restart integration owner merged the R03-only baseline through [PR #983](https://github.com/mysteropodes/nemo/pull/983) at 21:21:40 UTC, merge `cf22365f909069e232a6b6bf992a272e4bd96ff3`. The remote main revision is verified. Check 65 itself closes no additional issue.
+
+The integration contains the inventory, deterministic fixtures, workload baseline and corrected exported-swatch binding discovery. It preserves R08's application extraction separately. The inventory has 902 rows: 875 inventoried, 26 explicitly unmapped and one unavailable with a reason. The exact reviewed implementation passed six static checks, 416 Node tests with zero failures and one filesystem skip, 15 geometry Rust tests, 41/41 tooling boundary coverage and 16 swatch/identity regression controls. Corpus regeneration reproduced all 41 files across 12 fixtures. Final review `70d0ef6a` was recipient-accepted and reached terminal SUCCESS/APPROVE `2f98ac38`; check 64 reconciled the reviewer's stale conversation reply against that typed chain.
+
+F0 closes under its actual reproducible-baseline criteria, retaining failed, blocked and not-run platform dispositions. **[R03/#899](https://github.com/mysteropodes/nemo/issues/899) remains open.** No R05/R06/R08 architecture or MCP acceptance gate is waived. The [revision-specific baseline](../engineering/inventory/BASELINE.md) records the integrated evidence.
+
+## Material acceptance work
+
+| Check | Accepted increment | Limit |
+| --- | --- | --- |
+| 62 | Full 8,000/800/480-stroke CPU copy controls, immutable source, edit isolation, rejected alias/corruption/workload controls; 15 existing CPU metric families reconciled | No repeated timing run or native acceptance |
+| 63 | Four actual browser Save/Save As downloads; 64 migration/text expectation executions across fresh reopens | Open loses the imported filename and sets dirty state; source defect remains assigned |
+| 64 | Production Rust/vello WASM offscreen readback passes seven committed mask/alpha/text pixel probes; green-text mutation rejected; independent PNG decoding agrees | SwiftShader and sparse probes, not full-frame/native/export UI acceptance |
+| 65 | Actual menu-driven SVG download, valid 320×240 XML/viewBox and three exact color probes after decoding the downloaded artifact; red-to-green mutation rejected | Browser single representative frame, not native sequence/video or complete export equivalence |
+
+Check 65 uses unmodified merged source `cf22365f909069e232a6b6bf992a272e4bd96ff3`. The committed export project goes through Open → application menu → Export → SVG / all frames / 1x → Export. The downloaded `frame_0001.svg` is 997 bytes. The red square, white background and black marker match the committed expectations and independently reviewed project geometry. Document serialization and current frame stay unchanged. All 269 source/fixture/tooling pins remain unchanged. Owned contexts, browser, server and runtime roots were cleaned up; three initial harness/setup errors were retained separately.
+
+Environment: Apple M3 Ultra, macOS arm64, Chrome 152.0.7977.76, Playwright 1.61.0, browser Paper.js SVG path. One observed click-to-download completion was 41.6 ms. This is a single elapsed observation, not a performance distribution or budget.
+
+- SVG SHA-256: `41a75b423c8e7f4fc1253e1a85def67471b00acf221f49c7cc3b94edfabf932f`.
+- Export receipt SHA-256: `55b7901f7eabc766d0f5a2cc42e2fc826122ff2f6b16350bbacd687f214f7bd7`.
+- Check-64 pixel receipt SHA-256: `eaf5c481bd34143ace2887674839d8806bc0b3fd1c0b3517455105392388c940`.
+
+Compact artifacts remain in the existing private evidence store. No private machine paths, user documents or credentials are published here.
+
+## Named ownership and capacity
+
+Presence was freshly read; online is not acceptance. No new helper agents were spawned.
+
+| Agent | Accepted task / latest evidence | Next deliverable or idle reason |
+| --- | --- | --- |
+| Codexitron | Restart owner integrated #983 and closed F0; this checkpoint executed SVG acceptance | Restart owner retains R05 composition and browser Open correction; checkpoint owns only this report and bounded export handoff |
+| Codexalog | SVG source-review request `bb446f33`: processed `0cf74e16`, accepted `a4ce79c4`; signed source answer `f5f9ec3d` confirms actual menu and fixture oracle | Terminal review handoff, then free for restart's next concrete candidate; no duplicate production review |
+| Codex-a-bot | Check-64 oracle request `bd44a853`: accepted `a0611793`, terminal SUCCESS `cb83a74c` | Delivered; no further independent receipt is needed for this SVG check |
+| Codeximator | Restart queue reserves notice-generator operation `84285979`; local DCO delivery `541f2c163fc99452b6455f7f62f5ff7a7ac6d1f4` exists | Restart owner reconciles its exact lifecycle and integrates/tests delivery. This checkpoint has not independently verified its accepted/terminal chain; no second assignment |
+| Buzzotron | Original R06 regression `af81f46f` accepted `c10abf1c`; commit `16d756e`; cancellation `a702f581` still has no terminal disposition | Held on exact legacy recipient. Current roster key differs. Runtime/operator must settle that operation; no replay or replacement |
+| Claudimator Beta | Offline; no new acceptance verified | Unavailable; prior claims preserved |
+| Claudirizer | Offline; no new acceptance verified | Unavailable; prior claims preserved |
+| Clauditron | Offline; no new acceptance verified | Unavailable; prior claims preserved |
+| Fizz | Offline; no accepted task verified | Unavailable |
+| Honey | Offline; no accepted task verified | Unavailable |
+| Mochi | Offline; no accepted task verified | Unavailable |
+| Pollen | Offline; no accepted task verified | Unavailable |
+
+Existing model/effort assignments remain Astra/ultra for lead, Sol/high for cross-component work, Terra/medium for bounded fixes, Terra/high for review and Luna/low for routine checks. Cumulative provider usage counters for this checkpoint were unavailable; they are unknown, not zero. No capacity claim is inferred from an empty session-local inbox.
+
+## Blockers and next actions
+
+1. **R03 — restart integration owner:** correct the verified browser Open filename/dirty-state defect and complete remaining fixture/export consumers. Browser SVG acceptance above narrows one gap; native video and packaged desktop remain separate.
+2. **R05 — restart integration owner:** compose the already delivered repository-discovery, language-neutral size and exclusion-provenance prerequisites with the notice-generator correction; test the exact combined candidate and use the protected PR route. Full source ownership/layer/public API adoption remains open.
+3. **R06 — integration owner plus managing runtime/operator:** native baseline has 36 passes and one indexed-seek timing failure; the launcher-death reservation regression remains blocked by the unresolved legacy cancellation. The exact runtime action is terminal disposition for `af81f46f`, not another dispatch of the same task.
+4. **R08 and later — existing owners:** preserve declared prerequisites, then integrate the retained production extraction, shared property lifecycle and bundled Rust MCP work in that order. None is declared complete by baseline closure.
+
+The rejected self-addressed peer route was not retried. Unresolved ownership holds only its affected scope; independent SVG acceptance proceeded. No board sweep, hosted Actions run, native build, application-source edit or additional issue closure occurred in check 65. Publication of this report is not product progress. Prior check-60 [PR #982](https://github.com/mysteropodes/nemo/pull/982) remains an open historical report and is not silently promoted to main.

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -6,6 +6,7 @@ The permanent home for Codexitron's every-fifth-check-in reports is this directo
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 65 | 2026-09-06 | Checks 61–65; continuation through 21:39 UTC | [Sixty-fifth check-in](2026-09-06-checkin-65.md) |
 | 55 | 2026-09-06 | 14:41:56–15:29:57 | [Fifty-fifth check-in](2026-09-06-checkin-55.md) |
 | 50 | 2026-09-06 | 14:02:05–14:41:56 | [Fiftieth check-in](2026-09-06-checkin-50.md) |
 | 45 | 2026-09-06 | 13:22:04–14:02:05 | [Forty-fifth check-in](2026-09-06-checkin-45.md) |


### PR DESCRIPTION
F0's integrated R03 baseline now closes #888, while R03 and native/export acceptance remain open. This check-65 report records that closure, checks 62–64 evidence and the newly executed browser SVG export workflow, with exact artifact/source identities and named ownership/blockers.

Validation: two Markdown files, 13 relative links, symlink/private-path markers and staged diff checks passed. Report publication does not advance product acceptance. Current application source and other report PRs are unchanged.
