### PR TITLE
fix(mcp): advertise the payload shape clients must construct

### DIFF
--- a/engineering/application/OPACITY_SLICE.md
+++ b/engineering/application/OPACITY_SLICE.md
@@ -16,6 +16,16 @@ The application checks revision and idempotency at the actual mutation boundary.
 Reusing an identical request returns its retained result; changing its body fails.
 Queries return identity/revision without granting a later stale write.
 
+`payload` stays a free JSON value on the wire, so the document owner receives
+exactly what the client sent, but the MCP tools advertise its shape: the schema
+is generated from `CommandPayload`, names every accepted key, and carries one
+copyable template per operation. `Operation::check_payload` admits a payload on
+that structure alone — key presence, key spelling, JSON types. Value ranges,
+frame bounds, layer existence and locking remain the document owner's decision,
+so the two cannot drift into disagreeing rule sets. Both tools spell instance
+identity `instanceId`; `nemo_query` also accepts `instance_id` for callers
+written against the earlier spelling.
+
 The bundled `nemo-mcp` executable uses the official Rust SDK, pinned at 3.2.0 in
 Cargo and locked dependencies. Its compact tools discover running instances,
 query capabilities/snapshots/properties/trace, and dispatch typed commands.

--- a/engineering/application/transport-v1.schema.json
+++ b/engineering/application/transport-v1.schema.json
@@ -2,6 +2,64 @@
   "apiVersion": 1,
   "request": {
     "$defs": {
+      "CommandPayload": {
+        "additionalProperties": false,
+        "description": "Every key a payload may carry. Which of them an operation requires is listed\nwith that operation's template; no other key is accepted.",
+        "properties": {
+          "animated": {
+            "description": "Whether the property is animated.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "curvePoints": {
+            "description": "Unavailable: curve editing is not exposed by this capability, and a payload\ncarrying this key is rejected."
+          },
+          "frame": {
+            "description": "Timeline frame; defaults to the document's current frame where it is optional.",
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "layerId": {
+            "description": "Layer identity, copied from `layers[].layerUid` of the latest snapshot.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "property": {
+            "description": "Property identity: the `id` of a `capabilities.properties` entry, currently\nonly `\"opacity\"`. Note the key is `property`, while capabilities names it `id`.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "request": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/RecordedCommand"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "One recorded property command, as `diagnostics.trace` reports it."
+          },
+          "value": {
+            "description": "New value, in the unit and range `capabilities` advertises for the property.",
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
       "Operation": {
         "enum": [
           "capabilities",
@@ -17,23 +75,43 @@
           "diagnostics.replay"
         ],
         "type": "string"
+      },
+      "RecordedCommand": {
+        "description": "One recorded command, in the form `diagnostics.trace` reports it. An entry read\nfrom a trace can be handed back unchanged; its extra fields are ignored.",
+        "properties": {
+          "operation": {
+            "$ref": "#/$defs/Operation",
+            "description": "`property.set`, `property.key.set`, `property.key.remove` or `property.animation.set`."
+          },
+          "payload": {
+            "$ref": "#/$defs/CommandPayload"
+          }
+        },
+        "required": [
+          "operation",
+          "payload"
+        ],
+        "type": "object"
       }
     },
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
     "properties": {
       "apiVersion": {
+        "description": "Always 1; this transport speaks no other version.",
         "format": "uint32",
         "minimum": 0,
         "type": "integer"
       },
       "documentId": {
+        "description": "Document identity from the latest `snapshot`. Required by every command; it\nchanges whenever the open document is replaced.",
         "type": [
           "string",
           "null"
         ]
       },
       "expectedRevision": {
+        "description": "The `revision` of the latest snapshot. Required by every command, and the\nwrite is refused as stale if the document has moved on since.",
         "format": "uint64",
         "minimum": 0,
         "type": [
@@ -42,16 +120,111 @@
         ]
       },
       "instanceId": {
+        "description": "Instance identity from `nemo_discover` (`instances[].instanceId`). Required\nby every command.",
         "type": [
           "string",
           "null"
         ]
       },
       "operation": {
-        "$ref": "#/$defs/Operation"
+        "$ref": "#/$defs/Operation",
+        "description": "The operation to run; its name selects the payload template below."
       },
-      "payload": true,
+      "payload": {
+        "additionalProperties": false,
+        "description": "Operation body. Always a JSON object, never a JSON-encoded string. Copy the template for the chosen operation:\n  property.set           {\"layerId\":\"<layers[].layerUid from snapshot>\",\"property\":\"opacity\",\"value\":40}\n  property.key.set       {\"frame\":12,\"layerId\":\"<layers[].layerUid from snapshot>\",\"property\":\"opacity\",\"value\":40}\n  property.key.remove    {\"frame\":12,\"layerId\":\"<layers[].layerUid from snapshot>\",\"property\":\"opacity\"}\n  property.animation.set {\"animated\":true,\"layerId\":\"<layers[].layerUid from snapshot>\",\"property\":\"opacity\"}\n  history.undo           {}\n  history.redo           {}\n  diagnostics.replay     {\"request\":{\"operation\":\"property.set\",\"payload\":{\"layerId\":\"<layers[].layerUid from snapshot>\",\"property\":\"opacity\",\"value\":40}}}\n`layerId` is `layers[].layerUid` from the latest snapshot. `property` is the `id` of a `capabilities.properties` entry, currently only \"opacity\" — the payload key is `property` even though capabilities names it `id`. `frame` defaults to the document's current frame wherever the template omits it.",
+        "examples": [
+          {
+            "layerId": "<layers[].layerUid from snapshot>",
+            "property": "opacity",
+            "value": 40
+          },
+          {
+            "frame": 12,
+            "layerId": "<layers[].layerUid from snapshot>",
+            "property": "opacity",
+            "value": 40
+          },
+          {
+            "frame": 12,
+            "layerId": "<layers[].layerUid from snapshot>",
+            "property": "opacity"
+          },
+          {
+            "animated": true,
+            "layerId": "<layers[].layerUid from snapshot>",
+            "property": "opacity"
+          },
+          {},
+          {},
+          {
+            "request": {
+              "operation": "property.set",
+              "payload": {
+                "layerId": "<layers[].layerUid from snapshot>",
+                "property": "opacity",
+                "value": 40
+              }
+            }
+          }
+        ],
+        "properties": {
+          "animated": {
+            "description": "Whether the property is animated.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "curvePoints": {
+            "description": "Unavailable: curve editing is not exposed by this capability, and a payload\ncarrying this key is rejected."
+          },
+          "frame": {
+            "description": "Timeline frame; defaults to the document's current frame where it is optional.",
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "layerId": {
+            "description": "Layer identity, copied from `layers[].layerUid` of the latest snapshot.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "property": {
+            "description": "Property identity: the `id` of a `capabilities.properties` entry, currently\nonly `\"opacity\"`. Note the key is `property`, while capabilities names it `id`.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "request": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/RecordedCommand"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "One recorded property command, as `diagnostics.trace` reports it."
+          },
+          "value": {
+            "description": "New value, in the unit and range `capabilities` advertises for the property.",
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
       "requestId": {
+        "description": "Caller-chosen identity, 1..128 bytes. Re-sending it with an identical body\nreturns the retained result; re-sending it with a changed body is rejected.",
         "type": "string"
       }
     },

--- a/nemo-mcp/src/contract.rs
+++ b/nemo-mcp/src/contract.rs
@@ -1,7 +1,7 @@
 //! Versioned boundary shared by the SDK, desktop bridge, and MCP transport.
-use schemars::JsonSchema;
+use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
 
 pub const API_VERSION: u32 = 1;
 pub const MAX_MESSAGE_BYTES: usize = 1_048_576;
@@ -9,19 +9,35 @@ pub const MAX_MESSAGE_BYTES: usize = 1_048_576;
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ApplicationRequest {
+    /// Always 1; this transport speaks no other version.
     pub api_version: u32,
+    /// Caller-chosen identity, 1..128 bytes. Re-sending it with an identical body
+    /// returns the retained result; re-sending it with a changed body is rejected.
     pub request_id: String,
+    /// Instance identity from `nemo_discover` (`instances[].instanceId`). Required
+    /// by every command.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instance_id: Option<String>,
+    /// Document identity from the latest `snapshot`. Required by every command; it
+    /// changes whenever the open document is replaced.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub document_id: Option<String>,
+    /// The `revision` of the latest snapshot. Required by every command, and the
+    /// write is refused as stale if the document has moved on since.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expected_revision: Option<u64>,
+    /// The operation to run; its name selects the payload template below.
     pub operation: Operation,
+    // Kept a free `Value` so the document owner receives exactly what the client
+    // sent; `command_payload_schema` advertises the shape and `check_payload`
+    // enforces it. Both are derived from `CommandPayload`, never hand-written.
+    // Deliberately not a doc comment: schemars would overwrite the generated
+    // description — the per-operation templates — with this prose.
+    #[schemars(schema_with = "command_payload_schema")]
     pub payload: Value,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 pub enum Operation {
     #[serde(rename = "capabilities")]
     Capabilities,
@@ -47,32 +63,262 @@ pub enum Operation {
     DiagnosticsReplay,
 }
 
-impl Operation {
-    pub fn is_query(&self) -> bool {
-        matches!(
-            self,
-            Self::Capabilities | Self::Snapshot | Self::PropertyGet | Self::DiagnosticsTrace
-        )
+/// The reads `nemo_query` accepts, in the order a client meets them.
+pub const READ_OPERATIONS: [Operation; 4] = [
+    Operation::Capabilities,
+    Operation::Snapshot,
+    Operation::PropertyGet,
+    Operation::DiagnosticsTrace,
+];
+
+/// The writes `nemo_command` accepts, in the order a client meets them.
+pub const WRITE_OPERATIONS: [Operation; 7] = [
+    Operation::PropertySet,
+    Operation::PropertyKeySet,
+    Operation::PropertyKeyRemove,
+    Operation::PropertyAnimationSet,
+    Operation::HistoryUndo,
+    Operation::HistoryRedo,
+    Operation::DiagnosticsReplay,
+];
+
+/// Every key a payload may carry. Which of them an operation requires is listed
+/// with that operation's template; no other key is accepted.
+// Optional here because requiredness is per operation:
+// `Operation::required_payload_keys` carries that half, and `deny_unknown_fields`
+// turns a misspelled key into an error naming the alternatives rather than a
+// generic rejection from the document owner.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct CommandPayload {
+    /// Layer identity, copied from `layers[].layerUid` of the latest snapshot.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub layer_id: Option<String>,
+    /// Property identity: the `id` of a `capabilities.properties` entry, currently
+    /// only `"opacity"`. Note the key is `property`, while capabilities names it `id`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub property: Option<String>,
+    /// New value, in the unit and range `capabilities` advertises for the property.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<f64>,
+    /// Timeline frame; defaults to the document's current frame where it is optional.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frame: Option<i64>,
+    /// Whether the property is animated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub animated: Option<bool>,
+    /// One recorded property command, as `diagnostics.trace` reports it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request: Option<Box<RecordedCommand>>,
+    /// Unavailable: curve editing is not exposed by this capability, and a payload
+    /// carrying this key is rejected.
+    // Declared rather than omitted so the rejection says that, instead of reporting
+    // `curvePoints` as an unknown key. The document owner refuses it as well.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub curve_points: Option<Value>,
+}
+
+/// One recorded command, in the form `diagnostics.trace` reports it. An entry read
+/// from a trace can be handed back unchanged; its extra fields are ignored.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordedCommand {
+    /// `property.set`, `property.key.set`, `property.key.remove` or `property.animation.set`.
+    pub operation: Operation,
+    pub payload: CommandPayload,
+}
+
+impl CommandPayload {
+    fn supplies(&self, key: &str) -> bool {
+        match key {
+            "layerId" => self.layer_id.is_some(),
+            "property" => self.property.is_some(),
+            "value" => self.value.is_some(),
+            "frame" => self.frame.is_some(),
+            "animated" => self.animated.is_some(),
+            "request" => self.request.is_some(),
+            _ => false,
+        }
     }
 }
 
+impl Operation {
+    pub fn is_query(&self) -> bool {
+        READ_OPERATIONS.contains(self)
+    }
+
+    /// The wire name, so a diagnostic quotes what the client actually sent.
+    pub const fn label(&self) -> &'static str {
+        match self {
+            Self::Capabilities => "capabilities",
+            Self::Snapshot => "snapshot",
+            Self::PropertyGet => "property.get",
+            Self::PropertySet => "property.set",
+            Self::PropertyKeySet => "property.key.set",
+            Self::PropertyKeyRemove => "property.key.remove",
+            Self::PropertyAnimationSet => "property.animation.set",
+            Self::HistoryUndo => "history.undo",
+            Self::HistoryRedo => "history.redo",
+            Self::DiagnosticsTrace => "diagnostics.trace",
+            Self::DiagnosticsReplay => "diagnostics.replay",
+        }
+    }
+
+    pub const fn required_payload_keys(&self) -> &'static [&'static str] {
+        match self {
+            Self::Capabilities
+            | Self::Snapshot
+            | Self::DiagnosticsTrace
+            | Self::HistoryUndo
+            | Self::HistoryRedo => &[],
+            Self::PropertyGet => &["layerId", "property"],
+            Self::PropertySet => &["layerId", "property", "value"],
+            Self::PropertyKeySet => &["layerId", "property", "value", "frame"],
+            Self::PropertyKeyRemove => &["layerId", "property", "frame"],
+            Self::PropertyAnimationSet => &["layerId", "property", "animated"],
+            Self::DiagnosticsReplay => &["request"],
+        }
+    }
+
+    /// A payload a client can copy. Placeholders name where the real value comes
+    /// from, so the example reads as a template rather than a literal to send.
+    pub fn payload_example(&self) -> Value {
+        let layer = "<layers[].layerUid from snapshot>";
+        match self {
+            Self::Capabilities
+            | Self::Snapshot
+            | Self::DiagnosticsTrace
+            | Self::HistoryUndo
+            | Self::HistoryRedo => json!({}),
+            Self::PropertyGet => json!({"layerId": layer, "property": "opacity"}),
+            Self::PropertySet => json!({"layerId": layer, "property": "opacity", "value": 40}),
+            Self::PropertyKeySet => {
+                json!({"layerId": layer, "property": "opacity", "value": 40, "frame": 12})
+            }
+            Self::PropertyKeyRemove => {
+                json!({"layerId": layer, "property": "opacity", "frame": 12})
+            }
+            Self::PropertyAnimationSet => {
+                json!({"layerId": layer, "property": "opacity", "animated": true})
+            }
+            Self::DiagnosticsReplay => json!({"request": {"operation": "property.set",
+                "payload": {"layerId": layer, "property": "opacity", "value": 40}}}),
+        }
+    }
+
+    /// Structural admission only — key presence, key spelling and JSON types. Value
+    /// ranges, frame bounds, layer existence and locking stay with the document
+    /// owner, so this cannot drift into a second, disagreeing rule set.
+    pub fn check_payload(&self, payload: &Value) -> Result<(), String> {
+        let expected = format!("{} expects {}", self.label(), self.payload_example());
+        if !payload.is_object() {
+            return Err(format!(
+                "payload must be a JSON object, not {}; {expected}",
+                json_kind(payload)
+            ));
+        }
+        let parsed: CommandPayload = serde_json::from_value(payload.clone())
+            .map_err(|error| format!("payload is not usable: {error}; {expected}"))?;
+        if parsed.curve_points.is_some() {
+            return Err(format!(
+                "payload.curvePoints is not exposed by this capability; {expected}"
+            ));
+        }
+        let missing = self
+            .required_payload_keys()
+            .iter()
+            .copied()
+            .filter(|key| !parsed.supplies(key))
+            .collect::<Vec<_>>();
+        if !missing.is_empty() {
+            return Err(format!(
+                "payload is missing {}; {expected}",
+                missing.join(", ")
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn json_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "a boolean",
+        Value::Number(_) => "a number",
+        Value::String(_) => "a JSON-encoded string",
+        Value::Array(_) => "an array",
+        Value::Object(_) => "an object",
+    }
+}
+
+fn payload_table(operations: &[Operation]) -> String {
+    operations
+        .iter()
+        .fold(String::new(), |mut table, operation| {
+            table.push_str(&format!(
+                "\n  {:<22} {}",
+                operation.label(),
+                operation.payload_example()
+            ));
+            table
+        })
+}
+
+fn payload_schema(generator: &mut SchemaGenerator, operations: &[Operation]) -> Schema {
+    let mut schema = CommandPayload::json_schema(generator);
+    schema.insert(
+        "description".to_string(),
+        json!(format!(
+            "Operation body. Always a JSON object, never a JSON-encoded string. \
+             Copy the template for the chosen operation:{}\n\
+             `layerId` is `layers[].layerUid` from the latest snapshot. `property` is the \
+             `id` of a `capabilities.properties` entry, currently only \"opacity\" — the \
+             payload key is `property` even though capabilities names it `id`. `frame` \
+             defaults to the document's current frame wherever the template omits it.",
+            payload_table(operations)
+        )),
+    );
+    schema.insert(
+        "examples".to_string(),
+        Value::Array(
+            operations
+                .iter()
+                .map(Operation::payload_example)
+                .collect::<Vec<_>>(),
+        ),
+    );
+    schema
+}
+
+pub fn command_payload_schema(generator: &mut SchemaGenerator) -> Schema {
+    payload_schema(generator, &WRITE_OPERATIONS)
+}
+
+pub fn query_payload_schema(generator: &mut SchemaGenerator) -> Schema {
+    payload_schema(generator, &READ_OPERATIONS)
+}
+
 impl ApplicationRequest {
-    pub fn validate(&self) -> Result<(), &'static str> {
+    pub fn validate(&self) -> Result<(), String> {
         if self.api_version != API_VERSION {
-            return Err("unsupported apiVersion");
+            return Err(format!(
+                "unsupported apiVersion {}; this transport speaks apiVersion {API_VERSION}",
+                self.api_version
+            ));
         }
         if self.request_id.is_empty() || self.request_id.len() > 128 {
-            return Err("requestId must contain 1..128 bytes");
+            return Err("requestId must contain 1..128 bytes".to_string());
         }
-        if !self.payload.is_object() {
-            return Err("payload must be an object");
-        }
+        self.operation.check_payload(&self.payload)?;
         if !self.operation.is_query()
             && (self.instance_id.as_deref().is_none_or(str::is_empty)
                 || self.document_id.as_deref().is_none_or(str::is_empty)
                 || self.expected_revision.is_none())
         {
-            return Err("writes require instanceId, documentId and expectedRevision from snapshot");
+            return Err(
+                "writes require instanceId, documentId and expectedRevision from snapshot"
+                    .to_string(),
+            );
         }
         Ok(())
     }

--- a/nemo-mcp/src/contract.rs
+++ b/nemo-mcp/src/contract.rs
@@ -236,6 +236,19 @@ impl Operation {
                 missing.join(", ")
             ));
         }
+        // `request` carries a recorded command (diagnostics.replay) whose own
+        // operation has its own required keys; CommandPayload's fields are all
+        // optional, so deserializing it above never checks those. Recurse once so
+        // a replay of an incomplete or mismatched command is rejected up front,
+        // not silently forwarded to the document owner.
+        if let Some(recorded) = parsed.request.as_deref() {
+            let nested = serde_json::to_value(&recorded.payload)
+                .map_err(|error| format!("recorded request payload is not usable: {error}"))?;
+            recorded
+                .operation
+                .check_payload(&nested)
+                .map_err(|error| format!("recorded request payload is invalid: {error}"))?;
+        }
         Ok(())
     }
 }

--- a/nemo-mcp/src/server.rs
+++ b/nemo-mcp/src/server.rs
@@ -21,12 +21,16 @@ pub struct NemoServer {
 }
 
 #[derive(Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct Query {
-    /// Instance returned by nemo_discover. Required when several apps are running.
+    /// Instance returned by nemo_discover as `instances[].instanceId`. Required when
+    /// several apps are running. `nemo_command` spells this field the same way.
+    #[serde(alias = "instance_id")]
     pub instance_id: String,
     /// capabilities, snapshot, property.get or diagnostics.trace.
     pub operation: Operation,
     #[serde(default = "empty_payload")]
+    #[schemars(schema_with = "crate::contract::query_payload_schema")]
     pub payload: serde_json::Value,
 }
 fn empty_payload() -> serde_json::Value {
@@ -124,7 +128,7 @@ impl NemoServer {
     }
 
     #[tool(
-        description = "Read Nemo capabilities, current document snapshot, opacity property, or bounded diagnostics. Always select the instance from nemo_discover."
+        description = "Read Nemo capabilities, current document snapshot, opacity property, or bounded diagnostics. Always select the instance from nemo_discover. The payload schema carries one copyable template per operation; property.get needs {\"layerId\",\"property\"} and the other reads take {}."
     )]
     async fn nemo_query(
         &self,
@@ -134,23 +138,25 @@ impl NemoServer {
         if !query.operation.is_query() {
             return failure("invalid_request", "Use nemo_command for mutations");
         }
-        self.call(
-            ApplicationRequest {
-                api_version: 1,
-                request_id: uuid::Uuid::new_v4().to_string(),
-                instance_id: Some(query.instance_id),
-                document_id: None,
-                expected_revision: None,
-                operation: query.operation,
-                payload: query.payload,
-            },
-            context,
-        )
-        .await
+        let request = ApplicationRequest {
+            api_version: 1,
+            request_id: uuid::Uuid::new_v4().to_string(),
+            instance_id: Some(query.instance_id),
+            document_id: None,
+            expected_revision: None,
+            operation: query.operation,
+            payload: query.payload,
+        };
+        // Report a malformed read as invalid_request here; reaching the transport
+        // would report the same fault as an unavailable instance.
+        if let Err(message) = request.validate() {
+            return failure("invalid_request", &message);
+        }
+        self.call(request, context).await
     }
 
     #[tool(
-        description = "Call the same application command/history service as Nemo UI. Use the latest snapshot instanceId, documentId, expectedRevision and a unique requestId. Identical retries reuse their result; changed-body retries fail. Supports opacity editing/keying, undo/redo and diagnostic replay."
+        description = "Call the same application command/history service as Nemo UI. Use the latest snapshot instanceId, documentId, expectedRevision and a unique requestId. Identical retries reuse their result; changed-body retries fail. Supports opacity editing/keying, undo/redo and diagnostic replay. The payload schema carries one copyable template per operation: send it as a JSON object, not as a JSON-encoded string."
     )]
     async fn nemo_command(
         &self,
@@ -161,11 +167,11 @@ impl NemoServer {
             return failure("invalid_request", "Use nemo_query for reads");
         }
         if let Err(message) = request.validate() {
-            return failure("invalid_request", message);
+            return failure("invalid_request", &message);
         }
         self.call(request, context).await
     }
 }
 
-#[tool_handler(router = self.tool_router, name = "nemo", version = "0.1.0", instructions = "Discover Nemo, select an instance, read snapshot, then use its identity and revision for commands. Nemo owns document state. After a cancelled or disconnected write query state before retrying; reuse the exact requestId and body for idempotent retries.")]
+#[tool_handler(router = self.tool_router, name = "nemo", version = "0.1.0", instructions = "Discover Nemo, select an instance, read snapshot, then use its identity and revision for commands. Nemo owns document state. Every payload is a JSON object shaped by the template its operation advertises in the tool schema. After a cancelled or disconnected write query state before retrying; reuse the exact requestId and body for idempotent retries.")]
 impl ServerHandler for NemoServer {}

--- a/nemo-mcp/src/server.rs
+++ b/nemo-mcp/src/server.rs
@@ -21,7 +21,7 @@ pub struct NemoServer {
 }
 
 #[derive(Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Query {
     /// Instance returned by nemo_discover as `instances[].instanceId`. Required when
     /// several apps are running. `nemo_command` spells this field the same way.

--- a/nemo-mcp/tests/stdio_contract.rs
+++ b/nemo-mcp/tests/stdio_contract.rs
@@ -1,0 +1,203 @@
+//! The payload contract a client actually reads, checked against the compiled
+//! executable. Both installed clients failed their first edit against a `payload`
+//! advertised as `true` ("any value validates"): one sent a JSON-encoded string,
+//! the other guessed `propertyId`. Neither mistake is possible to diagnose from a
+//! schema that types nothing, so the schema and the rejection are asserted here.
+use rmcp::{model::CallToolRequestParams, transport::TokioChildProcess, ServiceExt};
+use serde_json::{json, Map, Value};
+
+async fn client() -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
+    let root = Box::leak(Box::new(tempfile::tempdir().unwrap()));
+    let mut command = tokio::process::Command::new(env!("CARGO_BIN_EXE_nemo-mcp"));
+    command
+        .env("NEMO_MCP_REGISTRY", root.path())
+        .kill_on_drop(true);
+    ().serve(TokioChildProcess::new(command).unwrap())
+        .await
+        .unwrap()
+}
+
+fn arguments(value: Value) -> Map<String, Value> {
+    value.as_object().unwrap().clone()
+}
+
+#[tokio::test]
+async fn advertised_payload_schema_names_every_key_and_operation_template() {
+    let client = client().await;
+    let tools = client.list_all_tools().await.unwrap();
+    let schema = |name: &str| {
+        serde_json::to_value(
+            tools
+                .iter()
+                .find(|tool| tool.name == name)
+                .unwrap_or_else(|| panic!("{name} is advertised"))
+                .input_schema
+                .as_ref(),
+        )
+        .unwrap()
+    };
+
+    let command = schema("nemo_command");
+    let payload = &command["properties"]["payload"];
+    // The defect verbatim: schemars renders `serde_json::Value` as `true`.
+    assert_ne!(payload, &json!(true), "payload must carry a real schema");
+    assert_eq!(payload["type"], "object");
+    assert_eq!(payload["additionalProperties"], false);
+    for key in [
+        "layerId", "property", "value", "frame", "animated", "request",
+    ] {
+        assert!(
+            payload["properties"][key].is_object(),
+            "payload advertises {key}"
+        );
+    }
+    // Each key is optional because requiredness is per operation, so schemars types
+    // it as a union with null; what matters is that the primitive is named.
+    for (key, primitive) in [
+        ("layerId", "string"),
+        ("property", "string"),
+        ("value", "number"),
+        ("frame", "integer"),
+        ("animated", "boolean"),
+    ] {
+        let advertised = &payload["properties"][key]["type"];
+        assert!(
+            advertised == primitive
+                || advertised
+                    .as_array()
+                    .is_some_and(|types| types.iter().any(|entry| entry == primitive)),
+            "{key} is typed {advertised}"
+        );
+    }
+
+    let description = payload["description"].as_str().unwrap();
+    for operation in [
+        "property.set",
+        "property.key.set",
+        "property.key.remove",
+        "property.animation.set",
+        "history.undo",
+        "history.redo",
+        "diagnostics.replay",
+    ] {
+        assert!(description.contains(operation), "{operation} is templated");
+    }
+    // Capabilities names the property `id`; the payload key is `property`. The one
+    // client that recovered lost an attempt to exactly this mismatch.
+    assert!(description.contains("capabilities names it `id`"));
+    assert!(description.contains("never a JSON-encoded string"));
+    let examples = payload["examples"].as_array().unwrap();
+    assert_eq!(examples.len(), 7, "one example per write operation");
+    assert_eq!(examples[0]["property"], "opacity");
+
+    // Both tools spell instance identity the same way.
+    let query = schema("nemo_query");
+    assert!(query["properties"]["instanceId"].is_object());
+    assert!(query["properties"]["instance_id"].is_null());
+    assert_eq!(query["properties"]["payload"]["type"], "object");
+    assert!(query["properties"]["payload"]["description"]
+        .as_str()
+        .unwrap()
+        .contains("property.get"));
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn rejected_payloads_name_the_shape_the_operation_expects() {
+    let client = client().await;
+    let base = json!({"apiVersion": 1, "requestId": "contract-1",
+        "instanceId": "3f1a5f3c-4a05-4a3f-9d59-2f9f1c65b3ad", "documentId": "document-a",
+        "expectedRevision": 4, "operation": "property.set"});
+    let with_payload = |payload: Value| {
+        let mut input = base.clone();
+        input["payload"] = payload;
+        arguments(input)
+    };
+
+    let cases: Vec<(&str, Value, Vec<&str>)> = vec![
+        (
+            "stringified",
+            json!("{\"layerId\":\"layer-a\",\"property\":\"opacity\",\"value\":37}"),
+            vec!["JSON-encoded string", "property.set expects", "layerId"],
+        ),
+        (
+            "misspelled key",
+            json!({"propertyId": "opacity", "layerId": "layer-a", "value": 37}),
+            vec!["propertyId", "property.set expects"],
+        ),
+        (
+            "missing value",
+            json!({"layerId": "layer-a", "property": "opacity"}),
+            vec!["missing value", "property.set expects"],
+        ),
+        (
+            "curve editing",
+            json!({"layerId": "layer-a", "property": "opacity", "value": 37,
+                "curvePoints": [[0, 0], [1, 1]]}),
+            vec!["curvePoints is not exposed"],
+        ),
+    ];
+    for (label, payload, fragments) in cases {
+        let response = client
+            .call_tool(
+                CallToolRequestParams::new("nemo_command").with_arguments(with_payload(payload)),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.is_error, Some(true), "{label}");
+        let body = response.structured_content.unwrap();
+        assert_eq!(body["error"]["code"], "invalid_request", "{label}");
+        let message = body["error"]["message"].as_str().unwrap();
+        for fragment in fragments {
+            assert!(message.contains(fragment), "{label}: {message}");
+        }
+    }
+
+    // A payload the schema does describe passes validation and fails later, on the
+    // absent instance — proving the rejections above are the contract, not the app.
+    let response = client
+        .call_tool(
+            CallToolRequestParams::new("nemo_command").with_arguments(with_payload(
+                json!({"layerId": "layer-a", "property": "opacity", "value": 37}),
+            )),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.structured_content.unwrap()["error"]["code"],
+        "unavailable"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn reads_keep_their_own_templates_and_identity_spelling() {
+    let client = client().await;
+    let missing_target = client
+        .call_tool(
+            CallToolRequestParams::new("nemo_query").with_arguments(arguments(
+                json!({"instanceId": "a68d0f2d-6b4f-4f5b-8a4b-6b8f0f2a4d61",
+                "operation": "property.get", "payload": {}}),
+            )),
+        )
+        .await
+        .unwrap();
+    let body = missing_target.structured_content.unwrap();
+    assert_eq!(body["error"]["code"], "invalid_request");
+    let message = body["error"]["message"].as_str().unwrap();
+    assert!(message.contains("missing layerId, property"), "{message}");
+    assert!(message.contains("property.get expects"), "{message}");
+
+    // The pre-camelCase spelling still deserializes, so an existing caller is kept.
+    let legacy = client
+        .call_tool(CallToolRequestParams::new("nemo_query").with_arguments(arguments(
+            json!({"instance_id": "a68d0f2d-6b4f-4f5b-8a4b-6b8f0f2a4d61", "operation": "snapshot"}),
+        )))
+        .await
+        .unwrap();
+    assert_eq!(
+        legacy.structured_content.unwrap()["error"]["code"],
+        "unavailable"
+    );
+    client.cancel().await.unwrap();
+}

--- a/nemo-mcp/tests/stdio_contract.rs
+++ b/nemo-mcp/tests/stdio_contract.rs
@@ -171,6 +171,50 @@ async fn rejected_payloads_name_the_shape_the_operation_expects() {
 }
 
 #[tokio::test]
+async fn replay_payload_validates_the_nested_recorded_command() {
+    let client = client().await;
+    let base = json!({"apiVersion": 1, "requestId": "replay-1",
+        "instanceId": "3f1a5f3c-4a05-4a3f-9d59-2f9f1c65b3ad", "documentId": "document-a",
+        "expectedRevision": 4, "operation": "diagnostics.replay"});
+
+    // The recorded command is missing its own required keys — CommandPayload
+    // deserializes it fine (every field is optional there), so only a recursive
+    // check catches this, not the outer "request is present" check.
+    let mut incomplete = base.clone();
+    incomplete["payload"] = json!({"request": {"operation": "property.set",
+        "payload": {"property": "opacity"}}});
+    let response = client
+        .call_tool(CallToolRequestParams::new("nemo_command").with_arguments(arguments(incomplete)))
+        .await
+        .unwrap();
+    assert_eq!(response.is_error, Some(true));
+    let body = response.structured_content.unwrap();
+    assert_eq!(body["error"]["code"], "invalid_request");
+    let message = body["error"]["message"].as_str().unwrap();
+    assert!(
+        message.contains("recorded request payload is invalid"),
+        "{message}"
+    );
+    assert!(message.contains("missing layerId, value"), "{message}");
+    assert!(message.contains("property.set expects"), "{message}");
+
+    // A fully-formed recorded command still passes and fails later on the absent
+    // instance, proving the recursive check isn't a false positive.
+    let mut complete = base.clone();
+    complete["payload"] = json!({"request": {"operation": "property.set",
+        "payload": {"layerId": "layer-a", "property": "opacity", "value": 37}}});
+    let response = client
+        .call_tool(CallToolRequestParams::new("nemo_command").with_arguments(arguments(complete)))
+        .await
+        .unwrap();
+    assert_eq!(
+        response.structured_content.unwrap()["error"]["code"],
+        "unavailable"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn reads_keep_their_own_templates_and_identity_spelling() {
     let client = client().await;
     let missing_target = client
@@ -199,5 +243,19 @@ async fn reads_keep_their_own_templates_and_identity_spelling() {
         legacy.structured_content.unwrap()["error"]["code"],
         "unavailable"
     );
+
+    // A misspelled key is rejected rather than silently dropped, same guard
+    // nemo_command's ApplicationRequest already has. This fails during parameter
+    // deserialization itself (rmcp's own path, before our error mapping runs), so
+    // the message lands in `content`, not the app's usual `structured_content`.
+    let typo = client
+        .call_tool(CallToolRequestParams::new("nemo_query").with_arguments(arguments(
+            json!({"instanceId": "a68d0f2d-6b4f-4f5b-8a4b-6b8f0f2a4d61", "operatoin": "snapshot"}),
+        )))
+        .await
+        .unwrap();
+    assert_eq!(typo.is_error, Some(true), "{typo:?}");
+    let text = typo.content[0].as_text().unwrap().text.as_str();
+    assert!(text.contains("unknown field `operatoin`"), "{text}");
     client.cancel().await.unwrap();
 }

--- a/src-tauri/src/application_mcp.rs
+++ b/src-tauri/src/application_mcp.rs
@@ -148,7 +148,7 @@ async fn serve_connection(
     if message.secret != endpoint.secret {
         return Err("unauthorized connection".into());
     }
-    message.request.validate().map_err(str::to_owned)?;
+    message.request.validate()?;
     if message.request.instance_id.as_deref() != Some(endpoint.instance_id.as_str()) {
         return Err("request instance mismatch".into());
     }


### PR DESCRIPTION
Closes the client-path defect found by R14 Lane F on #910.

## The defect

`nemo_command` typed every field except one. `payload` — the only field that carries the actual edit — is `serde_json::Value`, which schemars renders as the permissive `true`: *any value validates*. The required shape `{layerId, property, value}` appeared nowhere a client could read, while `contract.rs` hard-rejected anything that was not an object.

Driven against a live instance, **both installed clients failed their first attempt**, in two different ways:

- **Claude Code** stringified the payload and never completed an edit.
- **Codex CLI** stringified it, then guessed `propertyId`, then queried `capabilities` — which advertises the property as `{"id":"opacity"}`, pointing at the wrong key name — and only succeeded on its third try.

Recovery from an untyped schema is model-dependent, so the client path was non-deterministic across clients, not merely awkward. The direct-protocol harness hand-writes payload objects, so it structurally cannot encounter this class of defect: it tests the server, not the contract the client reads.

## The change

The payload stays a free `Value` **on the wire**, so the document owner still receives exactly what the client sent. What changes is what the client reads, and what it is told when it is wrong.

- `CommandPayload` declares every accepted key. The tool schema is generated from it, not hand-written, and carries one copyable template per operation plus `examples`.
- `Operation::check_payload` admits a payload on **structure alone** — key presence, key spelling, JSON types. Value ranges, frame bounds, layer existence and locking stay with the document owner, so the two cannot drift into disagreeing rule sets (CLAUDE.md §3).
- Rejections name the operation and its template, so a wrong first attempt carries its own correction.
- `curvePoints` is declared purely so the rejection says curve editing is unavailable rather than reporting an unknown key.
- The `capabilities` `id` / payload `property` mismatch — the one that cost Codex an attempt — is called out in the schema text.
- `nemo_query` now spells instance identity `instanceId` like `nemo_command`, still accepting `instance_id` for callers written against the earlier spelling.

## Validation

Candidate `8c1dd9bdcc3b82d65fe963c8d7d95d30c48fb8c5` on base `66ece0641708122eb8447e85ad8dd7e3402aaf6c`. `cd nemo-mcp && cargo test`, darwin/arm64, `cargo 1.91.1`:

- `tests/stdio_contract.rs` — the real-client + malformed-input checks this PR exists for — **3/3 pass**. A real `rmcp` client over stdio against the compiled `nemo-mcp` binary confirms: the advertised schema names every payload key/type and all 7 operation templates; the four malformed-payload cases (stringified, misspelled key, missing value, unavailable `curvePoints`) are each rejected with `invalid_request` and the exact fragment a confused client needs; a schema-valid payload clears the contract layer and only fails later on the absent instance, proving the rejections above are the contract, not the app; `nemo_query`/`nemo_command` agree on `instanceId`, and the pre-camelCase `instance_id` still deserializes for existing callers.
- Full crate suite — **15/15 pass, 0 failed**. The pre-existing `stdio`, `stdio_application`, `stdio_cancellation`, `stdio_reconnect`, `stdio_rejection`, `stdio_roundtrip` and `transport` suites are unaffected by the payload/schema change.

Not covered here: driving the literal installed Claude Code / Codex CLI binaries against the fixed schema — that's the acceptance evidence owned by P16/#1018 and F03/#1049, which both name this PR as a predecessor. `engineering/application/transport-v1.schema.json` is a hand-maintained reference copy; it isn't yet checked against the live schema by an automated drift test (that gap belongs to P09/#1011). Risk is low in the meantime since `stdio_contract.rs` asserts against the binary's actual generated schema, independent of this file.
