### PR TITLE
Record check 87 native opacity acceptance and remaining integration gates

### DIFF
--- a/40min-checkins/2026-09-07-checkin-87.md
+++ b/40min-checkins/2026-09-07-checkin-87.md
@@ -1,0 +1,98 @@
+# Check 87 — packaged native opacity acceptance advances
+
+Scheduled checkpoint: September 7, 2026, 01:20:47 UTC. Rolling 45-minute window:
+00:35:47–01:20:47 UTC; check-87 execution afterward is identified below. This is the
+first report under the new every-third-check instruction. Earlier reports retain
+their original windows and cadence.
+
+## Accepted outcomes and closures
+
+**Zero issues closed.** Check 87 advanced real packaged-desktop acceptance of the
+shared opacity/MCP slice. Installed Codex/Claude clients, native export, animated
+keys and cancellation still need their own evidence; whole-issue criteria remain
+open. Report publication is not product progress.
+
+The preceding interval landed R08 through [PR #986](https://github.com/mysteropodes/nemo/pull/986),
+R06 integration through [PR #991](https://github.com/mysteropodes/nemo/pull/991), and
+the rejected-import correction through [PR #993](https://github.com/mysteropodes/nemo/pull/993).
+Their exact accepted trees and retained tests are recorded in the
+[check-85 report](2026-09-07-checkin-85.md); those unchanged suites were not repeated here.
+
+## Check-87 native acceptance
+
+Candidate: `6c718b8225dae9563a263ad3360ae43077a78b77`,
+[draft PR #992](https://github.com/mysteropodes/nemo/pull/992).
+The existing unsigned macOS package was launched with a dedicated task data root,
+MCP registry and exclusive desktop-input reservation. Its bundled `nemo-mcp`
+SHA-256 was verified as
+`d7db869d14fe60dc452433d2f98c5efb812c999e0c1a9ee75f62524c4fc25853`.
+Live discovery reported the same source identity.
+
+| Actual workflow | Result |
+| --- | --- |
+| Bundled MCP discovers the real desktop app and reads its document snapshot | Pass |
+| Draw a rectangle using native UI; set its layer opacity to 37 through MCP | Pass |
+| Retry the identical request | Same retained result; no additional write |
+| Submit a different request with an old revision | Rejected; opacity remains 37 |
+| Undo and redo through MCP | 100, then 37 |
+| Inspect native Motion properties and rendered rectangle | Inspector reads 37; rectangle visibly fades |
+| Save through the native dialog, then Open that saved file | Pass; reopened opacity is 37 |
+| Reconnect a fresh stdio client and query reopened document | Pass; new document identity, revision zero |
+| Stop owned native process and release task state/registry | Pass; process-group exit verified |
+
+Saved fixture SHA-256:
+`72062d1f44dec1b55e0993bd889f6085ae2e29664a96457749447cb1fd400d07`.
+Protocol transcripts, artifact hashes and the cleanup receipt are retained in the
+lead's private evidence, with no connection secrets published.
+
+The initial detached shell controller exited and its test app received SIGTERM.
+The resulting empty discovery was a harness interruption, not evidence of a product
+failure. The lead reconciled the stopped process, retained and resumed the isolated
+project, kept the replacement controller attached, and completed the checks above.
+No source or shared MCP-client configuration changed.
+
+This used a direct stdio protocol client against the real packaged application.
+It does **not** establish installation or acceptance in Codex and Claude. Native
+export, animated-key behavior and cancellation were not exercised by this pass.
+
+## Integration and failure diagnosis
+
+Codexalog's accepted review `8241f955` completed with terminal SUCCESS `4824ccc1`.
+Exact candidate `6c718b8` does not merge cleanly into main `fb80ac5`: conflicts are
+limited to five generated boundary/inventory artifacts and their generated-count
+assertion. Application source and the rejected-import correction auto-merge.
+The sole source owner must compose the trees, regenerate the artifacts and derive
+the assertion from the actual checker result. Choosing either side's old count
+would be incorrect. No new behavior blocker was found in this changed surface.
+
+Codeximator's accepted diagnosis `e3e07dc5` completed with terminal SUCCESS
+`2278c8ec`. The retained 30-second browser timeout predates the readiness diagnostic
+wrapper, so it cannot identify a bootstrap cause. The candidate's diagnostic run
+and three final passes remain valid. No observed failure on `6c718b8` justified a
+speculative loader change. Preserve diagnostic output if the candidate fails again.
+
+## Agents, boards and next actions
+
+| Agent | Accepted work and latest evidence | Next deliverable or idle reason |
+| --- | --- | --- |
+| Codexitron | Native acceptance above; existing production continuation retains source/PR ownership | Production owner composes current main and completes identified installed-client and remaining native acceptance |
+| Codexalog | Processed `66eace66`, accepted `1c319646`, terminal `4824ccc1`; integration review delivered | Released; waits for the changed composed candidate |
+| Codeximator | Processed `8833803f`, accepted `2f0fa4ea`, terminal `2278c8ec`; timeout diagnosis delivered | Released; no current candidate failure or independent implementation input |
+| Codex-a-bot | Prior accepted test ended indeterminate; earlier incorrect claims withdrawn and effects reconciled | No replay; actual installed-client candidate/assignment remains with production owner |
+| Buzzotron | Board task `d9773df4` accepted `ae3d933b`; signed completion and paired UI-readback receipt delivered | Typed chain still lacks a terminal result; retain that lifecycle distinction |
+| Claudimator Beta, Claudirizer, Clauditron, Fizz, Honey, Mochi, Pollen | Offline in verified roster; prior claims preserved | Unavailable for a new accepted task |
+
+Buzzotron changed approach after GraphQL exhaustion, using the authenticated GitHub
+UI for remaining authorized writes and paired readback. Its signed result reports
+all ten assigned rows reconciled; receipt SHA-256 is
+`0f2340a49065c0b8203185886bb43708a85fa4f8aff26b278a98e672339826e1`.
+This is worker-delivered evidence, not an independent lead readback or terminal
+lifecycle receipt. No second board writer or full-board scan was started. The new
+native evidence in this report is later than that board snapshot.
+
+PR #992 remains draft and conflicted at the verified head. The production owner
+received the integration disposition and native acceptance evidence. Existing
+admin-authorized PR integration remains available without changing protections;
+no additional human approval requirement is inferred here. Historical report gaps
+60/70/75/80 remain with their publication owner. No hosted workflow, release or
+whole-issue closure occurred.

--- a/40min-checkins/README.md
+++ b/40min-checkins/README.md
@@ -1,11 +1,14 @@
-# 40-minute remediation check-ins
+# Remediation execution reports
 
-The permanent home for Codexitron's every-fifth-check-in reports is this directory on `main`:
+The permanent home for Codexitron's execution reports is this directory on `main`.
+Beginning with check 87, publish a 45-minute report every third check. Earlier
+40-minute reports retain their original cadence and reporting windows.
 
 **[All reports on main](https://github.com/mysteropodes/nemo/tree/main/40min-checkins)**
 
 | Check-in | Date (UTC) | Reporting window (UTC) | Report |
 | --- | --- | --- | --- |
+| 87 | 2026-09-07 | 00:35:47–01:20:47; subsequent native acceptance | [Eighty-seventh check-in](2026-09-07-checkin-87.md) |
 | 85 | 2026-09-07 | Checks 81–85; continuation after 00:52 UTC | [Eighty-fifth check-in](2026-09-07-checkin-85.md) |
 | 65 | 2026-09-06 | Checks 61–65; continuation through 21:39 UTC | [Sixty-fifth check-in](2026-09-06-checkin-65.md) |
 | 55 | 2026-09-06 | 14:41:56–15:29:57 | [Fifty-fifth check-in](2026-09-06-checkin-55.md) |
@@ -22,6 +25,6 @@ The permanent home for Codexitron's every-fifth-check-in reports is this directo
 
 ## Publication rule
 
-Every fifth check-in, add the dated 40-minute report here and update this index, newest first. Publish the documentation through the repository's normal PR route, merge it into `main` under the standing user authorization, and verify the report is available on `main` before marking reporting complete. A local worktree, branch, open PR, or Buzz-only post does not complete publication. Return the permanent index and report links in the initiating conversation; if repository protections or access prevent publication, report the exact blocker and keep publication pending.
+Every third check-in, add the dated 45-minute report here and update this index, newest first. Publish the documentation through the repository's normal PR route, merge it into `main` under the standing user authorization, and verify the report is available on `main` before marking reporting complete. A local worktree, branch, open PR, or Buzz-only post does not complete publication. Return the permanent index and report links in the initiating conversation; if repository protections or access prevent publication, report the exact blocker and keep publication pending.
 
 Preserve each report's original reporting window, accomplishments, validation scope and remaining gates. Identify results received after the cutoff separately. These are historical progress snapshots; current issue, pull request and board state remains on GitHub. Report publication does not promote product acceptance or authorize unrelated source changes.


### PR DESCRIPTION
Records real packaged-desktop opacity/MCP acceptance: discovery, editing, retry/stale-write controls, history, native save/reopen and visible rendering. Records current-main integration conflicts, accepted worker deliveries, and remaining installed-client/native gates without closing issues.

Updates the report index to the requested every-third-check, 45-minute cadence. Artifact validation passed: 15 relative links, ordinary files, private-marker scan and staged diff. No application source changes or hosted workflow.