### PR TITLE
[NEMO:T04] Rust coverage for nemo-mcp with a reviewed no-regression ratchet

### DIFF
--- a/engineering/boundaries/profiles/scripts-nemo.profile.json
+++ b/engineering/boundaries/profiles/scripts-nemo.profile.json
@@ -57,8 +57,14 @@
       "files": ["boundaries-ratchet.cjs"], "publicApi": ["boundaries-ratchet.cjs"], "sizeProfile": "Domain/application JS or TS" },
     { "id": "nemo.lib.boundariesApplication", "layer": "tooling-application", "dir": "scripts/nemo/lib",
       "files": ["boundaries-application.cjs"], "publicApi": ["boundaries-application.cjs"], "sizeProfile": "Domain/application JS or TS" },
+    { "id": "nemo.lib.coverageRust", "layer": "tooling-application", "dir": "scripts/nemo/lib",
+      "files": ["coverage-rust.cjs"], "publicApi": ["coverage-rust.cjs"], "sizeProfile": "Domain/application JS or TS" },
+    { "id": "nemo.lib.coverageRustJob", "layer": "tooling-application", "dir": "scripts/nemo/lib",
+      "files": ["coverage-rust-job.cjs"], "publicApi": ["coverage-rust-job.cjs"], "sizeProfile": "Domain/application JS or TS" },
     { "id": "nemo.ci", "layer": "tooling-application", "dir": "scripts/nemo",
       "files": ["ci.cjs"], "publicApi": ["ci.cjs"], "sizeProfile": "Domain/application JS or TS" },
+    { "id": "nemo.cli.coverageRust", "layer": "tooling-application", "dir": "scripts/nemo",
+      "files": ["coverage-rust.cjs"], "publicApi": ["coverage-rust.cjs"], "sizeProfile": "Domain/application JS or TS" },
 
     { "id": "nemo.cli.boundaries", "layer": "tooling-bootstrap", "dir": "scripts/nemo",
       "files": ["boundaries.cjs"], "publicApi": [], "sizeProfile": "Handwritten config/bootstrap" },
