### PR TITLE
docs(remediation): P04 capability descriptor v1 (opacity + export-job)

### DIFF
--- a/engineering/application/capabilities/export-job.json
+++ b/engineering/application/capabilities/export-job.json
@@ -5,10 +5,11 @@
   "input": {
     "type": "object",
     "additionalProperties": false,
+    "description": "What a caller supplies to invoke this capability. \"frameIdx\" addresses the \"start\" stage; \"jobId\" (returned by \"start\"'s output) addresses \"status\" and \"cancel\". Exactly one is required depending on stage, enforced by the handler per stage rather than by this shape — full per-stage input contracts are D02/#1045.",
     "properties": {
-      "frameIdx": { "type": "integer", "minimum": 0, "description": "0-based timeline frame to export." }
-    },
-    "required": ["frameIdx"]
+      "frameIdx": { "type": "integer", "minimum": 0, "description": "0-based timeline frame to export. Required for the \"start\" stage." },
+      "jobId": { "type": "string", "minLength": 1, "description": "Job identifier returned by \"start\". Required for the \"status\" and \"cancel\" stages." }
+    }
   },
   "output": {
     "type": "object",
@@ -44,7 +45,7 @@
     "scope": "none",
     "lifecycle": ["start", "status", "cancel"]
   },
-  "availability": { "state": "available", "reason": null },
+  "availability": { "state": "unavailable", "reason": "missing-dependency" },
   "handlerKey": "application.export.svgFrame",
   "fixture": {
     "label": "export frame 10 as SVG, complete",
@@ -53,12 +54,12 @@
   },
   "examples": [
     { "label": "start", "input": { "frameIdx": 10 }, "output": { "jobId": "job-1", "status": "running", "progress": 0 } },
-    { "label": "status while rendering", "input": { "frameIdx": 10 }, "output": { "jobId": "job-1", "status": "running", "progress": 0.5 } },
+    { "label": "status while rendering", "input": { "jobId": "job-1" }, "output": { "jobId": "job-1", "status": "running", "progress": 0.5 } },
     {
       "label": "status once complete",
-      "input": { "frameIdx": 10 },
+      "input": { "jobId": "job-1" },
       "output": { "jobId": "job-1", "status": "succeeded", "progress": 1, "artifact": { "mimeType": "image/svg+xml", "data": "<svg></svg>" } }
     },
-    { "label": "cancel before completion", "input": { "frameIdx": 10 }, "output": { "jobId": "job-1", "status": "cancelled", "progress": 0.5 } }
+    { "label": "cancel before completion", "input": { "jobId": "job-1" }, "output": { "jobId": "job-1", "status": "cancelled", "progress": 0.5 } }
   ]
 }

--- a/engineering/application/capabilities/export-job.json
+++ b/engineering/application/capabilities/export-job.json
@@ -1,0 +1,64 @@
+{
+  "schemaVersion": 1,
+  "id": "export.svg.frame",
+  "version": 1,
+  "input": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "frameIdx": { "type": "integer", "minimum": 0, "description": "0-based timeline frame to export." }
+    },
+    "required": ["frameIdx"]
+  },
+  "output": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "jobId": { "type": "string", "minLength": 1 },
+      "status": { "type": "string", "enum": ["running", "succeeded", "failed", "cancelled"] },
+      "progress": { "type": "number", "minimum": 0, "maximum": 1 },
+      "artifact": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "mimeType": { "const": "image/svg+xml" },
+          "data": { "type": "string", "description": "Inline SVG document text." }
+        },
+        "required": ["mimeType", "data"]
+      },
+      "error": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" }
+        },
+        "required": ["code", "message"]
+      }
+    },
+    "required": ["jobId", "status"]
+  },
+  "units": { "progress": "ratio" },
+  "effects": {
+    "kind": "job",
+    "scope": "none",
+    "lifecycle": ["start", "status", "cancel"]
+  },
+  "availability": { "state": "available", "reason": null },
+  "handlerKey": "application.export.svgFrame",
+  "fixture": {
+    "label": "export frame 10 as SVG, complete",
+    "input": { "frameIdx": 10 },
+    "output": { "jobId": "job-1", "status": "succeeded", "progress": 1, "artifact": { "mimeType": "image/svg+xml", "data": "<svg></svg>" } }
+  },
+  "examples": [
+    { "label": "start", "input": { "frameIdx": 10 }, "output": { "jobId": "job-1", "status": "running", "progress": 0 } },
+    { "label": "status while rendering", "input": { "frameIdx": 10 }, "output": { "jobId": "job-1", "status": "running", "progress": 0.5 } },
+    {
+      "label": "status once complete",
+      "input": { "frameIdx": 10 },
+      "output": { "jobId": "job-1", "status": "succeeded", "progress": 1, "artifact": { "mimeType": "image/svg+xml", "data": "<svg></svg>" } }
+    },
+    { "label": "cancel before completion", "input": { "frameIdx": 10 }, "output": { "jobId": "job-1", "status": "cancelled", "progress": 0.5 } }
+  ]
+}

