### PR TITLE
Record check 75 application MCP test integration

### DIFF
--- a/40min-checkins/2026-09-06-checkin-75.md
+++ b/40min-checkins/2026-09-06-checkin-75.md
@@ -1,0 +1,79 @@
+# Check 75 — combined application and compiled MCP regressions
+
+Scheduled checkpoint: September 6, 2026, 23:32:15 UTC. Reporting interval: checks 71–75, with check-75 continuation. Historical snapshot; GitHub issues, PRs and accepted runtime receipts remain canonical.
+
+## Accepted outcomes and closures
+
+**Zero issues closed during this interval.** The first opacity application/MCP slice now has permanent compiled-executable protocol, lifecycle and application/history regressions. Check 75 combined the delivered test commits, reproduced and corrected an existing fixture's incompatibility with the extracted bootstrap, and passed **12 Rust tests and 10 Node tests**, with no failures or skips in those runs.
+
+These results advance the shared command/history and MCP transport gates of [R11 #907](https://github.com/mysteropodes/nemo/issues/907) and [R14 #910](https://github.com/mysteropodes/nemo/issues/910). They do not close the slice: the production integration owner still needs to adopt the tests with the application extraction, finish its remaining consumer checks, and validate the installed bundled executable through actual Codex and Claude. Save/reload, render/export and supported-platform package acceptance remain open.
+
+The accepted sequence remains retained R08 extraction, one complete animated property through shared application services and Rust MCP, then further subsystem migrations. Whole-project R03/R05/R06 obligations remain tracked; only each slice's concrete characterization, boundary and isolation prerequisites gate its implementation. [R08 PR #986](https://github.com/mysteropodes/nemo/pull/986) and [R06 integration PR #988](https://github.com/mysteropodes/nemo/pull/988) remain open, requiring eligible review. No product merge occurred in this checkpoint.
+
+## Material progress
+
+| Check | Delivered implementation or acceptance | Limits |
+| --- | --- | --- |
+| 71 | Permanent compiled-stdio rejection and command roundtrip tests, `38600b8` and `aa24a825`: invalid writes rejected before application transport; request identity and application errors preserved | Roundtrip worker's terminal envelope is indeterminate. Its actual retained Git commit and clean worktree were inspected; no job replay or terminal-success promotion |
+| 72 | Permanent cancellation and reconnect tests, `5c4f050` and `34a83c1`: in-flight cancellation closes IPC, the same client can query afterward, registration replacement routes to the new endpoint, and distinct instances stay separate | Mock application endpoints; cancellation does not promise rollback of an already committed write |
+| 73 | `575e13c` calls the actual extracted application core/domain through compiled MCP and directly: shared revisions, identical retries, changed-body rejection, undo/redo and document replacement | Deterministic document/history ports and a development-only Node host. Previous retry-retention and revision-guard negative controls are retained |
+| 74 | `c54edb2` exercises complete production Motion, history, core and bootstrap scripts: API/UI history, stale-write invalidation, capped history, key storage, document replacement and gesture exclusion | Paper/display ports are inert. Previous independent history-hook and legacy-hook negative controls are retained |
+| 75 | Composed all six deliveries on `fc7145e`; corrected the pre-existing application fixture to load the extracted bootstrap; removed obsolete mock writer functions; corrected an overstated test name | Test composition is local and depends on the pinned production extraction. It is handed to the existing owner for adoption, not an installed application candidate |
+
+Check-75 test branch: `codex/check75-mcp-composition-20260906`, final commit `cbc870216ed5d7440100131a240f916acbd89bb0`, base `fc7145e6358434a7a07957aea416ed4470fa90cb`. Seven test files differ from that base. Original authorship, sign-offs and cherry-pick provenance are preserved. The new fixture correction is `cdc0f5c9d70f16b0eb01091be31b42289eb2fd7c`; `cbc8702` only corrects its test description.
+
+The old fixture loaded the application file assuming it installed global handlers. After extraction, that file exports the core factory and bootstrap installs the handlers. The combined run reproduced **7 passes / 3 failures** (`NemoApplication` undefined). Loading the actual bootstrap with deterministic identity and existing document ports yields **10 passes / 0 failures**. The original behavioral assertions remain intact. The description now claims key-command trace coverage, matching its assertions; it does not claim animation-toggle coverage or a trace-retention bound.
+
+## Validation and source identity
+
+| Check | Result |
+| --- | --- |
+| `cargo test --locked --manifest-path nemo-mcp/Cargo.toml` | 12 passed; zero failed or ignored across the combined crate |
+| `node --test tests/application-opacity-bootstrap.test.cjs tests/application-opacity.test.cjs` | Before fixture correction: 7 passed / 3 failed. After: 10 passed / zero failed or skipped |
+| Delivered stdio test formatting and scoped diff checks | Passed |
+| Independent bounded test review | Completed by `combined_test_review`; one inaccurate coverage description corrected, no other concrete test or lifecycle finding |
+| Production source pin readback | All six tested dependencies still matched the production owner's source after execution |
+
+The factory/bootstrap extraction is still owned and uncommitted in the production session. Only its exact six dependencies were copied into the isolated validation checkout; none was committed by check 75. The rest of that checkout is the stated base, so it is not a complete browser or package composition. The production owner's actual HTML already loads domain before Motion and bootstrap before the MCP adapter. Review concerns based on the partial validation checkout's older HTML were withdrawn after that readback.
+
+| Validation dependency | SHA-256 |
+| --- | --- |
+| `src/js/application/opacity-application.js` | `266da5ce2cc3c13822c2bb77c48c672052fac72fefbca0b749abc10e84c88ac3` |
+| `src/js/bootstrap/opacity-application.js` | `08f82708992dcf449beea0d796b48e8fe1efb356defd3527f39b1cba26c5a598` |
+| `src/js/domain/animation/opacity.js` | `4863f27ccc6396db285c70586d30d1284aff64885fa51ffffcd95aeddfda3841` |
+| `src/js/motion.js` | `b4f56bd04b19cbca5e2b72aef7bb42f1121b43c460825d42ef8b20e02a99d40d` |
+| `src/js/tweens.js` | `5cb3a6d47f49db0977a1c312bfbadddef45cedacd2090dadba174340b1ac243a` |
+| `src/js/animation/curve.js` | `d6c70a8848a8475f9d7ec62ce62127748e0938f3058dae40a8154a82389534c7` |
+
+Compact logs, original patches, source snapshots and the acceptance receipt remain in the existing private evidence store. Node is a development-test prerequisite for the parity fixture; this does not add a Node requirement to the installed MCP executable. No new dependency, test framework, native build, hosted workflow or board sweep was introduced here.
+
+## Agent accounting
+
+Fresh roster presence was read; presence is separate from acceptance and capacity. Existing claims were preserved.
+
+| Agent | Accepted work and latest evidence | Next deliverable and blocker or idle reason |
+| --- | --- | --- |
+| Codexitron | Check 75 composed, corrected, reviewed and tested the seven-file test package. Production session `f6a64b19` retains application/core/bootstrap/packaging integration | Adopt delivered tests with the extraction; register them in the owned source policy and run the remaining integrated consumer/package checks. No source takeover by the timed check |
+| Codexalog | Accepted opacity extraction `ef21b2d8`, acceptance `47ed75c0`, terminal SUCCESS `be42f6d7`; delivered `de959e04` and default-curve follow-up `ff32d10` | Offline. Production owner holds adoption; next candidate review needs a new available, accepted assignment |
+| Codex-a-bot | Accepted roundtrip `bbc081f6`, acceptance `1c5c5a3b`; readable `aa24a825`, typed INDETERMINATE `afe0db63` | Offline. Actual clean retained commit inspected and composed; lifecycle remains indeterminate, no replay or second assignment |
+| Codeximator | Prior application/history work; frozen correction `7d8c242` retained | Offline. Production owner retains correction reconciliation; no replacement assignment |
+| Buzzotron | Original `af81f46f` processed/accepted; `16d756e` retained. Fresh status still has cancellation `a702f581` and no terminal disposition | Online but held. Current roster identity differs from original recipient. Managing runtime/operator must settle the exact original job before reassignment |
+| Claudimator Beta | No new acceptance; prior claims preserved | Offline and unavailable |
+| Claudirizer | No new acceptance; prior claims preserved | Offline and unavailable |
+| Clauditron | No new acceptance; prior claims preserved | Offline and unavailable |
+| Fizz | No accepted assignment verified | Offline and unavailable |
+| Honey | No accepted assignment verified | Offline and unavailable |
+| Mochi | No accepted assignment verified | Offline and unavailable |
+| Pollen | No accepted assignment verified | Offline and unavailable |
+| `combined_test_review` | Exceptional native Terra/high helper accepted and delivered the bounded read-only review in its separate visible task thread | Complete. Description finding corrected; no further assigned work or descendants |
+| `reconnect_test` | Check-72 native support accepted and delivered `e6114d6`, reviewed and integrated as `34a83c1` | Complete; no active assignment |
+
+The single-assignment and no-recursion rules remain in effect. This check accounted for itself, the existing production owner, held Buzzotron and one exceptional helper within the team limit. Cumulative provider token counters were not exposed and remain unknown.
+
+## Changed approach, blockers and next actions
+
+1. **Production Codexitron:** integrate delivered work before further independent investigations. If earlier test commits are already adopted, apply only `cdc0f5c` and its description follow-up; otherwise use the preserved eight-commit test range. Adopt with the required production extraction, never as a standalone test change on main. Finish actual UI/timeline/save-reload/render/export and diagnostic behavior, then installed Codex/Claude discovery, edit, history, reconnect and cancellation acceptance.
+2. **Eligible GitHub reviewer:** protected main requires one approving review, dismisses stale reviews, and requires approval of the latest push. PRs #986, [#987](https://github.com/mysteropodes/nemo/pull/987) and #988 remain awaiting review. Check 75 uses the same protected PR route for this report; main publication remains pending until that review/merge gate passes. No protection change, admin bypass or unchanged failed merge retry.
+3. **Managing Buzz runtime/operator:** reconcile the exact original Buzzotron recipient/job and produce its terminal disposition. The repeated blocker was bypassed for independent test integration, not retried or silently reassigned.
+
+Remaining R-task acceptance stays open. Report publication is tracking work and is not counted as product progress.

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -6,6 +6,7 @@ The permanent home for Codexitron's every-fifth-check-in reports is this directo
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 75 | 2026-09-06 | Checks 71–75; scheduled 23:32:15 UTC with continuation | [Seventy-fifth check-in](2026-09-06-checkin-75.md) |
 | 65 | 2026-09-06 | Checks 61–65; continuation through 21:39 UTC | [Sixty-fifth check-in](2026-09-06-checkin-65.md) |
 | 55 | 2026-09-06 | 14:41:56–15:29:57 | [Fifty-fifth check-in](2026-09-06-checkin-55.md) |
 | 50 | 2026-09-06 | 14:02:05–14:41:56 | [Fiftieth check-in](2026-09-06-checkin-50.md) |


### PR DESCRIPTION
Records checks 71–75 and the combined application/Rust MCP test integration: 12 Rust passes, 10 Node passes, and the existing fixture/bootstrap incompatibility reproduced and corrected. Zero closures; production adoption, installed-client/consumer acceptance, named ownership and exact review/runtime blockers remain explicit.

Artifact validation: two Markdown files, 13 relative links, regular-file/private-marker checks and staged diff passed. Report-only change; no application tests required for these documentation bytes. Publication to main remains subject to the normal latest-push review requirement.