@@ -114,7 +120,9 @@
     { "id": "nemo.test.ci", "layer": "tooling-test", "dir": "scripts/nemo",
       "files": ["ci.test.cjs"], "publicApi": ["ci.test.cjs"], "sizeProfile": "Test file" },
     { "id": "nemo.test.baseline", "layer": "tooling-test", "dir": "scripts/nemo",
-      "files": ["baseline.test.cjs"], "publicApi": ["baseline.test.cjs"], "sizeProfile": "Test file" }
+      "files": ["baseline.test.cjs"], "publicApi": ["baseline.test.cjs"], "sizeProfile": "Test file" },
+    { "id": "nemo.test.coverageRust", "layer": "tooling-test", "dir": "scripts/nemo",
+      "files": ["coverage-rust.test.cjs"], "publicApi": ["coverage-rust.test.cjs"], "sizeProfile": "Test file" }
   ],
   "layerRules": {
     "tooling-shared": { "allowedLayers": [] },

--- a/engineering/coverage/rust-mcp.baseline.json
+++ b/engineering/coverage/rust-mcp.baseline.json
@@ -1,0 +1,80 @@
+{
+  "schema": "nemo.rust-coverage-baseline/1",
+  "metrics": [
+    "lines",
+    "regions",
+    "functions"
+  ],
+  "branchesExcluded": "branch coverage is not instrumented by the stable Rust toolchain (needs nightly -Z coverage-options=branch); every branch count is 0, so a branch floor would be a gate that cannot fail. Excluded on purpose — see T04/#1053.",
+  "crate": "nemo-mcp",
+  "manifestPath": "nemo-mcp/Cargo.toml",
+  "recorded": {
+    "sha": "391f2e347b098e0f7bb68000ebba6fc3119d28a3",
+    "treeDirty": true,
+    "crateDirty": false,
+    "date": "2026-09-10",
+    "issue": "T04/#1053"
+  },
+  "tool": {
+    "name": "cargo-llvm-cov",
+    "version": "0.9.1",
+    "versionLine": "cargo-llvm-cov 0.9.1",
+    "install": "cargo install cargo-llvm-cov --version 0.9.1 --locked",
+    "rustupComponent": "llvm-tools-preview",
+    "cargo": "1.91.1",
+    "rustc": "1.91.1",
+    "hostTriple": "aarch64-apple-darwin"
+  },
+  "tests": {
+    "binaries": 11,
+    "passed": 16,
+    "failed": 0
+  },
+  "exclusions": [],
+  "sourceRoot": "nemo-mcp/src",
+  "totals": {
+    "lines": 89.23,
+    "regions": 85.52,
+    "functions": 88.88
+  },
+  "files": {
+    "nemo-mcp/src/contract.rs": {
+      "lines": 94.44,
+      "regions": 93.39,
+      "functions": 94.11
+    },
+    "nemo-mcp/src/lib.rs": {
+      "noRegions": true,
+      "reason": "no executable regions in the coverage report",
+      "note": "Module declarations and one const only; llvm-cov emits no record because there are no executable regions. Baselined explicitly so that gaining real code here is caught as a change requiring re-baseline rather than passing unnoticed. T04/#1053."
+    },
+    "nemo-mcp/src/main.rs": {
+      "lines": 100,
+      "regions": 81.25,
+      "functions": 100,
+      "note": "Lines 100% but regions 81.25%: the binary entry point is executed by the stdio integration tests, while some error-path regions inside covered lines are not. T04/#1053."
+    },
+    "nemo-mcp/src/registry.rs": {
+      "lines": 69.49,
+      "regions": 71.17,
+      "functions": 75,
+      "note": "Lowest measured module (69.49% lines). Uncovered lines 21, 24-34, 39, 45, 49, 55 are the endpoint-discovery rejection paths: registry_root()'s NEMO_MCP_REGISTRY / NEMO_TAURI_DATA_DIR absolute-path rejection and the dirs::data_local_dir fallback, plus read_endpoints()'s missing-root, non-.json, non-file/over-4096-byte and malformed-record filters. These are the transport's input-validation branches, so this is the most load-bearing gap in the crate. T04/#1053."
+    },
+    "nemo-mcp/src/schema.rs": {
+      "lines": 0,
+      "regions": 0,
+      "functions": 0,
+      "note": "0% by construction: this file is the `nemo-mcp-schema` binary ([[bin]] in Cargo.toml) that dumps the request/response JSON Schema to stdout. No test in the crate executes that binary, so every one of its 7 lines is uncovered. Recorded as an observed gap, not excluded — a test that runs the binary and parses its output would raise this floor. T04/#1053."
+    },
+    "nemo-mcp/src/server.rs": {
+      "lines": 93.54,
+      "regions": 92.19,
+      "functions": 100
+    },
+    "nemo-mcp/src/wire.rs": {
+      "lines": 96.55,
+      "regions": 87.05,
+      "functions": 87.5
+    }
+  }
+}

--- a/scripts/nemo/README.md
+++ b/scripts/nemo/README.md
@@ -32,11 +32,26 @@ not `npm test` or the quick profile. The `nemo-mcp` crate is not selected by eit
 profile: use its applicable `cargo test --manifest-path nemo-mcp/Cargo.toml` command
 explicitly. Read the candidate's job source/help when selecting checks.
 
+The named `test:coverage-rust` job (T04) runs the same `nemo-mcp` suites under
+`cargo-llvm-cov`, writes LCOV/HTML/JSON for the crate's production source into the run's
+report directory, and compares each file against
+[`engineering/coverage/rust-mcp.baseline.json`](../../engineering/coverage/rust-mcp.baseline.json)
+— the coverage observed at a reviewed SHA. It is in no profile and is not required,
+because `cargo-llvm-cov` is not yet a declared prerequisite; run it with
+`node scripts/nemo/job.cjs test:coverage-rust`. Without the tool or the `llvm-tools`
+component it reports `blocked` and names what is missing; it never reports `pass`.
+`node scripts/nemo/coverage-rust.cjs` runs the same comparison directly, and `--update`
+re-records the baseline. Floors are per file: there is no invented global target, and
+**branch coverage is deliberately absent** — the stable toolchain does not instrument
+branches, so a branch floor would compare 0 against 0 and could never fail.
+
 `npm run check` does not run all architecture/type/coverage checks. The adopted boundary
 lane is described in [the local CI reference](../../engineering/ci/README.md). Its `quick`
 lane explicitly selects doctor/check/unit/geometry tests, whereas the verifier's default
-quick profile also includes inventory. c8, Rust coverage and general feature-registration
-enforcement are planned leaves, not capabilities delivered merely by this command list.
+quick profile also includes inventory. JS coverage (`test:coverage`, c8) and Rust coverage
+(`test:coverage-rust`) exist as explicitly selected, non-required jobs; neither is in a
+profile, so a green `verify` run does not mean either one ran. General feature-registration
+enforcement remains a planned leaf, not a capability delivered by this command list.
 
 The [R03 baseline](../../engineering/inventory/BASELINE.md) records the retained
 CPU, browser, native, and packaged-desktop evidence and their separate limitations.

--- a/scripts/nemo/ci.test.cjs
+++ b/scripts/nemo/ci.test.cjs
@@ -71,8 +71,9 @@ test('tooling coverage profiles every current scripts/nemo CommonJS source', () 
   const profile = JSON.parse(fs.readFileSync(path.join(ROOT, ci.PROFILE), 'utf8'));
   const result = ci.toolingCoverage(profile, ROOT);
   assert.equal(result.ok, true);
-  assert.equal(result.sourcePathCount, 55);
-  assert.equal(result.declaredPathCount, 55);
+  // 55 + the four T04 Rust-coverage sources (lib evaluator, lib job, CLI, tests).
+  assert.equal(result.sourcePathCount, 59);
+  assert.equal(result.declaredPathCount, 59);
   const incomplete = structuredClone(profile);
   incomplete.modules = incomplete.modules.filter((module) => module.id !== 'nemo.lib.boundariesApplication');
   const rejected = ci.toolingCoverage(incomplete, ROOT);

--- a/scripts/nemo/coverage-rust.cjs
+++ b/scripts/nemo/coverage-rust.cjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+'use strict';
+// CLI for the T04 Rust coverage ratchet (nemo-mcp).
+//
+//   node scripts/nemo/coverage-rust.cjs            # check against the baseline
+//   node scripts/nemo/coverage-rust.cjs --update   # re-record the baseline
+//   node scripts/nemo/coverage-rust.cjs --json     # machine-readable verdict
+//
+// Exit codes: 0 = every reviewed floor held, 1 = ratchet violation or failing
+// suite, 2 = bad usage or a missing tool/baseline (blocked). Blocked is never
+// reported as success.
+//
+// `--update` rewrites the committed baseline from a fresh measurement. It is a
+// reviewed action, not routine maintenance: raising a floor is how coverage
+// improvements are locked in, and LOWERING one is a deliberate admission that
+// needs its reason in the pull request.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { ROOT, run, exists, readJson } = require('./lib/util.cjs');
+const { evaluateRustCoverage, buildBaseline } = require('./lib/coverage-rust.cjs');
+const { produceReports, listSourceFiles, SOURCE_ROOT, MANIFEST, BASELINE } = require('./lib/coverage-rust-job.cjs');
+
+function parseArgs(argv) {
+  const out = { update: false, json: false, outDir: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--update') out.update = true;
+    else if (a === '--check') out.update = false;
+    else if (a === '--json') out.json = true;
+    else if (a === '--out') {
+      if (!argv[i + 1] || argv[i + 1].startsWith('--')) throw new Error('--out requires a directory');
+      out.outDir = argv[++i];
+    } else throw new Error(`unknown option: ${a}`);
+  }
+  return out;
+}
+
+function gitValue(args, fallback) {
+  const r = run('git', args, { timeout: 20000 });
+  return r.status === 0 ? r.stdout.trim() : fallback;
+}
+
+function toolVersion(line) {
+  const m = /(\d+\.\d+\.\d+)/.exec(line || '');
+  return m ? m[1] : null;
+}
+
+function main() {
+  let args;
+  try { args = parseArgs(process.argv.slice(2)); }
+  catch (e) { console.error(`usage error: ${e.message}`); return 2; }
+
+  const outDir = args.outDir
+    ? path.resolve(args.outDir)
+    : path.join(ROOT, 'reports', 'coverage-rust-cli');
+
+  const produced = produceReports(outDir);
+  if (produced.status === 'blocked') {
+    console.error(`blocked: ${produced.reason}`);
+    return 2;
+  }
+  if (produced.status === 'fail') {
+    console.error(`fail: ${produced.reason}`);
+    return 1;
+  }
+
+  const report = readJson(produced.jsonPath);
+  const sourceFiles = listSourceFiles(ROOT, SOURCE_ROOT);
+  const baselinePath = path.join(ROOT, ...BASELINE.split('/'));
+
+  if (args.update) {
+    const prior = exists(baselinePath) ? readJson(baselinePath) : null;
+    const next = buildBaseline({
+      report,
+      root: ROOT,
+      sourceRoot: SOURCE_ROOT,
+      sourceFiles,
+      meta: {
+        crate: 'nemo-mcp',
+        manifestPath: MANIFEST,
+        recorded: {
+          sha: gitValue(['rev-parse', 'HEAD'], null),
+          // Whole-tree dirt is expected while this tooling is itself in
+          // flight. What decides whether these numbers are reproducible is
+          // whether the measured CRATE was clean, so record that separately.
+          treeDirty: gitValue(['status', '--porcelain'], '') !== '',
+          crateDirty: gitValue(['status', '--porcelain', '--', 'nemo-mcp'], '') !== '',
+          date: new Date().toISOString().slice(0, 10),
+          issue: 'T04/#1053',
+        },
+        tool: {
+          name: 'cargo-llvm-cov',
+          version: toolVersion(produced.tool.version),
+          versionLine: produced.tool.version,
+          install: 'cargo install cargo-llvm-cov --version 0.9.1 --locked',
+          rustupComponent: 'llvm-tools-preview',
+          cargo: toolVersion(gitOrTool(['cargo', '--version'])),
+          rustc: toolVersion(gitOrTool(['rustc', '--version'])),
+          hostTriple: hostTriple(),
+        },
+        tests: produced.counts,
+        exclusions: (prior && prior.exclusions) || [],
+        priorFiles: (prior && prior.files) || {},
+      },
+    });
+    fs.mkdirSync(path.dirname(baselinePath), { recursive: true });
+    fs.writeFileSync(baselinePath, JSON.stringify(next, null, 2) + '\n');
+    console.log(`wrote ${BASELINE}: ${Object.keys(next.files).length} files, `
+      + `totals lines ${next.totals.lines}% / regions ${next.totals.regions}% / functions ${next.totals.functions}%`);
+    if (prior) reportBaselineDelta(prior, next);
+    return 0;
+  }
+
+  if (!exists(baselinePath)) {
+    console.error(`blocked: ${BASELINE} missing; run with --update and have the result reviewed`);
+    return 2;
+  }
+
+  let verdict;
+  try {
+    verdict = evaluateRustCoverage({ report, baseline: readJson(baselinePath), sourceFiles, root: ROOT });
+  } catch (e) {
+    console.error(`fail: coverage ratchet could not evaluate: ${e.message}`);
+    return 1;
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify(verdict, null, 2));
+    return verdict.ok ? 0 : 1;
+  }
+
+  for (const row of verdict.perFile) {
+    if (row.noRegions) { console.log(`  ${row.path.padEnd(28)} no executable regions`); continue; }
+    console.log(`  ${row.path.padEnd(28)} lines ${pct(row.percent.lines)} (floor ${pct(row.floor.lines)})  `
+      + `regions ${pct(row.percent.regions)}  functions ${pct(row.percent.functions)}`);
+  }
+  console.log(`  ${'TOTAL'.padEnd(28)} lines ${pct(verdict.totals.lines)}  regions ${pct(verdict.totals.regions)}  functions ${pct(verdict.totals.functions)}`);
+  for (const item of verdict.improvements) {
+    console.log(`improved: ${item.file} ${item.metric} ${pct(item.candidate)} > floor ${pct(item.floor)} — re-run --update to lock it in`);
+  }
+  for (const item of verdict.removals) console.log(`removed: ${item.file} (${item.reason})`);
+  for (const v of verdict.violations) console.error(`violation [${v.rule}] ${v.message}`);
+
+  console.log(verdict.ok
+    ? `ok: ${verdict.measuredFileCount} measured file(s), every reviewed floor held`
+    : `FAILED: ${verdict.violations.length} violation(s)`);
+  return verdict.ok ? 0 : 1;
+}
+
+function gitOrTool(argv) {
+  const r = run(argv[0], argv.slice(1), { timeout: 20000 });
+  return r.status === 0 ? r.stdout.trim() : null;
+}
+
+function hostTriple() {
+  const r = run('rustc', ['-vV'], { timeout: 20000 });
+  if (r.status !== 0) return null;
+  const m = /^host:\s*(.+)$/m.exec(r.stdout);
+  return m ? m[1].trim() : null;
+}
+
+function reportBaselineDelta(prior, next) {
+  for (const [file, entry] of Object.entries(next.files)) {
+    const before = prior.files ? prior.files[file] : null;
+    if (!before) { console.log(`  + ${file} newly baselined`); continue; }
+    for (const metric of ['lines', 'regions', 'functions']) {
+      if (typeof before[metric] !== 'number' || typeof entry[metric] !== 'number') continue;
+      if (entry[metric] < before[metric]) console.log(`  ! ${file} ${metric} floor LOWERED ${before[metric]} -> ${entry[metric]} (justify this in the PR)`);
+      else if (entry[metric] > before[metric]) console.log(`  ^ ${file} ${metric} floor raised ${before[metric]} -> ${entry[metric]}`);
+    }
+  }
+  for (const file of Object.keys(prior.files || {})) {
+    if (!Object.hasOwn(next.files, file)) console.log(`  - ${file} dropped from the baseline`);
+  }
+}
+
+function pct(value) {
+  return typeof value === 'number' ? `${value.toFixed(2)}%`.padStart(8) : '     n/a';
+}
+
+process.exit(main());

--- a/scripts/nemo/coverage-rust.test.cjs
+++ b/scripts/nemo/coverage-rust.test.cjs
@@ -1,0 +1,290 @@
+'use strict';
+// Receipt tests for the T04 Rust coverage ratchet.
+//
+// The evaluator is a hand-rolled comparator, so most of these are mutation
+// tests: take a report that legitimately passes, change exactly one thing that
+// SHOULD be caught, and assert it is. A gate is only worth its receipt if it
+// can be shown to fail.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  SCHEMA, METRICS, floorPct, readReport, validateBaseline, evaluateRustCoverage, buildBaseline,
+} = require('./lib/coverage-rust.cjs');
+const { listSourceFiles, SOURCE_ROOT, BASELINE } = require('./lib/coverage-rust-job.cjs');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const SRC = 'nemo-mcp/src';
+
+function summary(metrics) {
+  const out = { branches: { count: 0, covered: 0, percent: 0 } };
+  for (const metric of METRICS) {
+    out[metric] = { count: 100, covered: Math.round(metrics[metric]), percent: metrics[metric] };
+  }
+  return out;
+}
+
+// An llvm-cov JSON export shaped like the real one: absolute filenames under
+// `root`, a per-file summary, and a crate totals block.
+function makeReport(files, opts = {}) {
+  const root = opts.root || '/checkout';
+  const totals = opts.totals || { lines: 90, regions: 90, functions: 90 };
+  return {
+    type: 'llvm.coverage.json.export',
+    version: '3.0.1',
+    data: [{
+      files: files.map((f) => ({ filename: `${root}/${f.path}`, summary: summary(f) })),
+      totals: summary(totals),
+    }],
+  };
+}
+
+const TWO_FILES = [
+  { path: `${SRC}/wire.rs`, lines: 96.55, regions: 87.06, functions: 87.5 },
+  { path: `${SRC}/server.rs`, lines: 93.55, regions: 92.2, functions: 100 },
+];
+
+function baselineFor(files, extra = {}) {
+  return Object.assign({
+    schema: SCHEMA,
+    metrics: METRICS.slice(),
+    sourceRoot: SRC,
+    totals: { lines: 90, regions: 90, functions: 90 },
+    files: Object.fromEntries(files.map((f) => [f.path, {
+      lines: floorPct(f.lines), regions: floorPct(f.regions), functions: floorPct(f.functions),
+    }])),
+    exclusions: [],
+  }, extra);
+}
+
+function evaluate(report, baseline, sourceFiles, root = '/checkout') {
+  return evaluateRustCoverage({ report, baseline, sourceFiles, root });
+}
+
+const PATHS = TWO_FILES.map((f) => f.path);
+
+// ---- rounding -----------------------------------------------------------
+
+test('floorPct floors and never rounds up', () => {
+  // 93.5483…% rounds to 93.55. A 93.55 floor would fail against the very run
+  // that produced it, so the floor must be 93.54.
+  assert.strictEqual(floorPct(93.54838709677419), 93.54);
+  assert.strictEqual(floorPct(94.44444444444444), 94.44);
+  assert.strictEqual(floorPct(87.05882352941177), 87.05);
+  assert.strictEqual(floorPct(100), 100);
+  assert.strictEqual(floorPct(0), 0);
+});
+
+test('a baseline built from a report passes against that same report', () => {
+  const report = makeReport(TWO_FILES);
+  const built = buildBaseline({ report, root: '/checkout', sourceRoot: SRC, sourceFiles: PATHS, meta: {} });
+  const verdict = evaluate(report, built, PATHS);
+  assert.deepStrictEqual(verdict.violations, []);
+  assert.ok(verdict.ok);
+});
+
+// ---- regression detection (mutation) ------------------------------------
+
+test('any metric falling 0.01 below its floor is a violation', () => {
+  for (const target of TWO_FILES) {
+    for (const metric of METRICS) {
+      const mutated = TWO_FILES.map((f) => (f.path === target.path
+        ? Object.assign({}, f, { [metric]: floorPct(f[metric]) - 0.01 })
+        : f));
+      const verdict = evaluate(makeReport(mutated), baselineFor(TWO_FILES), PATHS);
+      const hit = verdict.violations.filter((v) => v.rule === 'coverage-baseline-regression'
+        && v.file === target.path && v.detail.metric === metric);
+      assert.strictEqual(hit.length, 1, `${target.path} ${metric} regression was not caught`);
+      assert.strictEqual(verdict.ok, false);
+    }
+  }
+});
+
+test('coverage above the floor is an improvement, not a violation', () => {
+  const better = TWO_FILES.map((f) => Object.assign({}, f, { lines: 99.99 }));
+  const verdict = evaluate(makeReport(better), baselineFor(TWO_FILES), PATHS);
+  assert.deepStrictEqual(verdict.violations, []);
+  assert.ok(verdict.improvements.some((i) => i.metric === 'lines'));
+});
+
+test('a candidate equal to its floor is neither a violation nor an improvement', () => {
+  const verdict = evaluate(makeReport(TWO_FILES), baselineFor(TWO_FILES), PATHS);
+  assert.deepStrictEqual(verdict.violations, []);
+  assert.deepStrictEqual(verdict.improvements, []);
+});
+
+test('crate totals falling below their floor is a violation', () => {
+  const report = makeReport(TWO_FILES, { totals: { lines: 89.99, regions: 90, functions: 90 } });
+  const verdict = evaluate(report, baselineFor(TWO_FILES), PATHS);
+  assert.ok(verdict.violations.some((v) => v.rule === 'coverage-baseline-totals-regression'));
+});
+
+// ---- the silence failure modes ------------------------------------------
+
+test('a baselined file still on disk but absent from the report fails', () => {
+  // The failure this whole leaf exists to prevent: source stops being
+  // instrumented and the run looks clean because nothing reports on it.
+  const report = makeReport([TWO_FILES[0]]);
+  const verdict = evaluate(report, baselineFor(TWO_FILES), PATHS);
+  const hit = verdict.violations.filter((v) => v.rule === 'coverage-baseline-unmeasured');
+  assert.strictEqual(hit.length, 1);
+  assert.strictEqual(hit[0].file, `${SRC}/server.rs`);
+  assert.strictEqual(verdict.ok, false);
+});
+
+test('a baselined file deleted from disk is a removal, not a violation', () => {
+  const report = makeReport([TWO_FILES[0]]);
+  const verdict = evaluate(report, baselineFor(TWO_FILES), [TWO_FILES[0].path]);
+  assert.deepStrictEqual(verdict.violations, []);
+  assert.deepStrictEqual(verdict.removals.map((r) => r.file), [`${SRC}/server.rs`]);
+});
+
+test('a measured file with no baseline entry fails', () => {
+  const extra = TWO_FILES.concat([{ path: `${SRC}/new.rs`, lines: 10, regions: 10, functions: 10 }]);
+  const verdict = evaluate(makeReport(extra), baselineFor(TWO_FILES), extra.map((f) => f.path));
+  assert.ok(verdict.violations.some((v) => v.rule === 'coverage-baseline-unbaselined' && v.file === `${SRC}/new.rs`));
+});
+
+test('a source file on disk that is neither baselined nor measured fails', () => {
+  // Produces no coverage record at all, so a report-only comparison would
+  // never see it. Only the on-disk source list catches this.
+  const verdict = evaluate(makeReport(TWO_FILES), baselineFor(TWO_FILES), PATHS.concat([`${SRC}/ghost.rs`]));
+  const hit = verdict.violations.filter((v) => v.rule === 'coverage-baseline-unlisted-source');
+  assert.strictEqual(hit.length, 1);
+  assert.strictEqual(hit[0].file, `${SRC}/ghost.rs`);
+});
+
+test('a reviewed exclusion suppresses the unlisted-source failure', () => {
+  const baseline = baselineFor(TWO_FILES, { exclusions: [{ path: `${SRC}/ghost.rs`, reason: 'reviewed' }] });
+  const verdict = evaluate(makeReport(TWO_FILES), baseline, PATHS.concat([`${SRC}/ghost.rs`]));
+  assert.deepStrictEqual(verdict.violations, []);
+});
+
+test('an unlisted source file is reported once, not twice', () => {
+  const extra = TWO_FILES.concat([{ path: `${SRC}/new.rs`, lines: 10, regions: 10, functions: 10 }]);
+  const verdict = evaluate(makeReport(extra), baselineFor(TWO_FILES), extra.map((f) => f.path));
+  assert.strictEqual(verdict.violations.filter((v) => v.file === `${SRC}/new.rs`).length, 1);
+});
+
+// ---- no-regions files ---------------------------------------------------
+
+test('a no-regions file that gains coverage demands a re-baseline', () => {
+  const baseline = baselineFor(TWO_FILES);
+  baseline.files[`${SRC}/lib.rs`] = { noRegions: true, reason: 'declarations only' };
+  const withLib = TWO_FILES.concat([{ path: `${SRC}/lib.rs`, lines: 50, regions: 50, functions: 50 }]);
+  const verdict = evaluate(makeReport(withLib), baseline, withLib.map((f) => f.path));
+  assert.ok(verdict.violations.some((v) => v.rule === 'coverage-baseline-gained-regions' && v.file === `${SRC}/lib.rs`));
+});
+
+test('a no-regions file that stays empty passes', () => {
+  const baseline = baselineFor(TWO_FILES);
+  baseline.files[`${SRC}/lib.rs`] = { noRegions: true, reason: 'declarations only' };
+  const verdict = evaluate(makeReport(TWO_FILES), baseline, PATHS.concat([`${SRC}/lib.rs`]));
+  assert.deepStrictEqual(verdict.violations, []);
+  assert.ok(verdict.perFile.some((r) => r.path === `${SRC}/lib.rs` && r.noRegions));
+});
+
+// ---- worktree independence ----------------------------------------------
+
+test('the same coverage evaluates identically from a different checkout path', () => {
+  // llvm-cov writes absolute paths. Two worktrees of this repo must not
+  // disagree about whether the baseline holds.
+  const a = evaluate(makeReport(TWO_FILES, { root: '/checkout' }), baselineFor(TWO_FILES), PATHS, '/checkout');
+  const b = evaluate(makeReport(TWO_FILES, { root: '/somewhere/else/nemo-wt' }), baselineFor(TWO_FILES), PATHS, '/somewhere/else/nemo-wt');
+  assert.deepStrictEqual(a.violations, b.violations);
+  assert.deepStrictEqual(a.perFile, b.perFile);
+  assert.ok(a.ok && b.ok);
+});
+
+test('files outside the crate source root are ignored, not compared', () => {
+  const report = makeReport(TWO_FILES.concat([{ path: 'vendor/dep/lib.rs', lines: 1, regions: 1, functions: 1 }]));
+  const verdict = evaluate(report, baselineFor(TWO_FILES), PATHS);
+  assert.deepStrictEqual(verdict.violations, []);
+  assert.ok(verdict.foreign.includes('vendor/dep/lib.rs'));
+});
+
+// ---- refusing a meaningless gate ----------------------------------------
+
+test('a branch floor is refused outright', () => {
+  // Branch counts are 0 on the stable toolchain, so a branch floor would be a
+  // gate that can never fail while looking like coverage.
+  const viaMetrics = baselineFor(TWO_FILES, { metrics: METRICS.concat(['branches']) });
+  assert.throws(() => validateBaseline(viaMetrics), /metrics must be exactly|branch floor/);
+
+  const viaFile = baselineFor(TWO_FILES);
+  viaFile.files[PATHS[0]].branches = 0;
+  assert.throws(() => validateBaseline(viaFile), /branch floor/);
+});
+
+// ---- malformed input never passes ---------------------------------------
+
+test('a malformed or foreign report throws instead of passing', () => {
+  const baseline = baselineFor(TWO_FILES);
+  const cases = [
+    [null, /report type/],
+    [{ type: 'something-else', data: [] }, /report type/],
+    [{ type: 'llvm.coverage.json.export' }, /data\[0\]\.files/],
+    [{ type: 'llvm.coverage.json.export', data: [{ files: 'nope' }] }, /data\[0\]\.files/],
+    [{ type: 'llvm.coverage.json.export', data: [{ files: [{ filename: `/checkout/${SRC}/wire.rs` }], totals: summary({ lines: 1, regions: 1, functions: 1 }) }] }, /no summary/],
+  ];
+  for (const [report, pattern] of cases) {
+    assert.throws(() => evaluate(report, baseline, PATHS), pattern);
+  }
+});
+
+test('a report entry missing one metric throws rather than scoring it', () => {
+  const broken = makeReport(TWO_FILES);
+  delete broken.data[0].files[0].summary.regions;
+  assert.throws(() => evaluate(broken, baselineFor(TWO_FILES), PATHS), /numeric regions\.percent/);
+});
+
+test('a baseline with the wrong schema or no source root is refused', () => {
+  assert.throws(() => validateBaseline(baselineFor(TWO_FILES, { schema: 'other/1' })), /baseline schema/);
+  assert.throws(() => validateBaseline(baselineFor(TWO_FILES, { sourceRoot: '' })), /sourceRoot/);
+  assert.throws(() => evaluateRustCoverage({ report: makeReport(TWO_FILES), baseline: baselineFor(TWO_FILES), root: '/checkout' }),
+    /sourceFiles/);
+});
+
+test('a baseline entry missing a metric floor throws', () => {
+  const baseline = baselineFor(TWO_FILES);
+  delete baseline.files[PATHS[0]].functions;
+  assert.throws(() => evaluate(makeReport(TWO_FILES), baseline, PATHS), /no numeric functions floor/);
+});
+
+// ---- the committed artifact --------------------------------------------
+
+test('the committed baseline is valid and describes files that exist', () => {
+  const baseline = JSON.parse(fs.readFileSync(path.join(ROOT, ...BASELINE.split('/')), 'utf8'));
+  validateBaseline(baseline);
+  assert.strictEqual(baseline.sourceRoot, SOURCE_ROOT);
+  const onDisk = listSourceFiles(ROOT, SOURCE_ROOT);
+  assert.ok(onDisk.length > 0, 'no Rust source discovered under ' + SOURCE_ROOT);
+  for (const rel of Object.keys(baseline.files)) {
+    assert.ok(onDisk.includes(rel), `baseline names ${rel}, which is not on disk`);
+  }
+  for (const rel of onDisk) {
+    assert.ok(Object.hasOwn(baseline.files, rel), `${rel} exists but is not baselined`);
+  }
+});
+
+test('the committed baseline records its tool pin and test result', () => {
+  const baseline = JSON.parse(fs.readFileSync(path.join(ROOT, ...BASELINE.split('/')), 'utf8'));
+  assert.strictEqual(baseline.tool.name, 'cargo-llvm-cov');
+  assert.match(baseline.tool.version, /^\d+\.\d+\.\d+$/);
+  assert.ok(baseline.recorded.sha, 'baseline records no source SHA');
+  // Floors measured against a dirty crate would not be reproducible.
+  assert.strictEqual(baseline.recorded.crateDirty, false);
+  assert.strictEqual(baseline.tests.failed, 0);
+  assert.ok(baseline.branchesExcluded.length > 0);
+});
+
+test('listSourceFiles finds the crate source and nothing else', () => {
+  const found = listSourceFiles(ROOT, SOURCE_ROOT);
+  assert.ok(found.every((f) => f.startsWith(SOURCE_ROOT + '/') && f.endsWith('.rs')));
+  assert.ok(found.includes('nemo-mcp/src/lib.rs'));
+  // build.rs sits beside the crate, not under src/, and is not instrumented.
+  assert.ok(!found.includes('nemo-mcp/build.rs'));
+});