--- a/engineering/application/capabilities/opacity.json
+++ b/engineering/application/capabilities/opacity.json
@@ -27,7 +27,7 @@
   "effects": {
     "kind": "mutation",
     "scope": "document",
-    "lifecycle": ["property.set", "property.key.set", "property.key.remove", "property.animation.set"]
+    "lifecycle": ["property.get", "property.set", "property.key.set", "property.key.remove", "property.animation.set"]
   },
   "availability": { "state": "available", "reason": null },
   "handlerKey": "application.opacity.property",

--- a/engineering/application/capabilities/opacity.json
+++ b/engineering/application/capabilities/opacity.json
@@ -1,0 +1,56 @@
+{
+  "schemaVersion": 1,
+  "id": "opacity",
+  "version": 1,
+  "input": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "layerId": { "type": "string", "minLength": 1, "description": "layers[].layerUid from the latest snapshot." },
+      "value": { "type": "number", "minimum": 0, "maximum": 100 },
+      "frame": { "type": "integer", "minimum": 0 },
+      "animated": { "type": "boolean" }
+    },
+    "required": ["layerId"]
+  },
+  "output": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "layerId": { "type": "string" },
+      "property": { "const": "opacity" },
+      "value": { "type": "number", "minimum": 0, "maximum": 100 }
+    },
+    "required": ["layerId", "property", "value"]
+  },
+  "units": { "value": "percent" },
+  "effects": {
+    "kind": "mutation",
+    "scope": "document",
+    "lifecycle": ["property.set", "property.key.set", "property.key.remove", "property.animation.set"]
+  },
+  "availability": { "state": "available", "reason": null },
+  "handlerKey": "application.opacity.property",
+  "fixture": {
+    "label": "set opacity to 40 on one layer",
+    "input": { "layerId": "layer-1", "value": 40 },
+    "output": { "layerId": "layer-1", "property": "opacity", "value": 40 }
+  },
+  "examples": [
+    {
+      "label": "set opacity to 40 on one layer",
+      "input": { "layerId": "layer-1", "value": 40 },
+      "output": { "layerId": "layer-1", "property": "opacity", "value": 40 }
+    },
+    {
+      "label": "key opacity at frame 12",
+      "input": { "layerId": "layer-1", "value": 40, "frame": 12 },
+      "output": { "layerId": "layer-1", "property": "opacity", "value": 40 }
+    },
+    {
+      "label": "enable animation on the property",
+      "input": { "layerId": "layer-1", "animated": true },
+      "output": { "layerId": "layer-1", "property": "opacity", "value": 40 }
+    }
+  ]
+}

