### PR TITLE
Cover the collaborator policy exception in normal CI regressions

### DIFF
--- a/.github/scripts/collaborator-pr-policy.test.cjs
+++ b/.github/scripts/collaborator-pr-policy.test.cjs
@@ -151,3 +151,21 @@ test('manual reconciliation records failure while evaluating remaining PRs', asy
   assert.equal(failures.length, 1);
   assert.equal(f.calls.approvals.length, 0);
 });
+
+test('automatic policy workflow cannot execute PR code or gain unrelated write scopes', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const workflow = fs.readFileSync(path.join(__dirname, '../workflows/collaborator-pr-policy.yml'), 'utf8');
+  const triggers = workflow.match(/^on:\n((?:[ \t].*\n|#.*\n|\n)*)/m)[1];
+  assert.deepEqual([...triggers.matchAll(/^  ([\w]+):/gm)].map(m => m[1]),
+    ['pull_request_target', 'workflow_dispatch']);
+  assert.match(triggers, /branches: \[main\]/);
+  assert.match(workflow, /^permissions: \{\}$/m);
+  assert.deepEqual([...workflow.matchAll(/^\s+([\w-]+): write$/gm)].map(m => m[1]), ['pull-requests']);
+  assert.match(workflow, /github\.ref == 'refs\/heads\/main'/);
+  assert.match(workflow, /ref: context\.sha,/);
+  assert.match(workflow, /path: '\.github\/scripts\/collaborator-pr-policy\.cjs'/);
+  assert.deepEqual([...workflow.matchAll(/uses: (.*)/g)].map(m => m[1]),
+    ['actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8']);
+  assert.doesNotMatch(workflow, /^\s*(?:- )?run:|secrets\.|pull_request\.head|actions\/checkout/m);
+});

--- a/scripts/nemo/ci.test.cjs
+++ b/scripts/nemo/ci.test.cjs
@@ -229,11 +229,13 @@ console.log(${JSON.stringify(JSON.stringify(receipt([{ name: 'test:browser', sta
   assert.equal(ci.verify(['test:browser'], root).ok, false);
 });
 
-test('all hosted workflows require manual dispatch and explicit build approval before allocating a runner', () => {
+test('hosted product workflows require manual dispatch and explicit build approval before allocating a runner', () => {
   const directory = path.join(ROOT, '.github/workflows');
   const files = fs.readdirSync(directory).filter((file) => /\.ya?ml$/.test(file));
   assert.ok(files.length > 0);
   for (const file of files) {
+    // The sole metadata-only exception has its own privilege/trigger regressions.
+    if (file === 'collaborator-pr-policy.yml') continue;
     const workflow = fs.readFileSync(path.join(directory, file), 'utf8');
     const triggerBlock = workflow.match(/^on:\n((?:[ \t].*\n|#.*\n|\n)*)/m)?.[1];
     assert.ok(triggerBlock, `${file}: expected a block-form trigger declaration`);

--- a/tests/nemo-ci.test.cjs
+++ b/tests/nemo-ci.test.cjs
@@ -1,3 +1,6 @@
 'use strict';
 // Include the CI regressions in the established npm test / verify command.
 require('../scripts/nemo/ci.test.cjs');
+
+// The sole automatic metadata exception remains covered by normal local validation.
+require('../.github/scripts/collaborator-pr-policy.test.cjs');


### PR DESCRIPTION
The existing CI regression rejected the new collaborator policy because it treated every Actions workflow as a hosted build. Admit only the named metadata policy exception and test its protected-main source, trigger set, pinned action and narrow permissions. Include policy behavior regressions in the established local `npm test`/`verify` CI wrapper.

Validation: `node --test tests/nemo-ci.test.cjs` passed all 42 tests; `git diff --check` passed. Solo technical review of the three-file diff. All other workflows still require manual dispatch and explicit hosted-build approval. This completes the local regression integration for #1078; no application or runtime behavior changes.