--- a/scripts/nemo/lib/capabilities.cjs
+++ b/scripts/nemo/lib/capabilities.cjs
@@ -120,6 +120,9 @@ function collect(build) {
     rustc: probeTool('rustc'),
     cargo: probeTool('cargo'),
     rustup: probeTool('rustup'),
+    // A cargo subcommand: `cargo-llvm-cov --version` is an error, so the
+    // probe has to go through the `llvm-cov` subcommand (T04).
+    'cargo-llvm-cov': probeTool('cargo-llvm-cov', ['llvm-cov', '--version']),
     'wasm-pack': probeTool('wasm-pack'),
     'wasm-bindgen': probeTool('wasm-bindgen'),
     'tauri-cli': localBin('tauri') ? probeTool('tauri', ['--version'], { path: localBin('tauri') }) : { present: false, path: null, version: null, note: 'node_modules/.bin/tauri missing — run npm ci' },

--- a/scripts/nemo/lib/coverage-rust-job.cjs
+++ b/scripts/nemo/lib/coverage-rust-job.cjs
@@ -1,0 +1,196 @@
+'use strict';
+// `test:coverage-rust` (T04): run the nemo-mcp Cargo suites under
+// cargo-llvm-cov, emit LCOV/HTML/JSON for production source, and compare the
+// result with the committed reviewed ratchet baseline.
+//
+// The status contract is the repo's existing vocabulary, and it is the point
+// of this job rather than a detail of it:
+//   blocked — the coverage tool or the llvm-tools component is absent, or the
+//             baseline is missing. Named exactly. Never downgraded to a skip
+//             and never reported as pass.
+//   fail    — a Cargo test failed under instrumentation, a report could not be
+//             produced, or coverage fell below a reviewed floor.
+//   pass    — the suites ran, reports exist, and every floor held.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { ROOT, run, which, exists, readJson, fileInfo } = require('./util.cjs');
+const { evaluateRustCoverage, SCHEMA } = require('./coverage-rust.cjs');
+
+const CRATE_DIR = 'nemo-mcp';
+const MANIFEST = 'nemo-mcp/Cargo.toml';
+const SOURCE_ROOT = 'nemo-mcp/src';
+const BASELINE = 'engineering/coverage/rust-mcp.baseline.json';
+const TIMEOUT_MS = 60 * 60 * 1000;
+
+function listSourceFiles(root, sourceRoot) {
+  const base = path.resolve(root, ...sourceRoot.split('/'));
+  const out = [];
+  (function walk(dir) {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.rs')) out.push(path.relative(root, full).split(path.sep).join('/'));
+    }
+  })(base);
+  return out;
+}
+
+// cargo-llvm-cov is a cargo subcommand: `cargo-llvm-cov --version` is an
+// error, the real probe is the `llvm-cov` subcommand.
+function probeCoverageTool() {
+  const bin = which('cargo-llvm-cov');
+  if (!bin) return { present: false, version: null };
+  const r = run(bin, ['llvm-cov', '--version'], { timeout: 60000 });
+  const line = (r.stdout + '\n' + r.stderr).split(/\r?\n/).find((l) => l.trim()) || '';
+  return { present: r.status === 0, version: r.status === 0 ? line.trim() : null, probeExit: r.status };
+}
+
+// llvm-tools ships the profdata/cov binaries cargo-llvm-cov drives. Without
+// rustup there is no read-only way to enumerate components, so absence is
+// only asserted when rustup can actually answer.
+function llvmToolsMissing() {
+  if (!which('rustup')) return false;
+  const r = run('rustup', ['component', 'list', '--installed'], { timeout: 60000 });
+  if (r.status !== 0) return false;
+  return !/^llvm-tools/m.test(r.stdout);
+}
+
+function logOf(r) {
+  return `$ ${r.cmd}\n(exit ${r.status}${r.signal ? ' signal ' + r.signal : ''}${r.error ? ' error ' + r.error : ''}, ${r.durationMs} ms)\n--- stdout ---\n${r.stdout}\n--- stderr ---\n${r.stderr}\n`;
+}
+
+function countTests(stdout) {
+  const results = [...stdout.matchAll(/^test result: \w+\. (\d+) passed; (\d+) failed/gm)];
+  return {
+    binaries: results.length,
+    passed: results.reduce((a, m) => a + Number(m[1]), 0),
+    failed: results.reduce((a, m) => a + Number(m[2]), 0),
+  };
+}
+
+/**
+ * Run the crate's suites under instrumentation and render LCOV/HTML/JSON.
+ *
+ * Returns `{ status: 'blocked'|'fail'|'ok', ... }` so the job and the
+ * baseline-update CLI share exactly one cargo invocation path — a second copy
+ * would be free to drift into measuring something the gate never checks.
+ */
+function produceReports(outDir) {
+  if (!which('cargo')) return { status: 'blocked', reason: 'cargo not found' };
+  const manifest = path.join(ROOT, ...MANIFEST.split('/'));
+  if (!exists(manifest)) return { status: 'blocked', reason: `${MANIFEST} missing` };
+
+  const tool = probeCoverageTool();
+  if (!tool.present) {
+    return { status: 'blocked', reason: 'cargo-llvm-cov not found; install the pinned tool with '
+      + '`cargo install cargo-llvm-cov --version 0.9.1 --locked` and '
+      + '`rustup component add llvm-tools-preview`' };
+  }
+  if (llvmToolsMissing()) {
+    return { status: 'blocked', tool, reason: 'the llvm-tools rustup component is not installed; run `rustup component add llvm-tools-preview`' };
+  }
+
+  fs.mkdirSync(outDir, { recursive: true });
+  const jsonPath = path.join(outDir, 'coverage.json');
+  const lcovPath = path.join(outDir, 'lcov.info');
+  const htmlDir = path.join(outDir, 'html');
+  const logs = [];
+
+  const clean = run('cargo', ['llvm-cov', 'clean', '--workspace', '--manifest-path', MANIFEST], { timeout: TIMEOUT_MS });
+  logs.push(logOf(clean));
+
+  // Run the suites once, then render three views of the same profile data.
+  const tests = run('cargo', ['llvm-cov', '--no-report', '--manifest-path', MANIFEST], { timeout: TIMEOUT_MS });
+  logs.push(logOf(tests));
+  const counts = countTests(tests.stdout);
+  if (tests.status !== 0) {
+    // A failing suite is a failing suite. Coverage is not reported as if the
+    // crate were healthy, and this is never softened to blocked.
+    const combined = tests.stdout + tests.stderr;
+    if (/llvm-tools|llvm-profdata/i.test(combined)) {
+      return { status: 'blocked', tool, counts, logs, exitCode: tests.status,
+        reason: 'cargo-llvm-cov could not find its llvm-tools binaries; run `rustup component add llvm-tools-preview`' };
+    }
+    return { status: 'fail', tool, counts, logs, exitCode: tests.status,
+      reason: `cargo llvm-cov: ${counts.binaries} binaries, ${counts.passed} passed, ${counts.failed} failed (exit ${tests.status})` };
+  }
+
+  for (const args of [['--json', '--output-path', jsonPath], ['--lcov', '--output-path', lcovPath], ['--html', '--output-dir', htmlDir]]) {
+    const r = run('cargo', ['llvm-cov', 'report', '--manifest-path', MANIFEST].concat(args), { timeout: TIMEOUT_MS });
+    logs.push(logOf(r));
+    if (r.status !== 0) {
+      return { status: 'fail', tool, counts, logs, exitCode: r.status, reason: `cargo llvm-cov report ${args[0]} exit ${r.status}` };
+    }
+  }
+  if (!exists(jsonPath)) return { status: 'fail', tool, counts, logs, exitCode: 1, reason: 'cargo llvm-cov produced no JSON export' };
+
+  return { status: 'ok', tool, counts, logs, jsonPath, lcovPath, htmlIndex: path.join(htmlDir, 'html', 'index.html') };
+}
+
+function jobCoverageRust(ctx) {
+  const pass = (reason, extra) => Object.assign({ status: 'pass', reason }, extra);
+  const fail = (reason, extra) => Object.assign({ status: 'fail', reason }, extra);
+  const blocked = (reason, extra) => Object.assign({ status: 'blocked', reason }, extra);
+
+  const baselinePath = path.join(ROOT, ...BASELINE.split('/'));
+  if (!exists(baselinePath)) {
+    return blocked(`${BASELINE} missing; regenerate it with \`node scripts/nemo/coverage-rust.cjs --update\` and have it reviewed`);
+  }
+  const baseline = readJson(baselinePath);
+
+  const produced = produceReports(path.join(ctx.reportDir, 'coverage-rust'));
+  const log = (produced.logs || []).join('\n') || null;
+  const tool = produced.tool || { version: null };
+  if (produced.status === 'blocked') return blocked(produced.reason, { log, details: { coverageTool: tool.version } });
+  if (produced.status === 'fail') {
+    return fail(produced.reason, { exitCode: produced.exitCode, log, details: { tests: produced.counts, coverageTool: tool.version } });
+  }
+
+  const { jsonPath, lcovPath, htmlIndex, counts } = produced;
+  const artifacts = [fileInfo(lcovPath), fileInfo(jsonPath), fileInfo(htmlIndex)].filter((a) => a.present);
+
+  let verdict;
+  try {
+    verdict = evaluateRustCoverage({
+      report: readJson(jsonPath),
+      baseline,
+      sourceFiles: listSourceFiles(ROOT, SOURCE_ROOT),
+      root: ROOT,
+    });
+  } catch (e) {
+    return fail(`coverage ratchet could not evaluate: ${e.message}`, { log: log, artifacts });
+  }
+
+  const limitations = [baseline.branchesExcluded].filter(Boolean);
+  const pinned = baseline.tool && baseline.tool.version;
+  if (pinned && tool.version && !tool.version.includes(pinned)) {
+    limitations.push(`coverage tool is "${tool.version}" but the baseline floors were recorded with cargo-llvm-cov ${pinned}; percentages are not strictly comparable across tool versions`);
+  }
+  limitations.push('doc-tests are excluded from coverage on the stable toolchain (cargo-llvm-cov reports them only under nightly)');
+
+  const details = {
+    tests: counts,
+    coverageTool: tool.version,
+    totals: verdict.totals,
+    perFile: verdict.perFile,
+    improvements: verdict.improvements,
+    removals: verdict.removals,
+  };
+  const label = `${counts.passed} tests, ${verdict.measuredFileCount}/${verdict.baselineFileCount} baselined files measured, `
+    + `lines ${verdict.totals.lines.toFixed(2)}% / regions ${verdict.totals.regions.toFixed(2)}% / functions ${verdict.totals.functions.toFixed(2)}%`;
+
+  if (!verdict.ok) {
+    return fail(`${label} — ${verdict.violations.length} ratchet violation(s): `
+      + verdict.violations.map((v) => v.message).join('; '),
+      { exitCode: 1, log: log, artifacts, limitations, details: Object.assign({ violations: verdict.violations }, details) });
+  }
+  return pass(`${label}; every reviewed floor held`, { exitCode: 0, log: log, artifacts, limitations, details });
+}
+
+module.exports = {
+  jobCoverageRust, produceReports, listSourceFiles, probeCoverageTool, llvmToolsMissing,
+  CRATE_DIR, MANIFEST, SOURCE_ROOT, BASELINE, SCHEMA,
+};