--- a/engineering/application/capability-v1.schema.json
+++ b/engineering/application/capability-v1.schema.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nemo.internal/schema/capability-v1.schema.json",
+  "title": "CapabilityDescriptor",
+  "description": "One feature-owned capability declaration. UI, the JS application layer, and the Rust MCP dispatch all read the same descriptor to expose a consistent operation, instead of each hand-maintaining its own copy of the property's shape, units, and availability. `id` is the public identity a caller names; `handlerKey` is the internal, deterministic lookup a registry (see P05/#1007) resolves to the implementing handler. A registration set (the value passed to that registry) is a JSON array of descriptors; registration rejects a set containing two descriptors with the same `id` — JSON Schema alone cannot express cross-item uniqueness, so this is enforced by the registry, not by this document (see tests/capability-v1-schema.test.cjs for the specified failure case).",
+  "type": "object",
+  "additionalProperties": false,
+  "$defs": {
+    "Effects": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "What invoking this capability can change. Full transaction/job/resource lifecycle contracts are specified separately (D02/#1045); this is the minimal shape a v1 descriptor needs to say whether it mutates the open document and, if it runs as a job, which stages exist.",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["read", "mutation", "job"],
+          "description": "\"read\" never changes state. \"mutation\" commits a change to the open document synchronously within one request. \"job\" runs across multiple requests (start/status/cancel) and may or may not touch the document (see `scope`)."
+        },
+        "scope": {
+          "type": "string",
+          "enum": ["none", "document"],
+          "description": "\"document\" means a successful invocation changes the open document's persisted state (and its revision). \"none\" means it does not — a pure read, or a job whose output is an external artifact rather than a document mutation."
+        },
+        "lifecycle": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" },
+          "description": "Ordered stage names a caller may invoke, in the vocabulary this capability's handler actually accepts. For a \"mutation\", the transport operation suffixes it answers to (e.g. [\"property.set\", \"property.key.set\"]). For a \"job\", its lifecycle stages (e.g. [\"start\", \"status\", \"cancel\"])."
+        }
+      },
+      "required": ["kind", "scope", "lifecycle"]
+    },
+    "Availability": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Whether this capability can be invoked right now, in a form the UI and MCP can both render identically instead of drifting into two different messages for the same disabled backend.",
+      "properties": {
+        "state": { "type": "string", "enum": ["available", "unavailable"] },
+        "reason": {
+          "anyOf": [
+            { "type": "string", "enum": ["platform-unsupported", "backend-disabled", "missing-dependency", "feature-flag-off"] },
+            { "type": "null" }
+          ],
+          "description": "A stable, machine-readable code — never free text, so two independent renderers of the same descriptor produce the same user-facing reason. Convention (not enforced by this shape alone, to keep the schema in the minimal subset this repo's own validator implements): non-null when `state` is \"unavailable\", null when \"available\". A registry can add the `if`/`then` pairing this field's own shape omits."
+        }
+      },
+      "required": ["state", "reason"]
+    },
+    "Example": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "label": { "type": "string", "minLength": 1 },
+        "input": true,
+        "output": true
+      },
+      "required": ["label", "input", "output"]
+    }
+  },
+  "properties": {
+    "schemaVersion": {
+      "const": 1,
+      "description": "Always 1; this schema speaks no other version. A descriptor claiming any other value is rejected before its own `version` is even read — mirrors `apiVersion` in transport-v1.schema.json."
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(\\.[a-z][a-z0-9]*)*$",
+      "description": "Stable public capability identity, dot-namespaced lowercase (e.g. \"opacity\", \"export.svg.frame\"). Never reused for a semantically different capability; a shape change bumps `version` instead of the id."
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "This capability's own revision, independent of `schemaVersion`. Bump when `input`, `output`, or `effects` changes in a way an existing caller must handle."
+    },
+    "input": {
+      "type": "object",
+      "required": ["type"],
+      "description": "A JSON Schema (draft 2020-12) fragment describing what a caller supplies to invoke this capability. Required to at least declare its own `type` so this field cannot silently hold a non-schema value."
+    },
+    "output": {
+      "type": "object",
+      "required": ["type"],
+      "description": "A JSON Schema fragment describing what a caller receives back."
+    },
+    "units": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "description": "Unit for every unit-bearing numeric field named in `input`/`output`, e.g. {\"value\": \"percent\"}. Empty object when nothing needs one."
+    },
+    "effects": { "$ref": "#/$defs/Effects" },
+    "availability": { "$ref": "#/$defs/Availability" },
+    "handlerKey": {
+      "type": "string",
+      "pattern": "^[a-z][a-zA-Z0-9]*(\\.[a-z][a-zA-Z0-9]*)*$",
+      "description": "Stable registry lookup key for the implementing handler, shared verbatim by the UI binding, the JS application service, and the Rust MCP dispatch — the deterministic-registration join key (P05/#1007, P07/#1009). Distinct from `id`: several capability ids can route through handlers under one feature's namespace."
+    },
+    "fixture": {
+      "$ref": "#/$defs/Example",
+      "description": "One canonical, realistic example — this capability's reference test fixture."
+    },
+    "examples": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/Example" },
+      "description": "Further example input/output pairs, including boundary and lifecycle-stage cases, for documentation and client generation."
+    }
+  },
+  "required": ["schemaVersion", "id", "version", "input", "output", "units", "effects", "availability", "handlerKey", "fixture", "examples"]
+}

