### PR TITLE
[NEMO:P28] Extract the FFmpeg probe text parser into media_probe

### DIFF
--- a/engineering/boundaries/profiles/rust.coverage.json
+++ b/engineering/boundaries/profiles/rust.coverage.json
@@ -13,15 +13,15 @@
   },
   "provenance": {
     "repository": "mysteropodes/nemo",
-    "candidateCommit": "9735e962e04e98ad49202d76ec085f406c687641",
+    "candidateCommit": "391f2e347b098e0f7bb68000ebba6fc3119d28a3",
     "discoveryHelper": "scripts/nemo/lib/boundaries-repository.cjs",
     "discoveryReport": {
       "ok": true,
       "diagnostics": 0,
-      "repositoryCandidates": 623,
-      "repositoryCandidatesNote": "Clean working tree at candidateCommit. Only the Rust figures below are asserted by the gate; the whole-repository total is context, so ordinary growth elsewhere cannot manufacture a failure here.",
-      "rustCandidates": 41,
-      "trackedRustCandidates": 41,
+      "repositoryCandidates": 629,
+      "repositoryCandidatesNote": "Measured on this packet's working tree: 628 tracked paths at candidateCommit plus the single new module this packet adds. The P11/#1013 adoption recorded 623 at its own earlier candidate commit; the difference is ordinary repository growth on main between the two, not a discovery change. Only the Rust figures below are asserted by the gate; the whole-repository total is context, so ordinary growth elsewhere cannot manufacture a failure here.",
+      "rustCandidates": 42,
+      "trackedRustCandidates": 42,
       "untrackedRustCandidates": 0
     },
     "lineCounter": "countNonBlankLines (scripts/nemo/lib/boundaries.cjs) — the same counter the size checker uses, so recorded ceilings and enforced ceilings cannot drift.",
@@ -58,13 +58,13 @@
     { "path": "geometry-wasm/src/fill.rs", "ceiling": 998, "nonblankLinesAtAdoption": 998 },
     { "path": "geometry-wasm/src/tweenmatch.rs", "ceiling": 1074, "nonblankLinesAtAdoption": 1074 },
     { "path": "geometry-wasm/tests/effect_layer_overlay_repro.rs", "ceiling": 503, "nonblankLinesAtAdoption": 503 },
-    { "path": "src-tauri/src/video_decode.rs", "ceiling": 2266, "nonblankLinesAtAdoption": 2266 }
+    { "path": "src-tauri/src/video_decode.rs", "ceiling": 2266, "nonblankLinesAtAdoption": 2266, "nonblankLinesNow": 2160, "note": "nonblankLinesAtAdoption is the P11/#1013 adoption record and is deliberately not rewritten; nonblankLinesNow records the 106-line reduction P28/#1030 produced by moving the ffmpeg probe parser out to src-tauri/src/media_probe.rs, so the win stays visible instead of being erased. The ceiling stays at the adoption value: an extraction packet changes code, not size policy, and lowering the candidate ceiling without lowering the frozen baseline would give the baseline growth check 106 lines of slack." }
   ],
   "exclusions": [],
-  "exclusionsRationale": "Every one of the 41 discovered Rust candidates is adopted into a module, so the reviewed exclusion list is empty. An empty list is an assertion, not an omission: checkSourceCoverage reports coverage-unprofiled-source for any selected path that is neither declared nor exactly excluded, and the regression test exercises that failure.",
+  "exclusionsRationale": "Every one of the 42 discovered Rust candidates is adopted into a module, so the reviewed exclusion list is empty. An empty list is an assertion, not an omission: checkSourceCoverage reports coverage-unprofiled-source for any selected path that is neither declared nor exactly excluded, and the regression test exercises that failure.",
   "snapshotCounts": {
-    "selectedSources": 41,
-    "declaredSources": 41,
+    "selectedSources": 42,
+    "declaredSources": 42,
     "exclusions": 0,
     "modules": 15,
     "retainedCeilings": 5

--- a/engineering/boundaries/profiles/rust.profile.json
+++ b/engineering/boundaries/profiles/rust.profile.json
@@ -69,10 +69,12 @@
       "layer": "desktop-shell",
       "dir": "src-tauri/src",
       "files": [
+        "media_probe.rs",
         "vectorize.rs",
         "video_decode.rs"
       ],
       "publicApi": [
+        "media_probe.rs",
         "vectorize.rs",
         "video_decode.rs"
       ],
@@ -260,7 +262,7 @@
       "ceiling": 2266,
       "owner": "mysteropodes",
       "issue": "1013",
-      "reason": "Legacy pre-extraction Rust source; ceiling captured as an exact-path no-growth baseline pending real module extraction (R02/R05), not an architectural review of this file's content.",
+      "reason": "Legacy pre-extraction Rust source; ceiling captured as an exact-path no-growth baseline pending real module extraction (R02/R05), not an architectural review of this file's content. P28/#1030 began that extraction and the file now measures 2160; the allowance is deliberately left at its adoption value so an extraction packet changes code, not size policy. See nonblankLinesNow in rust.coverage.json.",
       "expires": "2026-12-05"
     }
   ]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,8 @@ use tauri_plugin_shell::ShellExt;
 
 // EXPERIMENTAL (experimental/native-video-decode) — see the module header.
 mod video_decode;
