### PR TITLE
P02 — adopt one current-state comparison manifest

### DIFF
--- a/engineering/boundaries/profiles/scripts-nemo.profile.json
+++ b/engineering/boundaries/profiles/scripts-nemo.profile.json
@@ -38,6 +38,8 @@
       "files": ["boundaries-discovery.cjs"], "publicApi": ["boundaries-discovery.cjs"], "sizeProfile": "Platform/engine adapter" },
     { "id": "nemo.lib.receipt", "layer": "tooling-application", "dir": "scripts/nemo/lib",
       "files": ["receipt.cjs"], "publicApi": ["receipt.cjs"], "sizeProfile": "Domain/application JS or TS" },
+    { "id": "nemo.lib.baseline", "layer": "tooling-application", "dir": "scripts/nemo/lib",
+      "files": ["baseline.cjs"], "publicApi": ["baseline.cjs"], "sizeProfile": "Domain/application JS or TS" },
     { "id": "nemo.lib.inventoryBindings", "layer": "tooling-application", "dir": "scripts/nemo/lib",
       "files": ["inventory-bindings.cjs"], "publicApi": ["inventory-bindings.cjs"], "sizeProfile": "Domain/application JS or TS" },
     { "id": "nemo.lib.inventoryRecords", "layer": "tooling-application", "dir": "scripts/nemo/lib",
@@ -78,6 +80,8 @@
       "files": ["job.cjs"], "publicApi": [], "sizeProfile": "Handwritten config/bootstrap" },
     { "id": "nemo.cli.verify", "layer": "tooling-bootstrap", "dir": "scripts/nemo",
       "files": ["verify.cjs"], "publicApi": [], "sizeProfile": "Handwritten config/bootstrap" },
+    { "id": "nemo.cli.baseline", "layer": "tooling-bootstrap", "dir": "scripts/nemo",
+      "files": ["baseline.cjs"], "publicApi": [], "sizeProfile": "Handwritten config/bootstrap" },
 
     { "id": "nemo.test.boundaries", "layer": "tooling-test", "dir": "scripts/nemo",
       "files": ["boundaries.test.cjs"], "publicApi": ["boundaries.test.cjs"], "sizeProfile": "Test file" },
