### PR TITLE
test(browser): retain Playwright traces and HTML/JUnit reports on failure

### DIFF
--- a/playwright.config.cjs
+++ b/playwright.config.cjs
@@ -1,0 +1,45 @@
+'use strict';
+// Playwright config for tests/browser (T03/#1052). Previously there was no
+// config at all — scripts/nemo/lib/jobs.cjs invoked the CLI with only
+// `--output`, so a failure produced nothing but an exit code: no trace, no
+// HTML/JUnit report. This file is the single source of report/retention
+// policy; the job adapter only points NEMO_BROWSER_REPORT_DIR at its own
+// per-run report directory.
+const path = require('node:path');
+
+// Falls back under the already-gitignored /reports/ (scripts/nemo's own
+// report convention) rather than a new root-level directory, so a manual
+// standalone run needs no .gitignore change.
+const reportDir = process.env.NEMO_BROWSER_REPORT_DIR || path.join(__dirname, 'reports', 'playwright-manual');
+
+// The negative control (tests/browser/_negative-control.spec.cjs) exists to
+// prove this pipeline catches a real failure; it must never run as part of
+// the normal suite. Playwright's CLI --grep/--grep-invert compose with (not
+// override) the config's grep/grepInvert, so a CLI-only opt-in doesn't work
+// here — verified empirically. This env var is the actual switch: verify the
+// negative control on its own with
+//   NEMO_BROWSER_NEGATIVE_CONTROL=1 node_modules/.bin/playwright test tests/browser
+// which runs ONLY the tagged test (and is expected to fail).
+const negativeControlOnly = !!process.env.NEMO_BROWSER_NEGATIVE_CONTROL;
+
+module.exports = {
+  testDir: 'tests/browser',
+  outputDir: path.join(reportDir, 'test-results'),
+  // Explicit, not left to Playwright's CI-autodetect default: a retried test
+  // that then passes must never mask the original failure.
+  retries: 0,
+  grep: negativeControlOnly ? /@negative-control/ : undefined,
+  grepInvert: negativeControlOnly ? undefined : /@negative-control/,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: path.join(reportDir, 'html'), open: 'never' }],
+    ['junit', { outputFile: path.join(reportDir, 'junit.xml') }],
+  ],
+  use: {
+    // retain-on-failure: passing runs keep the bounded (empty) footprint they
+    // have today; only a real failure leaves inspectable evidence behind.
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+};