+// Pure text parsing of `ffmpeg -i` output, split out of video_decode (P28).
+mod media_probe;
 mod vectorize;
 mod application_mcp;
 // Per-task isolation of the app's native mutable state (R06, #902).

--- a/src-tauri/src/media_probe.rs
+++ b/src-tauri/src/media_probe.rs
@@ -1,0 +1,220 @@
+// ---- FFmpeg probe text parser (R05/P28) ----
+//
+// Extracted verbatim from `video_decode.rs` so that turning ffmpeg's
+// human-readable stream analysis into numbers is a unit that can be tested
+// without a decoder, without a sidecar and without any I/O at all. Every
+// function here takes a `&str` and returns values: this module deliberately
+// imports nothing from `std::process`, so a test can drive it with a captured
+// sample and no FFmpeg binary needs to exist on the machine running it.
+//
+// Owning the parsing separately also means the ffmpeg-invoking side keeps one
+// responsibility (spawn, pipe, lifetime) and this side keeps the other (read a
+// documented text format). The call sites in `video_decode.rs` are unchanged
+// apart from the path they call through.
+
+/// Parses `ffmpeg -i <path>` stderr (ffmpeg always prints full stream
+/// analysis there before erroring "At least one output file must be
+/// specified" — a well-established trick for probing without bundling
+/// ffprobe as a second sidecar, which would reintroduce a dynamically-
+/// linked-against-Homebrew binary and the exact dylib problem this
+/// rewrite exists to remove: confirmed via `otool -L` that Homebrew's
+/// ffprobe links ~78 /opt/homebrew paths, vs the bundled ffmpeg CLI's 23
+/// pure-OS-framework links). Hand-parsed (no `regex` dependency added —
+/// the format is small and stable enough, and every codec/container the
+/// decode module's own test matrix exercises was captured and used to
+/// build this parser against REAL output, not a guessed format) — see
+/// this module's `tests` for the captured samples this was built against.
+pub(crate) fn parse_probe(stderr: &str) -> Result<(u32, u32, f64, f64, String), String> {
+    // Duration: "  Duration: 00:00:02.00, start: 0.000000, bitrate: ..."
+    let duration = stderr
+        .lines()
+        .find_map(|l| l.trim_start().strip_prefix("Duration: "))
+        .and_then(|rest| rest.split(',').next())
+        .and_then(parse_hms)
+        .ok_or("could not find/parse a Duration: line in ffmpeg -i output")?;
+
+    // Video stream: "    Stream #0:0[...](...): Video: h264 (High) (...), yuv420p(...), 320x240 [SAR ...], ..., 30 fps, ..."
+    let video_line = stderr
+        .lines()
+        .find(|l| l.contains("Video:"))
+        .ok_or("no video stream found (no 'Video:' line in ffmpeg -i output — is this a video file?)")?;
+
+    let codec = video_line
+        .split("Video: ")
+        .nth(1)
+        .and_then(|rest| rest.split_whitespace().next())
+        .map(|tok| tok.trim_end_matches(|c: char| c == ',' || c == '(').to_lowercase())
+        .ok_or("could not parse codec name from Video: line")?;
+
+    // Resolution: scan whitespace-delimited tokens for the first "NxN"
+    // shape (SAR/DAR use "W:H" with a colon, never 'x', so this can't
+    // collide with them).
+    let (width, height) = video_line
+        .split(|c: char| c.is_whitespace() || c == ',')
+        .find_map(|tok| {
+            let (w, h) = tok.split_once('x')?;
+            Some((w.parse::<u32>().ok()?, h.parse::<u32>().ok()?))
+        })
+        .ok_or("could not find a WxH token on the Video: line")?;
+
+    // FPS: comma-separated segment ending in " fps".
+    let fps = video_line
+        .split(',')
+        .map(|seg| seg.trim())
+        .find_map(|seg| seg.strip_suffix(" fps"))
+        .and_then(|n| n.trim().parse::<f64>().ok())
+        .ok_or("could not find a '<N> fps' segment on the Video: line")?;
+
+    Ok((width, height, fps, duration, codec))
+}
+
+fn parse_hms(s: &str) -> Option<f64> {
+    let s = s.trim();
+    let mut it = s.split(':');
+    let h: f64 = it.next()?.parse().ok()?;
+    let m: f64 = it.next()?.parse().ok()?;
+    let sec: f64 = it.next()?.parse().ok()?;
+    Some(h * 3600.0 + m * 60.0 + sec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- probe parser, tested against REAL captured ffmpeg -i output
+    // (2026-07, run against the bundled binary against every file the decode
+    // module's codec matrix generates) — not a guessed format. Moved here
+    // unchanged with the parser (P28); the samples are the same strings. ----
+    #[test]
+    fn parse_probe_h264() {
+        let stderr = "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'x':\n  Duration: 00:00:02.00, start: 0.000000, bitrate: 338 kb/s\n  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 320x240 [SAR 1:1 DAR 4:3], 332 kb/s, 30 fps, 30 tbr, 15360 tbn (default)\n";
+        let (w, h, fps, dur, codec) = parse_probe(stderr).unwrap();
+        assert_eq!((w, h), (320, 240));
+        assert!((fps - 30.0).abs() < 0.001);
+        assert!((dur - 2.0).abs() < 0.001);
+        assert_eq!(codec, "h264");
+    }
+    #[test]
+    fn parse_probe_hevc() {
+        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 231 kb/s\n  Stream #0:0[0x1](und): Video: hevc (Main) (hvc1 / 0x31637668), yuv420p(tv, progressive), 320x240 [SAR 1:1 DAR 4:3], 214 kb/s, 30 fps, 30 tbr, 15360 tbn (default)\n";
+        let (w, h, fps, _dur, codec) = parse_probe(stderr).unwrap();
+        assert_eq!((w, h), (320, 240));
+        assert!((fps - 30.0).abs() < 0.001);
+        assert_eq!(codec, "hevc");
+    }
+    #[test]
+    fn parse_probe_vp9_webm_no_sar_paren() {
+        // WebM's Stream line has no [0x..] tag and no trailing (default) —
+        // a structurally different line shape from the mp4 samples.
+        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 397 kb/s\n  Stream #0:0: Video: vp9 (Profile 0), yuv420p(tv, progressive), 320x240, SAR 1:1 DAR 4:3, 30 fps, 30 tbr, 1k tbn\n";
+        let (w, h, fps, _dur, codec) = parse_probe(stderr).unwrap();
+        assert_eq!((w, h), (320, 240), "SAR/DAR '1:1'/'4:3' tokens must not be mistaken for the WxH token");
+        assert!((fps - 30.0).abs() < 0.001);
+        assert_eq!(codec, "vp9");
+    }
+    #[test]
+    fn parse_probe_prores_hq() {
+        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 8836 kb/s\n  Stream #0:0[0x1]: Video: prores (HQ) (apch / 0x68637061), yuv422p10le(tv, progressive), 320x240, 8832 kb/s, SAR 1:1 DAR 4:3, 30 fps, 30 tbr, 15360 tbn (default)\n";
+        let (w, h, fps, _dur, codec) = parse_probe(stderr).unwrap();
+        assert_eq!((w, h), (320, 240));
+        assert!((fps - 30.0).abs() < 0.001);
+        assert_eq!(codec, "prores");
+    }
+    #[test]
+    fn parse_probe_odd_dims_and_fractional_duration() {
+        let stderr = "  Duration: 00:00:01.00, start: 0.000000, bitrate: 1728 kb/s\n  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 954x542 [SAR 1:1 DAR 477:271], 1719 kb/s, 30 fps, 30 tbr, 15360 tbn (default)\n";
+        let (w, h, _fps, dur, _codec) = parse_probe(stderr).unwrap();
+        assert_eq!((w, h), (954, 542), "DAR 477:271 must not be mistaken for the WxH token");
+        assert!((dur - 1.0).abs() < 0.001);
+    }
+    #[test]
+    fn parse_probe_25fps() {
+        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 342 kb/s\n  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 320x240 [SAR 1:1 DAR 4:3], 336 kb/s, 25 fps, 25 tbr, 12800 tbn (default)\n";
+        let (_w, _h, fps, _dur, _codec) = parse_probe(stderr).unwrap();
+        assert!((fps - 25.0).abs() < 0.001, "fps was {fps}");
+    }
+    #[test]
+    fn parse_probe_rejects_audio_only_stderr() {
+        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 128 kb/s\n  Stream #0:0: Audio: mp3, 44100 Hz, stereo, fltp, 128 kb/s\n";
+        assert!(parse_probe(stderr).is_err(), "an audio-only file must not parse as having a video stream");
+    }
+
+    // ---- characterization of the failure paths (P28) ----
+    //
+    // These pin behavior that EXISTS today but had no test: each of the five
+    // `.ok_or(...)` arms, plus `parse_hms`. They assert the exact current
+    // error string, so the extraction — or any later edit — cannot quietly
+    // reword a diagnostic the JS side may be matching on. They document the
+    // parser as it is, including where it is lenient; they are not a
+    // statement that the current wording is the wording it should have.
+
+    #[test]
+    fn parse_probe_reports_a_missing_duration_line() {
+        let stderr = "  Stream #0:0[0x1](und): Video: h264 (High), yuv420p, 320x240, 30 fps, 30 tbr\n";
+        assert_eq!(
+            parse_probe(stderr).unwrap_err(),
+            "could not find/parse a Duration: line in ffmpeg -i output"
+        );
+    }
+
+    #[test]
+    fn parse_probe_reports_a_malformed_duration_line() {
+        // "N/A" is what ffmpeg prints for a stream whose duration it cannot
+        // determine; parse_hms rejects it and it surfaces as the same
+        // missing-Duration diagnostic rather than a distinct one.
+        let stderr = "  Duration: N/A, start: 0.000000, bitrate: N/A\n  Stream #0:0: Video: h264, yuv420p, 320x240, 30 fps\n";
+        assert_eq!(
+            parse_probe(stderr).unwrap_err(),
+            "could not find/parse a Duration: line in ffmpeg -i output"
+        );
+    }
+
+    #[test]
+    fn parse_probe_reports_an_absent_video_stream() {
+        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 128 kb/s\n  Stream #0:0: Audio: mp3, 44100 Hz, stereo, fltp, 128 kb/s\n";
+        assert_eq!(
+            parse_probe(stderr).unwrap_err(),
+            "no video stream found (no 'Video:' line in ffmpeg -i output — is this a video file?)"
+        );
+    }
+
+    #[test]
+    fn parse_probe_reports_unparseable_dimensions() {
+        // A Video: line with no WxH token at all — the codec parses, the
+        // resolution scan finds nothing, and that is the arm that reports.
+        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 338 kb/s\n  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), SAR 1:1 DAR 4:3, 30 fps, 30 tbr\n";
+        assert_eq!(
+            parse_probe(stderr).unwrap_err(),
+            "could not find a WxH token on the Video: line"
+        );
+    }
+
+    #[test]
+    fn parse_probe_reports_an_unparseable_fps_segment() {
+        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 338 kb/s\n  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 320x240 [SAR 1:1 DAR 4:3], 332 kb/s, 30 tbr, 15360 tbn (default)\n";
+        assert_eq!(
+            parse_probe(stderr).unwrap_err(),
+            "could not find a '<N> fps' segment on the Video: line"
+        );
+    }
+
+    #[test]
+    fn parse_probe_dimension_scan_is_lenient_about_a_non_numeric_x_token() {
+        // Characterizes a real property of the scan: it does not stop at the
+        // first token containing 'x', it keeps looking. "yuv420p(progressive)"
+        // has no 'x'; a pixel format that did would be skipped the same way.
+        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 338 kb/s\n  Stream #0:0[0x1](und): Video: h264 (High), xxx, 320x240 [SAR 1:1], 30 fps\n";
+        let (w, h, _fps, _dur, _codec) = parse_probe(stderr).unwrap();
+        assert_eq!((w, h), (320, 240));
+    }
+
+    #[test]
+    fn parse_hms_accepts_hours_minutes_seconds_and_rejects_short_forms() {
+        assert_eq!(parse_hms("00:00:02.00"), Some(2.0));
+        assert_eq!(parse_hms("01:02:03"), Some(3723.0));
+        assert_eq!(parse_hms("  00:00:01.50  "), Some(1.5), "surrounding whitespace is trimmed");
+        assert_eq!(parse_hms("02.00"), None, "a bare seconds value has no h:m:s shape");
+        assert_eq!(parse_hms("00:02.00"), None, "m:s is not accepted either");
+        assert_eq!(parse_hms("N/A"), None);
+    }
+}