--- a/scripts/nemo/lib/coverage-rust.cjs
+++ b/scripts/nemo/lib/coverage-rust.cjs
@@ -1,0 +1,289 @@
+'use strict';
+// Rust coverage ratchet evaluator (T04). Pure: no cargo, no child processes,
+// no filesystem. Report generation and tool probing live in
+// coverage-rust-job.cjs so this half can be exercised — and mutated — by unit
+// tests alone.
+//
+// The baseline is the coverage actually observed at a reviewed SHA, recorded
+// per production source file. A candidate run is compared against those
+// floors. There is deliberately no global target: a file's floor IS its own
+// last reviewed measurement, so the gate can only ever move one way.
+//
+// Metrics are lines/regions/functions. Branch coverage is NOT ratcheted and
+// must not be added without re-reading BRANCHES_UNAVAILABLE below.
+
+const path = require('node:path');
+
+const SCHEMA = 'nemo.rust-coverage-baseline/1';
+const REPORT_TYPE = 'llvm.coverage.json.export';
+const METRICS = ['lines', 'regions', 'functions'];
+
+// Observed 2026-09-10 on cargo/rustc 1.91.1 (aarch64-apple-darwin) with
+// cargo-llvm-cov 0.9.1: every file reports `branches: {count: 0, percent: 0}`,
+// including files that plainly contain `if`/`match`. Branch instrumentation
+// needs a nightly `-Z coverage-options=branch` build, so on this toolchain a
+// branch floor would compare 0 against 0 and pass unconditionally — a gate
+// that can never fail, reported as if it were coverage. It is refused instead.
+const BRANCHES_UNAVAILABLE =
+  'branch coverage is not instrumented by the stable Rust toolchain (needs nightly '
+  + '-Z coverage-options=branch); every branch count is 0, so a branch floor would be a '
+  + 'gate that cannot fail. Excluded on purpose — see T04/#1053.';
+
+// Floors are stored floored to two decimals, never rounded. Rounding
+// 93.5483…% up to 93.55 would make the very run that produced it fail.
+function floorPct(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`not a finite percentage: ${value}`);
+  }
+  return Math.floor(value * 100) / 100;
+}
+
+function toPosix(p) {
+  return String(p).split(path.sep).join('/');
+}
+
+/**
+ * Index an llvm-cov JSON export by repo-relative path.
+ *
+ * llvm-cov emits absolute filenames from whichever checkout produced the
+ * report. Two worktrees of this repo therefore yield different absolute paths
+ * for the same source, so everything is relativized against `root` before any
+ * comparison; a baseline stays valid across worktrees.
+ */
+function readReport(report, root, sourceRoot) {
+  if (!report || report.type !== REPORT_TYPE) {
+    throw new Error(`unexpected coverage report type: ${report ? report.type : report} (want ${REPORT_TYPE})`);
+  }
+  const data = Array.isArray(report.data) ? report.data[0] : null;
+  if (!data || !Array.isArray(data.files)) throw new Error('coverage report has no data[0].files array');
+
+  const prefix = toPosix(sourceRoot).replace(/\/+$/, '') + '/';
+  const files = new Map();
+  const foreign = [];
+  for (const entry of data.files) {
+    if (!entry || typeof entry.filename !== 'string') throw new Error('coverage report entry has no filename');
+    const rel = toPosix(path.relative(root, entry.filename));
+    if (!rel.startsWith(prefix)) { foreign.push(rel); continue; }
+    files.set(rel, summaryOf(rel, entry.summary));
+  }
+  return { files, foreign, totals: summaryOf('<totals>', data.totals) };
+}
+
+function summaryOf(label, summary) {
+  if (!summary || typeof summary !== 'object') throw new Error(`${label}: coverage entry has no summary`);
+  const percent = {};
+  const counts = {};
+  for (const metric of METRICS) {
+    const value = summary[metric];
+    if (!value || typeof value.percent !== 'number' || !Number.isFinite(value.percent)) {
+      throw new Error(`${label}: coverage summary has no numeric ${metric}.percent`);
+    }
+    percent[metric] = value.percent;
+    counts[metric] = { covered: value.covered, count: value.count };
+  }
+  return { percent, counts };
+}
+
+function validateBaseline(baseline) {
+  if (!baseline || baseline.schema !== SCHEMA) {
+    throw new Error(`unexpected baseline schema: ${baseline ? baseline.schema : baseline} (want ${SCHEMA})`);
+  }
+  if (typeof baseline.sourceRoot !== 'string' || !baseline.sourceRoot) {
+    throw new Error('baseline has no sourceRoot');
+  }
+  if (!baseline.files || typeof baseline.files !== 'object') throw new Error('baseline has no files map');
+  const metrics = baseline.metrics;
+  if (!Array.isArray(metrics) || metrics.length !== METRICS.length
+    || METRICS.some((m) => !metrics.includes(m))) {
+    throw new Error(`baseline metrics must be exactly ${METRICS.join(', ')}`);
+  }
+  // A branch floor on this toolchain compares 0 against 0 forever. Refuse it
+  // at load time rather than let it look like a passing branch gate.
+  if (metrics.includes('branches') || Object.values(baseline.files).some((e) => e && Object.hasOwn(e, 'branches'))) {
+    throw new Error(`baseline declares a branch floor: ${BRANCHES_UNAVAILABLE}`);
+  }
+}
+
+function violation(rule, file, message, detail) {
+  return { rule, file, message, detail: detail || null };
+}
+
+/**
+ * Compare a fresh coverage report with the committed reviewed baseline.
+ *
+ * `sourceFiles` is every production source file found on disk, repo-relative.
+ * It is required, and it is what makes a file that produces no coverage record
+ * at all visible: a report-only comparison cannot distinguish "measured 0%"
+ * from "never compiled in", and silence is the failure mode this whole leaf
+ * exists to prevent.
+ */
+function evaluateRustCoverage(input) {
+  const { report, baseline, sourceFiles, root } = input || {};
+  validateBaseline(baseline);
+  if (!Array.isArray(sourceFiles)) throw new Error('sourceFiles (repo-relative production source list) is required');
+  if (typeof root !== 'string' || !root) throw new Error('root is required');
+
+  const { files: candidate, foreign, totals } = readReport(report, root, baseline.sourceRoot);
+  const baselineFiles = baseline.files;
+  const excluded = new Map((baseline.exclusions || []).map((e) => [e.path, e.reason]));
+  const onDisk = new Set(sourceFiles.map(toPosix));
+
+  const violations = [];
+  const improvements = [];
+  const removals = [];
+  const perFile = [];
+
+  for (const [rel, entry] of Object.entries(baselineFiles)) {
+    const measured = candidate.get(rel);
+    const present = onDisk.has(rel);
+
+    if (entry && entry.noRegions) {
+      if (measured) {
+        violations.push(violation('coverage-baseline-gained-regions', rel,
+          `${rel} was baselined as having no executable regions but now reports coverage; re-baseline it with real floors`,
+          { candidate: measured.percent }));
+      } else if (!present) {
+        removals.push({ file: rel, reason: 'source-removed', noRegions: true });
+      } else {
+        perFile.push({ path: rel, noRegions: true, reason: entry.reason || null });
+      }
+      continue;
+    }
+
+    if (!measured) {
+      if (present) {
+        // Never a skip: a baselined file that stops being measured is an
+        // instrumentation gap, and reporting it as "fine" is the exact
+        // failure this gate refuses.
+        violations.push(violation('coverage-baseline-unmeasured', rel,
+          `${rel} is present on disk but absent from the coverage report; it was not measured`,
+          { floor: pick(entry) }));
+      } else {
+        removals.push({ file: rel, reason: 'source-removed', priorFloor: pick(entry) });
+      }
+      continue;
+    }
+
+    const row = { path: rel, percent: measured.percent, counts: measured.counts, floor: pick(entry) };
+    for (const metric of METRICS) {
+      const floor = entry[metric];
+      if (typeof floor !== 'number' || !Number.isFinite(floor)) {
+        throw new Error(`baseline ${rel} has no numeric ${metric} floor`);
+      }
+      const actual = measured.percent[metric];
+      if (actual < floor) {
+        violations.push(violation('coverage-baseline-regression', rel,
+          `${rel}: ${metric} ${fmt(actual)}% fell below its ${fmt(floor)}% floor`,
+          { metric, floor, candidate: actual, counts: measured.counts[metric] }));
+      } else if (floorPct(actual) > floor) {
+        improvements.push({ file: rel, metric, floor, candidate: actual });
+      }
+    }
+    perFile.push(row);
+  }
+
+  for (const rel of candidate.keys()) {
+    if (!Object.hasOwn(baselineFiles, rel)) {
+      violations.push(violation('coverage-baseline-unbaselined', rel,
+        `${rel} is measured but has no reviewed baseline entry; add it with its observed floors`,
+        { candidate: candidate.get(rel).percent }));
+    }
+  }
+
+  const flagged = new Set(violations.map((v) => v.file));
+  for (const rel of onDisk) {
+    if (!rel.startsWith(toPosix(baseline.sourceRoot).replace(/\/+$/, '') + '/')) continue;
+    if (Object.hasOwn(baselineFiles, rel) || excluded.has(rel) || flagged.has(rel)) continue;
+    violations.push(violation('coverage-baseline-unlisted-source', rel,
+      `${rel} exists under ${baseline.sourceRoot} but is neither baselined nor a reviewed exclusion`, null));
+  }
+
+  const totalsFloor = baseline.totals || null;
+  if (totalsFloor) {
+    for (const metric of METRICS) {
+      const floor = totalsFloor[metric];
+      if (typeof floor !== 'number') continue;
+      if (totals.percent[metric] < floor) {
+        violations.push(violation('coverage-baseline-totals-regression', null,
+          `crate totals: ${metric} ${fmt(totals.percent[metric])}% fell below the ${fmt(floor)}% floor`,
+          { metric, floor, candidate: totals.percent[metric] }));
+      }
+    }
+  }
+
+  return {
+    ok: violations.length === 0,
+    violations,
+    improvements,
+    removals,
+    perFile,
+    foreign,
+    totals: totals.percent,
+    baselineFileCount: Object.keys(baselineFiles).length,
+    measuredFileCount: candidate.size,
+  };
+}
+
+function pick(entry) {
+  const out = {};
+  for (const metric of METRICS) if (entry && typeof entry[metric] === 'number') out[metric] = entry[metric];
+  return out;
+}
+
+function fmt(value) {
+  return Number(value).toFixed(2);
+}
+
+/**
+ * Build a baseline object from an observed report. Used by the `--update`
+ * path so recorded floors are the measurement itself, never typed by hand.
+ */
+function buildBaseline(input) {
+  const { report, root, sourceRoot, sourceFiles, meta } = input || {};
+  if (typeof sourceRoot !== 'string' || !sourceRoot) throw new Error('sourceRoot is required');
+  if (!Array.isArray(sourceFiles)) throw new Error('sourceFiles is required');
+  const { files: candidate, totals } = readReport(report, root, sourceRoot);
+  const prefix = toPosix(sourceRoot).replace(/\/+$/, '') + '/';
+  const exclusions = (meta && meta.exclusions) || [];
+  const excluded = new Set(exclusions.map((e) => e.path));
+
+  // Reviewed prose (why a module sits where it does) is written by a human
+  // into the committed baseline. Regenerating floors must not silently erase
+  // it, so `note` is carried across from the prior baseline.
+  const priorFiles = (meta && meta.priorFiles) || {};
+  const files = {};
+  for (const rel of [...new Set(sourceFiles.map(toPosix))].sort()) {
+    if (!rel.startsWith(prefix) || excluded.has(rel)) continue;
+    const note = priorFiles[rel] && priorFiles[rel].note;
+    const measured = candidate.get(rel);
+    if (!measured) {
+      files[rel] = { noRegions: true, reason: 'no executable regions in the coverage report' };
+    } else {
+      const entry = {};
+      for (const metric of METRICS) entry[metric] = floorPct(measured.percent[metric]);
+      files[rel] = entry;
+    }
+    if (note) files[rel].note = note;
+  }
+
+  const totalFloors = {};
+  for (const metric of METRICS) totalFloors[metric] = floorPct(totals.percent[metric]);
+
+  // `priorFiles` is an input to this function, not a field of the baseline.
+  const { priorFiles: _carried, ...recordedMeta } = meta || {};
+  return Object.assign({
+    schema: SCHEMA,
+    metrics: METRICS.slice(),
+    branchesExcluded: BRANCHES_UNAVAILABLE,
+  }, recordedMeta, {
+    sourceRoot,
+    totals: totalFloors,
+    files,
+    exclusions,
+  });
+}
+
+module.exports = {
+  SCHEMA, REPORT_TYPE, METRICS, BRANCHES_UNAVAILABLE,
+  floorPct, readReport, validateBaseline, evaluateRustCoverage, buildBaseline,
+};

