### PR TITLE
Preserve complete native command receipts under pipe backpressure

### DIFF
--- a/scripts/nemo/native-runtime.test.cjs
+++ b/scripts/nemo/native-runtime.test.cjs
@@ -60,6 +60,7 @@ if (mode !== 'no-manifest') {
     dataStoreIdentifier: key.slice(0, 32),
     dataDir: seen.dataDir,
     pid: process.pid,
+    diagnostics: mode === 'large-manifest' ? 'x'.repeat(2 * 1024 * 1024) : null,
   };
   fs.mkdirSync(seen.dataDir, { recursive: true });
   fs.writeFileSync(path.join(seen.dataDir, 'native-runtime.json'), JSON.stringify(manifest, null, 2));
@@ -98,13 +99,15 @@ async function launch(task, capture, { mode = 'manifest', reserve = null, appDir
   return { child, info: JSON.parse(await firstLine(child)) };
 }
 
-function command(args) {
+function command(args, slowReader = false) {
   return new Promise((resolve) => {
     const child = spawn(process.execPath, [cli, ...args], { cwd: repoRoot, env: { ...process.env }, stdio: ['ignore', 'pipe', 'pipe'] });
     let stdout = ''; let stderr = '';
-    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    const read = () => child.stdout.on('data', (chunk) => { stdout += chunk; });
+    if (slowReader) child.stdout.once('readable', () => setTimeout(read, 50));
+    else read();
     child.stderr.on('data', (chunk) => { stderr += chunk; });
-    child.once('exit', (code, signal) => resolve({ code, signal, stdout, stderr }));
+    child.once('close', (code, signal) => resolve({ code, signal, stdout, stderr }));
   });
 }
 
@@ -221,6 +224,31 @@ test('only the owner stops an instance, and stopping removes its native state', 
     assert.equal(stopped.code, 0, stopped.stderr || stopped.stdout);
     await exited(instance.child);
     assert.equal(fs.existsSync(dataDir), false, 'the task tauri-data root is removed on release');
+  } finally {
+    await stopOwned(instance);
+  }
+});
+
+test('native status and stop drain complete receipts to a slow pipe reader', { timeout: 20_000 }, async () => {
+  const instance = await launch(`native-drain-${process.pid}`, path.join(scratch, 'capture-drain.json'), { mode: 'large-manifest' });
+  const dataDir = isolation.taskRoots(instance.info.taskId).tauriDataDir;
+  try {
+    await waitFor(() => runtime.readNativeStatus(instance.info.taskId).appRuntime, 'large app manifest');
+    for (const [action, owner, expectedCode] of [
+      ['status', instance.info.ownerToken, 0], ['status', 'not-the-owner', 1],
+      ['stop', 'not-the-owner', 1], ['stop', instance.info.ownerToken, 0],
+    ]) {
+      const result = await command([action, '--task', instance.info.taskId, '--owner', owner], true);
+      assert.equal(result.code, expectedCode, result.stderr);
+      const receipt = JSON.parse(result.stdout);
+      assert.equal(receipt.runtime.appRuntime.diagnostics, 'x'.repeat(2 * 1024 * 1024));
+      assert.ok(result.stdout.endsWith('\n'), 'the complete JSON line is delivered');
+      if (action === 'status') assert.equal(receipt.ok, expectedCode === 0);
+      else assert.equal(receipt.stopped, expectedCode === 0);
+      if (expectedCode === 1) assert.ok(isolation.pidAlive(instance.child.pid), 'refusal preserves the running app');
+    }
+    await exited(instance.child);
+    assert.equal(fs.existsSync(dataDir), false);
   } finally {
     await stopOwned(instance);
   }

--- a/scripts/nemo/native.cjs
+++ b/scripts/nemo/native.cjs
@@ -53,7 +53,7 @@ function status(args) {
   if (!args.task || !args.owner) throw new Error('status requires --task ID and --owner TOKEN');
   const result = nativeHandshake(args.task, args.owner);
   output(result);
-  process.exit(result.ok ? 0 : 1);
+  process.exitCode = result.ok ? 0 : 1;
 }
 
 async function stop(args) {
@@ -97,7 +97,7 @@ async function stop(args) {
   const ok = stopped.stopped && released && released.released;
   output({ ...stopped, stopped: !!ok, reason: ok ? stopped.reason : (released ? released.reason : stopped.reason),
     runtime: statusBeforeRelease, processTree, retainedData: !!ok && retainedData, appState, released });
-  process.exit(ok ? 0 : 1);
+  process.exitCode = ok ? 0 : 1;
 }
 
 async function main() {
@@ -109,4 +109,4 @@ async function main() {
   throw new Error('usage: native.cjs start [--task ID] [--app /path/Nemo.app | --executable /absolute/path] [--reserve desktop-input,gpu-reference] [--manifest-timeout-ms N] [-- args...] | status --task ID --owner TOKEN | stop --task ID --owner TOKEN [--timeout-ms N] [--retain-data]');
 }
 
-main().catch((err) => { process.stderr.write((err.stack || String(err)) + '\n'); process.exit(1); });
+main().catch((err) => { process.stderr.write((err.stack || String(err)) + '\n'); process.exitCode = 1; });


### PR DESCRIPTION
Native `status` and `stop` could exit successfully after emitting only part of their JSON receipt to a slow pipe reader. Set the exit code and allow stdout/stderr to drain before termination. Owner checks, stop effects and cleanup semantics remain unchanged.

The regression uses real CLI subprocesses and a 2 MiB native manifest, delays pipe consumption, and checks complete receipts for successful/refused status and stop, including preserved ownership and cleanup. It fails on the previous code with truncated JSON.

Validation: independent Terra/high review APPROVE; 17 native-runtime tests; standard verify (562 Node pass, one existing filesystem skip; 15 Rust pass; six static checks; 902-row inventory); protected-base boundary gate against `07658e4d286024c70262aabee80f31b5f001eccd`. Verification ran on the exact two-file diff before commit. No desktop rebuild is needed for this Node CLI correction.

Advances #902; full concurrent desktop/build acceptance remains open. PR #992 application/MCP integration remains with its existing owner.