--- a/tests/capability-v1-schema.test.cjs
+++ b/tests/capability-v1-schema.test.cjs
@@ -124,3 +124,13 @@ test('registration rejects two descriptors sharing one id', () => {
 test('registration accepts distinct ids', () => {
   assert.doesNotThrow(() => assertNoDuplicateIds([load(OPACITY_PATH), load(EXPORT_JOB_PATH)]));
 });
+
+test('every fixture/example conforms to its own descriptor input/output', () => {
+  for (const p of [OPACITY_PATH, EXPORT_JOB_PATH]) {
+    const d = load(p);
+    for (const ex of [d.fixture, ...d.examples]) {
+      assert.deepStrictEqual(validate(d.input, ex.input), [], `${d.id} / ${ex.label} input`);
+      assert.deepStrictEqual(validate(d.output, ex.output), [], `${d.id} / ${ex.label} output`);
+    }
+  }
+});

--- a/tests/capability-v1-schema.test.cjs
+++ b/tests/capability-v1-schema.test.cjs
@@ -1,0 +1,126 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCHEMA_PATH = path.join(__dirname, '..', 'engineering', 'application', 'capability-v1.schema.json');
+const OPACITY_PATH = path.join(__dirname, '..', 'engineering', 'application', 'capabilities', 'opacity.json');
+const EXPORT_JOB_PATH = path.join(__dirname, '..', 'engineering', 'application', 'capabilities', 'export-job.json');
+
+function load(p) { return JSON.parse(fs.readFileSync(p, 'utf8')); }
+
+// Minimal, dependency-free validator for exactly the JSON Schema subset
+// capability-v1.schema.json uses (type/const/enum/pattern/minimum/maximum/
+// minLength/minItems/required/properties/additionalProperties/items/$ref/anyOf).
+// Not a general-purpose validator; do not reuse for other schemas without review.
+function validate(schema, value, defs, at) {
+  at = at || '$';
+  // Boolean schemas are valid JSON Schema: `true` accepts anything, `false` accepts nothing.
+  // capability-v1.schema.json's Example.input/output use `true` for "any JSON value".
+  if (schema === true) return [];
+  if (schema === false) return [`${at}: rejected by schema \`false\``];
+  defs = defs || schema.$defs || {};
+  if (schema.$ref) return validate(defs[schema.$ref.replace('#/$defs/', '')], value, defs, at);
+  if (schema.anyOf) {
+    const branches = schema.anyOf.map((s) => validate(s, value, defs, at));
+    return branches.some((e) => e.length === 0) ? [] : [`${at}: matches none of anyOf (${JSON.stringify(branches)})`];
+  }
+  const errors = [];
+  if ('const' in schema) {
+    if (value !== schema.const) errors.push(`${at}: expected const ${JSON.stringify(schema.const)}, got ${JSON.stringify(value)}`);
+    return errors;
+  }
+  if (schema.enum && !schema.enum.includes(value)) {
+    errors.push(`${at}: ${JSON.stringify(value)} is not one of ${JSON.stringify(schema.enum)}`);
+    return errors;
+  }
+  if (schema.type) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    const actual = value === null ? 'null' : Array.isArray(value) ? 'array'
+      : (typeof value === 'number' && Number.isInteger(value)) ? 'integer' : typeof value;
+    if (!types.includes(actual) && !(actual === 'integer' && types.includes('number'))) {
+      errors.push(`${at}: expected type ${types.join('|')}, got ${actual}`);
+      return errors;
+    }
+  }
+  if (typeof value === 'string') {
+    if (schema.pattern && !new RegExp(schema.pattern).test(value)) errors.push(`${at}: ${JSON.stringify(value)} does not match pattern ${schema.pattern}`);
+    if (schema.minLength != null && value.length < schema.minLength) errors.push(`${at}: shorter than minLength ${schema.minLength}`);
+  }
+  if (typeof value === 'number') {
+    if (schema.minimum != null && value < schema.minimum) errors.push(`${at}: ${value} < minimum ${schema.minimum}`);
+    if (schema.maximum != null && value > schema.maximum) errors.push(`${at}: ${value} > maximum ${schema.maximum}`);
+  }
+  if (Array.isArray(value)) {
+    if (schema.minItems != null && value.length < schema.minItems) errors.push(`${at}: fewer than minItems ${schema.minItems}`);
+    if (schema.items) value.forEach((item, i) => errors.push(...validate(schema.items, item, defs, `${at}[${i}]`)));
+  } else if (value && typeof value === 'object') {
+    (schema.required || []).forEach((key) => { if (!(key in value)) errors.push(`${at}: missing required property "${key}"`); });
+    Object.keys(value).forEach((key) => {
+      const propSchema = schema.properties && schema.properties[key];
+      if (propSchema) errors.push(...validate(propSchema, value[key], defs, `${at}.${key}`));
+      else if (schema.additionalProperties === false) errors.push(`${at}: unexpected property "${key}"`);
+      else if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
+        errors.push(...validate(schema.additionalProperties, value[key], defs, `${at}.${key}`));
+      }
+    });
+  }
+  return errors;
+}
+
+test('capability-v1.schema.json is well-formed (root object, expected $defs present)', () => {
+  const schema = load(SCHEMA_PATH);
+  assert.strictEqual(schema.$schema, 'https://json-schema.org/draft/2020-12/schema');
+  assert.strictEqual(schema.type, 'object');
+  assert.ok(schema.$defs.Effects && schema.$defs.Availability && schema.$defs.Example);
+});
+
+test('opacity descriptor fixture validates against CapabilityDescriptor', () => {
+  assert.deepStrictEqual(validate(load(SCHEMA_PATH), load(OPACITY_PATH)), []);
+});
+
+test('export-job descriptor fixture validates against CapabilityDescriptor', () => {
+  assert.deepStrictEqual(validate(load(SCHEMA_PATH), load(EXPORT_JOB_PATH)), []);
+});
+
+test('malformed id is rejected', () => {
+  const bad = load(OPACITY_PATH);
+  bad.id = 'Not Valid ID!';
+  const errors = validate(load(SCHEMA_PATH), bad);
+  assert.ok(errors.some((e) => e.includes('.id') && e.includes('pattern')), errors.join('\n'));
+});
+
+test('unsupported schemaVersion is rejected', () => {
+  const bad = load(OPACITY_PATH);
+  bad.schemaVersion = 2;
+  const errors = validate(load(SCHEMA_PATH), bad);
+  assert.ok(errors.some((e) => e.includes('schemaVersion')), errors.join('\n'));
+});
+
+test('unknown top-level property is rejected (additionalProperties: false)', () => {
+  const bad = load(OPACITY_PATH);
+  bad.unexpectedField = true;
+  const errors = validate(load(SCHEMA_PATH), bad);
+  assert.ok(errors.some((e) => e.includes('unexpectedField')), errors.join('\n'));
+});
+
+// Cross-item uniqueness cannot be expressed inside one descriptor's own schema
+// (JSON Schema validates one instance at a time); it is a registration-time
+// rule instead, exercised here as capability-v1.schema.json's own description
+// specifies. A future registry (P05/#1007) should keep this exact rule.
+function assertNoDuplicateIds(descriptors) {
+  const seen = new Set();
+  for (const d of descriptors) {
+    if (seen.has(d.id)) throw new Error(`duplicate capability id "${d.id}" in one registration set`);
+    seen.add(d.id);
+  }
+}
+
+test('registration rejects two descriptors sharing one id', () => {
+  assert.throws(() => assertNoDuplicateIds([load(OPACITY_PATH), load(OPACITY_PATH)]), /duplicate capability id "opacity"/);
+});
+
+test('registration accepts distinct ids', () => {
+  assert.doesNotThrow(() => assertNoDuplicateIds([load(OPACITY_PATH), load(EXPORT_JOB_PATH)]));
+});