--- a/src-tauri/src/video_decode.rs
+++ b/src-tauri/src/video_decode.rs
@@ -73,6 +73,12 @@ use std::sync::{Arc, Mutex};
 use serde::Serialize;
 use tauri::ipc::Response;
 
+// The `ffmpeg -i` stderr parser lives in its own module (P28): this one owns
+// spawning ffmpeg and managing decode sessions, `media_probe` owns reading the
+// text it prints. `open_session_core` and `create_optimized_media_core` below
+// are its only callers.
+use crate::media_probe::parse_probe;
+
 static NEXT_SESSION_ID: AtomicU32 = AtomicU32::new(1);
 
 /// Resolves the bundled ffmpeg sidecar's actual path — Tauri places
@@ -693,71 +699,6 @@ pub struct VideoInfo {
     pub frame_count: u64,
     pub duration_seconds: f64,
     pub codec: String,
-}
-
-/// Parses `ffmpeg -i <path>` stderr (ffmpeg always prints full stream
-/// analysis there before erroring "At least one output file must be
-/// specified" — a well-established trick for probing without bundling
-/// ffprobe as a second sidecar, which would reintroduce a dynamically-
-/// linked-against-Homebrew binary and the exact dylib problem this
-/// rewrite exists to remove: confirmed via `otool -L` that Homebrew's
-/// ffprobe links ~78 /opt/homebrew paths, vs the bundled ffmpeg CLI's 23
-/// pure-OS-framework links). Hand-parsed (no `regex` dependency added —
-/// the format is small and stable enough, and every codec/container this
-/// module's own test matrix exercises was captured and used to build
-/// this parser against REAL output, not a guessed format) — see
-/// `parse_probe_tests` for the captured samples this was built against.
-fn parse_probe(stderr: &str) -> Result<(u32, u32, f64, f64, String), String> {
-    // Duration: "  Duration: 00:00:02.00, start: 0.000000, bitrate: ..."
-    let duration = stderr
-        .lines()
-        .find_map(|l| l.trim_start().strip_prefix("Duration: "))
-        .and_then(|rest| rest.split(',').next())
-        .and_then(parse_hms)
-        .ok_or("could not find/parse a Duration: line in ffmpeg -i output")?;
-
-    // Video stream: "    Stream #0:0[...](...): Video: h264 (High) (...), yuv420p(...), 320x240 [SAR ...], ..., 30 fps, ..."
-    let video_line = stderr
-        .lines()
-        .find(|l| l.contains("Video:"))
-        .ok_or("no video stream found (no 'Video:' line in ffmpeg -i output — is this a video file?)")?;
-
-    let codec = video_line
-        .split("Video: ")
-        .nth(1)
-        .and_then(|rest| rest.split_whitespace().next())
-        .map(|tok| tok.trim_end_matches(|c: char| c == ',' || c == '(').to_lowercase())
-        .ok_or("could not parse codec name from Video: line")?;
-
-    // Resolution: scan whitespace-delimited tokens for the first "NxN"
-    // shape (SAR/DAR use "W:H" with a colon, never 'x', so this can't
-    // collide with them).
-    let (width, height) = video_line
-        .split(|c: char| c.is_whitespace() || c == ',')
-        .find_map(|tok| {
-            let (w, h) = tok.split_once('x')?;
-            Some((w.parse::<u32>().ok()?, h.parse::<u32>().ok()?))
-        })
-        .ok_or("could not find a WxH token on the Video: line")?;
-
-    // FPS: comma-separated segment ending in " fps".
-    let fps = video_line
-        .split(',')
-        .map(|seg| seg.trim())
-        .find_map(|seg| seg.strip_suffix(" fps"))
-        .and_then(|n| n.trim().parse::<f64>().ok())
-        .ok_or("could not find a '<N> fps' segment on the Video: line")?;
-
-    Ok((width, height, fps, duration, codec))
-}
-
-fn parse_hms(s: &str) -> Option<f64> {
-    let s = s.trim();
-    let mut it = s.split(':');
-    let h: f64 = it.next()?.parse().ok()?;
-    let m: f64 = it.next()?.parse().ok()?;
-    let sec: f64 = it.next()?.parse().ok()?;
-    Some(h * 3600.0 + m * 60.0 + sec)
 }
 
 // ---- indexed optimized media (random-access MJPEG stream + sidecar index) ----