--- a/scripts/nemo/lib/jobs.cjs
+++ b/scripts/nemo/lib/jobs.cjs
@@ -171,11 +171,16 @@ function jobTestBrowser(ctx) {
   const dir = path.join(ROOT, 'tests', 'browser');
   if (!exists(dir) || !fs.readdirSync(dir).some((f) => /\.spec\.(c?js|mjs|ts)$/.test(f))) return notRun('runner present but no tests/browser/*.spec.* defined yet (R03 fixtures / R07 gates)');
   const bin = caps.localBin('playwright');
-  const output = path.join(ctx.reportDir, 'playwright-results');
+  // playwright.config.cjs owns trace/report/retention policy; it reads this
+  // var for where to put them so every job's evidence lands under its own
+  // report directory instead of a shared repo-root default.
+  const reportDir = path.join(ctx.reportDir, 'playwright-report');
   const r = run(bin || process.execPath,
-    bin ? ['test', 'tests/browser', '--output', output] : [runner, 'test', 'tests/browser', '--output', output],
-    { timeout: 60 * 60 * 1000 });
-  return (r.status === 0 ? pass : fail)(`playwright test tests/browser: exit ${r.status}`, { exitCode: r.status, log: logOf(r) });
+    bin ? ['test', 'tests/browser'] : [runner, 'test', 'tests/browser'],
+    { timeout: 60 * 60 * 1000, env: { NEMO_BROWSER_REPORT_DIR: reportDir } });
+  const artifacts = [fileInfo(path.join(reportDir, 'html', 'index.html')), fileInfo(path.join(reportDir, 'junit.xml'))]
+    .filter((a) => a.present);
+  return (r.status === 0 ? pass : fail)(`playwright test tests/browser: exit ${r.status}`, { exitCode: r.status, log: logOf(r), artifacts });
 }
 
 function jobTestDesktop(ctx) {

--- a/tests/browser/_negative-control.spec.cjs
+++ b/tests/browser/_negative-control.spec.cjs
@@ -1,0 +1,29 @@
+'use strict';
+
+const { test, expect } = require('@playwright/test');
+const { startPreview, withPreviews } = require('./preview-lifecycle.cjs');
+
+// Deliberately fails (T03/#1052). Excluded from the normal suite by
+// playwright.config.cjs's grepInvert — this proves the trace/HTML/JUnit
+// pipeline actually captures a real failure, it is not itself a regression
+// check. Run it on its own from repo root:
+//   NEMO_BROWSER_NEGATIVE_CONTROL=1 node_modules/.bin/playwright test tests/browser
+// Expect: failing exit code, a failing entry in playwright-report/junit.xml,
+// an HTML report showing the failure, and a retained trace/screenshot/video
+// for this test only. Reuses the same isolated preview harness as the real
+// specs rather than a synthetic page, so the capture is proven against the
+// actual app under real isolation.
+test('harness negative control: intentional assertion failure @negative-control', async ({ browser }, testInfo) => {
+  const runtimeRoot = testInfo.outputPath('runtime');
+  const taskId = `playwright-negative-control-${process.pid}-${Date.now()}`;
+  await withPreviews([() => startPreview(taskId, runtimeRoot)], async ([preview]) => {
+    const context = await browser.newContext();
+    try {
+      const page = await context.newPage();
+      await page.goto(preview.info.url, { waitUntil: 'domcontentloaded' });
+      await expect(page.locator('#this-element-does-not-exist-by-design')).toBeAttached({ timeout: 2000 });
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Closes the gap in #1052 (T03): `tests/browser` had no `playwright.config.*`, so a failing test produced only an exit code — no trace, no HTML/JUnit report.
- Adds `playwright.config.cjs`: HTML + JUnit reporters, `trace`/`screenshot`/`video: retain-on-failure` (or `only-on-failure`), explicit `retries: 0` so a retry can never mask a real failure.
- `scripts/nemo/lib/jobs.cjs`'s `jobTestBrowser` now points the config at its own per-run report dir via `NEMO_BROWSER_REPORT_DIR` (mirrors the existing `NEMO_DESKTOP_REPORT_DIR` pattern) and surfaces the produced HTML/JUnit as receipt artifacts.
- Adds `tests/browser/_negative-control.spec.cjs` — an intentionally-failing test (tagged `@negative-control`, reuses the existing isolated-preview harness) that proves the pipeline really captures a failure. Excluded from the normal run by the config; run on its own with `NEMO_BROWSER_NEGATIVE_CONTROL=1 node_modules/.bin/playwright test tests/browser`.
  - Note: Playwright's CLI `--grep`/`--grep-invert` **compose with** (don't override) the config's `grep`/`grepInvert` — confirmed empirically after an initial design assumed override semantics. The env-var switch in the config is the actual, verified mechanism.
- No `package.json`/`.gitignore` changes: kept scope to this issue's bounded ownership (package.json is T01/#1050's lane) and avoided the root `.gitignore`, which turns out to have its exact SHA-256 pinned in `engineering/boundaries/profiles/app-js.coverage.json` (an unrelated, adopted 140-file JS coverage policy) — verified by running the full unit suite, which failed on that pin after a first attempt touched `.gitignore`. Fixed by pointing the config's standalone-run fallback at the already-ignored `/reports/` instead.

## Real evidence (this session, base `419f192631b715b3a6c763575dac29162aefa2d9`)
- Baseline (before): `node scripts/nemo/job.cjs test:browser` → pass, exit 0, **zero artifacts**, no `playwright-report/`/`test-results/` anywhere.
- After, normal run: pass, exit 0, real `html/index.html` (533KB) + `junit.xml` produced as receipt artifacts; negative control correctly excluded (6 tests / 3 files, same as baseline).
- After, negative control run: **exit 1**, real failing JUnit entry, real HTML report showing the failure, real inspectable `trace.zip` (1.6MB, `playwright show-trace`-able) + failure screenshot. Passing tests retain nothing extra (checked the run's `test-results/`: only tests' own fixture output, no trace/video/screenshot) — confirms the retention policy is bounded as required.
- Full unit suite (`npm test`): 596 pass / 0 fail / 2 skipped (pre-existing), including the `.gitignore`-pin boundary test that caught my first draft's mistake.

## Test plan
- [x] `node scripts/nemo/job.cjs test:browser` passes and now returns HTML+JUnit artifacts.
- [x] `NEMO_BROWSER_NEGATIVE_CONTROL=1 node_modules/.bin/playwright test tests/browser` fails with a real trace/screenshot/HTML/JUnit.
- [x] `npm test` (full unit suite, 598 tests) still green.
- [ ] Orchestrator review/merge (per remediation protocol, delegate doesn't self-certify integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)