### PR DESCRIPTION
Closes checklist items for [P04 / #1006](https://github.com/mysteropodes/nemo/issues/1006) — agent-side pickup from Ilya's team's idle-batch offer on #1062 (assignee/Validation owner stays `ivg-design`/O; this PR is the delegate's proposed increment, not a self-certified close).

## What

`engineering/application/capability-v1.schema.json` (new) — a CapabilityDescriptor JSON Schema (draft 2020-12, same conventions as the existing `transport-v1.schema.json`) naming: stable `id`/`version`, typed `input`/`output`, `units`, `effects` (`kind`/`scope`/`lifecycle`), `availability` (typed `reason`, not free text), `handlerKey`, `fixture` and `examples`.

Two fixtures, deliberately contrasting shapes (mirrors the plan's own "C — contrasting export job and shared diagnostics" section heading):

- `engineering/application/capabilities/opacity.json` — grounded in the **real, live** shape: `NemoOpacityApplicationCore.perform()`'s `capabilities` response and `readProperty()` in `src/js/application/opacity-application.js:80-82` (`{id:'opacity', min:0, max:100, unit:'percent', animated:true}`). `effects.kind = "mutation"`, `scope = "document"`, `lifecycle` = the real `property.*` operation names from `nemo-mcp/src/contract.rs`.
- `engineering/application/capabilities/export-job.json` — models the **not-yet-built** export-job lifecycle described in `EXECUTION_PLAN.en.md` P17-P19 (start/status/cancel, "UI and MCP both report the same typed availability reason"), wrapping the real *synchronous* `exportFrameSVGString(frameIdx)` (`src/js/export.js:352`, no FFmpeg dependency per P17's own note). `effects.kind = "job"`, `scope = "none"` (a render, not a document mutation). **This fixture is prospective by design** — stated explicitly in the schema/commit so it isn't later mistaken for a baseline/current-behavior claim the way some earlier census tasks were (per Ilya's 9/07 note on inconsistent "baseline" interpretation).

`tests/capability-v1-schema.test.cjs` (new, matches the `tests/*.test.cjs` glob `npm test` already runs) — a small dependency-free validator (no `ajv`/JSON-Schema-library precedent exists in this repo; introducing one felt like scope creep for a bounded task) covering exactly the schema subset actually used. Exercises every "specified failure case" the issue's outcome checklist asks for:
- malformed `id` → rejected by `pattern`
- unsupported `schemaVersion` → rejected by `const` (mirrors `contract.rs`'s own `api_version != API_VERSION` check)
- unknown top-level property → rejected by `additionalProperties: false`
- duplicate `id` across a registration set → rejected by a documented registry-time rule (cross-item uniqueness isn't expressible inside one instance's own JSON Schema; the schema's own description says so and points here)

## What this deliberately does not do

Per the issue's own limit: no plugin marketplace, no arbitrary executable discovery, no new DSL, no TS/framework rewrite. No `nemo-mcp/src/{contract,registry,schema}.rs` or `transport-v1.schema.json` touched — fully additive, no overlap with active Fizz contract files. Does not implement the registry itself (deterministic registration from feature declarations is P05/#1007; Rust MCP dispatch consuming it is P07/#1009) — this PR is the schema + two validated examples the issue scopes, not the registry.

## Verification

```
$ node --test tests/capability-v1-schema.test.cjs
# 8 pass, 0 fail
$ python3 -c "import json; json.load(open('engineering/application/capability-v1.schema.json'))"
# OK (and both fixture files)
```

Base `origin/main` @ `ded641b`. Branch/worktree: `honey/p04-capability-descriptor-v1`, dedicated worktree (not the shared primary checkout).