@@ -1452,62 +1393,9 @@ pub fn autobench_report(report: String) -> Result<(), String> {
 mod tests {
     use super::*;
 
-    // ---- probe parser, tested against REAL captured ffmpeg -i output
-    // (2026-07, run against the bundled binary against every file this
-    // module's own codec matrix generates) — not a guessed format. ----
-    #[test]
-    fn parse_probe_h264() {
-        let stderr = "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'x':\n  Duration: 00:00:02.00, start: 0.000000, bitrate: 338 kb/s\n  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 320x240 [SAR 1:1 DAR 4:3], 332 kb/s, 30 fps, 30 tbr, 15360 tbn (default)\n";
-        let (w, h, fps, dur, codec) = parse_probe(stderr).unwrap();
-        assert_eq!((w, h), (320, 240));
-        assert!((fps - 30.0).abs() < 0.001);
-        assert!((dur - 2.0).abs() < 0.001);
-        assert_eq!(codec, "h264");
-    }
-    #[test]
-    fn parse_probe_hevc() {
-        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 231 kb/s\n  Stream #0:0[0x1](und): Video: hevc (Main) (hvc1 / 0x31637668), yuv420p(tv, progressive), 320x240 [SAR 1:1 DAR 4:3], 214 kb/s, 30 fps, 30 tbr, 15360 tbn (default)\n";
-        let (w, h, fps, _dur, codec) = parse_probe(stderr).unwrap();
-        assert_eq!((w, h), (320, 240));
-        assert!((fps - 30.0).abs() < 0.001);
-        assert_eq!(codec, "hevc");
-    }
-    #[test]
-    fn parse_probe_vp9_webm_no_sar_paren() {
-        // WebM's Stream line has no [0x..] tag and no trailing (default) —
-        // a structurally different line shape from the mp4 samples.
-        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 397 kb/s\n  Stream #0:0: Video: vp9 (Profile 0), yuv420p(tv, progressive), 320x240, SAR 1:1 DAR 4:3, 30 fps, 30 tbr, 1k tbn\n";
-        let (w, h, fps, _dur, codec) = parse_probe(stderr).unwrap();
-        assert_eq!((w, h), (320, 240), "SAR/DAR '1:1'/'4:3' tokens must not be mistaken for the WxH token");
-        assert!((fps - 30.0).abs() < 0.001);
-        assert_eq!(codec, "vp9");
-    }
-    #[test]
-    fn parse_probe_prores_hq() {
-        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 8836 kb/s\n  Stream #0:0[0x1]: Video: prores (HQ) (apch / 0x68637061), yuv422p10le(tv, progressive), 320x240, 8832 kb/s, SAR 1:1 DAR 4:3, 30 fps, 30 tbr, 15360 tbn (default)\n";
-        let (w, h, fps, _dur, codec) = parse_probe(stderr).unwrap();
-        assert_eq!((w, h), (320, 240));
-        assert!((fps - 30.0).abs() < 0.001);
-        assert_eq!(codec, "prores");
-    }
-    #[test]
-    fn parse_probe_odd_dims_and_fractional_duration() {
-        let stderr = "  Duration: 00:00:01.00, start: 0.000000, bitrate: 1728 kb/s\n  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 954x542 [SAR 1:1 DAR 477:271], 1719 kb/s, 30 fps, 30 tbr, 15360 tbn (default)\n";
-        let (w, h, _fps, dur, _codec) = parse_probe(stderr).unwrap();
-        assert_eq!((w, h), (954, 542), "DAR 477:271 must not be mistaken for the WxH token");
-        assert!((dur - 1.0).abs() < 0.001);
-    }
-    #[test]
-    fn parse_probe_25fps() {
-        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 342 kb/s\n  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 320x240 [SAR 1:1 DAR 4:3], 336 kb/s, 25 fps, 25 tbr, 12800 tbn (default)\n";
-        let (_w, _h, fps, _dur, _codec) = parse_probe(stderr).unwrap();
-        assert!((fps - 25.0).abs() < 0.001, "fps was {fps}");
-    }
-    #[test]
-    fn parse_probe_rejects_audio_only_stderr() {
-        let stderr = "  Duration: 00:00:02.00, start: 0.000000, bitrate: 128 kb/s\n  Stream #0:0: Audio: mp3, 44100 Hz, stereo, fltp, 128 kb/s\n";
-        assert!(parse_probe(stderr).is_err(), "an audio-only file must not parse as having a video stream");
-    }
+    // The `parse_probe`/`parse_hms` unit tests moved with the parser to
+    // `crate::media_probe` (P28). What remains here needs a real ffmpeg
+    // binary; those do not.
 
     use std::process::Command as StdCommand;
 

--- a/tests/nemo-boundaries-rust.test.cjs
+++ b/tests/nemo-boundaries-rust.test.cjs
@@ -75,7 +75,10 @@ function fixtureProfile(files) {
 test('committed Rust policy is a valid profile and its recorded budget matches the coverage policy', () => {
   validateProfile(profile);
   validateProfile(baseline);
-  assert.deepEqual(profile, baseline, 'baseline must be the reviewed candidate at adoption');
+  // The baseline is deliberately NOT required to equal the candidate. It is
+  // frozen at adoption; if every profile change had to change it too, the
+  // ratchet would only ever compare a file to itself. The invariant is the
+  // compareSizeBaseline result below, not equality.
   assert.equal(LIMITS.warn, coverage.sizePolicy.warn);
   assert.equal(LIMITS.hardMax, coverage.sizePolicy.hardMax);
   assert.equal(profile.layerRules, undefined, 'layer rules are not declared because no Rust dependency analyzer runs');
@@ -130,10 +133,25 @@ test('no declared Rust source exceeds its effective ceiling, and retained ceilin
     assert.ok(record, `retained ceiling for ${exception.path} is missing from the coverage policy`);
     assert.equal(exception.rule, 'size');
     assert.equal(exception.ceiling, record.ceiling);
-    // A no-growth baseline is the measured count, not a rounded allowance.
+    // A no-growth baseline is the measured count at ADOPTION, not a rounded
+    // allowance — and "no growth" is an upper bound, not an equality. The
+    // first version of this test asserted `actual === nonblankLinesAtAdoption`
+    // and `ceiling === actual`, which forbade a waived file from ever
+    // SHRINKING: exactly the outcome remediation exists to produce. P28/#1030
+    // tripped it by moving the probe parser out of video_decode.rs.
     const actual = countNonBlankLines(fs.readFileSync(path.join(ROOT, exception.path), 'utf8'));
-    assert.equal(actual, record.nonblankLinesAtAdoption);
-    assert.equal(exception.ceiling, actual);
+    assert.ok(actual <= record.nonblankLinesAtAdoption,
+      `${exception.path} grew past its adoption count (${actual} > ${record.nonblankLinesAtAdoption})`);
+    assert.ok(exception.ceiling <= record.nonblankLinesAtAdoption,
+      `${exception.path} waiver was widened above its adoption count`);
+    assert.ok(exception.ceiling >= actual,
+      `${exception.path} waiver no longer covers the file (${exception.ceiling} < ${actual})`);
+    // When a file has shrunk, the coverage policy must say so rather than
+    // silently carrying an allowance nobody can account for.
+    if (actual !== record.nonblankLinesAtAdoption) {
+      assert.equal(record.nonblankLinesNow, actual,
+        `${exception.path} shrank to ${actual}; record it as nonblankLinesNow in rust.coverage.json`);
+    }
     assert.ok(exception.ceiling > LIMITS.hardMax, `${exception.path} does not need a waiver`);
   }
   const applied = result.exceptionsApplied.map((entry) => entry.path).sort();
@@ -143,7 +161,12 @@ test('no declared Rust source exceeds its effective ceiling, and retained ceilin
 test('committed policy has no ratchet regression against its own baseline', () => {
   const result = compareSizeBaseline(baseline, profile, { root: ROOT });
   assert.equal(result.ok, true, JSON.stringify(result.violations, null, 2));
-  assert.equal(result.baselinePathCount, result.candidatePathCount);
+  // The candidate may declare MORE paths than the frozen baseline — that is a
+  // new module being adopted (P28/#1030 added src-tauri/src/media_probe.rs).
+  // It may never declare FEWER: a path dropping out of the candidate would be
+  // coverage silently disappearing, which is the case worth failing on.
+  assert.ok(result.candidatePathCount >= result.baselinePathCount,
+    `candidate declares ${result.candidatePathCount} path(s), fewer than the baseline's ${result.baselinePathCount}`);
 });
 
 test('the stricter MCP overlay stays consistent with the whole-tree profile', () => {


### PR DESCRIPTION
Closes #1030. Base `391f2e3`, candidate `61f431a`. Branch `pollen/p28-media-probe-parser`, worktree `nemo-p28-media-probe`. One writer.

## What changed

`parse_probe` and its private helper `parse_hms` move out of `src-tauri/src/video_decode.rs` into a new `src-tauri/src/media_probe.rs`. `video_decode` keeps one job (spawn ffmpeg, manage decode sessions), `media_probe` keeps the other (read the text ffmpeg prints). Both call sites — `open_session_core` and `create_optimized_media_core` — are unchanged apart from the path they call through. The packet named only the first; the second is in the same file and could not be left behind.

**Behaviour-preserving, mechanically checked.** The moved bodies are byte-identical to the originals at `391f2e3` (verified by `diff`; the sole change is `pub(crate)` visibility). Same tuple, same error strings, same doc comments. The seven captured-ffmpeg-output tests moved with the parser unchanged.

The new module imports nothing from `std::process` and performs no I/O — it takes a `&str` and returns values — so **its tests need no FFmpeg binary on the machine running them.** That is the point of the split.

## Two commits, reviewable separately

**`15e4b7c` — gate fix (my own defect from #1098, disclosed in the claim before writing any code).** Three assertions in `tests/nemo-boundaries-rust.test.cjs` encoded *"nothing ever changes"* where the invariant is *"nothing ever grows"*:

| assertion | what it actually forbade |
|---|---|
| `deepEqual(profile, baseline)` | any profile change without also moving the ratchet baseline — so `compareSizeBaseline` only ever compared a file to itself |
| `equal(actual, nonblankLinesAtAdoption)` + `equal(ceiling, actual)` | a waived file ever **shrinking** — precisely the outcome remediation exists to produce |
| `equal(baselinePathCount, candidatePathCount)` | adopting a new Rust module at all |

Replaced with the bounds that express no-growth: the file may not exceed its adoption count, the waiver may not be widened above it, the waiver must still cover the file, and a file that has shrunk must record the new measurement so the win is visible rather than leaving an allowance nobody can account for. Path count may rise, never fall. Verified green **in isolation** at that commit, before the extraction lands.

**`61f431a` — the extraction**, including the boundary declarations.

## Size policy: deliberately not moved

`media_probe.rs` is declared in `rust.desktop.media` (41 → 42 paths), 203 nonblank lines, under the 350 warn — no waiver needed. `video_decode.rs` measures **2266 → 2160 (−106)**.

Its ceiling is **left at the adoption value** and the reduction is recorded as `nonblankLinesNow`. I first ratcheted the ceiling down to 2160 and the gate's own mutation test caught the consequence: with the frozen baseline still at 2266, lowering only the candidate ceiling gives the growth check 106 lines of slack, and `a raised legacy ceiling fails` stopped failing. An extraction packet changes code, not size policy — lowering the allowance is a decision for its own packet, and it needs the baseline moved with it. `rust.baseline.json` is untouched: that is the ratchet working.

## Acceptance

| check | result |
|---|---|
| `cargo test --lib parse_probe` at base `391f2e3`, **before any edit** | **7 passed, 0 failed** |
| `cargo test --lib` (parser tests, after) | **14 passed, 0 failed** — 7 moved + 7 new |
| `cargo test --lib` full, at base | 47 tests, **17 pass / 30 fail** |
| `cargo test --lib` full, at candidate | 54 tests, **24 pass / 30 fail** |
| `node --test tests/nemo-boundaries-rust.test.cjs` | **10 pass, 0 fail** |
| `node scripts/nemo/verify.cjs --profile quick` | **PASS 5/5** (doctor, check, inventory, test:unit 667, test:rust 15) |

Same 30 failures before and after, +7 net passing tests, no regression.

## Native blocker — recorded, NOT passed off as green

The 30 `video_decode` failures are **not** caused by this change. Confirmed by stashing the packet and re-running the identical test at base `391f2e3`: same failure, same message. `npm run doctor` gives the authoritative diagnosis:

```
sidecar dylibs   26 external, 2 missing on this machine
                 MISSING /opt/homebrew/opt/libvpx/lib/libvpx.12.dylib
                 MISSING /opt/homebrew/opt/svt-av1/lib/libSvtAv1Enc.4.dylib
sidecar runs     MISSING dyld: Library not loaded: .../libvpx.12.dylib
```

This is exactly the failure mode CLAUDE.md §7 documents: the committed LGPL sidecar is dynamically linked against versioned Homebrew dylibs, and a `brew upgrade` past those majors breaks both `ffmpeg -version` and `bundle-ffmpeg-dylibs.py`. Homebrew here carries libvpx 1.15.2, so `.12` is gone. Remedy per §7 is re-running `scripts/rebuild-ffmpeg-lgpl.sh` and committing the relinked binary — **R04's lane, not this packet's.** Every native-decode assertion in this repo is unavailable on this machine until it is done; I am reporting that as an environment limitation, not as a pass.

Out of scope per the packet: no FFmpeg install, no codec or seek-timing repair, no product behaviour change, no hosted run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)