### PR TITLE
fix(R14): wording/hygiene nits from Pollen's #1047 review

### DIFF
--- a/engineering/remediation/receipts/R14-packaging/SUMMARY.md
+++ b/engineering/remediation/receipts/R14-packaging/SUMMARY.md
@@ -106,7 +106,7 @@ installed package, never the build tree.
 | Live server holds **0** handles into any source checkout | pass | `transcripts/isolation-live-process.txt` | — |
 | Live server: `cwd=/`, only mapped executable is the installed binary + `/usr/lib/dyld` | pass | `transcripts/isolation-live-process.txt` | — |
 | `scripts/bundle-ffmpeg-dylibs.py` run after the build | **fail (exit 1)** | `transcripts/dylib-bundling.txt` | Pre-existing ffmpeg/Homebrew drift, unrelated to MCP — finding 2 |
-| `npm run doctor` reports sidecar dylib state | pass (exit 0, reports 2 missing) | `transcripts/doctor.txt` | Reports the finding-2 failure |
+| `npm run doctor` reports sidecar dylib state | **as expected: 2 missing** (probe itself exits 0) | `transcripts/doctor.txt` | Reports the finding-2 failure |
 | Updater signing | not-run | — | Requires Cyril's personal key |
 | Windows / Linux / macOS x86_64 packaging | not-run | — | darwin/arm64 only on this host |
 

--- a/engineering/remediation/receipts/R14-packaging/transcripts/attach-1-handshake/environment.txt
+++ b/engineering/remediation/receipts/R14-packaging/transcripts/attach-1-handshake/environment.txt
@@ -9,7 +9,7 @@ PWD=/
 SHLVL=1
 HOME=<HOME>
 _=/usr/bin/env
-OLDPWD=<HOME>/.buzz/REPOS/nemo-worktrees/buzz-7f3a1c924b6d
+OLDPWD=<HOME>/.buzz/REPOS/<AGENT-WORKTREE>
 
 ## PATH contents (must be empty)
 PATH=/tmp/nemo-r14-emptybin

--- a/engineering/remediation/receipts/R14-packaging/transcripts/attach-2-discover/environment.txt
+++ b/engineering/remediation/receipts/R14-packaging/transcripts/attach-2-discover/environment.txt
@@ -9,7 +9,7 @@ PWD=/
 SHLVL=1
 HOME=<HOME>
 _=/usr/bin/env
-OLDPWD=<HOME>/.buzz/REPOS/nemo-worktrees/buzz-7f3a1c924b6d
+OLDPWD=<HOME>/.buzz/REPOS/<AGENT-WORKTREE>
 
 ## PATH contents (must be empty)
 PATH=/tmp/nemo-r14-emptybin

--- a/engineering/remediation/receipts/R14-packaging/transcripts/attach-3-select/environment.txt
+++ b/engineering/remediation/receipts/R14-packaging/transcripts/attach-3-select/environment.txt
@@ -9,7 +9,7 @@ PWD=/
 SHLVL=1
 HOME=<HOME>
 _=/usr/bin/env
-OLDPWD=<HOME>/.buzz/REPOS/nemo-worktrees/buzz-7f3a1c924b6d
+OLDPWD=<HOME>/.buzz/REPOS/<AGENT-WORKTREE>
 
 ## PATH contents (must be empty)
 PATH=/tmp/nemo-r14-emptybin

--- a/engineering/remediation/receipts/R14-packaging/transcripts/attach-4-isolation/environment.txt
+++ b/engineering/remediation/receipts/R14-packaging/transcripts/attach-4-isolation/environment.txt
@@ -9,7 +9,7 @@ PWD=/
 SHLVL=1
 HOME=<HOME>
 _=/usr/bin/env
-OLDPWD=<HOME>/.buzz/REPOS/nemo-worktrees/buzz-7f3a1c924b6d
+OLDPWD=<HOME>/.buzz/REPOS/<AGENT-WORKTREE>
 
 ## PATH contents (must be empty)
 PATH=/tmp/nemo-r14-emptybin

--- a/engineering/remediation/receipts/R14-packaging/transcripts/attach-5-stale/environment.txt
+++ b/engineering/remediation/receipts/R14-packaging/transcripts/attach-5-stale/environment.txt
@@ -9,7 +9,7 @@ PWD=/
 SHLVL=1
 HOME=<HOME>
 _=/usr/bin/env
-OLDPWD=<HOME>/.buzz/REPOS/nemo-worktrees/buzz-7f3a1c924b6d
+OLDPWD=<HOME>/.buzz/REPOS/<AGENT-WORKTREE>
 
 ## PATH contents (must be empty)
 PATH=/tmp/nemo-r14-emptybin


### PR DESCRIPTION
Small non-blocking follow-up to #1001 (already merged, so this lands as its own PR rather than an amend) — both points from Pollen's #1047 review comment.

1. `SUMMARY.md`'s doctor row led with "pass" for a probe that reports 2 missing dylibs — contradicts the adjacent bundling row's "fail" for the exact same underlying problem (finding 2). A reader scanning the Result column only sees "pass" next to a sidecar that doesn't start. Reworded to lead with the actual finding, exit code moved to a parenthetical.
2. The five `transcripts/attach-*/environment.txt` receipts had `HOME` redacted to `<HOME>` but `OLDPWD` still published this machine's agent worktree directory name (`nemo-worktrees/buzz-7f3a1c924b6d`) — redacted to `<AGENT-WORKTREE>`, same convention.

No behavior/evidence content changed, only wording and one redaction.