--- a/scripts/nemo/lib/jobs.cjs
+++ b/scripts/nemo/lib/jobs.cjs
@@ -367,6 +367,17 @@ const JOBS = {
   'build:wasm': { run: jobBuildWasm, required: false },
   'build:desktop': { run: jobBuildDesktop, required: true },
   'test:coverage': { run: jobTestCoverageJs, required: false },
+  // T04. Deliberately in NEITHER profile — cargo-llvm-cov is not yet a
+  // declared prerequisite, so no profile run depends on it — but `required`
+  // once it is explicitly selected: asking for coverage on a workstation that
+  // cannot measure it must exit 2, not report an overall pass with a blocked
+  // line buried in the receipt. Run it with:
+  //   node scripts/nemo/job.cjs test:coverage-rust
+  //
+  // Required lazily: this registry is loaded by every CLI entry point, and by
+  // harnesses that copy a minimal subset of scripts/nemo (build-job.test.cjs).
+  // A top-level require would make all of them depend on this leaf's modules.
+  'test:coverage-rust': { run: (ctx) => require('./coverage-rust-job.cjs').jobCoverageRust(ctx), required: true },
 };
 
 const PROFILES = {


### PR DESCRIPTION
Closes the executable work of **T04 / #1053**. Candidate SHA `56aba51857312fbe7a1a4edd542c3aef9d744e1d`, based on `391f2e3` (`origin/main`).

## What this delivers

`test:coverage-rust` runs the existing `nemo-mcp` Cargo suites under a pinned `cargo-llvm-cov`, writes LCOV + HTML + JSON for the crate's production source, and compares each file against `engineering/coverage/rust-mcp.baseline.json` — the coverage actually observed at a reviewed SHA.

**No invented global target.** Each file's floor is its own last reviewed measurement, so the gate can only move one way.

## Observed baseline

`cargo-llvm-cov 0.9.1`, `cargo`/`rustc` 1.91.1, `aarch64-apple-darwin`, crate clean at `391f2e3`. Suites: 11 binaries, **16 tests, 16 passed, 0 failed**.

| File | Lines | Regions | Functions |
|---|---:|---:|---:|
| `contract.rs` | 94.44% | 93.39% | 94.12% |
| `main.rs` | 100.00% | 81.25% | 100.00% |
| `registry.rs` | **69.49%** | 71.17% | 75.00% |
| `schema.rs` | **0.00%** | 0.00% | 0.00% |
| `server.rs` | 93.55% | 92.20% | 100.00% |
| `wire.rs` | 96.55% | 87.06% | 87.50% |
| **TOTAL** | **89.23%** | **85.52%** | **88.89%** |

`lib.rs` is baselined explicitly as having no executable regions (module declarations + one const), so gaining real code there is caught rather than passing unnoticed.

## Uncovered modules — recorded, not excluded

- **`schema.rs` (0%)** — 0% by construction: it is the `nemo-mcp-schema` binary and no test executes it.
- **`registry.rs` (69.49%)** — the lowest real module. Its uncovered lines (21, 24–34, 39, 45, 49, 55) are precisely the endpoint-discovery *rejection* paths: the absolute-path checks on `NEMO_MCP_REGISTRY` / `NEMO_TAURI_DATA_DIR`, the `dirs::data_local_dir` fallback, and `read_endpoints()`'s missing-root, non-`.json`, non-file/over-4096-byte and malformed-record filters. That is the transport's input validation, which makes it the most load-bearing gap in the crate.

Both are in the baseline with reasons, and `--update` preserves that reviewed prose instead of overwriting it.

## Two decisions worth reviewing

**Branch coverage is deliberately not ratcheted.** On this stable toolchain every branch count is 0 — including in files full of `if`/`match` — because branch instrumentation needs nightly `-Z coverage-options=branch`. A branch floor would compare 0 against 0 and could never fail, while reading like coverage. The baseline **refuses one at load time**.

**Floors are floored to 2 decimals, never rounded.** `server.rs` measures 93.5483%; a rounded 93.55 floor would fail the very run that produced it.

## Status contract — exercised, not asserted

| Path | How it was proven | Result |
|---|---|---|
| `blocked` | ran with `cargo-llvm-cov` off `PATH` (and separately without `cargo`) | exit 2, names the tool and the install command |
| `fail` (suite) | added a deliberately failing Rust test, then reverted | `16 passed, 1 failed`, exit 1 — never blocked, never pass |
| `fail` (ratchet) | raised `registry.rs`'s floor to 75% | exit 1, `lines 69.49% fell below its 75.00% floor` |
| `pass` | tool present, floors held | exit 0, LCOV/HTML/JSON attached to the receipt with hashes |

The crate and baseline were restored byte-identically after both fail probes.

## Placement

The job is in **neither** verifier profile — `cargo-llvm-cov` is not a declared prerequisite and no profile run should depend on it — but it is `required` **once explicitly selected**, so asking for coverage on a machine that cannot measure it exits 2 rather than reporting an overall pass with a blocked line buried in the receipt. Nothing enumerates all jobs, so profiles are unaffected (verified).

## Tests

24 receipt tests, mostly **mutation tests**: take a report that legitimately passes, break exactly one thing, assert it is caught — every metric 0.01 below its floor, an unbaselined file, a baselined file that stops being measured, a source file that produces no coverage record at all, a no-regions file that gains code, malformed/foreign reports, a missing metric, and a branch floor. Coverage is also proven to evaluate identically **from a different checkout path**, since llvm-cov emits absolute filenames and this repo is worked in several worktrees.

## Shared-file edits (additive, flagged to @Fizz)

| File | Change |
|---|---|
| `scripts/nemo/lib/jobs.cjs` | one registry entry, **lazy** require |
| `scripts/nemo/lib/capabilities.cjs` | `doctor` probes `cargo-llvm-cov` (via its `llvm-cov` subcommand — `cargo-llvm-cov --version` is an error) |
| `scripts/nemo/ci.test.cjs` | tooling-coverage counts 55 → 59 for the four new sources |
| `engineering/boundaries/profiles/scripts-nemo.profile.json` | four module registrations, inserted preserving the file's hand-maintained formatting (9 lines) |
| `scripts/nemo/README.md` | job row; also corrects the now-stale "c8 … planned leaves" sentence, since T01 landed `test:coverage` without updating it |

`package.json` is **untouched** — following T01's precedent, invocation is `node scripts/nemo/job.cjs test:coverage-rust`. `nemo-mcp/Cargo.toml` is untouched.

The lazy require is not a test workaround: `jobs.cjs` is loaded by every CLI entry point and by harnesses that copy a minimal subset of `scripts/nemo`. A top-level require made `build-job.test.cjs` fail on a missing module — I verified those four failures were **mine**, not pre-existing, before changing anything.

## Validation at `56aba51`

- `test:coverage-rust` → **PASS** (16 tests, every floor held)
- `node --test scripts/nemo/*.test.cjs` → **434 pass, 0 fail**
- `npm test` → **665 pass, 0 fail**
- `node scripts/nemo/verify.cjs --profile quick` → **5/5 PASS**
- boundaries → **59 modules, 0 violations**; ratchet **0 violations**
- Two full coverage runs produced **identical** percentages (determinism)

## Limitations

- Doc-tests are excluded from coverage on stable (0 exist in this crate today).
- Branch coverage unavailable (above).
- `nemo-mcp/build.rs` is not instrumented; it sits outside `src/` and is not baselined.
- Tool-version drift is reported as a receipt limitation, not a failure — percentages are not strictly comparable across `cargo-llvm-cov` versions.
- **`cargo-llvm-cov 0.9.1` and `llvm-tools-preview` were installed locally on this workstation** to do this work. No hosted run was requested or triggered.
- Geometry/`src-tauri` coverage adoption remains a separate leaf, per this issue's third completion check.

Validation owner is **Cyrill/O**; I am not self-certifying integration.