### PR TITLE
test(coverage): enforce c8 lines/branches thresholds on migrated JS modules

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -1,0 +1,27 @@
+{
+  "all": true,
+  "src": ["src/js", "tests/fixtures"],
+  "include": [
+    "src/js/domain/animation/opacity.js",
+    "src/js/application/opacity-application.js",
+    "src/js/bootstrap/opacity-application.js",
+    "src/js/adapters/application-mcp.js",
+    "src/js/animation/curve.js",
+    "tests/fixtures/coverage-negative-control.cjs"
+  ],
+  "reporter": ["html", "lcov", "json", "json-summary", "text"],
+  "clean": true,
+  "exclude": [],
+  "lines": 90,
+  "branches": 80,
+  "exceptions": [
+    {
+      "path": "tests/fixtures/coverage-negative-control.cjs",
+      "reason": "Deliberately unimported negative control proving c8 --all reports a real gap instead of silently omitting an unexecuted file; not real product code, kept out of src/js on purpose (see file header). T01/#1050."
+    },
+    {
+      "path": "src/js/adapters/application-mcp.js",
+      "reason": "Real tests exist (tests/nemo-mcp-adapter.test.cjs, tests/nemo-mcp-boundaries.test.cjs) but evaluate this classic-script file via vm.runInNewContext(source, context) with no `filename` in the options, so V8 cannot attribute executed ranges back to this path — c8 measures 0% regardless of actual behavioral coverage. Fixing the harness to pass a filename is a real, separate change to files outside T01's bounded ownership (tests/nemo-mcp-*.test.cjs are not curve/opacity coverage job tests); tracked here rather than silently excluded or worked around. T01/#1050."
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,56 @@
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@playwright/test": "^1.63.0",
-        "@tauri-apps/cli": "^2.11.4"
+        "@tauri-apps/cli": "^2.11.4",
+        "c8": "^12.0.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@playwright/test": {
@@ -246,6 +295,443 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/c8": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-12.0.0.tgz",
+      "integrity": "sha512-4zpJvrd1nKWutnnKC2pXkFmb6iM1l+ffN//o1CzlTNwW7GSOs9a1xrLqkC48nU8oEkjmPZLPiwMsIaOvoF4Pqg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.1",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^8.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^18.0.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      },
+      "peerDependencies": {
+        "monocart-coverage-reports": "^2"
+      },
+      "peerDependenciesMeta": {
+        "monocart-coverage-reports": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.63.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
@@ -273,6 +759,244 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
+      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^13.0.6",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "type": "commonjs",
   "devDependencies": {
     "@playwright/test": "^1.63.0",
-    "@tauri-apps/cli": "^2.11.4"
+    "@tauri-apps/cli": "^2.11.4",
+    "c8": "^12.0.0"
   }
 }

--- a/scripts/nemo/lib/jobs.cjs
+++ b/scripts/nemo/lib/jobs.cjs
@@ -294,6 +294,60 @@ function jobInventory() {
   return (r.status === 0 ? pass : fail)(last, { exitCode: r.status, log: logOf(r), artifacts });
 }
 
+// ---- coverage:js (T01) --------------------------------------------------
+// c8 has no per-file threshold with named exceptions built in — --check-coverage
+// is all-or-nothing across --include. This reads c8's own coverage-summary.json
+// (istanbul's computed per-file percentages, not reimplemented here) and applies
+// lines/branches thresholds file by file, skipping paths in .c8rc.json's
+// "exceptions" (each with a reviewed reason) while still reporting them.
+function evaluateCoverageSummary(summary, config, root) {
+  const exceptions = new Map((config.exceptions || []).map((e) => [e.path, e.reason]));
+  const perFile = [];
+  const violations = [];
+  for (const relPath of config.include || []) {
+    const absPath = path.resolve(root, relPath);
+    const entry = summary[absPath];
+    const exceptionReason = exceptions.get(relPath) || null;
+    if (!entry) {
+      if (exceptionReason) { perFile.push({ path: relPath, linesPct: null, branchesPct: null, exception: exceptionReason }); continue; }
+      violations.push(`${relPath}: missing from coverage summary`);
+      continue;
+    }
+    const linesPct = entry.lines.pct;
+    const branchesPct = entry.branches.pct;
+    perFile.push({ path: relPath, linesPct, branchesPct, exception: exceptionReason });
+    if (exceptionReason) continue;
+    if (linesPct < config.lines) violations.push(`${relPath}: lines ${linesPct}% < ${config.lines}%`);
+    if (branchesPct < config.branches) violations.push(`${relPath}: branches ${branchesPct}% < ${config.branches}%`);
+  }
+  return { ok: violations.length === 0, perFile, violations };
+}
+
+function jobTestCoverageJs(ctx) {
+  const c8Bin = caps.localBin('c8');
+  if (!c8Bin) return blocked('c8 is not installed (not in devDependencies); run npm ci');
+  const configPath = path.join(ROOT, '.c8rc.json');
+  if (!exists(configPath)) return blocked('.c8rc.json is missing');
+  const config = readJson(configPath);
+  const reportDir = path.join(ctx.reportDir, 'coverage-js');
+  const r = run(c8Bin,
+    ['--config', configPath, '--report-dir', reportDir, process.execPath, '--test', 'tests/*.test.cjs', 'tests/animation/*.test.cjs'],
+    { timeout: 10 * 60 * 1000 });
+  if (r.status !== 0) return fail(`node --test under c8 exit ${r.status}`, { exitCode: r.status, log: logOf(r) });
+  const summaryPath = path.join(reportDir, 'coverage-summary.json');
+  if (!exists(summaryPath)) return fail('c8 did not produce coverage-summary.json', { log: logOf(r) });
+  const verdict = evaluateCoverageSummary(readJson(summaryPath), config, ROOT);
+  const artifacts = [
+    fileInfo(path.join(reportDir, 'index.html')),
+    fileInfo(path.join(reportDir, 'lcov.info')),
+    fileInfo(path.join(reportDir, 'coverage-final.json')),
+  ].filter((a) => a.present);
+  const exceptionCount = (config.exceptions || []).length;
+  const label = `${verdict.perFile.length} migrated module(s), lines>=${config.lines}%/branches>=${config.branches}%, ${exceptionCount} reviewed exception(s)`;
+  if (!verdict.ok) return fail(`${label} — violations: ${verdict.violations.join('; ')}`, { details: { perFile: verdict.perFile }, artifacts });
+  return pass(label, { details: { perFile: verdict.perFile }, artifacts });
+}
+
 const JOBS = {
   doctor: { run: jobDoctor, required: true },
   check: { run: jobCheck, required: true },
@@ -307,6 +361,7 @@ const JOBS = {
   bench: { run: jobBench, required: false },
   'build:wasm': { run: jobBuildWasm, required: false },
   'build:desktop': { run: jobBuildDesktop, required: true },
+  'test:coverage': { run: jobTestCoverageJs, required: false },
 };
 
 const PROFILES = {
@@ -326,4 +381,4 @@ function execute(name, ctx) {
   return job;
 }
 
-module.exports = { JOBS, PROFILES, execute };
+module.exports = { JOBS, PROFILES, execute, evaluateCoverageSummary };

--- a/tests/fixtures/coverage-negative-control.cjs
+++ b/tests/fixtures/coverage-negative-control.cjs
@@ -1,0 +1,18 @@
+'use strict';
+// Deliberately unimported (T01/#1050). No test requires this file, and it is
+// not product source (kept out of src/js and scripts/nemo on purpose — both
+// have their own pinned boundary/inventory profiles that a new committed
+// source file would break; this is a coverage-tooling fixture, not a module
+// under architectural governance). It exists only to prove that `c8 --all`
+// reports zero coverage for a real gap instead of silently omitting a file
+// nothing happened to execute. See .c8rc.json's "exceptions" for how the
+// coverage job excludes it from the pass/fail threshold while still
+// reporting it. Do not import this from product code or a real test.
+function coverageNegativeControlNeverCalled(flag) {
+  if (flag) {
+    return 'unreachable branch A';
+  }
+  return 'unreachable branch B';
+}
+
+module.exports = { coverageNegativeControlNeverCalled };

--- a/tests/nemo-coverage-job.test.cjs
+++ b/tests/nemo-coverage-job.test.cjs
@@ -1,0 +1,68 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { evaluateCoverageSummary } = require('../scripts/nemo/lib/jobs.cjs');
+
+const root = '/repo';
+const entry = (linesPct, branchesPct) => ({ lines: { pct: linesPct }, branches: { pct: branchesPct } });
+
+test('evaluateCoverageSummary passes when every included file meets the threshold', () => {
+  const config = { include: ['a.js', 'b.js'], lines: 90, branches: 80, exceptions: [] };
+  const summary = { '/repo/a.js': entry(100, 100), '/repo/b.js': entry(90, 80) };
+  const result = evaluateCoverageSummary(summary, config, root);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.violations, []);
+  assert.equal(result.perFile.length, 2);
+});
+
+test('evaluateCoverageSummary fails a file below the lines threshold', () => {
+  const config = { include: ['a.js'], lines: 90, branches: 80, exceptions: [] };
+  const summary = { '/repo/a.js': entry(89.9, 100) };
+  const result = evaluateCoverageSummary(summary, config, root);
+  assert.equal(result.ok, false);
+  assert.equal(result.violations.length, 1);
+  assert.match(result.violations[0], /a\.js: lines 89\.9% < 90%/);
+});
+
+test('evaluateCoverageSummary fails a file below the branches threshold', () => {
+  const config = { include: ['a.js'], lines: 90, branches: 80, exceptions: [] };
+  const summary = { '/repo/a.js': entry(100, 79) };
+  const result = evaluateCoverageSummary(summary, config, root);
+  assert.equal(result.ok, false);
+  assert.match(result.violations[0], /a\.js: branches 79% < 80%/);
+});
+
+test('a declared exception is reported but never counted as a violation, however low its coverage', () => {
+  const config = {
+    include: ['a.js', 'negative-control.js'], lines: 90, branches: 80,
+    exceptions: [{ path: 'negative-control.js', reason: 'deliberately unimported' }],
+  };
+  const summary = { '/repo/a.js': entry(95, 90), '/repo/negative-control.js': entry(0, 0) };
+  const result = evaluateCoverageSummary(summary, config, root);
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.violations, []);
+  const exceptionEntry = result.perFile.find((f) => f.path === 'negative-control.js');
+  assert.equal(exceptionEntry.exception, 'deliberately unimported');
+  assert.equal(exceptionEntry.linesPct, 0);
+});
+
+test('an included file missing from the coverage summary is a violation unless it is a declared exception', () => {
+  const config = { include: ['missing.js', 'excepted-missing.js'], lines: 90, branches: 80,
+    exceptions: [{ path: 'excepted-missing.js', reason: 'never instrumented, reviewed' }] };
+  const summary = {};
+  const result = evaluateCoverageSummary(summary, config, root);
+  assert.equal(result.ok, false);
+  assert.equal(result.violations.length, 1);
+  assert.match(result.violations[0], /missing\.js: missing from coverage summary/);
+  const exceptionEntry = result.perFile.find((f) => f.path === 'excepted-missing.js');
+  assert.equal(exceptionEntry.exception, 'never instrumented, reviewed');
+  assert.equal(exceptionEntry.linesPct, null);
+});
+
+test('legacy modules outside .c8rc.json\'s include list are never evaluated', () => {
+  const config = { include: ['a.js'], lines: 90, branches: 80, exceptions: [] };
+  const summary = { '/repo/a.js': entry(100, 100), '/repo/legacy/whatever.js': entry(0, 0) };
+  const result = evaluateCoverageSummary(summary, config, root);
+  assert.equal(result.ok, true);
+  assert.equal(result.perFile.length, 1);
+});


### PR DESCRIPTION
## Summary
- Adds the first JS coverage gate for #1050 (T01): `c8` devDependency, `.c8rc.json`, and a new `test:coverage` job (`scripts/nemo/lib/jobs.cjs`) enforcing **90% lines / 80% branches per file** on six explicitly declared "migrated" modules — the extracted opacity domain/application/bootstrap slice, its MCP adapter, and the curve kernel. Legacy `src/js/*.js` files are never in the include list, so they're never held to this threshold.
- c8 has no per-file exception mechanism, so enforcement reads c8's own `coverage-summary.json` (istanbul's computed percentages, not reimplemented) and applies the threshold itself (`evaluateCoverageSummary`), skipping paths declared in `.c8rc.json`'s `exceptions` array while still reporting them in the full HTML/LCOV/JSON output.
- New `tests/nemo-coverage-job.test.cjs` unit-tests `evaluateCoverageSummary` against synthetic data (6 cases: pass, lines violation, branches violation, exception skip, missing-file violation, legacy-file exclusion).

## Two reviewed exceptions — both real findings, not assumptions
1. **`tests/fixtures/coverage-negative-control.cjs`** — deliberately unimported, proves `c8 --all` reports a real 0%-covered file instead of silently omitting it. Deliberately placed under `tests/fixtures/`, not `src/js/domain/animation/` where I first put it: that broke `scripts/nemo/inventory.test.cjs`'s staleness check, because `src/js` (and separately `scripts/nemo`) each have their own pinned/adopted boundary-profile artifacts (`engineering/boundaries/profiles/app-js.coverage.json`, `scripts-nemo.profile.json`) that git-blob-pin every file under their root — a new committed file there breaks them. `tests/` has no such profile.
2. **`src/js/adapters/application-mcp.js`** — real tests exist (`tests/nemo-mcp-adapter.test.cjs`, `tests/nemo-mcp-boundaries.test.cjs`) but evaluate this classic-script file via `vm.runInNewContext(source, context)` with no `filename` in the options, so V8 can't attribute executed ranges back to the file — c8 measures 0% regardless of actual behavioral coverage. Fixing that harness (adding `filename` to the vm calls) is a real change to files outside T01's bounded ownership (not "curve/opacity coverage job tests"); flagged as a follow-up rather than silently excluded or worked around.

## Honest baseline: two real modules fail today
`src/js/domain/animation/opacity.js` (73.19% lines / 69.69% branches) and `src/js/bootstrap/opacity-application.js` (89.74% lines) are genuinely below threshold right now. Not fixed here — no unrelated test-writing, per baseline-preservation rules. This doubles as the "intentionally below-threshold run fails the receipt" proof required by the issue: it's today's real state, not a contrived scenario.

Because of this, `test:coverage` is registered `required: false` and **not** added to the `full` profile — promoting it is a follow-up decision once those two gaps are addressed or explicitly accepted as exceptions.

## Real evidence (this session, base `419f192631b715b3a6c763575dac29162aefa2d9`)
- `node scripts/nemo/job.cjs test:coverage`: real run, `node --test` under c8 discovers the same **598 tests / 596 pass / 0 fail / 2 skipped** as the plain suite (no coverage-instrumentation drift), then fails with `violations: src/js/domain/animation/opacity.js: lines 73.19% < 90%; ...branches 69.69% < 80%; src/js/bootstrap/opacity-application.js: lines 89.74% < 90%` — everything else (curve.js 100/97.67, application/opacity-application.js 96.35/84.03) passes; both exceptions correctly skipped from violations while still appearing in the per-file report.
- Real HTML (`index.html`), LCOV (`lcov.info`), and full JSON (`coverage-final.json`) reports produced as receipt artifacts.
- `tests/nemo-coverage-job.test.cjs`: 6/6 pass.
- `npm run check`: 6/6 pass. Full `npm test`: 604 pass (598 existing + 6 new) / 0 fail / 2 skipped (pre-existing).

## Test plan
- [x] `node scripts/nemo/job.cjs test:coverage` produces real HTML/LCOV/JSON and correctly fails on genuine per-file threshold violations.
- [x] Negative control appears at 0% in the report and is excluded from violations.
- [x] `tests/nemo-coverage-job.test.cjs` (new) passes.
- [x] `npm run check` and full `npm test` still green.
- [ ] Orchestrator review/merge (delegate doesn't self-certify integration, per remediation protocol).

🤖 Generated with [Claude Code](https://claude.com/claude-code)