### PR TITLE
[NEMO:P11] Cover Rust source classification and size ratchet

### DIFF
--- a/engineering/boundaries/profiles/rust.baseline.json
+++ b/engineering/boundaries/profiles/rust.baseline.json
@@ -1,0 +1,267 @@
+{
+  "modules": [
+    {
+      "id": "rust.mcp.transport",
+      "layer": "adapters",
+      "dir": "nemo-mcp",
+      "files": [
+        "build.rs",
+        "src/contract.rs",
+        "src/lib.rs",
+        "src/main.rs",
+        "src/registry.rs",
+        "src/schema.rs",
+        "src/server.rs",
+        "src/wire.rs"
+      ],
+      "publicApi": [
+        "src/contract.rs",
+        "src/lib.rs",
+        "src/registry.rs",
+        "src/wire.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.mcp.transport.tests",
+      "layer": "tests",
+      "dir": "nemo-mcp/tests",
+      "files": [
+        "stdio.rs",
+        "stdio_application.rs",
+        "stdio_cancellation.rs",
+        "stdio_contract.rs",
+        "stdio_reconnect.rs",
+        "stdio_rejection.rs",
+        "stdio_roundtrip.rs",
+        "transport.rs"
+      ],
+      "publicApi": [],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.desktop.mcp.adapter",
+      "layer": "adapters",
+      "dir": "src-tauri/src",
+      "files": [
+        "application_mcp.rs"
+      ],
+      "publicApi": [
+        "application_mcp.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.desktop.shell",
+      "layer": "desktop-shell",
+      "dir": "src-tauri/src",
+      "files": [
+        "lib.rs",
+        "main.rs"
+      ],
+      "publicApi": [
+        "lib.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.desktop.media",
+      "layer": "desktop-shell",
+      "dir": "src-tauri/src",
+      "files": [
+        "vectorize.rs",
+        "video_decode.rs"
+      ],
+      "publicApi": [
+        "vectorize.rs",
+        "video_decode.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.desktop.tasks",
+      "layer": "desktop-shell",
+      "dir": "src-tauri/src",
+      "files": [
+        "task_runtime.rs"
+      ],
+      "publicApi": [
+        "task_runtime.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.desktop.tasks.tests",
+      "layer": "tests",
+      "dir": "src-tauri/src/task_runtime",
+      "files": [
+        "tests.rs"
+      ],
+      "publicApi": [],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.desktop.build",
+      "layer": "build",
+      "dir": "src-tauri",
+      "files": [
+        "build.rs"
+      ],
+      "publicApi": [],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.geometry.engine",
+      "layer": "engine",
+      "dir": "geometry-wasm/src",
+      "files": [
+        "engine.rs"
+      ],
+      "publicApi": [
+        "engine.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.geometry.shapes",
+      "layer": "engine",
+      "dir": "geometry-wasm/src",
+      "files": [
+        "eraser.rs",
+        "fill.rs",
+        "hit.rs",
+        "shapes.rs"
+      ],
+      "publicApi": [
+        "eraser.rs",
+        "fill.rs",
+        "hit.rs",
+        "shapes.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.geometry.animation",
+      "layer": "engine",
+      "dir": "geometry-wasm/src",
+      "files": [
+        "interp.rs",
+        "strokemodeler.rs",
+        "timeline.rs",
+        "track.rs",
+        "tween.rs",
+        "tweenmatch.rs"
+      ],
+      "publicApi": [
+        "interp.rs",
+        "strokemodeler.rs",
+        "timeline.rs",
+        "track.rs",
+        "tween.rs",
+        "tweenmatch.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.geometry.api",
+      "layer": "adapters",
+      "dir": "geometry-wasm/src",
+      "files": [
+        "lib.rs"
+      ],
+      "publicApi": [
+        "lib.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.geometry.tests",
+      "layer": "tests",
+      "dir": "geometry-wasm/tests",
+      "files": [
+        "dab_dense_overlap_repro.rs",
+        "effect_layer_overlay_repro.rs",
+        "shader_library_validation.rs"
+      ],
+      "publicApi": [],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.vectorize.core",
+      "layer": "engine",
+      "dir": "vectorize-core/src",
+      "files": [
+        "lib.rs"
+      ],
+      "publicApi": [
+        "lib.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.vectorize.wasm",
+      "layer": "adapters",
+      "dir": "vectorize-wasm/src",
+      "files": [
+        "lib.rs"
+      ],
+      "publicApi": [
+        "lib.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    }
+  ],
+  "sizeProfiles": {
+    "Rust production module": {
+      "warn": 350,
+      "hardMax": 500
+    }
+  },
+  "exceptions": [
+    {
+      "path": "geometry-wasm/src/engine.rs",
+      "rule": "size",
+      "ceiling": 4151,
+      "owner": "mysteropodes",
+      "issue": "1013",
+      "reason": "Legacy pre-extraction Rust source; ceiling captured as an exact-path no-growth baseline pending real module extraction (R02/R05), not an architectural review of this file's content.",
+      "expires": "2026-12-05"
+    },
+    {
+      "path": "geometry-wasm/src/fill.rs",
+      "rule": "size",
+      "ceiling": 998,
+      "owner": "mysteropodes",
+      "issue": "1013",
+      "reason": "Legacy pre-extraction Rust source; ceiling captured as an exact-path no-growth baseline pending real module extraction (R02/R05), not an architectural review of this file's content.",
+      "expires": "2026-12-05"
+    },
+    {
+      "path": "geometry-wasm/src/tweenmatch.rs",
+      "rule": "size",
+      "ceiling": 1074,
+      "owner": "mysteropodes",
+      "issue": "1013",
+      "reason": "Legacy pre-extraction Rust source; ceiling captured as an exact-path no-growth baseline pending real module extraction (R02/R05), not an architectural review of this file's content.",
+      "expires": "2026-12-05"
+    },
+    {
+      "path": "geometry-wasm/tests/effect_layer_overlay_repro.rs",
+      "rule": "size",
+      "ceiling": 503,
+      "owner": "mysteropodes",
+      "issue": "1013",
+      "reason": "Legacy pre-extraction Rust source; ceiling captured as an exact-path no-growth baseline pending real module extraction (R02/R05), not an architectural review of this file's content.",
+      "expires": "2026-12-05"
+    },
+    {
+      "path": "src-tauri/src/video_decode.rs",
+      "rule": "size",
+      "ceiling": 2266,
+      "owner": "mysteropodes",
+      "issue": "1013",
+      "reason": "Legacy pre-extraction Rust source; ceiling captured as an exact-path no-growth baseline pending real module extraction (R02/R05), not an architectural review of this file's content.",
+      "expires": "2026-12-05"
+    }
+  ]
+}

--- a/engineering/boundaries/profiles/rust.coverage.json
+++ b/engineering/boundaries/profiles/rust.coverage.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": 1,
+  "policyId": "nemo.rust.coverage",
+  "status": "adopted",
+  "purpose": "Adopted whole-repository Rust source classification and no-growth size enforcement for every tracked .rs file across the desktop shell, geometry/vectorize engines and the MCP transport crate. Establishes the coverage and ratchet controls that a later extraction packet (for example P28/#1030, which adds src-tauri/src/media_probe.rs) must satisfy before a new Rust module can land.",
+  "scope": {
+    "sourceRoot": ".",
+    "profileSourceRoot": "engineering/boundaries/profiles",
+    "sourceKinds": [".rs"],
+    "selection": "Git candidate inventory via discoverRepositoryFiles (scripts/nemo/lib/boundaries-repository.cjs): all tracked paths plus non-ignored untracked paths, filtered to the .rs suffix. Selection is not a filesystem walk and applies no root, vendor or generated policy of its own.",
+    "pathConvention": "Repository-relative POSIX paths.",
+    "outsideSelection": "Ignored build output is never a Git candidate, so generated Rust under */target/ is outside the selection rather than an exclusion. This is a reviewed consequence of the committed .gitignore, not a filename heuristic: no rule in this policy matches on the substring 'target'. At the candidate commit the working tree carried 5 generated .rs files under nemo-mcp/target/; that count is local build state and is deliberately not asserted as a repository fact. The regression test asserts the mechanism instead, on a purpose-built scratch repository."
+  },
+  "provenance": {
+    "repository": "mysteropodes/nemo",
+    "candidateCommit": "9735e962e04e98ad49202d76ec085f406c687641",
+    "discoveryHelper": "scripts/nemo/lib/boundaries-repository.cjs",
+    "discoveryReport": {
+      "ok": true,
+      "diagnostics": 0,
+      "repositoryCandidates": 623,
+      "repositoryCandidatesNote": "Clean working tree at candidateCommit. Only the Rust figures below are asserted by the gate; the whole-repository total is context, so ordinary growth elsewhere cannot manufacture a failure here.",
+      "rustCandidates": 41,
+      "trackedRustCandidates": 41,
+      "untrackedRustCandidates": 0
+    },
+    "lineCounter": "countNonBlankLines (scripts/nemo/lib/boundaries.cjs) — the same counter the size checker uses, so recorded ceilings and enforced ceilings cannot drift.",
+    "profiles": {
+      "candidate": "engineering/boundaries/profiles/rust.profile.json",
+      "baseline": "engineering/boundaries/profiles/rust.baseline.json"
+    }
+  },
+  "relatedPolicies": [
+    {
+      "path": "engineering/boundaries/profiles/mcp-rust.profile.json",
+      "relationship": "stricter overlay",
+      "reason": "The MCP slice (nemo-mcp/** plus src-tauri/src/application_mcp.rs) additionally forbids size waivers entirely, asserted by tests/nemo-mcp-boundaries.test.cjs. That file is left byte-identical by this packet. Its 9 declared paths are also declared here, and the regression test asserts the two profiles agree on the overlap so they cannot drift apart."
+    }
+  ],
+  "layerEnforcement": {
+    "claimed": false,
+    "reason": "Module.layer values in rust.profile.json are classification labels only. This packet proves discovery and size; it does not claim Cargo dependency or module-graph enforcement, and no Rust dependency analyzer exists in the repository. layerRules is therefore deliberately omitted from rust.profile.json rather than declared unenforced. checkProfile is a JavaScript lexer and is never run against Rust source.",
+    "checksApplied": ["checkSourceCoverage", "checkSourceSizes", "compareSizeBaseline"]
+  },
+  "sizePolicy": {
+    "ordinaryProfile": "Rust production module",
+    "warn": 350,
+    "hardMax": 500,
+    "singleProfileRationale": "One ordinary budget covers production, test and build sources. Introducing a laxer test-specific budget here would define existing debt away instead of recording it; a future packet that actually reviews Rust test-size policy can add one, and compareSizeBaseline will surface it as size-baseline-new-profile if it exceeds the prior ordinary maximum.",
+    "warnOnlyAtAdoption": [
+      { "path": "geometry-wasm/src/interp.rs", "nonblankLines": 384 },
+      { "path": "geometry-wasm/src/track.rs", "nonblankLines": 410 },
+      { "path": "src-tauri/src/task_runtime.rs", "nonblankLines": 367 }
+    ]
+  },
+  "retainedCeilings": [
+    { "path": "geometry-wasm/src/engine.rs", "ceiling": 4151, "nonblankLinesAtAdoption": 4151 },
+    { "path": "geometry-wasm/src/fill.rs", "ceiling": 998, "nonblankLinesAtAdoption": 998 },
+    { "path": "geometry-wasm/src/tweenmatch.rs", "ceiling": 1074, "nonblankLinesAtAdoption": 1074 },
+    { "path": "geometry-wasm/tests/effect_layer_overlay_repro.rs", "ceiling": 503, "nonblankLinesAtAdoption": 503 },
+    { "path": "src-tauri/src/video_decode.rs", "ceiling": 2266, "nonblankLinesAtAdoption": 2266 }
+  ],
+  "exclusions": [],
+  "exclusionsRationale": "Every one of the 41 discovered Rust candidates is adopted into a module, so the reviewed exclusion list is empty. An empty list is an assertion, not an omission: checkSourceCoverage reports coverage-unprofiled-source for any selected path that is neither declared nor exactly excluded, and the regression test exercises that failure.",
+  "snapshotCounts": {
+    "selectedSources": 41,
+    "declaredSources": 41,
+    "exclusions": 0,
+    "modules": 15,
+    "retainedCeilings": 5
+  },
+  "integration": {
+    "gate": "tests/nemo-boundaries-rust.test.cjs",
+    "runsUnder": "npm test and the test:unit job, which is in both the quick and full verify profiles — normal local validation, not an opt-in CLI.",
+    "requiredChecks": [
+      "every discovered .rs is declared or exactly excluded",
+      "no declared .rs exceeds its effective ceiling",
+      "no effective ceiling grows against rust.baseline.json",
+      "an oversized in-scope .rs fails",
+      "an undeclared .rs fails",
+      "a raised legacy ceiling fails",
+      "negative fixtures leave the committed policy and its retained ceilings byte-identical"
+    ],
+    "openGates": [
+      "Cargo dependency/module-graph enforcement for Rust (not claimed by this packet).",
+      "Rust source is not wired into scripts/nemo/ci.cjs applicability; that file is shared and serialized."
+    ]
+  }
+}

--- a/engineering/boundaries/profiles/rust.profile.json
+++ b/engineering/boundaries/profiles/rust.profile.json
@@ -1,0 +1,267 @@
+{
+  "modules": [
+    {
+      "id": "rust.mcp.transport",
+      "layer": "adapters",
+      "dir": "nemo-mcp",
+      "files": [
+        "build.rs",
+        "src/contract.rs",
+        "src/lib.rs",
+        "src/main.rs",
+        "src/registry.rs",
+        "src/schema.rs",
+        "src/server.rs",
+        "src/wire.rs"
+      ],
+      "publicApi": [
+        "src/contract.rs",
+        "src/lib.rs",
+        "src/registry.rs",
+        "src/wire.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.mcp.transport.tests",
+      "layer": "tests",
+      "dir": "nemo-mcp/tests",
+      "files": [
+        "stdio.rs",
+        "stdio_application.rs",
+        "stdio_cancellation.rs",
+        "stdio_contract.rs",
+        "stdio_reconnect.rs",
+        "stdio_rejection.rs",
+        "stdio_roundtrip.rs",
+        "transport.rs"
+      ],
+      "publicApi": [],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.desktop.mcp.adapter",
+      "layer": "adapters",
+      "dir": "src-tauri/src",
+      "files": [
+        "application_mcp.rs"
+      ],
+      "publicApi": [
+        "application_mcp.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.desktop.shell",
+      "layer": "desktop-shell",
+      "dir": "src-tauri/src",
+      "files": [
+        "lib.rs",
+        "main.rs"
+      ],
+      "publicApi": [
+        "lib.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.desktop.media",
+      "layer": "desktop-shell",
+      "dir": "src-tauri/src",
+      "files": [
+        "vectorize.rs",
+        "video_decode.rs"
+      ],
+      "publicApi": [
+        "vectorize.rs",
+        "video_decode.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.desktop.tasks",
+      "layer": "desktop-shell",
+      "dir": "src-tauri/src",
+      "files": [
+        "task_runtime.rs"
+      ],
+      "publicApi": [
+        "task_runtime.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.desktop.tasks.tests",
+      "layer": "tests",
+      "dir": "src-tauri/src/task_runtime",
+      "files": [
+        "tests.rs"
+      ],
+      "publicApi": [],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.desktop.build",
+      "layer": "build",
+      "dir": "src-tauri",
+      "files": [
+        "build.rs"
+      ],
+      "publicApi": [],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.geometry.engine",
+      "layer": "engine",
+      "dir": "geometry-wasm/src",
+      "files": [
+        "engine.rs"
+      ],
+      "publicApi": [
+        "engine.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.geometry.shapes",
+      "layer": "engine",
+      "dir": "geometry-wasm/src",
+      "files": [
+        "eraser.rs",
+        "fill.rs",
+        "hit.rs",
+        "shapes.rs"
+      ],
+      "publicApi": [
+        "eraser.rs",
+        "fill.rs",
+        "hit.rs",
+        "shapes.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.geometry.animation",
+      "layer": "engine",
+      "dir": "geometry-wasm/src",
+      "files": [
+        "interp.rs",
+        "strokemodeler.rs",
+        "timeline.rs",
+        "track.rs",
+        "tween.rs",
+        "tweenmatch.rs"
+      ],
+      "publicApi": [
+        "interp.rs",
+        "strokemodeler.rs",
+        "timeline.rs",
+        "track.rs",
+        "tween.rs",
+        "tweenmatch.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.geometry.api",
+      "layer": "adapters",
+      "dir": "geometry-wasm/src",
+      "files": [
+        "lib.rs"
+      ],
+      "publicApi": [
+        "lib.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.geometry.tests",
+      "layer": "tests",
+      "dir": "geometry-wasm/tests",
+      "files": [
+        "dab_dense_overlap_repro.rs",
+        "effect_layer_overlay_repro.rs",
+        "shader_library_validation.rs"
+      ],
+      "publicApi": [],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.vectorize.core",
+      "layer": "engine",
+      "dir": "vectorize-core/src",
+      "files": [
+        "lib.rs"
+      ],
+      "publicApi": [
+        "lib.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    },
+    {
+      "id": "rust.vectorize.wasm",
+      "layer": "adapters",
+      "dir": "vectorize-wasm/src",
+      "files": [
+        "lib.rs"
+      ],
+      "publicApi": [
+        "lib.rs"
+      ],
+      "sizeProfile": "Rust production module"
+    }
+  ],
+  "sizeProfiles": {
+    "Rust production module": {
+      "warn": 350,
+      "hardMax": 500
+    }
+  },
+  "exceptions": [
+    {
+      "path": "geometry-wasm/src/engine.rs",
+      "rule": "size",
+      "ceiling": 4151,
+      "owner": "mysteropodes",
+      "issue": "1013",
+      "reason": "Legacy pre-extraction Rust source; ceiling captured as an exact-path no-growth baseline pending real module extraction (R02/R05), not an architectural review of this file's content.",
+      "expires": "2026-12-05"
+    },
+    {
+      "path": "geometry-wasm/src/fill.rs",
+      "rule": "size",
+      "ceiling": 998,
+      "owner": "mysteropodes",
+      "issue": "1013",
+      "reason": "Legacy pre-extraction Rust source; ceiling captured as an exact-path no-growth baseline pending real module extraction (R02/R05), not an architectural review of this file's content.",
+      "expires": "2026-12-05"
+    },
+    {
+      "path": "geometry-wasm/src/tweenmatch.rs",
+      "rule": "size",
+      "ceiling": 1074,
+      "owner": "mysteropodes",
+      "issue": "1013",
+      "reason": "Legacy pre-extraction Rust source; ceiling captured as an exact-path no-growth baseline pending real module extraction (R02/R05), not an architectural review of this file's content.",
+      "expires": "2026-12-05"
+    },
+    {
+      "path": "geometry-wasm/tests/effect_layer_overlay_repro.rs",
+      "rule": "size",
+      "ceiling": 503,
+      "owner": "mysteropodes",
+      "issue": "1013",
+      "reason": "Legacy pre-extraction Rust source; ceiling captured as an exact-path no-growth baseline pending real module extraction (R02/R05), not an architectural review of this file's content.",
+      "expires": "2026-12-05"
+    },
+    {
+      "path": "src-tauri/src/video_decode.rs",
+      "rule": "size",
+      "ceiling": 2266,
+      "owner": "mysteropodes",
+      "issue": "1013",
+      "reason": "Legacy pre-extraction Rust source; ceiling captured as an exact-path no-growth baseline pending real module extraction (R02/R05), not an architectural review of this file's content.",
+      "expires": "2026-12-05"
+    }
+  ]
+}

--- a/tests/nemo-boundaries-rust.test.cjs
+++ b/tests/nemo-boundaries-rust.test.cjs
@@ -1,0 +1,277 @@
+'use strict';
+
+// P11 (#1013) — Rust source classification and size ratchet.
+//
+// Discovery is the Git candidate inventory, not a filesystem walk: ignored build
+// output (*/target/) is never a candidate, so generated Rust stays outside the
+// selection by reviewed ignore rules instead of a filename heuristic.
+//
+// Only the path/size helpers run here. checkProfile is a JavaScript lexer and is
+// never applied to Rust source; this packet proves discovery and size, and makes
+// no claim about Cargo dependency or module-graph enforcement.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { countNonBlankLines, validateProfile } = require('../scripts/nemo/lib/boundaries.cjs');
+const { discoverRepositoryFiles } = require('../scripts/nemo/lib/boundaries-repository.cjs');
+const { checkSourceCoverage } = require('../scripts/nemo/lib/boundaries-coverage.cjs');
+const { checkSourceSizes } = require('../scripts/nemo/lib/boundaries-size.cjs');
+const { compareSizeBaseline } = require('../scripts/nemo/lib/boundaries-ratchet.cjs');
+
+const ROOT = path.resolve(__dirname, '..');
+const PROFILES = path.join(ROOT, 'engineering/boundaries/profiles');
+const POLICY_FILES = ['rust.profile.json', 'rust.baseline.json', 'rust.coverage.json'];
+
+// Read the committed bytes once. Every negative case below works on a deep clone;
+// the final test proves that by re-reading these files and comparing.
+const committedBytes = new Map(POLICY_FILES.map((name) => [name, fs.readFileSync(path.join(PROFILES, name))]));
+const read = (name) => JSON.parse(committedBytes.get(name));
+const profile = read('rust.profile.json');
+const baseline = read('rust.baseline.json');
+const coverage = read('rust.coverage.json');
+
+const declaredPaths = () => profile.modules
+  .flatMap((module) => module.files.map((file) => path.posix.join(module.dir, file))).sort();
+
+function discoverRust(root = ROOT) {
+  const report = discoverRepositoryFiles({ root });
+  assert.equal(report.ok, true, `repository discovery failed: ${JSON.stringify(report.diagnostics)}`);
+  return { report, rust: report.entries.filter((entry) => entry.path.endsWith('.rs')).map((entry) => entry.path).sort() };
+}
+
+function scratch(t, label) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `nemo rust boundaries ${label} `));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }));
+  return dir;
+}
+
+function writeSource(root, relative, nonblankLines) {
+  const absolute = path.join(root, ...relative.split('/'));
+  fs.mkdirSync(path.dirname(absolute), { recursive: true });
+  // A blank line between each pair proves the counter measures nonblank lines,
+  // not file length: a length-based check would see twice this number.
+  fs.writeFileSync(absolute, `${Array.from({ length: nonblankLines }, (_, i) => `let x${i} = ${i};`).join('\n\n')}\n`);
+  assert.equal(countNonBlankLines(fs.readFileSync(absolute, 'utf8')), nonblankLines);
+  return relative;
+}
+
+const ORDINARY = coverage.sizePolicy.ordinaryProfile;
+const LIMITS = profile.sizeProfiles[ORDINARY];
+
+// A fixture profile is built from the committed size budget, so lowering the real
+// hard maximum cannot quietly turn these negative cases into passes.
+function fixtureProfile(files) {
+  return {
+    modules: [{ id: 'fixture.crate', layer: 'engine', dir: 'crate/src', files, publicApi: [], sizeProfile: ORDINARY }],
+    sizeProfiles: structuredClone(profile.sizeProfiles),
+    exceptions: [],
+  };
+}
+
+test('committed Rust policy is a valid profile and its recorded budget matches the coverage policy', () => {
+  validateProfile(profile);
+  validateProfile(baseline);
+  assert.deepEqual(profile, baseline, 'baseline must be the reviewed candidate at adoption');
+  assert.equal(LIMITS.warn, coverage.sizePolicy.warn);
+  assert.equal(LIMITS.hardMax, coverage.sizePolicy.hardMax);
+  assert.equal(profile.layerRules, undefined, 'layer rules are not declared because no Rust dependency analyzer runs');
+  assert.equal(coverage.layerEnforcement.claimed, false);
+});
+
+test('every tracked Rust source is discovered independently and adopted or exactly excluded', () => {
+  const { report, rust } = discoverRust();
+  const declared = declaredPaths();
+  const exclusions = coverage.exclusions.map((entry) => entry.path);
+
+  const result = checkSourceCoverage(profile, { sourcePaths: rust, exclusions, root: ROOT });
+  assert.equal(result.ok, true, JSON.stringify(result.violations, null, 2));
+  assert.equal(result.sourcePathCount, rust.length);
+  assert.equal(result.declaredPathCount, declared.length);
+  assert.equal(result.excludedPathCount, exclusions.length);
+
+  // Guard against a discovery regression that silently returns one crate: the
+  // packet names native, geometry and nemo-mcp explicitly.
+  const areas = { 'src-tauri/': 0, 'geometry-wasm/': 0, 'nemo-mcp/': 0, 'vectorize-core/': 0, 'vectorize-wasm/': 0 };
+  for (const file of rust) for (const prefix of Object.keys(areas)) if (file.startsWith(prefix)) areas[prefix]++;
+  for (const [prefix, count] of Object.entries(areas)) assert.ok(count > 0, `no Rust discovered under ${prefix}`);
+
+  assert.equal(rust.length, coverage.snapshotCounts.selectedSources);
+  assert.equal(declared.length, coverage.snapshotCounts.declaredSources);
+  assert.equal(exclusions.length, coverage.snapshotCounts.exclusions);
+  assert.equal(profile.modules.length, coverage.snapshotCounts.modules);
+
+  // Check 3, first half: emit the discovered count and the classified/excluded list.
+  const byModule = profile.modules.map((module) =>
+    `    ${module.id} [${module.layer}] ${module.files.length} file(s): ${module.dir}/{${module.files.join(', ')}}`);
+  console.log([
+    `  Rust discovery at HEAD ${report.head}:`,
+    `    ${report.entries.length} repository candidate(s), ${rust.length} .rs, ${areas['src-tauri/']} native / `
+      + `${areas['geometry-wasm/']} geometry / ${areas['nemo-mcp/']} mcp / `
+      + `${areas['vectorize-core/'] + areas['vectorize-wasm/']} vectorize`,
+    `  Classified into ${profile.modules.length} module(s):`,
+    ...byModule,
+    `  Excluded (${exclusions.length}): ${exclusions.length ? exclusions.join(', ') : '(none — every discovered path is adopted)'}`,
+  ].join('\n'));
+});
+
+test('no declared Rust source exceeds its effective ceiling, and retained ceilings are exact', () => {
+  const result = checkSourceSizes(profile, { root: ROOT });
+  assert.equal(result.ok, true, JSON.stringify(result.violations, null, 2));
+
+  const retained = new Map(coverage.retainedCeilings.map((entry) => [entry.path, entry]));
+  assert.equal(profile.exceptions.length, retained.size);
+  assert.equal(profile.exceptions.length, coverage.snapshotCounts.retainedCeilings);
+  for (const exception of profile.exceptions) {
+    const record = retained.get(exception.path);
+    assert.ok(record, `retained ceiling for ${exception.path} is missing from the coverage policy`);
+    assert.equal(exception.rule, 'size');
+    assert.equal(exception.ceiling, record.ceiling);
+    // A no-growth baseline is the measured count, not a rounded allowance.
+    const actual = countNonBlankLines(fs.readFileSync(path.join(ROOT, exception.path), 'utf8'));
+    assert.equal(actual, record.nonblankLinesAtAdoption);
+    assert.equal(exception.ceiling, actual);
+    assert.ok(exception.ceiling > LIMITS.hardMax, `${exception.path} does not need a waiver`);
+  }
+  const applied = result.exceptionsApplied.map((entry) => entry.path).sort();
+  assert.deepEqual(applied, [...retained.keys()].sort());
+});
+
+test('committed policy has no ratchet regression against its own baseline', () => {
+  const result = compareSizeBaseline(baseline, profile, { root: ROOT });
+  assert.equal(result.ok, true, JSON.stringify(result.violations, null, 2));
+  assert.equal(result.baselinePathCount, result.candidatePathCount);
+});
+
+test('the stricter MCP overlay stays consistent with the whole-tree profile', () => {
+  const mcp = JSON.parse(fs.readFileSync(path.join(PROFILES, 'mcp-rust.profile.json'), 'utf8'));
+  const declared = new Set(declaredPaths());
+  const mcpPaths = mcp.modules.flatMap((module) => module.files.map((file) => path.posix.join(module.dir, file)));
+  for (const file of mcpPaths) assert.ok(declared.has(file), `${file} is in the MCP overlay but not the whole-tree profile`);
+  // The overlay's own guarantee is that the MCP slice carries no size waivers.
+  assert.deepEqual(mcp.exceptions, []);
+  const waived = new Set(profile.exceptions.map((exception) => exception.path));
+  for (const file of mcpPaths) assert.equal(waived.has(file), false, `${file} acquired a waiver the MCP overlay forbids`);
+});
+
+test('an oversized in-scope .rs file fails', (t) => {
+  const root = scratch(t, 'size');
+  writeSource(root, 'crate/src/small.rs', 10);
+  writeSource(root, 'crate/src/big.rs', LIMITS.hardMax + 1);
+
+  const atLimit = checkSourceSizes(fixtureProfile(['small.rs']), { root });
+  assert.equal(atLimit.ok, true);
+
+  const result = checkSourceSizes(fixtureProfile(['small.rs', 'big.rs']), { root });
+  assert.equal(result.ok, false);
+  const violation = result.violations.find((entry) => entry.file === 'crate/src/big.rs');
+  assert.ok(violation, JSON.stringify(result.violations));
+  assert.equal(violation.rule, 'size');
+  assert.equal(violation.detail.lines, LIMITS.hardMax + 1);
+  assert.equal(violation.detail.hardMax, LIMITS.hardMax);
+});
+
+test('an undeclared .rs file fails, both as a new source and as a dropped declaration', (t) => {
+  const root = scratch(t, 'coverage');
+  const selected = [
+    writeSource(root, 'crate/src/small.rs', 10),
+    writeSource(root, 'crate/src/new.rs', 5),
+  ].sort();
+
+  const declaredOnly = checkSourceCoverage(fixtureProfile(['small.rs']), { sourcePaths: [selected[1]], root });
+  assert.equal(declaredOnly.ok, true);
+
+  const undeclared = checkSourceCoverage(fixtureProfile(['small.rs']), { sourcePaths: selected, root });
+  assert.equal(undeclared.ok, false);
+  assert.deepEqual(undeclared.violations.map((entry) => [entry.rule, entry.file]),
+    [['coverage-unprofiled-source', 'crate/src/new.rs']]);
+
+  // Same rule against the real tree: dropping a module orphans its real sources.
+  const { rust } = discoverRust();
+  const incomplete = structuredClone(profile);
+  const dropped = incomplete.modules.find((module) => module.id === 'rust.geometry.engine');
+  incomplete.modules = incomplete.modules.filter((module) => module.id !== dropped.id);
+  incomplete.exceptions = incomplete.exceptions.filter((exception) => exception.path !== 'geometry-wasm/src/engine.rs');
+  const result = checkSourceCoverage(incomplete, { sourcePaths: rust, root: ROOT });
+  assert.equal(result.ok, false);
+  assert.ok(result.violations.some((entry) => entry.rule === 'coverage-unprofiled-source'
+    && entry.file === 'geometry-wasm/src/engine.rs'), JSON.stringify(result.violations));
+});
+
+test('a raised legacy ceiling fails, per path and as a raised ordinary budget', () => {
+  const perPath = structuredClone(profile);
+  const raised = perPath.exceptions.find((exception) => exception.path === 'src-tauri/src/video_decode.rs');
+  raised.ceiling += 1;
+  const growth = compareSizeBaseline(baseline, perPath, { root: ROOT });
+  assert.equal(growth.ok, false);
+  const violation = growth.violations.find((entry) => entry.file === 'src-tauri/src/video_decode.rs');
+  assert.ok(violation, JSON.stringify(growth.violations));
+  assert.equal(violation.rule, 'size-baseline-growth');
+  assert.equal(violation.detail.candidateCeiling, violation.detail.priorCeiling + 1);
+
+  const ordinary = structuredClone(profile);
+  ordinary.sizeProfiles[ORDINARY].hardMax += 1;
+  const widened = compareSizeBaseline(baseline, ordinary, { root: ROOT });
+  assert.equal(widened.ok, false);
+  assert.ok(widened.violations.some((entry) => entry.rule === 'size-baseline-profile-growth'),
+    JSON.stringify(widened.violations));
+
+  // Deleting a waiver is the opposite of growth: the allowance drops to the
+  // ordinary budget, so the ratchet records a reduction. The debt does not
+  // vanish quietly, though — the size check then fails on the same file.
+  const dropped = structuredClone(profile);
+  dropped.exceptions = dropped.exceptions.filter((exception) => exception.path !== 'geometry-wasm/src/fill.rs');
+  const removal = compareSizeBaseline(baseline, dropped, { root: ROOT });
+  assert.equal(removal.ok, true);
+  assert.deepEqual(removal.reductions.map((entry) => [entry.file, entry.priorCeiling, entry.candidateCeiling]),
+    [['geometry-wasm/src/fill.rs', 998, LIMITS.hardMax]]);
+  const unwaived = checkSourceSizes(dropped, { root: ROOT });
+  assert.equal(unwaived.ok, false);
+  assert.deepEqual(unwaived.violations.map((entry) => [entry.rule, entry.file]),
+    [['size', 'geometry-wasm/src/fill.rs']]);
+});
+
+test('generated build output stays outside the selection because it is ignored, not name-matched', (t) => {
+  const root = scratch(t, 'ignored');
+  const git = (...args) => {
+    const result = spawnSync('git', ['-C', root, ...args], { encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+  };
+  git('init', '-q');
+  git('config', 'user.name', 'P11 fixture');
+  git('config', 'user.email', 'p11@example.invalid');
+  fs.writeFileSync(path.join(root, '.gitignore'), 'target/\n');
+  writeSource(root, 'src/lib.rs', 4);
+  git('add', '-A');
+  git('-c', 'commit.gpgsign=false', 'commit', '-q', '-m', 'fixture');
+  writeSource(root, 'target/generated.rs', 4);
+
+  const { report, rust } = discoverRust(root);
+  assert.deepEqual(rust, ['src/lib.rs']);
+  assert.equal(report.entries.some((entry) => entry.path === 'target/generated.rs'), false);
+  assert.ok(fs.existsSync(path.join(root, 'target/generated.rs')), 'the generated file must really exist on disk');
+
+  // The exclusion is the ignore rule, not the directory name: an ignored file
+  // that Git tracks anyway is still a candidate, and would need real coverage.
+  git('add', '-f', 'target/generated.rs');
+  git('-c', 'commit.gpgsign=false', 'commit', '-q', '-m', 'force-add');
+  assert.deepEqual(discoverRust(root).rust, ['src/lib.rs', 'target/generated.rs']);
+});
+
+test('negative fixtures left the committed policy, retained ceilings and exclusions untouched', () => {
+  for (const name of POLICY_FILES) {
+    assert.deepEqual(fs.readFileSync(path.join(PROFILES, name)), committedBytes.get(name),
+      `${name} was modified while the negative cases ran`);
+  }
+  // structuredClone, not a shared reference: the in-memory policy is intact too.
+  assert.deepEqual(profile, read('rust.profile.json'));
+  assert.deepEqual(baseline, read('rust.baseline.json'));
+  assert.deepEqual(coverage, read('rust.coverage.json'));
+  assert.equal(profile.sizeProfiles[ORDINARY].hardMax, LIMITS.hardMax);
+  assert.deepEqual(coverage.exclusions, []);
+  assert.deepEqual(profile.exceptions.map((exception) => [exception.path, exception.ceiling]).sort(),
+    coverage.retainedCeilings.map((entry) => [entry.path, entry.ceiling]).sort());
+});


### PR DESCRIPTION
Closes the Rust half of the size/coverage gate. Issue #1013 · candidate SHA `2b8ba31aa64a7034e1f9d035766f34f882c17f19` · base `9735e962e04e98ad49202d76ec085f406c687641`.

## The gap this closes

`mcp-rust.profile.json` declared **9** of the repository's **41** tracked `.rs` files. The other **32 were undeclared and unratcheted**, including the two largest sources in the tree — `geometry-wasm/src/engine.rs` (4151 nonblank lines) and `src-tauri/src/video_decode.rs` (2266). Nothing failed if a Rust file grew, and nothing noticed if a new one appeared.

## Approach

Discovery is the **Git candidate inventory** (`discoverRepositoryFiles`), not a filesystem walk. Ignored build output is never a candidate, so generated Rust under `*/target/` is outside the *selection* by reviewed ignore rules rather than by matching a directory name. No rule in this change matches the substring `target`; the test proves the distinction by force-adding an ignored file and watching it become a candidate again.

| File | What it is |
|---|---|
| `rust.profile.json` / `rust.baseline.json` | All 41 paths in 15 modules, one ordinary budget (`Rust production module`, warn 350 / hardMax 500), 5 exact-path legacy waivers pinned at the measured count. Generated from source, not transcribed. |
| `rust.coverage.json` | Reviewed classification, selection rationale, retained ceilings, and the empty exclusion list recorded as an assertion. |
| `tests/nemo-boundaries-rust.test.cjs` | The gate. In `tests/`, so it runs under `test:unit` — normal local validation, not an opt-in CLI. |

## Evidence at the candidate SHA

- `node --test tests/nemo-boundaries-rust.test.cjs` → **10 tests, 10 pass, 0 fail**, clean tree at `2b8ba31`.
- `node scripts/nemo/verify.cjs --profile quick` → **overall PASS (exit 0)**, 5 pass / 0 fail / 0 blocked. `test:unit` 667 tests, 665 pass, 0 fail (657 before this change, +10 here). Receipt `reports/20260910T071755Z-9735e96-dirty/receipt.json`.
- Emitted by the gate: 627 repository candidates, **41 `.rs`** — 8 native / 15 geometry / 16 mcp / 2 vectorize — classified into 15 modules, 0 excluded.

**Negative cases are asserted to fail**, since a gate that cannot fail proves nothing: an oversized in-scope `.rs`; an undeclared `.rs` (both as a new source and as a dropped declaration); a raised per-path ceiling; a raised ordinary budget. Deleting a waiver is shown to be a ratchet *reduction* whose debt resurfaces immediately as a size violation — I had this one backwards at first and the test caught it, so it is written the way `compareSizeBaseline` actually behaves, not the way I assumed.

A final test re-reads the three committed policy files and asserts the negative fixtures left them **byte-identical** (they work on `structuredClone`s), which is the second half of the packet's check 3.

## Deliberate choices worth a reviewer's attention

- **One size budget for production, test and build sources.** A laxer test-specific budget would define existing debt away instead of recording it — `geometry-wasm/tests/effect_layer_overlay_repro.rs` (503) gets a waiver like everything else over 500. `compareSizeBaseline` would flag a laxer new profile as `size-baseline-new-profile` anyway. A packet that actually reviews Rust test-size policy can add one.
- **`layerRules` is omitted, not declared-but-unenforced.** No Rust dependency analyzer exists; `checkProfile` is a JavaScript lexer and is never run against Rust. Declaring rules nothing enforces would imply a guarantee this packet does not make. `module.layer` stays as a classification label and `rust.coverage.json` says so explicitly.
- **`mcp-rust.profile.json` is byte-identical.** It is a stricter no-waiver overlay asserted by its own test, which is not mine to weaken. The new gate asserts the two profiles agree on the 9 overlapping paths *and* that no MCP path ever acquires a waiver the overlay forbids, so they cannot drift.
- **No shared-file edits.** `tests/` is under no coverage profile, so this needs no change to `scripts-nemo.profile.json` or the `toolingCoverage` count in `scripts/nemo/ci.test.cjs` — both contended by #955/#963/#967 and my own open #1088. Nothing here needs serialization through Ilya's orchestrator.

## Scope

Per the packet: **discovery and size only.** No Cargo dependency/module-graph enforcement, no product repair, no hosted run. Rust is not wired into `scripts/nemo/ci.cjs` applicability (shared, serialized) — recorded as an open gate in the coverage policy.

Note for the reviewer: `test:rust` in the quick profile exercises `geometry-wasm` only (4 binaries, 15 passed); `src-tauri` and `nemo-mcp` tests live in `test:rust-tauri` in the full profile. That does not affect this packet — classification and size are static — but it means "Rust is covered" here refers to source classification, not test execution.

Unblocks P28/#1030, whose new `src-tauri/src/media_probe.rs` now has to land declared and under 500 lines, with `video_decode.rs` shrinking against its pinned 2266 ceiling.

Refs #1013