@@ -108,7 +112,9 @@
     { "id": "nemo.test.isolation", "layer": "tooling-test", "dir": "scripts/nemo",
       "files": ["isolation.test.cjs"], "publicApi": ["isolation.test.cjs"], "sizeProfile": "Test file" },
     { "id": "nemo.test.ci", "layer": "tooling-test", "dir": "scripts/nemo",
-      "files": ["ci.test.cjs"], "publicApi": ["ci.test.cjs"], "sizeProfile": "Test file" }
+      "files": ["ci.test.cjs"], "publicApi": ["ci.test.cjs"], "sizeProfile": "Test file" },
+    { "id": "nemo.test.baseline", "layer": "tooling-test", "dir": "scripts/nemo",
+      "files": ["baseline.test.cjs"], "publicApi": ["baseline.test.cjs"], "sizeProfile": "Test file" }
   ],
   "layerRules": {
     "tooling-shared": { "allowedLayers": [] },

--- a/engineering/inventory/BASELINE.md
+++ b/engineering/inventory/BASELINE.md
@@ -1,15 +1,131 @@
-# R03 baseline acceptance
+# Nemo baseline
+
+Two things live here. [The adopted current-state baseline](#adopted-current-state-baseline)
+is what a later run is compared against today. [The R03 baseline acceptance](#historical-r03-baseline-acceptance)
+below it is retained historical evidence at its own revision, which P02 does not
+restate or supersede.
+
+Baseline means the exact observed state, including its known defects. Nothing on
+this page is a target, a budget, or a promise that a check will pass.
+
+## Adopted current-state baseline
+
+The machine-readable manifest is [`baseline-manifest.json`](baseline-manifest.json)
+(schema `nemo.baseline-manifest/1`). It, not this page, is the comparison
+authority: prose cannot be diffed, and a result quoted without the bytes it was
+measured on is not evidence.
+
+```sh
+node scripts/nemo/baseline.cjs --check          # compare the newest receipt
+node scripts/nemo/baseline.cjs --check --from <runId> --json
+node scripts/nemo/baseline.cjs --adopt --from <runId>[,<runId>]   # re-adopt
+```
+
+`--check` classifies every job as **new regression**, **unchanged known
+failure** or **environment mismatch**, and verifies the immutable references
+first. Exit `0` reproduces the baseline, `1` is a blocking verdict (a new,
+changed or newly observed failure), `2` is inconclusive (a stale reference, an
+environment mismatch, or a job this run did not cover). A job the run did not
+cover is reported as `missing-entry` — never as a pass.
+
+### Selected source and environment
+
+| | |
+|---|---|
+| Source | `ded641bd763379f36d629bf1686fcce8a6137a66` (`origin/main`), clean |
+| Version | package / `tauri.conf.json` / `index.html` fallback all `0.7.0-alpha.4` |
+| Fixtures | `tests/fixtures/manifest.json` `eea9aa1cb9e3`, format version 13 |
+| `geometry_wasm_bg.wasm` | `c35ad2045f18`, 1 644 666 bytes |
+| FFmpeg sidecar | `ffmpeg-aarch64-apple-darwin` `8fbf0afc8a0c`, 22 127 000 bytes |
+| Host | darwin 25.6.0 arm64, Apple M4 Max ×14, node v24.4.1, host triple `aarch64-apple-darwin` |
+
+Evidence is two receipts on that commit: `20260909T154312Z-ded641b`
+(sha256 `d1aae6928fb9`, quick profile, clean tree) and
+`20260909T154544Z-ded641b-dirty` (sha256 `1d5c7768ccf9`, the remaining
+full-profile jobs). The second ran with this task's own tooling files present
+but uncommitted; they add no application source and ship in the same change.
+The manifest records that as `references.source.worktreeIgnored`, rather than
+hiding it.
+
+This host is not the one that produced the R03 evidence below (Apple M3 Ultra
+×32, node 22.17.1). Timing-sensitive results are not transferable between them,
+which is why the environment is part of the manifest rather than a footnote.
+
+### Current state — 12 jobs: 9 pass, 1 fail, 2 blocked
+
+| Job | Result | Exact case |
+|---|---|---|
+| `doctor` | Pass | 16 tools probed, 1 absent (`wasm-bindgen`) |
+| `check` | Pass | 6 static checks |
+| `inventory` | Pass | up to date, 902 rows, digest `c4c968bc2d41` |
+| `test:unit` | Pass | 634 tests, 632 pass, 0 fail |
+| `test:rust` | Pass | `geometry-wasm`, 4 binaries, 15 passed |
+| `test:integration` | Pass | `tests/integration` exit 0 |
+| `test:browser` | Pass | `tests/browser` Playwright exit 0 |
+| `build:wasm` | Pass | `wasm-pack` build ok; output differs from the committed `src/wasm` bundle — wasm-pack is not byte-reproducible across toolchains, recorded as information |
+| `bench` | Pass | 15 workloads measured, **2 not-run** (`render.engine.export`, `export.mp4.export` — no render backend outside a browser or the packaged app); no budgets |
+| `build:desktop` | **Fail** | `bundle-ffmpeg-dylibs.py failed (1)` |
+| `test:rust-tauri` | **Blocked** | native fixture sidecar unavailable: `SIGABRT`, no FFmpeg version banner, `dyld: Library not loaded: /opt/homebrew/opt/libvpx/lib/libvpx.12.dylib` |
+| `test:desktop` | **Blocked** | no packaged app (`src-tauri/target/*/release/bundle/macos/Nemo.app` or `NEMO_DESKTOP_APP`) |
+
+`blocked` is a missing capability, never a skip and never a pass. `not-run` is
+an intentional non-attempt. Neither is evidence that the underlying behavior
+works.
+
+### The one native blocker, and what it actually is
+
+`build:desktop`, `test:rust-tauri` and `test:desktop` are **one** root cause,
+not three. The committed sidecar is dynamically linked (the LGPL rebuild of
+2026-08-18, `CLAUDE.md` §7) and references versioned Homebrew library names. Of
+its 26 external dylibs, exactly two are absent on this host:
+
+- `/opt/homebrew/opt/libvpx/lib/libvpx.12.dylib` — installed libvpx is 1.15.2
+- `/opt/homebrew/opt/svt-av1/lib/libSvtAv1Enc.4.dylib`
+
+So `ffmpeg -version` aborts under dyld, `test:rust-tauri` is blocked on its
+native fixture, `bundle-ffmpeg-dylibs.py` cannot resolve the dependency and
+fails the desktop build, and `test:desktop` is then blocked for want of a
+packaged app. This is precisely the drift `CLAUDE.md` §7 documents: the build
+host must carry the Homebrew **major** versions the committed sidecar was
+linked against.
+
+Two facts worth keeping separate: `doctor` reports **pass** while the sidecar
+cannot execute, because it records sidecar health as a capability rather than a
+job result; and the sidecar file itself is present and hash-stable. The failure
+is the host's library set, not a missing or corrupted artifact.
+
+Remedy is re-running `scripts/rebuild-ffmpeg-lgpl.sh` and committing the
+relinked sidecar, or installing the matching majors. Doing either is **not**
+part of P02 — this task records the baseline, and a repair would change the
+thing being recorded.
+
+### Known limits of this baseline
+
+- No packaged-desktop evidence at this commit. `build:desktop` would in any case
+  produce an unsigned local verification package, which is not release
+  acceptance.
+- `render.engine.export` and `export.mp4.export` remain unmeasured; they need
+  the WebGPU engine in a browser or the packaged app.
+- WebGPU availability is not observable from node; `test:browser` passing shows
+  the browser harness, not the packaged app's GPU path.
+- `test:coverage` is not part of the `full` profile and has no entry here.
+- The manifest records this commit. Once it is committed, `--check` reports
+  `source.head` as moved and exits `2`. That is the intended behavior — re-adopt
+  deliberately rather than let a stale baseline answer for a tree it never saw.
+
+## Historical R03 baseline acceptance
+
+Retained unchanged as evidence for [R03](https://github.com/mysteropodes/nemo/issues/899)
+and [F0](https://github.com/mysteropodes/nemo/issues/888) at its own revision. It
+does not close the later application extraction, shared-command, native-isolation
+or installed MCP gates, and it is not the current comparison baseline.
 
 This candidate combines the retained R03 inventory, fixture corpus, initial CPU
 workloads, and browser harnesses on main `b86c69dda2a061ef551fc522dd96327a5b9a4f66`.
 The existing R08 extraction remains separate. Application JavaScript, Rust, WASM,
 and packaged sidecar bytes are unchanged from that base.
 
-This is evidence for [R03](https://github.com/mysteropodes/nemo/issues/899) and
-[F0](https://github.com/mysteropodes/nemo/issues/888). It does not close the later
-application extraction, shared-command, native-isolation, or installed MCP gates.
-
-## Reproduction
+### Reproduction
 
 Run the named commands from a clean checkout. Fixture generation requires one of
 the compression runtimes documented in the [fixture guide](../../tests/fixtures/README.md).
@@ -29,7 +145,7 @@ and [render workload](../../tests/bench/BROWSER_RENDER.md) document their extern
 Playwright dependency and exact commands. Neither installs dependencies or changes
 user projects. Missing platform capabilities must remain explicit in the receipt.
 
-## Standard verification
+### Standard verification
 
 Clean candidate `74a2b0059e74bb0321e388650aabc9172d2f9144` passed `npm run verify`:
 all six static checks, the current 902-row inventory, 416 Node tests (zero failures,
@@ -47,7 +163,7 @@ No application source change or new policy exception is needed.
 Quick receipt SHA-256:
 `d487251f9815dbc554dafc5bae44629c088ce3634f81a1f9b37de2d0979f60cd`.
 
-## CPU workload evidence
+### CPU workload evidence
 
 The retained CPU runner measured all 15 evaluation, copy, serialization, and memory
 workloads on an Apple M3 Ultra (32 logical CPUs, arm64, Node 22.17.1). Representative
@@ -61,7 +177,7 @@ The CPU receipt identifies `ad20a824efacbd7d439d21645c00a798f4695faa` plus dirty
 file was this baseline document. Benchmark and application inputs were unchanged.
 Receipt SHA-256: `0e8c6fcb51d30e80541f439a4d590b07db4bbce72f0788d059f9b22a58b6605b`.
 
-## Browser and native evidence
+### Browser and native evidence
 
 These runs identify clean candidate
 `ad20a824efacbd7d439d21645c00a798f4695faa`. Later inventory-only corrections do not
@@ -89,7 +205,7 @@ Retained receipt SHA-256 values:
 - Browser render: `716d68af8d842b7e9170c0cba97f8485ca3db00453887f775e8c4ce906f73d29`.
 - Fixture manifest: `eea9aa1cb9e39e1ed86b9d44169f415fdc36fef0e65c96640acbc8cd999ecbc6`.
 
-## Remaining acceptance
+### Remaining acceptance
 
 Browser document round trips do not exercise browser Save/download UI. Software
 rendering does not establish fixture pixel equality, native GPU behavior, or the

--- a/engineering/inventory/baseline-manifest.json
+++ b/engineering/inventory/baseline-manifest.json
@@ -1,0 +1,663 @@
+{
+  "schema": "nemo.baseline-manifest/1",
+  "adoptedAt": "2026-09-09T16:14:59.569Z",
+  "task": "P02 / #1004",
+  "note": "Adopted for P02 (#1004) at ded641bd (origin/main). Two receipts on the same commit: the quick profile on a clean tree, and the remaining full-profile jobs with the P02 tooling files present uncommitted (scripts/nemo/baseline*.cjs, tests/nemo-baseline.test.cjs) — those add no application source and are committed together with this manifest.",
+  "references": {
+    "source": {
+      "head": "ded641bd763379f36d629bf1686fcce8a6137a66",
+      "branch": "pollen/p02-current-state-manifest",
+      "commitDate": "2026-09-09T16:35:17+02:00",
+      "dirty": false,
+      "dirtyDigest": null,
+      "worktreeIgnored": true,
+      "worktreeWasDirty": true,
+      "worktreeDigest": "12a26fc65796ff3c4522120732a235de412a97af9bfc8227898b9dacbd0784fc"
+    },
+    "fixtures": {
+      "path": "tests/fixtures/manifest.json",
+      "present": true,
+      "sha256": "eea9aa1cb9e39e1ed86b9d44169f415fdc36fef0e65c96640acbc8cd999ecbc6",
+      "formatVersion": 13
+    },
+    "artifacts": {
+      "geometryWasm": {
+        "path": "src/wasm/geometry_wasm_bg.wasm",
+        "present": true,
+        "bytes": 1644666,
+        "sha256": "c35ad2045f183c69c6fec40721886cc48c14f9e7b05cf127192f4739d15fd3d5"
+      },
+      "vectorizeWasm": {
+        "path": "src/wasm-vectorize/vectorize_wasm_bg.wasm",
+        "present": true,
+        "bytes": 862315,
+        "sha256": "a1d67c391782c6ba2d16b435c9bc9885e56af78950ef546f5cb2562063c92422"
+      },
+      "ffmpegSidecar": {
+        "path": "src-tauri/binaries/ffmpeg-aarch64-apple-darwin",
+        "present": true,
+        "bytes": 22127000,
+        "sha256": "8fbf0afc8a0cf3b30307da69eebc4c7b21585ac3f90f3f82f90405a1a367eeb7"
+      }
+    },
+    "build": {
+      "packageVersion": "0.7.0-alpha.4",
+      "tauriVersion": "0.7.0-alpha.4",
+      "indexHtmlTitleVersion": "0.7.0-alpha.4",
+      "hostTriple": "aarch64-apple-darwin"
+    }
+  },
+  "platform": {
+    "os": "darwin",
+    "osRelease": "25.6.0",
+    "arch": "arm64",
+    "cpuModel": "Apple M4 Max",
+    "cpuCount": 14,
+    "node": "v24.4.1"
+  },
+  "receipts": [
+    {
+      "runId": "20260909T154312Z-ded641b",
+      "command": "verify",
+      "profile": "quick",
+      "finishedAt": "2026-09-09T15:44:17.500Z",
+      "path": "reports/20260909T154312Z-ded641b/receipt.json",
+      "sha256": "d1aae6928fb9fd769e4ab74c464964fd640748b9bf61ce1c0d10f65a4ccf90b9",
+      "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+      "sourceDirty": false
+    },
+    {
+      "runId": "20260909T154544Z-ded641b-dirty",
+      "command": "verify",
+      "profile": "custom",
+      "finishedAt": "2026-09-09T15:48:29.904Z",
+      "path": "reports/20260909T154544Z-ded641b-dirty/receipt.json",
+      "sha256": "1d5c7768ccf916d63a9191b04be6ac97f7c3aefda3900ecfbaa103c70ec1587d",
+      "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+      "sourceDirty": true
+    }
+  ],
+  "entries": [
+    {
+      "job": "bench",
+      "required": false,
+      "status": "pass",
+      "case": {
+        "reason": "15 workloads measured, 2 not-run (no render backend); budgets: none (R19)",
+        "exitCode": 0,
+        "limitations": [
+          "render.engine.export: requires the WebGPU engine in a browser or the packaged desktop app (test:browser / test:desktop, R21); the fixture and its expectations are in tests/fixtures/export/",
+          "export.mp4.export: requires the WebGPU engine in a browser or the packaged desktop app (test:browser / test:desktop, R21); the fixture and its expectations are in tests/fixtures/export/"
+        ],
+        "details": {
+          "evaluation.valueAtFrame": {
+            "median": 526.597,
+            "p90": 618.444,
+            "unit": "ns/evaluation"
+          },
+          "evaluation.evalCurvePoints": {
+            "median": 1580.775,
+            "p90": 1587,
+            "unit": "ns/evaluation"
+          },
+          "evaluation.expression": {
+            "median": 649.688,
+            "p90": 744.931,
+            "unit": "ns/evaluation"
+          },
+          "copy.undoClone.bench-vectors-40x24": {
+            "median": 59.992,
+            "p90": 61.249,
+            "unit": "ms"
+          },
+          "copy.jsonClone.bench-vectors-40x24": {
+            "median": 53.669,
+            "p90": 54.027,
+            "unit": "ms"
+          },
+          "copy.serialize.bench-vectors-40x24": {
+            "median": 27.457,
+            "p90": 27.541,
+            "unit": "ms"
+          },
+          "memory.parsedDocument.bench-vectors-40x24": {
+            "median": 19713568,
+            "p90": 19713568,
+            "unit": "bytes"
+          },
+          "copy.undoClone.bench-vectors-8x24": {
+            "median": 5.886,
+            "p90": 5.981,
+            "unit": "ms"
+          },
+          "copy.jsonClone.bench-vectors-8x24": {
+            "median": 5.523,
+            "p90": 5.616,
+            "unit": "ms"
+          },
+          "copy.serialize.bench-vectors-8x24": {
+            "median": 2.784,
+            "p90": 2.83,
+            "unit": "ms"
+          },
+          "memory.parsedDocument.bench-vectors-8x24": {
+            "median": 1971432,
+            "p90": 1971432,
+            "unit": "bytes"
+          },
+          "copy.undoClone.bench-images-20x24": {
+            "median": 3.251,
+            "p90": 3.263,
+            "unit": "ms"
+          },
+          "copy.jsonClone.bench-images-20x24": {
+            "median": 2.891,
+            "p90": 2.905,
+            "unit": "ms"
+          },
+          "copy.serialize.bench-images-20x24": {
+            "median": 1.467,
+            "p90": 1.531,
+            "unit": "ms"
+          },
+          "memory.parsedDocument.bench-images-20x24": {
+            "median": 1188952,
+            "p90": 1188952,
+            "unit": "bytes"
+          },
+          "render.engine.export": {
+            "status": "not-run",
+            "reason": "requires the WebGPU engine in a browser or the packaged desktop app (test:browser / test:desktop, R21); the fixture and its expectations are in tests/fixtures/export/"
+          },
+          "export.mp4.export": {
+            "status": "not-run",
+            "reason": "requires the WebGPU engine in a browser or the packaged desktop app (test:browser / test:desktop, R21); the fixture and its expectations are in tests/fixtures/export/"
+          }
+        }
+      },
+      "caseSignature": null,
+      "evidence": {
+        "runId": "20260909T154544Z-ded641b-dirty",
+        "command": "verify",
+        "profile": "custom",
+        "finishedAt": "2026-09-09T15:48:29.904Z",
+        "path": "reports/20260909T154544Z-ded641b-dirty/receipt.json",
+        "sha256": "1d5c7768ccf916d63a9191b04be6ac97f7c3aefda3900ecfbaa103c70ec1587d",
+        "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+        "sourceDirty": true
+      },
+      "measuredDirty": true,
+      "carriedOver": false,
+      "carriedOverNote": null
+    },
+    {
+      "job": "build:desktop",
+      "required": true,
+      "status": "fail",
+      "case": {
+        "reason": "bundle-ffmpeg-dylibs.py failed (1)",
+        "exitCode": 1,
+        "limitations": [
+          "Unsigned local verification package; not release acceptance."
+        ],
+        "details": {
+          "taskId": "desktop-build-88f0cf7bd973dbc281cc88adb84a908c",
+          "source": {
+            "head": "ded641bd763379f36d629bf1686fcce8a6137a66",
+            "branch": "pollen/p02-current-state-manifest",
+            "describe": "v0.7.0-alpha.4-188-gded641b",
+            "commitDate": "2026-09-09T16:35:17+02:00",
+            "subject": "Merge pull request #1068 from mysteropodes/fizz/t03-playwright-failure-traces",
+            "upstream": "origin/main",
+            "worktree": "<repo>",
+            "dirty": true,
+            "modifiedTracked": 0,
+            "untracked": 2,
+            "dirtyDigest": "2eeba8fc268414b64363957c2cf6be50e13bed69d8c1803640778123f60c71cb",
+            "changedPaths": [
+              "?? scripts/nemo/baseline.cjs",
+              "?? scripts/nemo/lib/baseline.cjs"
+            ]
+          },
+          "build": {
+            "startup": {
+              "packageVersion": "0.7.0-alpha.4",
+              "tauriVersion": "0.7.0-alpha.4",
+              "indexHtmlTitleVersion": "0.7.0-alpha.4",
+              "indexHtmlStatusVersion": "0.7.0-alpha.4",
+              "productName": "Nemo",
+              "identifier": "com.strokemotion.app",
+              "tauriCliRange": "^2.11.4",
+              "crates": {
+                "geometry-wasm": "0.1.0",
+                "vectorize-wasm": "0.1.0",
+                "src-tauri": "0.5.0"
+              },
+              "hostTriple": "aarch64-apple-darwin",
+              "artifacts": {
+                "geometryWasm": {
+                  "path": "src/wasm/geometry_wasm_bg.wasm",
+                  "present": true,
+                  "bytes": 1644666,
+                  "sha256": "c35ad2045f183c69c6fec40721886cc48c14f9e7b05cf127192f4739d15fd3d5"
+                },
+                "vectorizeWasm": {
+                  "path": "src/wasm-vectorize/vectorize_wasm_bg.wasm",
+                  "present": true,
+                  "bytes": 862315,
+                  "sha256": "a1d67c391782c6ba2d16b435c9bc9885e56af78950ef546f5cb2562063c92422"
+                },
+                "ffmpegSidecar": {
+                  "path": "src-tauri/binaries/ffmpeg-aarch64-apple-darwin",
+                  "present": true,
+                  "bytes": 22127000,
+                  "sha256": "8fbf0afc8a0cf3b30307da69eebc4c7b21585ac3f90f3f82f90405a1a367eeb7"
+                }
+              }
+            }
+          },
+          "state": "completed",
+          "buildExitCode": 0,
+          "processTree": {
+            "stopped": true,
+            "forced": false,
+            "reason": "owned build process tree already exited"
+          },
+          "handshake": {
+            "ok": false,
+            "reason": "source moved: recorded source identity differs from current checkout"
+          },
+          "finalState": "stopped",
+          "cleanup": {
+            "stopped": true,
+            "released": true,
+            "retainedData": false,
+            "slots": {
+              "scanned": 0,
+              "reconciled": [],
+              "retained": [],
+              "otherTasks": 0,
+              "truncated": false
+            }
+          }
+        }
+      },
+      "caseSignature": "01b88f58ab770032a848f706c6db3142765a83bbb5cd7b902af13387d08aa48d",
+      "evidence": {
+        "runId": "20260909T154544Z-ded641b-dirty",
+        "command": "verify",
+        "profile": "custom",
+        "finishedAt": "2026-09-09T15:48:29.904Z",
+        "path": "reports/20260909T154544Z-ded641b-dirty/receipt.json",
+        "sha256": "1d5c7768ccf916d63a9191b04be6ac97f7c3aefda3900ecfbaa103c70ec1587d",
+        "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+        "sourceDirty": true
+      },
+      "measuredDirty": true,
+      "carriedOver": false,
+      "carriedOverNote": null
+    },
+    {
+      "job": "build:wasm",
+      "required": false,
+      "status": "pass",
+      "case": {
+        "reason": "wasm-pack build ok; differs from committed src/wasm bundle",
+        "exitCode": 0,
+        "limitations": [
+          "built bundle differs from the committed one — wasm-pack output is not guaranteed reproducible across toolchains; treat as information, not failure"
+        ],
+        "details": null
+      },
+      "caseSignature": null,
+      "evidence": {
+        "runId": "20260909T154544Z-ded641b-dirty",
+        "command": "verify",
+        "profile": "custom",
+        "finishedAt": "2026-09-09T15:48:29.904Z",
+        "path": "reports/20260909T154544Z-ded641b-dirty/receipt.json",
+        "sha256": "1d5c7768ccf916d63a9191b04be6ac97f7c3aefda3900ecfbaa103c70ec1587d",
+        "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+        "sourceDirty": true
+      },
+      "measuredDirty": true,
+      "carriedOver": false,
+      "carriedOverNote": null
+    },
+    {
+      "job": "check",
+      "required": true,
+      "status": "pass",
+      "case": {
+        "reason": "6 checks pass",
+        "exitCode": null,
+        "limitations": [],
+        "details": {
+          "version-sync": {
+            "status": "pass",
+            "reason": "all four version strings say 0.7.0-alpha.4"
+          },
+          "json-valid": {
+            "status": "pass",
+            "reason": "6 JSON files parse"
+          },
+          "js-syntax": {
+            "status": "pass",
+            "reason": "150 scripts under src/js parse (3 as ES modules)"
+          },
+          "script-refs": {
+            "status": "pass",
+            "reason": "138 <script src> references in index.html resolve"
+          },
+          "private-labs-guard": {
+            "status": "pass",
+            "reason": "no private-labs leakage under src/"
+          },
+          "artifacts-present": {
+            "status": "pass",
+            "reason": "committed wasm bundles and host ffmpeg sidecar present"
+          }
+        }
+      },
+      "caseSignature": null,
+      "evidence": {
+        "runId": "20260909T154312Z-ded641b",
+        "command": "verify",
+        "profile": "quick",
+        "finishedAt": "2026-09-09T15:44:17.500Z",
+        "path": "reports/20260909T154312Z-ded641b/receipt.json",
+        "sha256": "d1aae6928fb9fd769e4ab74c464964fd640748b9bf61ce1c0d10f65a4ccf90b9",
+        "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+        "sourceDirty": false
+      },
+      "measuredDirty": false,
+      "carriedOver": false,
+      "carriedOverNote": null
+    },
+    {
+      "job": "doctor",
+      "required": true,
+      "status": "pass",
+      "case": {
+        "reason": "probed 16 tools, 1 absent (wasm-bindgen)",
+        "exitCode": null,
+        "limitations": [
+          "WebGPU availability is only observable inside a browser or the packaged app (test:browser / test:desktop)"
+        ],
+        "details": {
+          "absentTools": [
+            "wasm-bindgen"
+          ],
+          "gpu": "ok",
+          "sidecar": "present but does not run"
+        }
+      },
+      "caseSignature": null,
+      "evidence": {
+        "runId": "20260909T154312Z-ded641b",
+        "command": "verify",
+        "profile": "quick",
+        "finishedAt": "2026-09-09T15:44:17.500Z",
+        "path": "reports/20260909T154312Z-ded641b/receipt.json",
+        "sha256": "d1aae6928fb9fd769e4ab74c464964fd640748b9bf61ce1c0d10f65a4ccf90b9",
+        "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+        "sourceDirty": false
+      },
+      "measuredDirty": false,
+      "carriedOver": false,
+      "carriedOverNote": null
+    },
+    {
+      "job": "inventory",
+      "required": true,
+      "status": "pass",
+      "case": {
+        "reason": "inventory up to date (902 rows, digest c4c968bc2d41)",
+        "exitCode": 0,
+        "limitations": [],
+        "details": null
+      },
+      "caseSignature": null,
+      "evidence": {
+        "runId": "20260909T154312Z-ded641b",
+        "command": "verify",
+        "profile": "quick",
+        "finishedAt": "2026-09-09T15:44:17.500Z",
+        "path": "reports/20260909T154312Z-ded641b/receipt.json",
+        "sha256": "d1aae6928fb9fd769e4ab74c464964fd640748b9bf61ce1c0d10f65a4ccf90b9",
+        "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+        "sourceDirty": false
+      },
+      "measuredDirty": false,
+      "carriedOver": false,
+      "carriedOverNote": null
+    },
+    {
+      "job": "test:browser",
+      "required": false,
+      "status": "pass",
+      "case": {
+        "reason": "playwright test tests/browser: exit 0",
+        "exitCode": 0,
+        "limitations": [],
+        "details": null
+      },
+      "caseSignature": null,
+      "evidence": {
+        "runId": "20260909T154544Z-ded641b-dirty",
+        "command": "verify",
+        "profile": "custom",
+        "finishedAt": "2026-09-09T15:48:29.904Z",
+        "path": "reports/20260909T154544Z-ded641b-dirty/receipt.json",
+        "sha256": "1d5c7768ccf916d63a9191b04be6ac97f7c3aefda3900ecfbaa103c70ec1587d",
+        "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+        "sourceDirty": true
+      },
+      "measuredDirty": true,
+      "carriedOver": false,
+      "carriedOverNote": null
+    },
+    {
+      "job": "test:desktop",
+      "required": true,
+      "status": "blocked",
+      "case": {
+        "reason": "no packaged app found (src-tauri/target/*/release/bundle/macos/Nemo.app or NEMO_DESKTOP_APP)",
+        "exitCode": null,
+        "limitations": [],
+        "details": null
+      },
+      "caseSignature": "978c5bbffb2eeca0ce112531b6e1f09e63f59813f4d2d80f6844641a9bc21f51",
+      "evidence": {
+        "runId": "20260909T154544Z-ded641b-dirty",
+        "command": "verify",
+        "profile": "custom",
+        "finishedAt": "2026-09-09T15:48:29.904Z",
+        "path": "reports/20260909T154544Z-ded641b-dirty/receipt.json",
+        "sha256": "1d5c7768ccf916d63a9191b04be6ac97f7c3aefda3900ecfbaa103c70ec1587d",
+        "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+        "sourceDirty": true
+      },
+      "measuredDirty": true,
+      "carriedOver": false,
+      "carriedOverNote": null
+    },
+    {
+      "job": "test:integration",
+      "required": false,
+      "status": "pass",
+      "case": {
+        "reason": "node --test tests/integration: exit 0",
+        "exitCode": 0,
+        "limitations": [],
+        "details": null
+      },
+      "caseSignature": null,
+      "evidence": {
+        "runId": "20260909T154544Z-ded641b-dirty",
+        "command": "verify",
+        "profile": "custom",
+        "finishedAt": "2026-09-09T15:48:29.904Z",
+        "path": "reports/20260909T154544Z-ded641b-dirty/receipt.json",
+        "sha256": "1d5c7768ccf916d63a9191b04be6ac97f7c3aefda3900ecfbaa103c70ec1587d",
+        "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+        "sourceDirty": true
+      },
+      "measuredDirty": true,
+      "carriedOver": false,
+      "carriedOverNote": null
+    },
+    {
+      "job": "test:rust",
+      "required": true,
+      "status": "pass",
+      "case": {
+        "reason": "cargo test geometry-wasm: 4 binaries, 15 passed, 0 failed",
+        "exitCode": 0,
+        "limitations": [],
+        "details": null
+      },
+      "caseSignature": null,
+      "evidence": {
+        "runId": "20260909T154312Z-ded641b",
+        "command": "verify",
+        "profile": "quick",
+        "finishedAt": "2026-09-09T15:44:17.500Z",
+        "path": "reports/20260909T154312Z-ded641b/receipt.json",
+        "sha256": "d1aae6928fb9fd769e4ab74c464964fd640748b9bf61ce1c0d10f65a4ccf90b9",
+        "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+        "sourceDirty": false
+      },
+      "measuredDirty": false,
+      "carriedOver": false,
+      "carriedOverNote": null
+    },
+    {
+      "job": "test:rust-tauri",
+      "required": false,
+      "status": "blocked",
+      "case": {
+        "reason": "native fixture sidecar unavailable (bundled): src-tauri/binaries/ffmpeg-aarch64-apple-darwin: exit null; SIGABRT; missing FFmpeg version banner; dyld[41600]: Library not loaded: /opt/homebrew/opt/libvpx/lib/libvpx.12.dylib |   Referenced from: <249CE339-765B-3B08-A2C1-C44CE163B729> <repo>/src-tauri/binaries/ffmpeg-aarch64-apple-darwin |   Reason: tried: '/opt/homebrew/opt/libvpx/lib/libvpx.12.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/libvpx/lib/libvpx.12.dylib' (no such file), '/opt/homebrew/opt/libvpx/lib/libvpx.12.dylib' (no such file), '/opt/homebrew/Cellar/libvpx/1.15.2/lib/libvpx.12.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/libvpx/1.15.2/lib/libvpx.12.dylib' (no such file), '/opt/homebrew/Cellar/libvpx/1.15.2/lib/libvpx.12.dylib' (no such file)",
+        "exitCode": null,
+        "limitations": [],
+        "details": {
+          "nativeFixtureSidecar": {
+            "path": "src-tauri/binaries/ffmpeg-aarch64-apple-darwin",
+            "source": "bundled",
+            "present": true,
+            "runs": false,
+            "exitCode": null,
+            "signal": "SIGABRT",
+            "error": null,
+            "failure": "exit null; SIGABRT; missing FFmpeg version banner; dyld[41600]: Library not loaded: /opt/homebrew/opt/libvpx/lib/libvpx.12.dylib |   Referenced from: <249CE339-765B-3B08-A2C1-C44CE163B729> <repo>/src-tauri/binaries/ffmpeg-aarch64-apple-darwin |   Reason: tried: '/opt/homebrew/opt/libvpx/lib/libvpx.12.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/libvpx/lib/libvpx.12.dylib' (no such file), '/opt/homebrew/opt/libvpx/lib/libvpx.12.dylib' (no such file), '/opt/homebrew/Cellar/libvpx/1.15.2/lib/libvpx.12.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/libvpx/1.15.2/lib/libvpx.12.dylib' (no such file), '/opt/homebrew/Cellar/libvpx/1.15.2/lib/libvpx.12.dylib' (no such file)"
+          }
+        }
+      },
+      "caseSignature": "38beee7566f233bb8c7ecc28a7c084700af8253e35660a6942cf27edc3b46be6",
+      "evidence": {
+        "runId": "20260909T154544Z-ded641b-dirty",
+        "command": "verify",
+        "profile": "custom",
+        "finishedAt": "2026-09-09T15:48:29.904Z",
+        "path": "reports/20260909T154544Z-ded641b-dirty/receipt.json",
+        "sha256": "1d5c7768ccf916d63a9191b04be6ac97f7c3aefda3900ecfbaa103c70ec1587d",
+        "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+        "sourceDirty": true
+      },
+      "measuredDirty": true,
+      "carriedOver": false,
+      "carriedOverNote": null
+    },
+    {
+      "job": "test:unit",
+      "required": true,
+      "status": "pass",
+      "case": {
+        "reason": "node --test: 634 tests, 632 pass, 0 fail",
+        "exitCode": 0,
+        "limitations": [],
+        "details": {
+          "files": [
+            "application-opacity-bootstrap.test.cjs",
+            "application-opacity-replay.test.cjs",
+            "application-opacity.test.cjs",
+            "domain-opacity.test.cjs",
+            "duplicator-hue.test.cjs",
+            "easing-reference.test.cjs",
+            "expr-bake.test.cjs",
+            "feedback-2026-08-22.test.cjs",
+            "nemo-bench.test.cjs",
+            "nemo-boundaries-ratchet.test.cjs",
+            "nemo-boundaries.test.cjs",
+            "nemo-browser-runtime.test.cjs",
+            "nemo-build-job.test.cjs",
+            "nemo-build-runtime.test.cjs",
+            "nemo-ci.test.cjs",
+            "nemo-coverage-job.test.cjs",
+            "nemo-desktop-harness.test.cjs",
+            "nemo-desktop-job.test.cjs",
+            "nemo-exclusion-provenance.test.cjs",
+            "nemo-fixtures.test.cjs",
+            "nemo-inventory-records.test.cjs",
+            "nemo-inventory-swatch.test.cjs",
+            "nemo-inventory.test.cjs",
+            "nemo-isolation.test.cjs",
+            "nemo-mcp-adapter.test.cjs",
+            "nemo-mcp-boundaries.test.cjs",
+            "nemo-mcp-bundle.test.cjs",
+            "nemo-native-ffmpeg-preflight.test.cjs",
+            "nemo-native-runtime.test.cjs",
+            "nemo-third-party-notices.test.cjs",
+            "performance-regressions.test.cjs",
+            "project-entry-repaint.test.cjs",
+            "project-open.test.cjs",
+            "text-selector.test.cjs",
+            "animation/boundaries.test.cjs",
+            "animation/curve.test.cjs",
+            "animation/motion-facade.test.cjs"
+          ]
+        }
+      },
+      "caseSignature": null,
+      "evidence": {
+        "runId": "20260909T154312Z-ded641b",
+        "command": "verify",
+        "profile": "quick",
+        "finishedAt": "2026-09-09T15:44:17.500Z",
+        "path": "reports/20260909T154312Z-ded641b/receipt.json",
+        "sha256": "d1aae6928fb9fd769e4ab74c464964fd640748b9bf61ce1c0d10f65a4ccf90b9",
+        "source": "ded641bd763379f36d629bf1686fcce8a6137a66",
+        "sourceDirty": false
+      },
+      "measuredDirty": false,
+      "carriedOver": false,
+      "carriedOverNote": null
+    }
+  ],
+  "summary": {
+    "total": 12,
+    "counts": {
+      "pass": 9,
+      "fail": 1,
+      "blocked": 2
+    },
+    "carriedOver": [],
+    "knownNonPass": [
+      {
+        "job": "build:desktop",
+        "status": "fail",
+        "reason": "bundle-ffmpeg-dylibs.py failed (1)"
+      },
+      {
+        "job": "test:desktop",
+        "status": "blocked",
+        "reason": "no packaged app found (src-tauri/target/*/release/bundle/macos/Nemo.app or NEMO_DESKTOP_APP)"
+      },
+      {
+        "job": "test:rust-tauri",
+        "status": "blocked",
+        "reason": "native fixture sidecar unavailable (bundled): src-tauri/binaries/ffmpeg-aarch64-apple-darwin: exit null; SIGABRT; missing FFmpeg version banner; dyld[41600]: Library not loaded: /opt/homebrew/opt/libvpx/lib/libvpx.12.dylib |   Referenced from: <249CE339-765B-3B08-A2C1-C44CE163B729> <repo>/src-tauri/binaries/ffmpeg-aarch64-apple-darwin |   Reason: tried: '/opt/homebrew/opt/libvpx/lib/libvpx.12.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/libvpx/lib/libvpx.12.dylib' (no such file), '/opt/homebrew/opt/libvpx/lib/libvpx.12.dylib' (no such file), '/opt/homebrew/Cellar/libvpx/1.15.2/lib/libvpx.12.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/libvpx/1.15.2/lib/libvpx.12.dylib' (no such file), '/opt/homebrew/Cellar/libvpx/1.15.2/lib/libvpx.12.dylib' (no such file)"
+      }
+    ]
+  }
+}

--- a/scripts/nemo/baseline.cjs
+++ b/scripts/nemo/baseline.cjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+'use strict';
+// P02 — adopt and check the current-state comparison manifest.
+//
+//   node scripts/nemo/baseline.cjs --adopt [--from <runId|path>,...] [--note "..."]
+//                                          [--ignore-worktree]
+//   node scripts/nemo/baseline.cjs --check [--from <runId|path>] [--json]
+//
+// --ignore-worktree records the committed tree only, for adopting a baseline
+// in the same change that introduces it. It is recorded, not hidden:
+// `references.source.worktreeIgnored` stays in the manifest.
+//
+// --adopt records the selected current state as the comparison baseline in
+// engineering/inventory/baseline-manifest.json. --check classifies a receipt
+// against it: new regression vs unchanged known failure vs environment
+// mismatch, with every immutable reference verified first.
+//
+// Exit: 0 nothing to answer for, 1 a blocking verdict (new/changed/newly
+// observed failure), 2 inconclusive (stale reference, environment mismatch,
+// or an uncomparable job).
+const fs = require('node:fs');
+const path = require('node:path');
+const { ROOT, exists, readJson } = require('./lib/util.cjs');
+const baseline = require('./lib/baseline.cjs');
+
+function reportsDir() {
+  return process.env.NEMO_REPORT_DIR || path.join(ROOT, 'reports');
+}
+
+// Accepts a runId, a report directory, or a direct path to a receipt.json.
+function resolveReceipt(ref) {
+  const candidates = [ref, path.join(ref, 'receipt.json'), path.join(reportsDir(), ref, 'receipt.json'), path.join(ROOT, ref), path.join(ROOT, ref, 'receipt.json')];
+  for (const c of candidates) {
+    if (exists(c) && fs.statSync(c).isFile()) return path.resolve(c);
+  }
+  throw new Error(`no receipt found for "${ref}"`);
+}
+
+function latestReceipt() {
+  const dir = reportsDir();
+  if (!exists(dir)) throw new Error(`no reports directory at ${path.relative(ROOT, dir)} — run \`npm run verify\` first`);
+  const runs = fs.readdirSync(dir).filter((d) => exists(path.join(dir, d, 'receipt.json'))).sort();
+  if (!runs.length) throw new Error('no receipts found; run `npm run verify` first');
+  return path.join(dir, runs[runs.length - 1], 'receipt.json');
+}
+
+function parse(argv) {
+  const out = { adopt: false, check: false, from: null, note: null, json: false, manifest: null, out: null, ignoreWorktree: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--adopt') out.adopt = true;
+    else if (a === '--check') out.check = true;
+    else if (a === '--json') out.json = true;
+    else if (a === '--ignore-worktree') out.ignoreWorktree = true;
+    else if (a === '--from') out.from = argv[++i];
+    else if (a.startsWith('--from=')) out.from = a.slice(7);
+    else if (a === '--note') out.note = argv[++i];
+    else if (a.startsWith('--note=')) out.note = a.slice(7);
+    else if (a === '--manifest') out.manifest = argv[++i];
+    else if (a.startsWith('--manifest=')) out.manifest = a.slice(11);
+    else if (a === '--out') out.out = argv[++i];
+    else if (a.startsWith('--out=')) out.out = a.slice(6);
+    else { console.error(`unknown argument "${a}"`); process.exit(64); }
+  }
+  return out;
+}
+
+function main() {
+  const args = parse(process.argv.slice(2));
+  if (args.adopt === args.check) {
+    console.error('usage: baseline.cjs --adopt [--from a,b] [--note "..."] | --check [--from run] [--json]');
+    process.exit(64);
+  }
+
+  if (args.adopt) {
+    const refs = args.from ? args.from.split(',').map((s) => s.trim()).filter(Boolean) : [latestReceipt()];
+    const inputs = refs.map((r) => {
+      const receiptPath = resolveReceipt(r);
+      return { receipt: readJson(receiptPath), receiptPath };
+    });
+    const manifest = baseline.adopt(inputs, {
+      note: args.note,
+      references: baseline.currentReferences({ ignoreWorktree: args.ignoreWorktree }),
+    });
+    const target = args.out ? path.resolve(args.out) : baseline.MANIFEST_PATH;
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, JSON.stringify(manifest, null, 2) + '\n');
+    if (args.json) { process.stdout.write(JSON.stringify(manifest, null, 2) + '\n'); return 0; }
+    console.log(`adopted ${manifest.entries.length} entr${manifest.entries.length === 1 ? 'y' : 'ies'} at ${String(manifest.references.source.head).slice(0, 12)} -> ${path.relative(ROOT, target)}`);
+    for (const e of manifest.entries) {
+      console.log(`  ${e.status.padEnd(8)} ${e.job.padEnd(18)} ${e.carriedOver ? '[carried over] ' : ''}${e.case.reason || ''}`);
+    }
+    const carried = manifest.summary.carriedOver;
+    if (carried.length) console.log(`\n${carried.length} entr${carried.length === 1 ? 'y' : 'ies'} carried over from another source: ${carried.join(', ')}`);
+    return 0;
+  }
+
+  const manifest = baseline.loadManifest(args.manifest ? path.resolve(args.manifest) : null);
+  const receiptPath = args.from ? resolveReceipt(args.from) : latestReceipt();
+  const receipt = readJson(receiptPath);
+  const cmp = baseline.compare(manifest, receipt, { receiptPath });
+  process.stdout.write(args.json ? JSON.stringify(cmp, null, 2) + '\n' : baseline.renderComparison(cmp));
+  return cmp.summary.exitCode;
+}
+
+try {
+  process.exit(main());
+} catch (e) {
+  console.error(String((e && e.message) || e));
+  process.exit(64);
+}

--- a/scripts/nemo/baseline.test.cjs
+++ b/scripts/nemo/baseline.test.cjs
@@ -1,0 +1,325 @@
+'use strict';
+// Regressions for the P02 current-state comparison manifest
+// (scripts/nemo/lib/baseline.cjs + scripts/nemo/baseline.cjs).
+// Included in `npm test` / `verify` through tests/nemo-baseline.test.cjs.
+// Run directly:  node --test scripts/nemo/baseline.test.cjs
+//
+// The property under test is the one P02 exists for: a later run must be
+// classifiable as a NEW regression, an UNCHANGED known failure, or an
+// environment mismatch — and a result whose immutable references no longer
+// match the tree must be reported rather than silently reused.
+//
+// Everything here is synthetic. Real receipts are host- and clock-dependent,
+// so the classification table is exercised against constructed receipts; only
+// the CLI round trip touches the filesystem, in a temp directory.
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const baseline = require('./lib/baseline.cjs');
+const { VERDICT } = baseline;
+const ROOT = path.resolve(__dirname, '..', '..');
+
+// --- synthetic fixtures ----------------------------------------------------
+
+const REFS = {
+  source: { head: 'a'.repeat(40), branch: 'main', commitDate: '2026-09-09T00:00:00Z', dirty: false, dirtyDigest: null },
+  fixtures: { path: 'tests/fixtures/manifest.json', present: true, sha256: 'f'.repeat(64), formatVersion: 13 },
+  artifacts: {
+    geometryWasm: { path: 'src/wasm/geometry_wasm_bg.wasm', present: true, bytes: 10, sha256: '1'.repeat(64) },
+    ffmpegSidecar: { path: 'src-tauri/binaries/ffmpeg-x', present: true, bytes: 20, sha256: '2'.repeat(64) },
+  },
+  build: { packageVersion: '0.7.0', tauriVersion: '0.7.0', indexHtmlTitleVersion: '0.7.0', hostTriple: 'aarch64-apple-darwin' },
+};
+const PLATFORM = { os: 'darwin', osRelease: '25.6.0', arch: 'arm64', cpuModel: 'Apple M3 Ultra', cpuCount: 32, node: 'v22.17.1' };
+
+function job(name, status, extra = {}) {
+  return Object.assign({ name, required: true, status, reason: null, exitCode: null, artifacts: [], limitations: [], details: null }, extra);
+}
+
+function receipt(jobs, over = {}) {
+  return Object.assign({
+    schema: 'nemo.receipt/1', runId: 'run-' + jobs.map((j) => j.status).join(''), command: 'verify', profile: 'quick',
+    startedAt: '2026-09-09T00:00:00Z', finishedAt: '2026-09-09T00:01:00Z',
+    source: { head: REFS.source.head, dirty: false }, jobs,
+  }, over);
+}
+
+function adoptOf(jobs, over = {}) {
+  return baseline.adopt([{ receipt: receipt(jobs, over), receiptPath: null }], { references: REFS, platform: PLATFORM, now: '2026-09-09T00:02:00Z' });
+}
+
+function compareOf(manifest, jobs, opts = {}) {
+  return baseline.compare(manifest, receipt(jobs), Object.assign({ references: REFS, platform: PLATFORM, now: '2026-09-09T00:03:00Z' }, opts));
+}
+
+// --- the three classifications P02 names -----------------------------------
+
+test('pass -> fail is a new regression, and it blocks', () => {
+  const m = adoptOf([job('test:unit', 'pass')]);
+  const c = compareOf(m, [job('test:unit', 'fail', { reason: '3 tests failed' })]);
+  assert.equal(c.results[0].verdict, VERDICT.NEW_REGRESSION);
+  assert.equal(c.summary.overall, 'blocking');
+  assert.equal(c.summary.exitCode, 1);
+});
+
+test('the same failing case twice is an unchanged known failure, and does not block', () => {
+  const failing = job('test:rust', 'fail', { reason: 'indexed_random_seek_cost_is_flat_and_small failed at p95 36.2 ms' });
+  const m = adoptOf([failing]);
+  const c = compareOf(m, [failing]);
+  assert.equal(c.results[0].verdict, VERDICT.UNCHANGED_KNOWN_FAILURE);
+  assert.equal(c.summary.overall, 'ok');
+  assert.equal(c.summary.exitCode, 0);
+});
+
+test('a different failure in the same job does not inherit the known-failure acceptance', () => {
+  const m = adoptOf([job('test:rust', 'fail', { reason: 'seek timing assertion' })]);
+  const c = compareOf(m, [job('test:rust', 'fail', { reason: 'segmentation fault in decoder' })]);
+  assert.equal(c.results[0].verdict, VERDICT.CHANGED_KNOWN_FAILURE);
+  assert.equal(c.summary.overall, 'blocking');
+});
+
+test('same reason but different details is still a changed failure', () => {
+  const m = adoptOf([job('test:coverage', 'fail', { reason: 'coverage below threshold', details: { file: 'a.js' } })]);
+  const c = compareOf(m, [job('test:coverage', 'fail', { reason: 'coverage below threshold', details: { file: 'b.js' } })]);
+  assert.equal(c.results[0].verdict, VERDICT.CHANGED_KNOWN_FAILURE);
+});
+
+test('pass -> blocked is an environment mismatch, not a pass and not a failure', () => {
+  const m = adoptOf([job('test:browser', 'pass')]);
+  const c = compareOf(m, [job('test:browser', 'blocked', { reason: 'playwright not installed' })]);
+  assert.equal(c.results[0].verdict, VERDICT.ENVIRONMENT_MISMATCH);
+  assert.equal(c.summary.overall, 'inconclusive');
+  assert.equal(c.summary.exitCode, 2);
+});
+
+// --- blocked / not-run are never rounded up --------------------------------
+
+test('blocked -> blocked stays blocked and is never reported as a pass', () => {
+  const b = job('test:desktop', 'blocked', { reason: 'no packaged app found' });
+  const c = compareOf(adoptOf([b]), [b]);
+  assert.equal(c.results[0].verdict, VERDICT.UNCHANGED_BLOCKED);
+  assert.notEqual(c.results[0].verdict, VERDICT.PASS);
+  assert.equal(c.summary.overall, 'ok'); // known and unchanged, but still not a pass
+  assert.equal(c.results[0].current, 'blocked');
+});
+
+test('a failure first observed while blocked is not called a regression against a pass it never had', () => {
+  const m = adoptOf([job('build:desktop', 'blocked', { reason: 'no rust toolchain' })]);
+  const c = compareOf(m, [job('build:desktop', 'fail', { reason: 'bundle-ffmpeg-dylibs.py failed (1)' })]);
+  assert.equal(c.results[0].verdict, VERDICT.NEWLY_OBSERVED_FAILURE);
+  assert.equal(c.summary.overall, 'blocking');
+});
+
+test('not-run -> pass is reported as resolved rather than hidden', () => {
+  const c = compareOf(adoptOf([job('test:integration', 'not-run', { reason: 'no suite in this candidate' })]), [job('test:integration', 'pass')]);
+  assert.equal(c.results[0].verdict, VERDICT.RESOLVED);
+  assert.equal(c.summary.overall, 'ok');
+});
+
+// --- references: reported, never silently reused ---------------------------
+
+test('a changed source commit is reported as a stale reference', () => {
+  const m = adoptOf([job('test:unit', 'pass')]);
+  const moved = JSON.parse(JSON.stringify(REFS));
+  moved.source.head = 'b'.repeat(40);
+  const c = baseline.compare(m, receipt([job('test:unit', 'pass')]), { references: moved, platform: PLATFORM });
+  assert.equal(c.references.stale, true);
+  assert.ok(c.summary.staleReferences.includes('source.head'));
+  assert.equal(c.summary.overall, 'inconclusive'); // every job passed; the reference is still reported
+});
+
+test('a changed fixture corpus is reported, so fixture-dependent results are not transferable', () => {
+  const m = adoptOf([job('test:unit', 'pass')]);
+  const moved = JSON.parse(JSON.stringify(REFS));
+  moved.fixtures.sha256 = 'e'.repeat(64);
+  const c = baseline.compare(m, receipt([job('test:unit', 'pass')]), { references: moved, platform: PLATFORM });
+  assert.ok(c.summary.staleReferences.includes('fixtures.manifest'));
+  assert.equal(c.summary.overall, 'inconclusive');
+});
+
+test('a missing artifact is reported as missing, not as an unchanged reference', () => {
+  const m = adoptOf([job('test:unit', 'pass')]);
+  const gone = JSON.parse(JSON.stringify(REFS));
+  gone.artifacts.ffmpegSidecar = { path: 'src-tauri/binaries/ffmpeg-x', present: false };
+  const c = baseline.compare(m, receipt([job('test:unit', 'pass')]), { references: gone, platform: PLATFORM });
+  const f = c.references.findings.find((x) => x.ref === 'artifacts.ffmpegSidecar');
+  assert.equal(f.kind, 'reference-missing');
+  assert.equal(c.references.stale, true);
+});
+
+test('a differing host is recorded as an environment difference', () => {
+  const m = adoptOf([job('test:unit', 'pass')]);
+  const c = baseline.compare(m, receipt([job('test:unit', 'pass')]), { references: REFS, platform: Object.assign({}, PLATFORM, { arch: 'x64' }) });
+  const f = c.references.findings.find((x) => x.ref === 'platform.arch');
+  assert.equal(f.kind, 'environment-difference');
+  assert.equal(f.expected, 'arm64');
+  assert.equal(f.actual, 'x64');
+});
+
+// --- coverage of the comparison itself -------------------------------------
+
+test('a job with no baseline entry is uncomparable rather than assumed fine', () => {
+  const c = compareOf(adoptOf([job('test:unit', 'pass')]), [job('test:unit', 'pass'), job('test:brandnew', 'pass')]);
+  const r = c.results.find((x) => x.job === 'test:brandnew');
+  assert.equal(r.verdict, VERDICT.UNKNOWN_ENTRY);
+  assert.equal(c.summary.overall, 'inconclusive');
+});
+
+test('a baseline entry the run did not cover is reported as missing, not as passing', () => {
+  const c = compareOf(adoptOf([job('test:unit', 'pass'), job('test:desktop', 'blocked')]), [job('test:unit', 'pass')]);
+  const r = c.results.find((x) => x.job === 'test:desktop');
+  assert.equal(r.verdict, VERDICT.MISSING_ENTRY);
+  assert.equal(r.current, null);
+});
+
+// --- adoption --------------------------------------------------------------
+
+test('adoption keeps the exact case and marks entries measured elsewhere as carried over', () => {
+  const here = receipt([job('test:unit', 'pass')]);
+  const elsewhere = receipt([job('build:desktop', 'fail', { reason: 'bundle-ffmpeg-dylibs.py failed (1)' })], {
+    runId: 'other', source: { head: 'c'.repeat(40), dirty: false },
+  });
+  const m = baseline.adopt([{ receipt: here, receiptPath: null }, { receipt: elsewhere, receiptPath: null }], { references: REFS, platform: PLATFORM });
+  const unit = m.entries.find((e) => e.job === 'test:unit');
+  const desktop = m.entries.find((e) => e.job === 'build:desktop');
+  assert.equal(unit.carriedOver, false);
+  assert.equal(desktop.carriedOver, true);
+  assert.match(desktop.carriedOverNote, /Not re-measured here/);
+  assert.equal(desktop.case.reason, 'bundle-ffmpeg-dylibs.py failed (1)');
+  assert.deepEqual(m.summary.carriedOver, ['build:desktop']);
+  assert.deepEqual(m.summary.knownNonPass.map((e) => e.job), ['build:desktop']);
+});
+
+test('a later receipt supersedes an earlier entry for the same job', () => {
+  const first = receipt([job('test:rust', 'fail', { reason: 'old' })], { runId: 'first' });
+  const second = receipt([job('test:rust', 'pass')], { runId: 'second' });
+  const m = baseline.adopt([{ receipt: first, receiptPath: null }, { receipt: second, receiptPath: null }], { references: REFS, platform: PLATFORM });
+  assert.equal(m.entries.find((e) => e.job === 'test:rust').status, 'pass');
+  assert.equal(m.entries.length, 1);
+});
+
+test('a pass entry carries no case signature, so it can never match a failure', () => {
+  const m = adoptOf([job('test:unit', 'pass')]);
+  assert.equal(m.entries[0].caseSignature, null);
+});
+
+// --- the committed manifest and the CLI ------------------------------------
+
+test('the committed manifest is valid, current and self-consistent', () => {
+  const m = baseline.loadManifest();
+  assert.equal(m.schema, baseline.SCHEMA);
+  assert.ok(m.entries.length > 0, 'manifest has entries');
+  assert.equal(m.entries.length, m.summary.total);
+
+  // Every entry names a real job, and every non-pass entry states its case.
+  const { JOBS } = require('./lib/jobs.cjs');
+  for (const e of m.entries) {
+    assert.ok(JOBS[e.job], `manifest entry "${e.job}" is a real job`);
+    assert.ok(['pass', 'fail', 'blocked', 'not-run'].includes(e.status), `${e.job} has a receipt status`);
+    if (e.status !== 'pass') assert.ok(e.case && e.case.reason, `${e.job} is ${e.status} and must state its exact case`);
+    assert.ok(e.evidence && e.evidence.runId, `${e.job} names the receipt it came from`);
+  }
+
+  // The manifest describes THIS tree: its recorded source must be an ancestor
+  // of, or equal to, what is checked out. A stale committed manifest is the
+  // failure mode this whole task exists to prevent.
+  const head = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: ROOT, encoding: 'utf8' });
+  if (head.status === 0) {
+    const merge = spawnSync('git', ['merge-base', '--is-ancestor', m.references.source.head, head.stdout.trim()], { cwd: ROOT, encoding: 'utf8' });
+    assert.equal(merge.status, 0, `manifest source ${m.references.source.head.slice(0, 12)} must be an ancestor of HEAD; re-adopt after moving the baseline`);
+  }
+});
+
+test('the committed manifest quotes no absolute machine path', () => {
+  // Receipts are gitignored and may hold absolute paths; the manifest is
+  // committed source. A checkout path in here would leak a private machine
+  // path and make the case signature machine-specific.
+  const raw = fs.readFileSync(baseline.MANIFEST_PATH, 'utf8');
+  assert.ok(!raw.includes(os.homedir()), 'manifest must not contain the home directory');
+  assert.ok(!raw.includes(ROOT), 'manifest must not contain the checkout path');
+  for (const m of raw.matchAll(/"(?:\/Users|\/home|\/private\/var\/folders)\/[^"]*"/g)) {
+    assert.fail(`manifest contains an absolute machine path: ${m[0].slice(0, 80)}`);
+  }
+});
+
+test('redaction survives a round trip and keeps the case comparable', () => {
+  const abs = path.join(ROOT, 'src-tauri', 'binaries', 'ffmpeg-x');
+  const c = baseline.exactCase(job('test:rust-tauri', 'blocked', { reason: `sidecar unavailable: ${abs}`, details: { path: abs } }));
+  assert.equal(c.reason, 'sidecar unavailable: <repo>/src-tauri/binaries/ffmpeg-x');
+  assert.equal(c.details.path, '<repo>/src-tauri/binaries/ffmpeg-x');
+  // The same job observed from a different checkout must produce the same
+  // signature, otherwise every machine would report a changed known failure.
+  assert.equal(baseline.caseSignature(c), baseline.caseSignature(baseline.exactCase(
+    job('test:rust-tauri', 'blocked', { reason: `sidecar unavailable: ${abs}`, details: { path: abs } }))));
+});
+
+test('the manifest covers every job the full verify profile runs', () => {
+  const { PROFILES } = require('./lib/jobs.cjs');
+  const m = baseline.loadManifest();
+  const covered = new Set(m.entries.map((e) => e.job));
+  const missing = PROFILES.full.filter((j) => !covered.has(j));
+  assert.deepEqual(missing, [], 'every full-profile job has a baseline entry');
+});
+
+test('--check round trips through the CLI and reports a synthetic regression', (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-baseline-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const reports = path.join(dir, 'reports');
+  const runDir = path.join(reports, '20260909T000000Z-test');
+  fs.mkdirSync(runDir, { recursive: true });
+
+  // A receipt that fails a job the committed manifest records as passing.
+  const m = baseline.loadManifest();
+  const passing = m.entries.find((e) => e.status === 'pass');
+  assert.ok(passing, 'committed manifest has at least one passing entry to regress');
+  fs.writeFileSync(path.join(runDir, 'receipt.json'), JSON.stringify(receipt([
+    job(passing.job, 'fail', { reason: 'synthetic failure injected by the P02 regression test' }),
+  ]), null, 2));
+
+  const r = spawnSync(process.execPath, [path.join(__dirname, 'baseline.cjs'), '--check', '--from', runDir, '--json'], {
+    cwd: ROOT, encoding: 'utf8', env: Object.assign({}, process.env, { NEMO_REPORT_DIR: reports }),
+  });
+  assert.equal(r.status, 1, 'a new regression exits 1');
+  const cmp = JSON.parse(r.stdout);
+  const hit = cmp.results.find((x) => x.job === passing.job);
+  assert.equal(hit.verdict, VERDICT.NEW_REGRESSION);
+  assert.ok(cmp.summary.blocking.some((b) => b.job === passing.job));
+});
+
+test('--check exits 0 when the run reproduces the adopted state', (t) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-baseline-ok-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const reports = path.join(dir, 'reports');
+  const runDir = path.join(reports, '20260909T000001Z-test');
+  fs.mkdirSync(runDir, { recursive: true });
+
+  // Replay the manifest's own entries as a receipt: same statuses, same cases.
+  const m = baseline.loadManifest();
+  const jobs = m.entries.map((e) => job(e.job, e.status, {
+    reason: e.case.reason, exitCode: e.case.exitCode, limitations: e.case.limitations, details: e.case.details,
+  }));
+  fs.writeFileSync(path.join(runDir, 'receipt.json'), JSON.stringify(receipt(jobs), null, 2));
+
+  const r = spawnSync(process.execPath, [path.join(__dirname, 'baseline.cjs'), '--check', '--from', runDir, '--json'], {
+    cwd: ROOT, encoding: 'utf8', env: Object.assign({}, process.env, { NEMO_REPORT_DIR: reports }),
+  });
+  const cmp = JSON.parse(r.stdout);
+  assert.deepEqual(cmp.summary.blocking, [], 'replaying the adopted state produces no blocking verdict');
+  assert.deepEqual(cmp.summary.inconclusive, [], 'every adopted entry is comparable');
+  assert.notEqual(r.status, 1, 'replaying the adopted state is never a failure');
+
+  // Exit is then decided by the references alone: 0 when the tree still
+  // matches what was adopted, 2 when it does not. Which one applies here
+  // depends on the checkout the suite runs in (a dirty worktree, or a commit
+  // later than the adopted one, both legitimately report stale), so assert
+  // the implication rather than a fixed code.
+  assert.equal(r.status, cmp.references.stale ? 2 : 0);
+  if (cmp.references.stale) {
+    assert.ok(cmp.summary.staleReferences.length > 0, 'a stale result names which reference moved');
+  }
+});

--- a/scripts/nemo/ci.test.cjs
+++ b/scripts/nemo/ci.test.cjs
@@ -71,8 +71,8 @@ test('tooling coverage profiles every current scripts/nemo CommonJS source', () 
   const profile = JSON.parse(fs.readFileSync(path.join(ROOT, ci.PROFILE), 'utf8'));
   const result = ci.toolingCoverage(profile, ROOT);
   assert.equal(result.ok, true);
-  assert.equal(result.sourcePathCount, 52);
-  assert.equal(result.declaredPathCount, 52);
+  assert.equal(result.sourcePathCount, 55);
+  assert.equal(result.declaredPathCount, 55);
   const incomplete = structuredClone(profile);
   incomplete.modules = incomplete.modules.filter((module) => module.id !== 'nemo.lib.boundariesApplication');
   const rejected = ci.toolingCoverage(incomplete, ROOT);

--- a/scripts/nemo/lib/baseline.cjs
+++ b/scripts/nemo/lib/baseline.cjs
@@ -1,0 +1,384 @@
+'use strict';
+// P02 — the current-state comparison manifest (schema `nemo.baseline-manifest/1`).
+//
+// A receipt (`nemo.receipt/1`) records what ONE run observed. It cannot say
+// whether a failure is new. This module adds the missing half: it adopts a
+// selected current state as the comparison baseline, and classifies a later
+// receipt against it.
+//
+// Two rules drive every decision here:
+//
+//   1. A result is quoted only together with the bytes it was measured on.
+//      Each entry carries its own immutable source/fixture/artifact references
+//      plus the sha256 of the receipt it came from. If a reference is missing
+//      or no longer matches, the entry is REPORTED as stale — never silently
+//      reused as if it still described the current tree.
+//   2. `blocked` and `not-run` are never rounded up to `pass`. A native,
+//      packaged-desktop or browser check that could not genuinely run keeps
+//      its own disposition and its exact reason.
+const path = require('node:path');
+const { ROOT, sha256File, exists, readJson, nowIso, fileInfo, sha256Text } = require('./util.cjs');
+const identity = require('./identity.cjs');
+
+const SCHEMA = 'nemo.baseline-manifest/1';
+const MANIFEST_PATH = path.join(ROOT, 'engineering', 'inventory', 'baseline-manifest.json');
+const FIXTURE_MANIFEST = path.join(ROOT, 'tests', 'fixtures', 'manifest.json');
+
+// Comparison verdicts. The three P02 requires are `new-regression`,
+// `unchanged-known-failure` and `environment-mismatch`; the rest exist so that
+// none of those three has to absorb a case it does not actually describe.
+const VERDICT = {
+  PASS: 'pass',
+  RESOLVED: 'resolved',
+  UNCHANGED_KNOWN_FAILURE: 'unchanged-known-failure',
+  CHANGED_KNOWN_FAILURE: 'changed-known-failure',
+  NEW_REGRESSION: 'new-regression',
+  NEWLY_OBSERVED_FAILURE: 'newly-observed-failure',
+  ENVIRONMENT_MISMATCH: 'environment-mismatch',
+  UNCHANGED_BLOCKED: 'unchanged-blocked',
+  UNCHANGED_NOT_RUN: 'unchanged-not-run',
+  UNKNOWN_ENTRY: 'unknown-entry',
+  MISSING_ENTRY: 'missing-entry',
+};
+
+// Verdicts that must stop an integration. `changed-known-failure` is here on
+// purpose: a failure that moved to a different case is a different failure, and
+// letting it inherit the old one's acceptance is how a regression hides.
+const BLOCKING = new Set([VERDICT.NEW_REGRESSION, VERDICT.CHANGED_KNOWN_FAILURE, VERDICT.NEWLY_OBSERVED_FAILURE]);
+// Verdicts that mean "this run cannot answer the question", not "this run is bad".
+const INCONCLUSIVE = new Set([VERDICT.ENVIRONMENT_MISMATCH, VERDICT.UNKNOWN_ENTRY, VERDICT.MISSING_ENTRY]);
+
+const EXIT = { ok: 0, blocking: 1, inconclusive: 2 };
+
+// ---------------------------------------------------------------------------
+// References: the immutable bytes an entry is allowed to be quoted against.
+// ---------------------------------------------------------------------------
+
+// `ignoreWorktree` records the committed tree only. It exists for adopting a
+// baseline in the same change that introduces it: the manifest must describe
+// the commit it ships in, not the working copy that produced it. It is never
+// silent — `worktreeIgnored` stays in the manifest, so a reader can see that
+// uncommitted changes were present and excluded on purpose.
+function currentReferences(opts = {}) {
+  const build = identity.buildIdentity();
+  return {
+    source: (() => {
+      const s = identity.sourceIdentity();
+      if (opts.ignoreWorktree) {
+        return { head: s.head, branch: s.branch, commitDate: s.commitDate, dirty: false, dirtyDigest: null, worktreeIgnored: true, worktreeWasDirty: s.dirty, worktreeDigest: s.dirtyDigest };
+      }
+      return { head: s.head, branch: s.branch, commitDate: s.commitDate, dirty: s.dirty, dirtyDigest: s.dirtyDigest };
+    })(),
+    fixtures: exists(FIXTURE_MANIFEST)
+      ? { path: path.relative(ROOT, FIXTURE_MANIFEST), present: true, sha256: sha256File(FIXTURE_MANIFEST), formatVersion: readJson(FIXTURE_MANIFEST).formatVersion ?? null }
+      : { path: path.relative(ROOT, FIXTURE_MANIFEST), present: false, sha256: null, formatVersion: null },
+    artifacts: {
+      geometryWasm: build.artifacts.geometryWasm,
+      vectorizeWasm: build.artifacts.vectorizeWasm,
+      ffmpegSidecar: build.artifacts.ffmpegSidecar,
+    },
+    build: {
+      packageVersion: build.packageVersion,
+      tauriVersion: build.tauriVersion,
+      indexHtmlTitleVersion: build.indexHtmlTitleVersion,
+      hostTriple: build.hostTriple,
+    },
+  };
+}
+
+// Compare a recorded reference block against a current one. Anything that
+// cannot be proven identical is returned as a finding; nothing is dropped.
+function diffReferences(recorded, current) {
+  const findings = [];
+  const add = (kind, ref, expected, actual, note) => findings.push({ kind, ref, expected: expected ?? null, actual: actual ?? null, note: note || null });
+
+  if (recorded.source.head !== current.source.head) {
+    add('reference-mismatch', 'source.head', recorded.source.head, current.source.head,
+      'Results adopted at a different commit do not describe this tree.');
+  }
+  if (recorded.source.dirty || current.source.dirty) {
+    add(recorded.source.dirtyDigest === current.source.dirtyDigest ? 'reference-dirty' : 'reference-mismatch',
+      'source.dirtyDigest', recorded.source.dirtyDigest, current.source.dirtyDigest,
+      'Uncommitted changes are part of what was measured.');
+  }
+
+  if (!current.fixtures.present) add('reference-missing', 'fixtures.manifest', recorded.fixtures.sha256, null, 'Fixture manifest absent from this checkout.');
+  else if (recorded.fixtures.sha256 !== current.fixtures.sha256) {
+    add('reference-mismatch', 'fixtures.manifest', recorded.fixtures.sha256, current.fixtures.sha256,
+      'Fixture corpus changed; fixture-dependent results are not transferable.');
+  }
+
+  for (const key of Object.keys(recorded.artifacts || {})) {
+    const r = recorded.artifacts[key] || {};
+    const c = (current.artifacts || {})[key] || {};
+    if (r.present && !c.present) add('reference-missing', 'artifacts.' + key, r.sha256, null, 'Artifact recorded in the baseline is absent here.');
+    else if (r.present && c.present && r.sha256 !== c.sha256) add('reference-mismatch', 'artifacts.' + key, r.sha256, c.sha256, 'Artifact bytes differ.');
+    else if (!r.present && c.present) add('reference-added', 'artifacts.' + key, null, c.sha256, 'Artifact absent when the baseline was adopted, present now.');
+  }
+  return findings;
+}
+
+// Environment differences do not invalidate a result by themselves, but they
+// decide whether a status change is a code regression or a host difference.
+function diffEnvironment(recorded, current) {
+  const findings = [];
+  for (const key of ['os', 'arch', 'node']) {
+    if (recorded[key] !== current[key]) findings.push({ kind: 'environment-difference', ref: 'platform.' + key, expected: recorded[key], actual: current[key], note: null });
+  }
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// Adoption
+// ---------------------------------------------------------------------------
+
+// Receipts live under the gitignored reports/ directory and may quote absolute
+// paths; the manifest is committed source and must not. Checkout and home
+// directory are replaced by stable placeholders, which also makes a case
+// signature comparable across machines and worktrees.
+const HOME = require('node:os').homedir();
+function redact(value) {
+  if (typeof value === 'string') {
+    let s = value.split(ROOT).join('<repo>');
+    if (HOME && HOME !== '/') s = s.split(HOME).join('<home>');
+    return s;
+  }
+  if (Array.isArray(value)) return value.map(redact);
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const k of Object.keys(value)) out[k] = redact(value[k]);
+    return out;
+  }
+  return value;
+}
+
+// The exact case a non-pass entry is about. Kept verbatim from the receipt
+// (modulo path redaction) so a later run compares against what was actually
+// observed, not a paraphrase.
+function exactCase(job) {
+  return redact({
+    reason: job.reason || null,
+    exitCode: job.exitCode ?? null,
+    limitations: (job.limitations || []).slice(),
+    details: job.details === undefined ? null : job.details,
+  });
+}
+
+// A stable signature for "is this the same failure?". Reason text is the
+// receipt's own identification of the case; details are included because two
+// runs can share a reason string while failing different specifics.
+function caseSignature(entryCase) {
+  if (!entryCase) return null;
+  return sha256Text(JSON.stringify({ reason: entryCase.reason ?? null, details: entryCase.details ?? null }));
+}
+
+function receiptRef(receipt, receiptPath) {
+  return {
+    runId: receipt.runId,
+    command: receipt.command,
+    profile: receipt.profile || null,
+    finishedAt: receipt.finishedAt || null,
+    path: receiptPath ? path.relative(ROOT, receiptPath) : null,
+    sha256: receiptPath && exists(receiptPath) ? sha256File(receiptPath) : null,
+    source: receipt.source ? receipt.source.head : null,
+    sourceDirty: receipt.source ? !!receipt.source.dirty : null,
+  };
+}
+
+// Build the manifest from one or more receipts. Later receipts win for a job
+// they both cover, so a targeted re-run can supersede an entry without
+// re-running everything (P02: reuse equivalent prior receipts).
+//
+// A receipt taken at a different source than the adopted one is NOT rejected —
+// it is recorded with `carriedOver: true` and its own mismatch findings, so the
+// entry stays usable while never pretending to have been measured here.
+function adopt(inputs, opts = {}) {
+  const references = opts.references || currentReferences();
+  const platform = opts.platform || identity.platformIdentity();
+  const entries = new Map();
+  const sources = [];
+
+  for (const { receipt, receiptPath } of inputs) {
+    if (!receipt || !Array.isArray(receipt.jobs)) continue;
+    const ref = receiptRef(receipt, receiptPath);
+    sources.push(ref);
+    // With `ignoreWorktree` the adopted reference deliberately describes the
+    // commit, so a receipt measured on the same commit with uncommitted work
+    // present is still "here" — but the entry keeps `measuredDirty` so the
+    // reader can see it.
+    const refDirty = references.source.worktreeIgnored ? null : !!references.source.dirty;
+    const sameSource = !!receipt.source && receipt.source.head === references.source.head
+      && (refDirty === null || !!receipt.source.dirty === refDirty);
+    for (const job of receipt.jobs) {
+      const c = exactCase(job);
+      entries.set(job.name, {
+        job: job.name,
+        required: !!job.required,
+        status: job.status,
+        case: c,
+        caseSignature: job.status === 'pass' ? null : caseSignature(c),
+        evidence: ref,
+        measuredDirty: !!(receipt.source && receipt.source.dirty),
+        carriedOver: !sameSource,
+        carriedOverNote: sameSource ? null
+          : `Measured at ${(ref.source || 'unknown').slice(0, 12)}${ref.sourceDirty ? ' (dirty)' : ''}, adopted at ${(references.source.head || 'unknown').slice(0, 12)}. Not re-measured here.`,
+      });
+    }
+  }
+
+  const ordered = Array.from(entries.values()).sort((a, b) => a.job.localeCompare(b.job));
+  const counts = {};
+  for (const e of ordered) counts[e.status] = (counts[e.status] || 0) + 1;
+
+  return {
+    schema: SCHEMA,
+    adoptedAt: opts.now || nowIso(),
+    task: opts.task || 'P02 / #1004',
+    note: opts.note || null,
+    references,
+    platform: { os: platform.os, osRelease: platform.osRelease, arch: platform.arch, cpuModel: platform.cpuModel, cpuCount: platform.cpuCount, node: platform.node },
+    receipts: sources,
+    entries: ordered,
+    summary: {
+      total: ordered.length,
+      counts,
+      carriedOver: ordered.filter((e) => e.carriedOver).map((e) => e.job),
+      knownNonPass: ordered.filter((e) => e.status !== 'pass').map((e) => ({ job: e.job, status: e.status, reason: e.case.reason })),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+function classify(entry, job) {
+  if (!entry) return { verdict: VERDICT.UNKNOWN_ENTRY, note: 'No baseline entry for this job; it cannot be judged new or known.' };
+  if (!job) return { verdict: VERDICT.MISSING_ENTRY, note: 'Baseline entry not covered by this run.' };
+
+  const b = entry.status, c = job.status;
+
+  if (c === 'pass') {
+    return b === 'pass'
+      ? { verdict: VERDICT.PASS, note: null }
+      : { verdict: VERDICT.RESOLVED, note: `Was ${b} in the baseline.` };
+  }
+
+  if (c === 'fail') {
+    if (b === 'fail') {
+      const same = entry.caseSignature && entry.caseSignature === caseSignature(exactCase(job));
+      return same
+        ? { verdict: VERDICT.UNCHANGED_KNOWN_FAILURE, note: entry.case.reason || null }
+        : { verdict: VERDICT.CHANGED_KNOWN_FAILURE, note: `Still failing, but not the recorded case. Baseline: ${entry.case.reason || 'n/a'} — now: ${job.reason || 'n/a'}` };
+    }
+    if (b === 'pass') return { verdict: VERDICT.NEW_REGRESSION, note: 'Passed in the baseline.' };
+    return { verdict: VERDICT.NEWLY_OBSERVED_FAILURE, note: `Baseline was ${b}, so this failure was not previously observed.` };
+  }
+
+  // c is blocked or not-run: no result was produced.
+  if (c === b) {
+    return {
+      verdict: c === 'blocked' ? VERDICT.UNCHANGED_BLOCKED : VERDICT.UNCHANGED_NOT_RUN,
+      note: entry.case.reason || null,
+    };
+  }
+  return {
+    verdict: VERDICT.ENVIRONMENT_MISMATCH,
+    note: `Baseline ${b}, this run ${c} — this run produced no result for it (${job.reason || 'no reason recorded'}).`,
+  };
+}
+
+function compare(manifest, receipt, opts = {}) {
+  const current = opts.references || currentReferences();
+  const platform = opts.platform || identity.platformIdentity();
+
+  const referenceFindings = diffReferences(manifest.references, current).concat(diffEnvironment(manifest.platform, platform));
+  const stale = referenceFindings.some((f) => f.kind === 'reference-mismatch' || f.kind === 'reference-missing');
+
+  const byName = new Map(manifest.entries.map((e) => [e.job, e]));
+  const jobs = new Map((receipt.jobs || []).map((j) => [j.name, j]));
+  const results = [];
+
+  for (const job of receipt.jobs || []) {
+    const entry = byName.get(job.name);
+    const { verdict, note } = classify(entry, job);
+    results.push({
+      job: job.name,
+      required: !!job.required,
+      baseline: entry ? entry.status : null,
+      current: job.status,
+      verdict,
+      note,
+      baselineCarriedOver: entry ? !!entry.carriedOver : null,
+      baselineEvidence: entry ? entry.evidence : null,
+      currentReason: job.reason || null,
+    });
+  }
+  for (const entry of manifest.entries) {
+    if (jobs.has(entry.job)) continue;
+    results.push({
+      job: entry.job, required: entry.required, baseline: entry.status, current: null,
+      verdict: VERDICT.MISSING_ENTRY, note: 'Not covered by this run.',
+      baselineCarriedOver: !!entry.carriedOver, baselineEvidence: entry.evidence, currentReason: null,
+    });
+  }
+  results.sort((a, b) => a.job.localeCompare(b.job));
+
+  const counts = {};
+  for (const r of results) counts[r.verdict] = (counts[r.verdict] || 0) + 1;
+  const blocking = results.filter((r) => BLOCKING.has(r.verdict));
+  const inconclusive = results.filter((r) => INCONCLUSIVE.has(r.verdict));
+
+  let overall = 'ok';
+  if (blocking.length) overall = 'blocking';
+  else if (stale || inconclusive.length) overall = 'inconclusive';
+
+  return {
+    schema: 'nemo.baseline-comparison/1',
+    comparedAt: opts.now || nowIso(),
+    manifest: { adoptedAt: manifest.adoptedAt, source: manifest.references.source.head, task: manifest.task || null },
+    receipt: receiptRef(receipt, opts.receiptPath || null),
+    references: { recorded: manifest.references, current, findings: referenceFindings, stale },
+    results,
+    summary: {
+      overall,
+      exitCode: EXIT[overall === 'ok' ? 'ok' : overall === 'blocking' ? 'blocking' : 'inconclusive'],
+      counts,
+      blocking: blocking.map((r) => ({ job: r.job, verdict: r.verdict, note: r.note })),
+      inconclusive: inconclusive.map((r) => ({ job: r.job, verdict: r.verdict, note: r.note })),
+      staleReferences: referenceFindings.filter((f) => f.kind === 'reference-mismatch' || f.kind === 'reference-missing').map((f) => f.ref),
+    },
+  };
+}
+
+function renderComparison(cmp) {
+  const lines = [];
+  const short = (s) => (s ? String(s).slice(0, 12) : 'n/a');
+  lines.push(`baseline ${short(cmp.manifest.source)} (adopted ${cmp.manifest.adoptedAt})  vs  receipt ${cmp.receipt.runId}`);
+  lines.push('');
+  for (const r of cmp.results) {
+    lines.push(`  ${String(r.verdict).padEnd(24)} ${String(r.job).padEnd(18)} ${String(r.baseline ?? '—').padEnd(8)} -> ${String(r.current ?? '—').padEnd(8)} ${r.note || ''}`);
+  }
+  if (cmp.references.findings.length) {
+    lines.push('');
+    lines.push('references:');
+    for (const f of cmp.references.findings) lines.push(`  ${f.kind.padEnd(22)} ${f.ref} expected ${short(f.expected)} actual ${short(f.actual)}${f.note ? ' — ' + f.note : ''}`);
+  }
+  lines.push('');
+  lines.push(`overall ${cmp.summary.overall.toUpperCase()} (exit ${cmp.summary.exitCode})  ` + Object.entries(cmp.summary.counts).map(([k, v]) => `${k} ${v}`).join(', '));
+  return lines.join('\n') + '\n';
+}
+
+function loadManifest(file) {
+  const f = file || MANIFEST_PATH;
+  if (!exists(f)) throw new Error(`no baseline manifest at ${path.relative(ROOT, f)} — adopt one first`);
+  const m = readJson(f);
+  if (m.schema !== SCHEMA) throw new Error(`unexpected manifest schema "${m.schema}" (want ${SCHEMA})`);
+  return m;
+}
+
+module.exports = {
+  SCHEMA, MANIFEST_PATH, VERDICT, BLOCKING, INCONCLUSIVE, EXIT,
+  currentReferences, diffReferences, diffEnvironment,
+  adopt, classify, compare, caseSignature, exactCase, renderComparison, loadManifest, receiptRef,
+};

--- a/tests/nemo-baseline.test.cjs
+++ b/tests/nemo-baseline.test.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+// Normal-discovery entry (tests/*.test.cjs) for the P02 current-state
+// comparison manifest regressions, which live next to the tool.
+require('../scripts/nemo/baseline.test.cjs');


### PR DESCRIPTION
Closes the P02 outcome on #1004. Human assignee stays **Ilya (`ivg-design`)**; validation owner stays **Ilya/O**. This is an agent-side pickup of a leaf Ilya's team offered on #1062, not an ownership transfer — please do not treat this PR as self-certifying integration.

## What was missing

A receipt (`nemo.receipt/1`) records what **one** run observed. Nothing compared two runs, so a failure could not be distinguished from a known one, and a result could be quoted without the bytes it was measured on.

## What this adds

**`engineering/inventory/baseline-manifest.json`** (`nemo.baseline-manifest/1`) — the adopted observed state of `ded641bd763379f36d629bf1686fcce8a6137a66`, 12 jobs: **9 pass, 1 fail, 2 blocked**, 0 carried over. Each entry keeps its exact case, the receipt sha256 it came from, and the immutable source / fixture / artifact references it was measured against.

**`scripts/nemo/baseline.cjs`** — `--adopt` and `--check`. `--check` classifies a later receipt as **new regression**, **unchanged known failure** or **environment mismatch**, verifying references first. Exit `0` reproduces, `1` blocking, `2` inconclusive.

Two rules drive the design:

1. A result is quoted only with the bytes it was measured on. A missing or mismatched reference is **reported**, never silently reused.
2. `blocked` and `not-run` are never rounded up to `pass`, and a job a run did not cover is `missing-entry` — not a pass.

## Recorded baseline, including its defects

| Job | Result | Exact case |
|---|---|---|
| `build:desktop` | **fail** | `bundle-ffmpeg-dylibs.py failed (1)` |
| `test:rust-tauri` | **blocked** | sidecar `SIGABRT`, `dyld: Library not loaded: .../libvpx.12.dylib` |
| `test:desktop` | **blocked** | no packaged app |
| `bench` | pass | 15 workloads, **2 not-run** (no render backend) |
| the other 8 | pass | — |

Those three are **one** root cause, not three: the committed LGPL sidecar (`CLAUDE.md` §7) is dynamically linked and, of its 26 external dylibs, exactly two are absent here — `libvpx.12.dylib` (installed libvpx is 1.15.2) and `libSvtAv1Enc.4.dylib`. Deliberately **not repaired**: P02 records the baseline, and a repair would change the state being recorded. `doctor` still reports pass because it records sidecar health as a capability, not a job result — worth knowing, not changed here.

## Acceptance evidence

At the pushed commit `e6ee5f89bb5d`, a real `verify --profile quick` compared against the adopted baseline:

- 5 covered jobs reproduce as `pass` — including `test:unit`, whose test count changed from 634 to 657 because this PR adds tests, confirming count drift does not create a false verdict.
- 7 uncovered jobs report `missing-entry`, **not** pass.
- `source.head` mismatch reported (`ded641bd7633` → `e6ee5f89bb5d`), overall `INCONCLUSIVE`, exit 2 — the documented, intended behavior once the manifest is committed. Re-adopt deliberately rather than let a stale baseline answer for a tree it never saw.

Also run locally: `npm test` **657 tests, 655 pass, 0 fail, 2 skipped**; `npm run check` 6/6; `node scripts/nemo/boundaries.cjs` **55 modules, 0 violations** (13 warnings, 12 pre-existing — `lib/baseline.cjs` at 348 nonblank lines warns above 300 like 8 sibling modules, and is under the 400 hard max).

23 new regression tests cover the classification table, reference staleness, adoption, redaction and the CLI round trip.

## Shared files touched — please confirm

Two edits fall in the orchestrator-serialized set and are additive only:

- `engineering/boundaries/profiles/scripts-nemo.profile.json` — 3 module declarations (`nemo.lib.baseline`, `nemo.cli.baseline`, `nemo.test.baseline`).
- `scripts/nemo/ci.test.cjs` — source count 52 → 55.

Both are exactly what the existing tooling-coverage gate requires for new `scripts/nemo` sources; `ci.cjs` itself is untouched. No `package.json`, lockfile, or workflow edits. No hosted Actions run requested or authorized.

Committed manifest entries are path-redacted (`<repo>`/`<home>`), so no machine path ships and case signatures stay comparable across checkouts.
