### PR TITLE
feat(P03A): freeze source census and reject unproven completeness

### DIFF
--- a/engineering/boundaries/profiles/scripts-nemo.profile.json
+++ b/engineering/boundaries/profiles/scripts-nemo.profile.json
@@ -1,5 +1,7 @@
 {
   "modules": [
+    { "id": "nemo.remediationScope", "layer": "tooling-adapters", "dir": "scripts/nemo",
+      "files": ["remediation-scope.cjs"], "publicApi": ["remediation-scope.cjs"], "sizeProfile": "Platform/engine adapter" },
     { "id": "nemo.lib.inventoryLexer", "layer": "tooling-shared", "dir": "scripts/nemo/lib",
       "files": ["inventory-lexer.cjs"], "publicApi": ["inventory-lexer.cjs"], "sizeProfile": "Domain/application JS or TS" },
     { "id": "nemo.lib.inventoryRender", "layer": "tooling-shared", "dir": "scripts/nemo/lib",

--- a/engineering/inventory/REMEDIATION_SCOPE.md
+++ b/engineering/inventory/REMEDIATION_SCOPE.md
@@ -1,0 +1,78 @@
+# Frozen remediation source index
+
+[P03A / #1116](https://github.com/mysteropodes/nemo/issues/1116) supplies the mechanical
+index for [P03 / #1005](https://github.com/mysteropodes/nemo/issues/1005). It does not
+complete P03 or admit an extraction queue.
+
+[remediation-scope.json](remediation-scope.json) freezes all **657 Git-tracked paths**
+at `59a5a38c514f5da830dd2f2df4c83c63b1b22fba`. Every path has one classification,
+Git mode/blob identity, a reason, and historical packet references when a packet's
+`files` declaration names it. Multiple references preserve overlapping census evidence;
+they do not authorize concurrent writers or settle range ownership.
+
+The sorted source-set SHA-256 hashes UTF-8 records `mode + " " + blob + " " + path + "\n"`.
+The index pins all 14 census files by blob and retains each census's original source SHA.
+Those older SHAs are deliberately preserved: the index reconciles their references at one
+fixed source tree; it does not claim their source-level observations were all repeated there.
+
+There are **329 packet references**: 292 from C01–C07 (C04 has two files), 33 from
+C09/C13/C15/C17/C18, and four C08 documentation/process references. The supplements
+replace C08's other 29 preliminary packets. The remaining C08 references cover process
+artifacts, not executable extraction tasks. Vendor/generated/static entries retain their
+provenance obligations. Handwritten shader logic and executable tooling remain included.
+
+All 329 packet admissions are `pending`. The 18 original uncovered-responsibility notes
+remain verbatim with `needs-reconciliation`, even where later work may have resolved one.
+No stale assertion is silently dropped. Counts of paths, packets, features and executable
+issues are different quantities.
+
+## Checks
+
+From the repository root:
+
+```sh
+node scripts/nemo/remediation-scope.cjs --integrity-only
+node --test tests/nemo-remediation-scope.test.cjs
+node scripts/nemo/remediation-scope.cjs
+```
+
+The first command verifies sorted file coverage against `git ls-tree` at the frozen SHA,
+content/mode identities, digest/counts, census pins, packet provenance, and retained gap
+notes. Exit 0 means **index integrity**, while the output still says `complete: false`.
+It does not validate semantic classification, line ranges, consumer coverage, source
+behavior, issue ownership or extraction readiness. Those require P03's remaining review.
+
+The third command is the completeness gate and currently exits **1**. Version 1 never
+accepts completion: it rejects invented accepted admissions, resolved gap dispositions
+and `complete: true`. A reviewed successor must implement actual leaf/consumer evidence
+before P03 can pass this gate. This guard is opt-in tooling; no hosted workflow or normal
+CI job was added by P03A. The regression suite runs through the existing Node test glob.
+
+An explicit comparison with another full commit SHA fails on any source-tree drift:
+
+```sh
+node scripts/nemo/remediation-scope.cjs --integrity-only --source FULL_COMMIT_SHA
+```
+
+This includes P03A's own newly added files when comparing its candidate with the older
+frozen source. It is intentional: the frozen inventory is historical evidence, not an
+unannounced rolling baseline. Compare future amendments explicitly; do not auto-refresh
+the digest to hide additions or changed bytes. No working-tree or installed-app parity
+is implied by checking a Git tree. Git source history must be available locally.
+
+## Remaining admission work
+
+The checker lists paths without a `files`-field packet reference. This conservative list
+includes new capability/domain modules since the original census and eight MCP test files
+that C07 names as oracles rather than extraction targets. A missing reference here does
+not mean the tests are absent or failing; it needs an explicit coverage disposition.
+
+P03's ordered work is the mechanical index, then bounded timeline/Motion gap mapping,
+then family-by-family extraction admission. Timeline's recorded uncovered ranges and
+Motion's range drift must be reconciled with current symbols and consumers. Broad tooling,
+renderer and editor packet groups must be split before Ready. Reuse existing executable
+leaves where their exact scopes fit; do not create duplicate writers from packet names.
+
+The existing execution plan and leaf issues remain the queue and ownership authority.
+D01 and T05 retain their separate reservations. No application settings, persisted fields,
+rendering behavior, runtime availability or known product defects change in this leaf.

--- a/engineering/inventory/remediation-scope.json
+++ b/engineering/inventory/remediation-scope.json
@@ -1,0 +1,8517 @@
+{
+  "schema": "nemo.remediation-scope/1",
+  "issue": "https://github.com/mysteropodes/nemo/issues/1116",
+  "complete": false,
+  "source": {
+    "commit": "59a5a38c514f5da830dd2f2df4c83c63b1b22fba",
+    "fileCount": 657,
+    "sha256": "08fc647c1bb9bfaf6a15cae0bfe4a4f86091bfd4c695af85e3f6386a6b65b4dc"
+  },
+  "counts": {
+    "configuration": 47,
+    "documentation": 68,
+    "generated": 14,
+    "handwritten-runtime": 195,
+    "handwritten-tooling": 52,
+    "static-data": 136,
+    "test": 138,
+    "vendor": 7
+  },
+  "censuses": [
+    {
+      "id": "C01",
+      "path": "engineering/inventory/census/C01-document-history.json",
+      "blob": "d81b618308f9f4849b0ba24fa512af6be90aa72c",
+      "sourceCommit": "ded641bd763379f36d629bf1686fcce8a6137a66"
+    },
+    {
+      "id": "C02",
+      "path": "engineering/inventory/census/C02-animation-time.json",
+      "blob": "70bdb5abec721a248fbe89228182f501f8ca1f35",
+      "sourceCommit": "ded641bd763379f36d629bf1686fcce8a6137a66"
+    },
+    {
+      "id": "C03",
+      "path": "engineering/inventory/census/C03-rendering-resource-ownership.json",
+      "blob": "337c9035f94f5290b2adf898d406550558560bfa",
+      "sourceCommit": "ded641bd763379f36d629bf1686fcce8a6137a66"
+    },
+    {
+      "id": "C04a",
+      "path": "engineering/inventory/census/C04a-editor-tools-selection.json",
+      "blob": "8ffb669c5018190bd448b787a09ade35bd594b30",
+      "sourceCommit": "419f192631b715b3a6c763575dac29162aefa2d9"
+    },
+    {
+      "id": "C04b",
+      "path": "engineering/inventory/census/C04b-editor-presentation-support.json",
+      "blob": "f76259d59dedb715edc18b9f84db98ac00ee7cb8",
+      "sourceCommit": "89215abb8dd9c7e00365b681551052df313e381c"
+    },
+    {
+      "id": "C05",
+      "path": "engineering/inventory/census/C05-media-import-export-native.json",
+      "blob": "725d7875da509cd99a77bc404fc62296280399a0",
+      "sourceCommit": "419f192631b715b3a6c763575dac29162aefa2d9"
+    },
+    {
+      "id": "C06",
+      "path": "engineering/inventory/census/C06-preferences-labs-bootstrap.json",
+      "blob": "1e57da9181bf436c67f058354c95760a3ac29988",
+      "sourceCommit": "419f192631b715b3a6c763575dac29162aefa2d9"
+    },
+    {
+      "id": "C07",
+      "path": "engineering/inventory/census/C07-application-mcp-diagnostics.json",
+      "blob": "1ccb542a681d1781161e382889dc611b97681f51",
+      "sourceCommit": "ded641bd763379f36d629bf1686fcce8a6137a66"
+    },
+    {
+      "id": "C08",
+      "path": "engineering/inventory/census/C08-completeness.json",
+      "blob": "5cb8ea986f30820fff8b450c556302fce08aeaf0",
+      "sourceCommit": "a19cc20656c27789867ea52bf6994669c2cf399c"
+    },
+    {
+      "id": "C09",
+      "path": "engineering/inventory/census/C09-remaining-browser-modules.json",
+      "blob": "91921f4865509f3481e7f43bcecf21cf3c2156b4",
+      "sourceCommit": "2ff0599246b56be1bf01cd400a03fd1ecf2483fe"
+    },
+    {
+      "id": "C13",
+      "path": "engineering/inventory/census/C13-tooling-and-ci.json",
+      "blob": "797fb99519b96d051f63b5edbbefd841175d441c",
+      "sourceCommit": "9735e962e04e98ad49202d76ec085f406c687641"
+    },
+    {
+      "id": "C15",
+      "path": "engineering/inventory/census/C15-native-shell-and-services.json",
+      "blob": "02c3a543a44a8483db76fb90fc28c49a6a46a608",
+      "sourceCommit": "391f2e347b098e0f7bb68000ebba6fc3119d28a3"
+    },
+    {
+      "id": "C17",
+      "path": "engineering/inventory/census/C17-rust-wasm-engine-crates.json",
+      "blob": "b2e9b66d7fff13de7cbc988897ffcf8fb6ebf9bc",
+      "sourceCommit": "e94dd799a817b78fd1e9f1a42017343ae3c59755"
+    },
+    {
+      "id": "C18",
+      "path": "engineering/inventory/census/C18-vendor-provenance.json",
+      "blob": "58c4fc127112a0d4072bed800c8baf96e8c2db23",
+      "sourceCommit": "391f2e347b098e0f7bb68000ebba6fc3119d28a3"
+    }
+  ],
+  "packets": [
+    {
+      "id": "C01.asset-tree.folder-widget",
+      "census": "C01",
+      "admission": "pending"
+    },
+    {
+      "id": "C01.history-panel.ui",
+      "census": "C01",
+      "admission": "pending"
+    },
+    {
+      "id": "C01.idb-store.kv",
+      "census": "C01",
+      "admission": "pending"
+    },
+    {
+      "id": "C01.project-document.validation",
+      "census": "C01",
+      "admission": "pending"
+    },
+    {
+      "id": "C01.project-entry.repaint",
+      "census": "C01",
+      "admission": "pending"
+    },
+    {
+      "id": "C01.project.close-unsaved-work-guard",
+      "census": "C01",
+      "admission": "pending"
+    },
+    {
+      "id": "C01.project.document-io-and-dirty-tracking",
+      "census": "C01",
+      "admission": "pending"
+    },
+    {
+      "id": "C01.project.project-tabs",
+      "census": "C01",
+      "admission": "pending"
+    },
+    {
+      "id": "C01.project.start-screen",
+      "census": "C01",
+      "admission": "pending"
+    },
+    {
+      "id": "C01.project.team-sync",
+      "census": "C01",
+      "admission": "pending"
+    },
+    {
+      "id": "C01.project.version-history",
+      "census": "C01",
+      "admission": "pending"
+    },
+    {
+      "id": "C01.timeline.autosave-tick",
+      "census": "C01",
+      "admission": "pending"
+    },
+    {
+      "id": "C01.tweens.undo-redo-engine",
+      "census": "C01",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.camera.interaction-and-overlay-render",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.camera.keyframe-model-and-viewport-lock",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.expressions.expr-bake-to-keyframes",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.expressions.expr-code-split-editor",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.expressions.expr-reference-library",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.expressions.expression-runtime",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.layer-inout.bar-rendering",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.layer-inout.drag-and-batch-ops",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.layer-inout.selection-and-marquee",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.markers-and-bpm.bpm-guides",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.markers-and-bpm.timeline-markers",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.math-kernels.curve-evaluator",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.math-kernels.opacity-domain-writers",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.motion-advanced.3d-layers-and-gizmo",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.motion-advanced.canvas-drag-interactions",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.motion-advanced.component-shape-tree",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.motion-advanced.duplicator-and-effector-props",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.motion-advanced.geometry-motion-integrations",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.motion-advanced.mode-toggle-and-workspace-continuity",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.motion-advanced.point-mapping-and-parent-chain",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.motion-advanced.time-remap",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.motion-advanced.transform-application",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.playback-integration.camera-markers-bpm-row-integration",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.playback-integration.motion-shape-tree-rendering",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.playback-integration.onion-and-tween-controls-wiring",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.playback-integration.playback-transport",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.properties-and-curves.curves-and-easing",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.properties-and-curves.key-selection-and-clipboard",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.properties-and-curves.keyframe-track-model",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.properties-and-curves.properties-and-metadata",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.text-animation.presets",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.text-animation.selectors-panel",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.tween-engine.arc-rendering-and-reassignment",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.tween-engine.feature-extraction-and-matching",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.tween-engine.interpolation-core",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.tween-engine.onion-skinning",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.tween-engine.resampling-and-nonrigid-warping",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C02.tween-engine.tween-generation-and-splitting",
+      "census": "C02",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.gpu-engine-core.composite-scene-pipeline",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.gpu-engine-core.effect-pipeline-library",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.gpu-engine-core.public-wasm-api",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.gpu-engine-core.vello-engine-state",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.gpu-engine-core.viewport-and-wire-helpers",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-effects-and-playback.color-manager-panel",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-effects-and-playback.custom-effects-authoring",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-effects-and-playback.path-fx-stack",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-effects-and-playback.playback-bake-cache",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-effects-and-playback.render-manager-queue",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-effects-and-playback.shader-effects-library",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-engine-bridge.bounded-image-store",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-engine-bridge.build-scene-json",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-engine-bridge.editor-overlay-builders",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-engine-bridge.engine-lifecycle",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-engine-bridge.preview-scale-calibration",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-engine-bridge.public-api-surface",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-engine-bridge.render-entry-points",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-engine-bridge.retained-path-store",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.js-engine-bridge.viewport-sync-and-coords",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.wasm-geometry-ops.basic-shape-segments",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.wasm-geometry-ops.crate-root-and-boolean-ops",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.wasm-geometry-ops.eraser-boolean-subtract",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.wasm-geometry-ops.hit-test",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.wasm-geometry-ops.motion-flow-interp",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.wasm-geometry-ops.stroke-input-modeler",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.wasm-geometry-ops.timeline-frame-resolution",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.wasm-geometry-ops.tween-interpolation-math",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.wasm-tween-matching.align-pair",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.wasm-tween-matching.auto-match-correspondence",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.wasm-tween-matching.fill-region-tracer",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.wasm-tween-matching.pyramidal-point-tracker",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C03.wasm-tween-matching.resample-stroke",
+      "census": "C03",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.boolean.flatten-combine",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.boolean.path-operations",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.brush.centerline-width-profile",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.brush.dab-shape-presets",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.brush.dab-stamping",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.brush.pressure-vector-brush-nib",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.brush.stroke-profiles",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.brush.taper-width-helpers",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.brush.texture-apply-placement",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.brush.trim-rebuild-outline",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.brush.variable-width-outline",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.fill.auto-gap-closure",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.fill.closing-lines",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.fill.find-wasm-js-raster",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.fill.graph-tracer",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.fill.match-merge",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.fill.propagation-frames",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.fill.regenerate-linked",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.combine-hit-confirm",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.distort",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.handle-computation",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.hover-helpers",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.multi-layer-box",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.on-context",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.on-down",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.on-move",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.on-up",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.param-shape-handles",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.public-api-init",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.role-suggestions",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.tracked-role-attach",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.select.tween-toggle",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.subselect.on-down",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.subselect.on-move-up-init",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.subselect.space-mapping",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.symmetry.geometry-guide",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.symmetry.stroke-commit",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.symmetry.tool-interaction",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.component-element-hit-geometry",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.core-pointer-dispatch",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.cursor-hover-overlays",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.double-click-dispatch-zoom",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.dynamic-shapes",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.fs-select-hit-promote",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.fs-select-region-ops",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.misc-globals",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.node-tangent-edit",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.pen-tool-finalize",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.point-type-conversion",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.selection-clone-clipboard",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.stroke-ownership-revision",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.stylus-pressure-edit-guard",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.tools.transform-box-oriented",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04a.vecerase.precision-vector-eraser",
+      "census": "C04a",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.animated-primitives.image-mesh",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.animated-primitives.rig-widget-interaction-authoring",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.animated-primitives.rig-widget-model-overlay",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.animated-primitives.text-animator",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.animated-primitives.text-selector",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.brush-engine.bitmap-brush-bake-engine",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.brush-engine.bitmap-brush-preview-panel",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.brush-engine.bitmap-tip-picker",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.brush-engine.brush-editor",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.brush-engine.brush-preset-picker",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.brush-engine.brush-tool-presets",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.brush-engine.path-fx",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.brush-engine.stroke-modeler",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.canvas-aids.manual-rulers-guides",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.canvas-aids.perspective-guides",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.canvas-aids.rotoscopy-reference",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.canvas-aids.smart-alignment-guides",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.canvas-aids.viewport-tools",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.color-tools.popover-picker",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.color-tools.selected-colors-panel",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.content-tools.feedback-local-log-storage",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.content-tools.feedback-triage-sync",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.content-tools.feedback-worker-publish",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.content-tools.google-fonts-live-fetch",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.content-tools.vector-text-glyphs",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.content-tools.vectorize-orchestration",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.content-tools.vectorize-shape-fitting",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.deform.image-mesh-editor",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.deform.image-mesh-shape-to-mask",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.deform.rig-tool",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.docked-panels.assets-tab-switch",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.docked-panels.effects-stack",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.docked-panels.expr-code-editor",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.docked-panels.history-panel",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.docked-panels.palette-find-replace",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.docked-panels.palette-library",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.docked-panels.path-fx-stack",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.docked-panels.scripting-panel-ui-builder",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.docked-panels.shapes-drag-reorder-engine",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.docked-panels.shapes-tree-render",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.docked-panels.text-animator-panel",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.docked-panels.tracker-panel",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.editor-shell.context-menu-system",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.editor-shell.detachable-panel-sections-dnd",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.editor-shell.easing-curve-editor",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.editor-shell.fill-stroke-swatch-toggles",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.editor-shell.panel-layout-resize-and-workspace",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.editor-shell.scrub-input-mechanism",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.editor-shell.timeline-scrub-playhead",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.editor-shell.tooltip-system",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.editor-shell.work-area-and-onion-bar-drag",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.paint-brush.brush-menu-popover",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.paint-brush.fill-bucket",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.paint-brush.gradient-fill",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.paint-brush.shadow-brush",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.presets-and-effects.custom-wgsl-authoring",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.presets-and-effects.motion-preset-library",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.presets-and-effects.shader-table-data-1",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.presets-and-effects.shader-table-data-2",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.presets-and-effects.shader-table-data-3",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.presets-and-effects.shader-table-registry",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.stroke-input.draw-commit-materialize",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.stroke-input.draw-gesture-lifecycle",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.stroke-input.draw-input-pipeline",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.stroke-input.draw-live-overlay",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.stroke-input.eraser-tool",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.stroke-input.pen-tool",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.stroke-input.shape-tools",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.structure-audio.audio-data-playback",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.structure-audio.audio-timeline-ui",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.structure-audio.group-combine-model",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.structure-audio.group-combine-render-adapters",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.structure-audio.group-crud-nesting",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.viewer-and-chrome.asset-tree",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.viewer-and-chrome.comp-preview",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.viewer-and-chrome.second-viewer",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C04b.viewer-and-chrome.tools-panel-dock",
+      "census": "C04b",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.export.ae-camera-jsx",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.export.browser-native-fallbacks",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.export.engine-routing-gate",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.export.frame-compositor",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.export.lottie-bodymovin",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.export.rive-mcp",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.export.tauri-io-ffmpeg",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.import.abr-parse",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.import.drop-dispatch",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.import.figma-convert",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.import.figma-network",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.import.psd-import",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.import.svg-core",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.media.library-canvas-actions",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.media.library-panel",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.media.linked-bulk-convert",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.media.linked-resolve-core",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.media.mode-setting-ui",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.native-rust.bootstrap",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.native-rust.ffmpeg-run-command",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.native-rust.google-font-fetch",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.native-rust.image-vectorize-command",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.native-rust.tablet-pressure-monitor",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.native-rust.task-runtime-isolation",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.native-rust.video-decode",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.native-video.bench",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.native-video.decode-session",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.native-video.layer-lifecycle",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C05.native-video.layer-sync",
+      "census": "C05",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.bootstrap.feature-flags",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.bootstrap.paper-dom-setup",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.bootstrap.sm-namespace-init",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.bootstrap.storage-key-migration",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.i18n.translation-core",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.boil-effect",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.canvas-grid",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.dormant-timeline-zoom",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.dormant-unreachable",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.flip-roll",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.float-panel",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.follow-path",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.french-curve",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.interval-assistant",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.lagoon-menu",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.mirror-check",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.move-to-layer",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.multiframe-draw",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.out-of-pegs",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.pingpong-cycle",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.pose-library",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.predictive-stroke",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.reference-3d",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.reference-fill",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.registry-core",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.retime-exposure",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.settings-panel",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.speed-lines",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.timeline-markers",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.vector-sculpt",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.vector-trim",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.view-filter",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.labs.xsheet-panel",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.preferences.profile-fields-ui",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.preferences.settings-modal-shell",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.preferences.shortcuts-system",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.preferences.sync-folder-ui",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C06.preferences.user-profile",
+      "census": "C06",
+      "admission": "pending"
+    },
+    {
+      "id": "C07.application-service.bootstrap-bindings",
+      "census": "C07",
+      "admission": "pending"
+    },
+    {
+      "id": "C07.application-service.command-core",
+      "census": "C07",
+      "admission": "pending"
+    },
+    {
+      "id": "C07.mcp-contract.request-response-types",
+      "census": "C07",
+      "admission": "pending"
+    },
+    {
+      "id": "C07.mcp-contract.schema-dump-binary",
+      "census": "C07",
+      "admission": "pending"
+    },
+    {
+      "id": "C07.mcp-server.binary-entrypoint",
+      "census": "C07",
+      "admission": "pending"
+    },
+    {
+      "id": "C07.mcp-server.discovery-registry",
+      "census": "C07",
+      "admission": "pending"
+    },
+    {
+      "id": "C07.mcp-server.tool-router",
+      "census": "C07",
+      "admission": "pending"
+    },
+    {
+      "id": "C07.mcp-server.wire-framing",
+      "census": "C07",
+      "admission": "pending"
+    },
+    {
+      "id": "C07.native-transport.tauri-listener",
+      "census": "C07",
+      "admission": "pending"
+    },
+    {
+      "id": "C07.native-transport.webview-adapter",
+      "census": "C07",
+      "admission": "pending"
+    },
+    {
+      "id": "C08.docs.boundary-enforcement-config-data",
+      "census": "C08",
+      "admission": "pending"
+    },
+    {
+      "id": "C08.docs.inventory-and-census-artifacts",
+      "census": "C08",
+      "admission": "pending"
+    },
+    {
+      "id": "C08.docs.periodic-checkin-logs",
+      "census": "C08",
+      "admission": "pending"
+    },
+    {
+      "id": "C08.docs.remediation-program-docs",
+      "census": "C08",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.app-utilities.project-transplant",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.app-utilities.updater-bridge",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.engine-readiness.vectorize-worker-bridge",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.engine-readiness.wasm-engine-loaders",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.extensibility-api.scripting-and-plugins",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.footage-import.core",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.media-misc.kitsu",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.media-misc.lipsync",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.media-misc.lottie-preview",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.media-misc.p2p-contacts",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.media-misc.tracker",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.motion-extensions.effector-duplicator-layer",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.motion-extensions.graph-editor",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.storyboard-mode.core",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.timeline-panel-support.layer-kind-taxonomy",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.timeline-panel-support.scroll-and-zoom",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C09.tutorial-onboarding.core",
+      "census": "C09",
+      "admission": "pending"
+    },
+    {
+      "id": "C13.tooling.browser-and-app-test-suites",
+      "census": "C13",
+      "admission": "pending"
+    },
+    {
+      "id": "C13.tooling.ci-workflows-and-root-config",
+      "census": "C13",
+      "admission": "pending"
+    },
+    {
+      "id": "C13.tooling.nemo-tooling-test-suite",
+      "census": "C13",
+      "admission": "pending"
+    },
+    {
+      "id": "C13.tooling.scripts-nemo-core",
+      "census": "C13",
+      "admission": "pending"
+    },
+    {
+      "id": "C13.tooling.scripts-nemo-lib",
+      "census": "C13",
+      "admission": "pending"
+    },
+    {
+      "id": "C13.tooling.standalone-build-scripts",
+      "census": "C13",
+      "admission": "pending"
+    },
+    {
+      "id": "C15.native.feedback-worker-service",
+      "census": "C15",
+      "admission": "pending"
+    },
+    {
+      "id": "C15.native.ffmpeg-sidecar-binary",
+      "census": "C15",
+      "admission": "pending"
+    },
+    {
+      "id": "C15.native.nemo-mcp-build-metadata",
+      "census": "C15",
+      "admission": "pending"
+    },
+    {
+      "id": "C15.native.src-tauri-build-and-config",
+      "census": "C15",
+      "admission": "pending"
+    },
+    {
+      "id": "C15.native.web-deploy-worker",
+      "census": "C15",
+      "admission": "pending"
+    },
+    {
+      "id": "C17.engines.geometry-wasm-shaders-and-tests",
+      "census": "C17",
+      "admission": "pending"
+    },
+    {
+      "id": "C17.engines.vectorize-engine-crates",
+      "census": "C17",
+      "admission": "pending"
+    },
+    {
+      "id": "C18.vendor.static-assets",
+      "census": "C18",
+      "admission": "pending"
+    },
+    {
+      "id": "C18.vendor.vendored-js-libraries",
+      "census": "C18",
+      "admission": "pending"
+    },
+    {
+      "id": "C18.vendor.wasm-generated-bindings",
+      "census": "C18",
+      "admission": "pending"
+    }
+  ],
+  "uncoveredResponsibilities": [
+    {
+      "id": "C02:1",
+      "note": "motion-graph.js (exists in the repo, ~26KB) is the graph-editor UI for the same track/curve model this census owns — motion.js's own comment says 'the graph editor plots both (see motion-graph.js)' for rawValueAtFrame — but is not in C02's bounded file list, and was not found claimed by any other delivered census as of this writing (grepped across every delivered census JSON). Likely needs an explicit owner in a future pass or C08's set-difference check.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C02:2",
+      "note": "image-mesh.js (the mesh data model/topology/masking/rendering, CLAUDE.md §12/§12bis) is a close neighbor of this census's C02.motion-advanced.geometry-motion-integrations packet (which owns only the motion-TRACK integration, meshVertexOffsetAt etc.) but the mesh model itself is out of C02's bounded files, and its ownership by another census was not verified in this pass.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C02:3",
+      "note": "bpm-grid.js's snapFrame helper has no call site anywhere inside this census's bounded files — either it is invoked from a file outside C02's scope (tools.js's or layer-inout.js's own drag code would be the natural caller) or it is currently unreachable. Not resolved by this read-only pass; worth a quick grep across the full repo before assuming either way.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C02:4",
+      "note": "motion.js:4048-4283 — text-animator per-frame integration (taSelectorAt, taUnitCount, _taStrokeRestBounds, taUnitPivotCenter, textAnimatorContribution, addTextAnimator, removeTextAnimator, textAnimatorWeights) lives in motion.js itself and is referenced by C02.text-animation.selectors-panel's own responsibility text ('evaluated per-character via motion.js's textAnimatorWeights') but was never given a files entry by that packet or any other. Found while redrawing canvas-drag-interactions (#1084 review); belongs to text-animation.selectors-panel's ownership, not fixed here.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C02:5",
+      "note": "motion.js:4336-4380 — per-element fill/stroke color and width resolution (rgba255, elementFillColorAt, elementStrokeColorAt, elementStrokeWidthAt) has no packet owner in this census.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C02:6",
+      "note": "motion.js:6791-6869 and 6969-7046 — property-field scrub-editing helpers (fmtVal, scrubField, selectedKeysForEditableProperty, selectedDimensionDisplay, setSelectedKeyDimension, offsetSelectedKeyDimension, setSelectedKeyVector) and Motion-context-header sync (syncMotionContextHeader, ensureMotionHeaderTools) have no packet owner.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C02:7",
+      "note": "motion.js:7576-8453 (878 lines) — an entire layer-feature right-panel rendering block (renderMotionPropsPanel, renderMatteRow, renderWidgetSizeRow, renderBlendRow, openMatteConfigMenu/openExtraMatteMenu/firstFreeMatteLayer, renderNullShapeRow, renderFollowPathRow, renderParentRow/openExtraParentMenu/firstFreeParentLayer, renderTimeLinkRow) has no packet owner anywhere in this census. This was silently absorbed into canvas-drag-interactions's old 298-13134 catch-all; redrawing that packet's real range (per Pollen's #1084 review) exposes it as a genuine gap rather than fixing it — a strong candidate for its own future packet.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C02:8",
+      "note": "motion.js:8494-8568 — buildKeyLockMenuItems/buildKeySelectionLockMenuItems have no owner anywhere in this census; keysLockedTo in this same span is C02.properties-and-curves.key-selection-and-clipboard's own named symbol, but that packet's declared range (1033-1157) doesn't reach here — see the new cross_cutting_notes entry on declared-vs-real-location drift.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C02:9",
+      "note": "motion.js:8667-9450 (784 lines) — Transform property-group rendering plus the inline ƒx row's own expression-editor UI (renderTransformGroup, renderTransformHeader, renderDupGroupHeader, renderTransformProps, buildAnchorGridRow, exprPanelLabelFor, buildExprEditorRow, startExprPickwhip) has no packet owner.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C02:10",
+      "note": "motion.js:9841-11140 (1300 lines) — per-property row rendering (renderElementsList, renderColorRow/renderFillColorRow/renderStrokeColorRow, renderTrimScalarRow/renderTrimPathsGroup, renderTextAnimatorsList, renderPathVertexGroup/renderPathGroupTrackRow, renderMeshVertexGroup/renderVertexRow, trackRowHtml, renderTracksFor) has no packet owner.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C03:1",
+      "note": "src/js/geometry-wasm-loader.js — binds every geometry-wasm wasm-bindgen export onto window.GeometryWasm.*; read for context throughout this census but not in C03's bounded source ownership. A future extraction of ANY geometry-wasm-consuming JS file must account for this loader as a shared dependency.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C03:2",
+      "note": "src/js/second-viewer.js — an independent second VelloEngine instance and its own buildSceneJson call seam; read for context (see cross_cutting_notes on the shared-resource-budget question) but not in C03's bounded source ownership.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C03:3",
+      "note": "engine.rs's Phase-C3 selection API (select_at and friends, DEF-6) and engine-bridge.js's preview-calibration introspection API (DEF-7) are both fully-built but entirely unwired to any UI — flagged here in case a completeness sweep (C08) or a future feature owner wants to either finish wiring them in or explicitly deprecate/remove them, since neither decision was this census's to make.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C06:1",
+      "note": "src/js/timeline.js:2354-2374 (21 lines, inside importJSON's SMLabs.resetAll()/clearRetainedPaths()/version-check block) is named in this census's own scope_files but not owned by any packet here. Not this census's job to extract — it's three statements embedded inside importJSON's own much larger, mostly out-of-scope body, not a standalone module boundary — but checked and confirmed unclaimed by any of the 5 sibling censuses merged so far (C01/C03/C04a/C05/C07) too, per Fizz's #1067 review (2026-09-09): still genuinely unowned program-wide, not silently someone else's already-documented job.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C08:1",
+      "note": "src/js/timeline.js's real ~11187-line gap (DEF-5) is flagged with full evidence here but NOT sized or packet-split — at over 11,000 lines with CLAUDE.md §11's documented alignment/scroll/zoom invariants, a proper packet-level treatment is itself several leaf tasks' worth of work, which would blow this census's own work-size budget. The orchestrator should treat this as its own multi-leaf mini-program (candidate: C19+), not a single proposed ID.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C08:2",
+      "note": "vectorize-core/src/lib.rs and vectorize-wasm/src/lib.rs line counts and internal structure were not read (map-level only, per C08's own 'no packet requires days of implementation' guidance applied to the mapping step itself) — a future leaf executing C08.engines.vectorize-engine-crates should confirm actual size before committing to a single-leaf work estimate.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C08:3",
+      "note": "40min-checkins/ (17 files) purpose is genuinely unknown to this census — not characterized as either process-live or archivable; flagged for a human decision rather than guessed.",
+      "disposition": "needs-reconciliation"
+    },
+    {
+      "id": "C08:4",
+      "note": "worker/index.js and root wrangler.jsonc (C08.native.web-deploy-worker) were confirmed to exist and be distinct from worker-feedback/, but not read beyond that — lowest-confidence packet in this census.",
+      "disposition": "needs-reconciliation"
+    }
+  ],
+  "files": [
+    {
+      "path": ".c8rc.json",
+      "mode": "100644",
+      "blob": "a2538bfe1b201c006d6c81da095a46db59f530b4",
+      "classification": "configuration",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": ".claude/launch.json",
+      "mode": "100644",
+      "blob": "ce656bffcda67b1f77442371bf6ba78d253a10b8",
+      "classification": "configuration",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": ".github/scripts/collaborator-pr-policy.cjs",
+      "mode": "100644",
+      "blob": "f1df3162fdf1dfd154cf57c22a08bb79a72b54c8",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": ".github/scripts/collaborator-pr-policy.test.cjs",
+      "mode": "100644",
+      "blob": "9d5a8fed41b7a5d99eb6a9eff22be30ccebf66da",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": ".github/workflows/collaborator-pr-policy.yml",
+      "mode": "100644",
+      "blob": "93cadc0633a05fac32262deb723b9b21725bed00",
+      "classification": "configuration",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": ".github/workflows/deploy-feedback-worker.yml",
+      "mode": "100644",
+      "blob": "052a52a9fabb9a49f6fbc2d6b4b16c9c80998cd8",
+      "classification": "configuration",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": ".github/workflows/deploy-web.yml",
+      "mode": "100644",
+      "blob": "8d884c71841c99a9c5dec1d13bbfc53a0f552af1",
+      "classification": "configuration",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": ".github/workflows/nemo-validation.yml",
+      "mode": "100644",
+      "blob": "28d2b598dc07153af204c9ba9b7074cd1636274f",
+      "classification": "configuration",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": ".github/workflows/release.yml",
+      "mode": "100644",
+      "blob": "1e410f5209c087af7720e45ffb8b97c0e63b5ec4",
+      "classification": "configuration",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": ".gitignore",
+      "mode": "100644",
+      "blob": "bd4832bff7e91fbd758f386f3a844f44f5d3e386",
+      "classification": "configuration",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "40min-checkins/2026-09-05-checkin-05.md",
+      "mode": "100644",
+      "blob": "50116f88029567cd61a7808659ce079838eef77b",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-05-checkin-10.md",
+      "mode": "100644",
+      "blob": "bf25f2f7456ecb538828658eed9f94271e6e3e24",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-06-checkin-15.md",
+      "mode": "100644",
+      "blob": "8a694febf1075ffc7f644233add2398e832c59f4",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-06-checkin-20.md",
+      "mode": "100644",
+      "blob": "7f86cd9df43f783b2d94e6a3c4c8be5b7189d569",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-06-checkin-25.md",
+      "mode": "100644",
+      "blob": "959cf90d3e9d23dd45558a64688ea1e4d80e0515",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-06-checkin-30.md",
+      "mode": "100644",
+      "blob": "991a40e8c3d686b96e2ad5845d573319bf452e52",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-06-checkin-35.md",
+      "mode": "100644",
+      "blob": "8a44c8d1e0c4b0514086f2197086f966e554c069",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-06-checkin-40.md",
+      "mode": "100644",
+      "blob": "4b6953c854bdaf0fc188c4fc4e167a44dda07cbf",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-06-checkin-45.md",
+      "mode": "100644",
+      "blob": "5341c36dce14479ddc8ecca37666e79e0e276452",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-06-checkin-50.md",
+      "mode": "100644",
+      "blob": "dd821e90fdb7a43a6fc4d89261a0de6bd576f974",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-06-checkin-55.md",
+      "mode": "100644",
+      "blob": "b88f14c20e5a70e5a6aba4b42b7a823cdc46d569",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-06-checkin-65.md",
+      "mode": "100644",
+      "blob": "11dbbbae6e955ca34d68d67e593c5e90ad0d97e6",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-07-checkin-85.md",
+      "mode": "100644",
+      "blob": "21b84dcf0b89b195ecb0a0b5050fc85a781d5745",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-07-checkin-87.md",
+      "mode": "100644",
+      "blob": "fba10211a2e4258f85037709c8ac9ea4c9ed4b86",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-07-checkin-90.md",
+      "mode": "100644",
+      "blob": "5d7e0b54e5cd2cd43e35b7a9c1c7013b02920961",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/2026-09-07-weekend-final-handoff.md",
+      "mode": "100644",
+      "blob": "e4644fef8e1f228f2c3983f628a98efe156c40b7",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "40min-checkins/README.md",
+      "mode": "100644",
+      "blob": "43511df1aee2858bf771cfacd94d9452bfd9aa75",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.periodic-checkin-logs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "AGENTS.md",
+      "mode": "100644",
+      "blob": "6297ce42504c90c14ea455f233d108ef934d62c1",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "CLAUDE.md",
+      "mode": "100644",
+      "blob": "b38aa07e168e5da87c7e804396db33d0c1adaede",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "mode": "100644",
+      "blob": "198ee2b5398519c051a56e6d24c24497f8a3e0ee",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "LICENSE",
+      "mode": "100644",
+      "blob": "f288702d2fa16d3cdf0035b15a9fcbc552cd88e7",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "README.md",
+      "mode": "100644",
+      "blob": "b7648923b63775c65c8530faed8349ef140e9837",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "THIRD_PARTY_LICENSES_RUST_TAURI.txt",
+      "mode": "100644",
+      "blob": "cad2b49fdb49da261fc7a667fe816190e8e7c1a3",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "THIRD_PARTY_LICENSES_RUST_WASM.txt",
+      "mode": "100644",
+      "blob": "8ed015944ba95b9b8cb36d7bd68141ccbbd96a49",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "THIRD_PARTY_NOTICES.md",
+      "mode": "100644",
+      "blob": "7886b7fad14b2015815e21b6ae268327658afe14",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "assets/logo.ai",
+      "mode": "100644",
+      "blob": "0b1617d5ec1c252d0e5b7f6f3026538182acc1a0",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "assets/logo_nemo.png",
+      "mode": "100644",
+      "blob": "8a71d0552d4ca74326eb93c38d8b71f57b90829c",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "assets/logo_nemo.svg",
+      "mode": "100644",
+      "blob": "cb539782df1590d30180cf69ee3dbb152433f739",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "assets/logo_nemo_alpha.png",
+      "mode": "100644",
+      "blob": "2cdb8f99d1cb1f77075a4a7ce69cf26fdb0a5836",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "assets/logo_nemo_alpha.svg",
+      "mode": "100644",
+      "blob": "84e3fe31ef289642d4bb372393d0dcfb367d1df4",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "assets/logo_nemo_alpha_white.png",
+      "mode": "100644",
+      "blob": "2838fbe11b13a3e63237745bf9c2669c275b0483",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "assets/screenshot-motion.png",
+      "mode": "100644",
+      "blob": "1dbe25f1e6e79fce92f387258c1285dfe7e23125",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "docs/FUNCTIONAL_GAPS.md",
+      "mode": "100644",
+      "blob": "e635f55160346cfc2015bb736ee22238eb4dda13",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/animation/ADR-001-curve-runner.md",
+      "mode": "100644",
+      "blob": "7fb52345585403140e1e5204ef481bff011fc4d9",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/animation/BROWSER_ACCEPTANCE.md",
+      "mode": "100644",
+      "blob": "ce5e344de67624f963c881af8158eb90b6c62024",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/before-0.png",
+      "mode": "100644",
+      "blob": "b0fa32f0e5c2a17b85f552946c3e2420c661d947",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/before-10.png",
+      "mode": "100644",
+      "blob": "65a0966a696fb42ad711ca6056b081e762abbf33",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/before-15.png",
+      "mode": "100644",
+      "blob": "dc0647ae268dfb4cb8b1508e2eae4090dee142e7",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/before-20.png",
+      "mode": "100644",
+      "blob": "e5c2394e319161d346cb1534d6bd5d1560da06bc",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/before-5.png",
+      "mode": "100644",
+      "blob": "039dbf778a349bda75cbfb4ed64b82a448125d5f",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/edited-0.png",
+      "mode": "100644",
+      "blob": "65a0966a696fb42ad711ca6056b081e762abbf33",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/edited-10.png",
+      "mode": "100644",
+      "blob": "e33e0566fbb5f99c58a6a66c9672136ae2d5c412",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/edited-15.png",
+      "mode": "100644",
+      "blob": "e3103c231e7a81ae7403040b751f55d522f011b7",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/edited-20.png",
+      "mode": "100644",
+      "blob": "e5c2394e319161d346cb1534d6bd5d1560da06bc",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/edited-5.png",
+      "mode": "100644",
+      "blob": "4891e2d2355207eabc620d79f464301aec6cd437",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/edited-project.json",
+      "mode": "100644",
+      "blob": "400e26223f2ef92649631ad17367157d199357bf",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/export-0.svg",
+      "mode": "100644",
+      "blob": "85f362c77606721baa53792bbdbd80adfbc0c912",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/export-10.svg",
+      "mode": "100644",
+      "blob": "a48d61ccdb3b7c439e5aa0acaeed24609ff7c74f",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/export-15.svg",
+      "mode": "100644",
+      "blob": "6af87d89e10b4a1d9e18eee20fc992c274018d43",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/export-20.svg",
+      "mode": "100644",
+      "blob": "0b000d4a8604fc72702c47b0bc1e8b658614bc1b",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/export-5.svg",
+      "mode": "100644",
+      "blob": "09b656d054d609c88eb8ef79b6b231a0a1778d58",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/receipt.json",
+      "mode": "100644",
+      "blob": "b871cc507e14d326dad0b5b8b0e90eb994327fe1",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/redo-0.png",
+      "mode": "100644",
+      "blob": "65a0966a696fb42ad711ca6056b081e762abbf33",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/redo-10.png",
+      "mode": "100644",
+      "blob": "e33e0566fbb5f99c58a6a66c9672136ae2d5c412",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/redo-15.png",
+      "mode": "100644",
+      "blob": "e3103c231e7a81ae7403040b751f55d522f011b7",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/redo-20.png",
+      "mode": "100644",
+      "blob": "e5c2394e319161d346cb1534d6bd5d1560da06bc",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/redo-5.png",
+      "mode": "100644",
+      "blob": "4891e2d2355207eabc620d79f464301aec6cd437",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/reopened-0.png",
+      "mode": "100644",
+      "blob": "65a0966a696fb42ad711ca6056b081e762abbf33",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/reopened-10.png",
+      "mode": "100644",
+      "blob": "e33e0566fbb5f99c58a6a66c9672136ae2d5c412",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/reopened-15.png",
+      "mode": "100644",
+      "blob": "e3103c231e7a81ae7403040b751f55d522f011b7",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/reopened-20.png",
+      "mode": "100644",
+      "blob": "e5c2394e319161d346cb1534d6bd5d1560da06bc",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/reopened-5.png",
+      "mode": "100644",
+      "blob": "4891e2d2355207eabc620d79f464301aec6cd437",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/reopened-frame-5.png",
+      "mode": "100644",
+      "blob": "9cae2dfa69f727932d489d2c318e71c684701528",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/undo-0.png",
+      "mode": "100644",
+      "blob": "b0fa32f0e5c2a17b85f552946c3e2420c661d947",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/undo-10.png",
+      "mode": "100644",
+      "blob": "65a0966a696fb42ad711ca6056b081e762abbf33",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/undo-15.png",
+      "mode": "100644",
+      "blob": "dc0647ae268dfb4cb8b1508e2eae4090dee142e7",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/undo-20.png",
+      "mode": "100644",
+      "blob": "e5c2394e319161d346cb1534d6bd5d1560da06bc",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/browser-evidence-20260905/undo-5.png",
+      "mode": "100644",
+      "blob": "039dbf778a349bda75cbfb4ed64b82a448125d5f",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/animation/runner-trial-20260905.json",
+      "mode": "100644",
+      "blob": "b79eaef1e9571ec04c465eb3a0e534c9b5139cd0",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/application/MCP_INSTALL.md",
+      "mode": "100644",
+      "blob": "81575706914e8d8af32966d5dc0da8db10affadd",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/application/OPACITY_SLICE.md",
+      "mode": "100644",
+      "blob": "d562cc5d17cf00a7f79c46afbe1dacccc06a59a7",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/application/capabilities/export-job.json",
+      "mode": "100644",
+      "blob": "e45f20317afc87ddf69e6fe83a94e3599de63bce",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/application/capabilities/opacity.json",
+      "mode": "100644",
+      "blob": "d271b4b3a3766f22cee5d75e06d29695a4b87119",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/application/capability-v1.schema.json",
+      "mode": "100644",
+      "blob": "74e023618b287a2c83a8d1ababb963fac962e10b",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/application/operation-contract-v1.schema.json",
+      "mode": "100644",
+      "blob": "050bc4a400555e61a8d31c19d22502ec7666c59c",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/application/transport-v1.schema.json",
+      "mode": "100644",
+      "blob": "c8715ed6454fb7d18a6470fc02581c81730cf2b4",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/boundaries/README.md",
+      "mode": "100644",
+      "blob": "b566422817113f4db2ea8546663cad9b4dda2dd1",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/boundaries/profile.schema.json",
+      "mode": "100644",
+      "blob": "b3965cf733946352ca5e80accd21019682302192",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/boundaries/profiles/app-js.baseline.json",
+      "mode": "100644",
+      "blob": "3528d014efcbcc5c5e8bf4fbe61f1786b6e80dc8",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/boundaries/profiles/app-js.coverage.json",
+      "mode": "100644",
+      "blob": "c6ebee853325e76d6b9bc25973165af84da08331",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/boundaries/profiles/app-js.profile.json",
+      "mode": "100644",
+      "blob": "977bceb0d65c025fd1d8fe0671d56bd011116b84",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/boundaries/profiles/app-surfaces.md",
+      "mode": "100644",
+      "blob": "07a65a4468bd73b850f26c829017bebf77db5ac5",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/boundaries/profiles/mcp-rust.profile.json",
+      "mode": "100644",
+      "blob": "0589de61dc6a22ef0b9d9776d3fb0269e4d4d5b9",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/boundaries/profiles/rust.baseline.json",
+      "mode": "100644",
+      "blob": "c01dd46df20222d2d949e8e042b1d318feb6a02c",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/boundaries/profiles/rust.coverage.json",
+      "mode": "100644",
+      "blob": "d48b9a5fc83031d763b6f9e0f94ca9fed98b2606",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/boundaries/profiles/rust.profile.json",
+      "mode": "100644",
+      "blob": "232e427270595c1868ecff66bad3943af768b4ff",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.baseline.json",
+      "mode": "100644",
+      "blob": "214ca25cb59630befa1957850552e0fd568524a9",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.fixture/profile.json",
+      "mode": "100644",
+      "blob": "6abb61c06947cfbbca8be31a3a6cf679c2bc8d1e",
+      "classification": "test",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.fixture/src/adapter-target.cjs",
+      "mode": "100644",
+      "blob": "d6328458e54b81f97afa9707db10e6fc898da564",
+      "classification": "test",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.fixture/src/cycle-a.cjs",
+      "mode": "100644",
+      "blob": "ac40a474b6ca20de363a2ef80c305927224843ae",
+      "classification": "test",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.fixture/src/cycle-b.cjs",
+      "mode": "100644",
+      "blob": "420994776be15b449550f111c288b8716a5fe41e",
+      "classification": "test",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.fixture/src/expired.cjs",
+      "mode": "100644",
+      "blob": "322bc546fc2d4b8edf0e211352d7b4db2f221af9",
+      "classification": "test",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.fixture/src/global-offender.cjs",
+      "mode": "100644",
+      "blob": "178314d29226a98f541d67af823203783596b0c6",
+      "classification": "test",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.fixture/src/oversized.cjs",
+      "mode": "100644",
+      "blob": "9a4994aed73b6c99602e028fb06ea40a2abab74f",
+      "classification": "test",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.fixture/src/priv-importer.cjs",
+      "mode": "100644",
+      "blob": "56c6e2c5591aed0218cf2b8ece246685e2ee0405",
+      "classification": "test",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.fixture/src/priv-secret.cjs",
+      "mode": "100644",
+      "blob": "d73e48cbb50567efa273fc23466a1add2178099c",
+      "classification": "test",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.fixture/src/priv-target.cjs",
+      "mode": "100644",
+      "blob": "4a2318c088cc1ee27a9c8c5935a2211ab1602463",
+      "classification": "test",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.fixture/src/shared-violator.cjs",
+      "mode": "100644",
+      "blob": "79cea057b741b1fe778696861debd43a1ed25cf3",
+      "classification": "test",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.md",
+      "mode": "100644",
+      "blob": "c10f7fb56590451d8472140d5c3a69e46cc89707",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/boundaries/profiles/scripts-nemo.profile.json",
+      "mode": "100644",
+      "blob": "047d1ab6c4c8b406324070a88eb1ff47c67b7864",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.boundary-enforcement-config-data"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/ci/README.md",
+      "mode": "100644",
+      "blob": "33db422f227d5ef9e4c632fc3c8dd46c2d108d4f",
+      "classification": "documentation",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/contracts/evidence/cross-contract-acceptance.md",
+      "mode": "100644",
+      "blob": "c05d929b81593a09f29cf3d5e3fd7e65753de77b",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/contracts/evidence/inventory-contract-gaps.md",
+      "mode": "100644",
+      "blob": "21a973c83a5cbebfec42efe6c3955656c8135df4",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/contracts/evidence/schema-generation-plan.md",
+      "mode": "100644",
+      "blob": "a727fcd1dfc13edfd2ca5b66f21524decbb40053",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/coverage/rust-mcp.baseline.json",
+      "mode": "100644",
+      "blob": "cadfe0cbb94e4dd1e5652deabf4a244d94b15170",
+      "classification": "configuration",
+      "censusRefs": [],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/inventory/BASELINE.md",
+      "mode": "100644",
+      "blob": "75b9ce904741c2b8728f89cc1a112cafa543cc4c",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/inventory/BINDING_REPAIR_20260905.md",
+      "mode": "100644",
+      "blob": "fea02393de6382b993c2783cf5bd2881ed05d1ed",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/inventory/SURFACES.md",
+      "mode": "100644",
+      "blob": "6fc231da39b5f4a78f45b275de841f9e589fa861",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/inventory/baseline-manifest.json",
+      "mode": "100644",
+      "blob": "c2f15a4aa757bcd3606e96864104d9abd19c697f",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/inventory/census/C01-document-history.json",
+      "mode": "100644",
+      "blob": "d81b618308f9f4849b0ba24fa512af6be90aa72c",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/census/C02-animation-time.json",
+      "mode": "100644",
+      "blob": "70bdb5abec721a248fbe89228182f501f8ca1f35",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/census/C03-rendering-resource-ownership.json",
+      "mode": "100644",
+      "blob": "337c9035f94f5290b2adf898d406550558560bfa",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/census/C04a-editor-tools-selection.json",
+      "mode": "100644",
+      "blob": "8ffb669c5018190bd448b787a09ade35bd594b30",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/census/C04b-editor-presentation-support.json",
+      "mode": "100644",
+      "blob": "f76259d59dedb715edc18b9f84db98ac00ee7cb8",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/census/C05-media-import-export-native.json",
+      "mode": "100644",
+      "blob": "725d7875da509cd99a77bc404fc62296280399a0",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/census/C06-preferences-labs-bootstrap.json",
+      "mode": "100644",
+      "blob": "1e57da9181bf436c67f058354c95760a3ac29988",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/census/C07-application-mcp-diagnostics.json",
+      "mode": "100644",
+      "blob": "1ccb542a681d1781161e382889dc611b97681f51",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/census/C08-completeness.json",
+      "mode": "100644",
+      "blob": "5cb8ea986f30820fff8b450c556302fce08aeaf0",
+      "classification": "static-data",
+      "censusRefs": [],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/census/C09-remaining-browser-modules.json",
+      "mode": "100644",
+      "blob": "91921f4865509f3481e7f43bcecf21cf3c2156b4",
+      "classification": "static-data",
+      "censusRefs": [],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/census/C13-tooling-and-ci.json",
+      "mode": "100644",
+      "blob": "797fb99519b96d051f63b5edbbefd841175d441c",
+      "classification": "static-data",
+      "censusRefs": [],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/census/C15-native-shell-and-services.json",
+      "mode": "100644",
+      "blob": "02c3a543a44a8483db76fb90fc28c49a6a46a608",
+      "classification": "static-data",
+      "censusRefs": [],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/census/C17-rust-wasm-engine-crates.json",
+      "mode": "100644",
+      "blob": "b2e9b66d7fff13de7cbc988897ffcf8fb6ebf9bc",
+      "classification": "static-data",
+      "censusRefs": [],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/census/C18-vendor-provenance.json",
+      "mode": "100644",
+      "blob": "58c4fc127112a0d4072bed800c8baf96e8c2db23",
+      "classification": "static-data",
+      "censusRefs": [],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/surfaces.csv",
+      "mode": "100644",
+      "blob": "935a3457dafa915460adad23521b055a7c7391cb",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/inventory/surfaces.json",
+      "mode": "100644",
+      "blob": "e1760912a8cd5bd2a09ad030db934de8f814547a",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.inventory-and-census-artifacts"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/project-management/PLAN_REVIEW.md",
+      "mode": "100644",
+      "blob": "c5b98dd1099766e99557d25a3a90578f86689f1e",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/project-management/PUBLICATION.md",
+      "mode": "100644",
+      "blob": "689fcfeb19189ccad2fc8442efe4b9b961b3f7a6",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/project-management/README.md",
+      "mode": "100644",
+      "blob": "9509ba39294622606a93711331bea0e81d2ecdcf",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/project-management/TIMELINE.md",
+      "mode": "100644",
+      "blob": "3d83997e7e47ee9f3d33e9fcf9fd6716053a1a64",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/project-management/issue-triage.csv",
+      "mode": "100644",
+      "blob": "6accc1c3cee45085da3e8bea8af55953fc5dd4ce",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/project-management/project-schema.json",
+      "mode": "100644",
+      "blob": "8d6aac12d493dd263026816c59e8e5e350e2e0fd",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/project-management/remediation-schedule.json",
+      "mode": "100644",
+      "blob": "43ee20114fcfa13008c20873773807b12cb86b5f",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/project-management/remediation-tasks.json",
+      "mode": "100644",
+      "blob": "5f34dd53af9cbb14ce4f2e70e635709e33287cdb",
+      "classification": "configuration",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "engineering/remediation/EXECUTION_PLAN.en.md",
+      "mode": "100644",
+      "blob": "7ae4cc8ba3bbb52e31c4ff35d8f72e5d34c2eabe",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/EXECUTION_PLAN.fr.md",
+      "mode": "100644",
+      "blob": "9aa1c8c61f11278d30e5ff084f252c038873341e",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/README.md",
+      "mode": "100644",
+      "blob": "0e7112652bc7eec2bf58fa94c107905ef4c983ff",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/archive/2026-09-07-handbook/02_REMEDIATION_PLAN.md",
+      "mode": "100644",
+      "blob": "9eda83ef59059cfdaa4512b1776ab0396ecac6f6",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/archive/2026-09-07-handbook/06_BUZZ_A2A_AND_ENROLLMENT.md",
+      "mode": "100644",
+      "blob": "5ca1c9eb08c3f934c13553e00cf15c358aa2c808",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/archive/2026-09-07-handbook/07_GITHUB_PROJECT_AND_PARALLEL_WORK.md",
+      "mode": "100644",
+      "blob": "84481093633cf63aecfda4241b76015519b81b83",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/archive/2026-09-07-handbook/08_ACCEPTANCE_AND_MAINTENANCE.md",
+      "mode": "100644",
+      "blob": "af2a04a48f9c5192eb96c2d39f559547ad1cf013",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/archive/2026-09-07-handbook/MANIFEST.md",
+      "mode": "100644",
+      "blob": "380bbc86e86dfb6c9e72c6b924970f5d06796089",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/SUMMARY.md",
+      "mode": "100644",
+      "blob": "b51899b37203473618f4f5f0d7ae238b34c513e7",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/clean-attach.sh",
+      "mode": "100755",
+      "blob": "35dea2788e7cd4c4e34fb7e33c46878c13acea6f",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/requests-discover.jsonl",
+      "mode": "100644",
+      "blob": "42502a9a5332ea825eccd9faf7dc51f3af11e822",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/requests-handshake.jsonl",
+      "mode": "100644",
+      "blob": "bbe2a2d24f9c5be2925fa4f8a3f623c81298c50b",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/ANALYSIS.txt",
+      "mode": "100644",
+      "blob": "8c20815b86ed2a1d6a89a20b7372f4af2ee211e7",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-1-handshake/binary.txt",
+      "mode": "100644",
+      "blob": "f2f4a78ccc648e50e9f2d418c80939e3d97e6803",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-1-handshake/environment.txt",
+      "mode": "100644",
+      "blob": "e9888b69f8f80993a534e5a874dff550d202b860",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-1-handshake/exit-status.txt",
+      "mode": "100644",
+      "blob": "573541ac9702dd3969c9bc859d2b91ec1f7e6e56",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-1-handshake/requests.jsonl",
+      "mode": "100644",
+      "blob": "bbe2a2d24f9c5be2925fa4f8a3f623c81298c50b",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-1-handshake/stderr.log",
+      "mode": "100644",
+      "blob": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-1-handshake/stdout.jsonl",
+      "mode": "100644",
+      "blob": "3449ade356ff3131c17d42df9c818909ae273a4b",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-2-discover/binary.txt",
+      "mode": "100644",
+      "blob": "f2f4a78ccc648e50e9f2d418c80939e3d97e6803",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-2-discover/environment.txt",
+      "mode": "100644",
+      "blob": "e9888b69f8f80993a534e5a874dff550d202b860",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-2-discover/exit-status.txt",
+      "mode": "100644",
+      "blob": "573541ac9702dd3969c9bc859d2b91ec1f7e6e56",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-2-discover/requests.jsonl",
+      "mode": "100644",
+      "blob": "42502a9a5332ea825eccd9faf7dc51f3af11e822",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-2-discover/stderr.log",
+      "mode": "100644",
+      "blob": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-2-discover/stdout.jsonl",
+      "mode": "100644",
+      "blob": "e7008d1bb9560103f0400b87af2e39124fda72c7",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-3-select/binary.txt",
+      "mode": "100644",
+      "blob": "f2f4a78ccc648e50e9f2d418c80939e3d97e6803",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-3-select/environment.txt",
+      "mode": "100644",
+      "blob": "e9888b69f8f80993a534e5a874dff550d202b860",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-3-select/exit-status.txt",
+      "mode": "100644",
+      "blob": "573541ac9702dd3969c9bc859d2b91ec1f7e6e56",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-3-select/requests.jsonl",
+      "mode": "100644",
+      "blob": "809a3eb7ca8845acd61eba86727af35e1598cd62",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-3-select/stderr.log",
+      "mode": "100644",
+      "blob": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-3-select/stdout.jsonl",
+      "mode": "100644",
+      "blob": "4f8c304842c3f90283cdaf9c7af0f4d733fa777f",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-4-isolation/binary.txt",
+      "mode": "100644",
+      "blob": "f2f4a78ccc648e50e9f2d418c80939e3d97e6803",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-4-isolation/environment.txt",
+      "mode": "100644",
+      "blob": "e9888b69f8f80993a534e5a874dff550d202b860",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-4-isolation/exit-status.txt",
+      "mode": "100644",
+      "blob": "573541ac9702dd3969c9bc859d2b91ec1f7e6e56",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-4-isolation/requests.jsonl",
+      "mode": "100644",
+      "blob": "42502a9a5332ea825eccd9faf7dc51f3af11e822",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-4-isolation/stderr.log",
+      "mode": "100644",
+      "blob": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-4-isolation/stdout.jsonl",
+      "mode": "100644",
+      "blob": "e2e0ef0f80c7c9fd1be57edf35df60863c72e41e",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-5-stale/binary.txt",
+      "mode": "100644",
+      "blob": "f2f4a78ccc648e50e9f2d418c80939e3d97e6803",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-5-stale/environment.txt",
+      "mode": "100644",
+      "blob": "e9888b69f8f80993a534e5a874dff550d202b860",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-5-stale/exit-status.txt",
+      "mode": "100644",
+      "blob": "573541ac9702dd3969c9bc859d2b91ec1f7e6e56",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-5-stale/requests.jsonl",
+      "mode": "100644",
+      "blob": "7a1a2f23c1a5a486124595ce023bf2bfadf0abc5",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-5-stale/stderr.log",
+      "mode": "100644",
+      "blob": "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/attach-5-stale/stdout.jsonl",
+      "mode": "100644",
+      "blob": "82d4f98d0d3b10b5a4a5b1b7ab2877b131151dac",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/build.txt",
+      "mode": "100644",
+      "blob": "db0d91a531b04c3e593236aea7032b698c237410",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/doctor.txt",
+      "mode": "100644",
+      "blob": "bd4d8499709c9764e9e194862b7b7c4c6eafbf43",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/dylib-bundling.txt",
+      "mode": "100644",
+      "blob": "2f2a3af99f1201081add14a047709424d2adf209",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/install-from-dmg.txt",
+      "mode": "100644",
+      "blob": "5b0a886f828bb510c0be10214b8e11695f0ca46f",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/isolation-live-process.txt",
+      "mode": "100644",
+      "blob": "14631512ea98699146b53144ac93ccfca152fd1b",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/registry-lifecycle.txt",
+      "mode": "100644",
+      "blob": "d67abb84ed8224b61957bc199628d67751aa9352",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/registry-liveness-finding.txt",
+      "mode": "100644",
+      "blob": "b1fb8de9b32b865e5fbf1c2dcce7b364cf594676",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/receipts/R14-packaging/transcripts/requests-select.jsonl",
+      "mode": "100644",
+      "blob": "809a3eb7ca8845acd61eba86727af35e1598cd62",
+      "classification": "static-data",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Recorded evidence or census data; identity frozen with the source set, no handwritten control logic."
+    },
+    {
+      "path": "engineering/remediation/reference/01_CURRENT_AND_TARGET.md",
+      "mode": "100644",
+      "blob": "e4b15ecbb475240fbcb300813093596774c35a66",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/reference/03_TESTING_AND_DEBUGGING.md",
+      "mode": "100644",
+      "blob": "697706bdd2f0db114c8fe654be8112db3772f6a5",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/reference/04_MODULARITY_POLICY.md",
+      "mode": "100644",
+      "blob": "717df0edf27170fa54ce1e4f3b11ccbcf73c2036",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/reference/05_CAPABILITIES_MCP_AND_STANDARDS.md",
+      "mode": "100644",
+      "blob": "86ef3afcb99ac7f5d261fccf32fd859df37eef1e",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/reference/templates/HANDOFF_RECEIPT.md",
+      "mode": "100644",
+      "blob": "96be5265bb3847658efa6848cab49f9a50829be7",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/remediation/reference/templates/TASK_PACKET.md",
+      "mode": "100644",
+      "blob": "f12ce341421d7d39cc5ef345a19fc2b07da822bb",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "engineering/runtime-isolation.md",
+      "mode": "100644",
+      "blob": "c647cdc165fd6f7bad79f1caccca82cea1cf6097",
+      "classification": "documentation",
+      "censusRefs": [
+        "C08.docs.remediation-program-docs"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "geometry-wasm/Cargo.lock",
+      "mode": "100644",
+      "blob": "2a8d4f73cfee5725a29fa74c0b58529cd1f559f6",
+      "classification": "configuration",
+      "censusRefs": [
+        "C17.engines.geometry-wasm-shaders-and-tests"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "geometry-wasm/Cargo.toml",
+      "mode": "100644",
+      "blob": "f99894b42cf3d775f456e56e5482bfa96fc9fe48",
+      "classification": "configuration",
+      "censusRefs": [
+        "C17.engines.geometry-wasm-shaders-and-tests"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "geometry-wasm/src/blend.wgsl",
+      "mode": "100644",
+      "blob": "bf21fcc4e780e62bf66d3bb5911a59d3b87f1e41",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C17.engines.geometry-wasm-shaders-and-tests"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/blur.wgsl",
+      "mode": "100644",
+      "blob": "863952f5164cf868027dbfa886ce3e606f90aa42",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C17.engines.geometry-wasm-shaders-and-tests"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/color_adjust.wgsl",
+      "mode": "100644",
+      "blob": "4854288d6b9d12ae01e63cbcc3f283ed8ff64c4b",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C17.engines.geometry-wasm-shaders-and-tests"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/engine.rs",
+      "mode": "100644",
+      "blob": "4135c7db71c3a5e2eb720b05c7e348ca598c37f3",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.gpu-engine-core.composite-scene-pipeline",
+        "C03.gpu-engine-core.effect-pipeline-library",
+        "C03.gpu-engine-core.public-wasm-api",
+        "C03.gpu-engine-core.vello-engine-state",
+        "C03.gpu-engine-core.viewport-and-wire-helpers"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/eraser.rs",
+      "mode": "100644",
+      "blob": "5c5382d4e5cffa80eaf457c8c21ace06fb7cd061",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.wasm-geometry-ops.eraser-boolean-subtract"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/fill.rs",
+      "mode": "100644",
+      "blob": "ec664c8023ab8d43eeb1f4963764e3486d27c1b3",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.wasm-tween-matching.fill-region-tracer"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/hit.rs",
+      "mode": "100644",
+      "blob": "1bb8e5e995a411d762fb5aa441b75e3729bd75c8",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.wasm-geometry-ops.hit-test"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/interp.rs",
+      "mode": "100644",
+      "blob": "cc852cee32c55b8b770550f853e01efe56d11290",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.wasm-geometry-ops.motion-flow-interp"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/lib.rs",
+      "mode": "100644",
+      "blob": "6a81acb17dc5520709eeb51a1221076fc6bceea8",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.wasm-geometry-ops.crate-root-and-boolean-ops"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/matte.wgsl",
+      "mode": "100644",
+      "blob": "f80047ad2e3a907628984d3b64d6624ad0d95e32",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C17.engines.geometry-wasm-shaders-and-tests"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/shapes.rs",
+      "mode": "100644",
+      "blob": "4fa4f3b89b647357afe9a7518e2893aba3fb540e",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.wasm-geometry-ops.basic-shape-segments"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/simple_fx.wgsl",
+      "mode": "100644",
+      "blob": "f1d6a5d40f03bbf3f8b7fe70d85ede7cca188ad4",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C17.engines.geometry-wasm-shaders-and-tests"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/strokemodeler.rs",
+      "mode": "100644",
+      "blob": "ba91ca684aec3ae9cecce88241c6e4d1dc13057a",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.wasm-geometry-ops.stroke-input-modeler"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/timeline.rs",
+      "mode": "100644",
+      "blob": "8e8b54f0b07410293388012c10d64adba430b9c6",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.wasm-geometry-ops.timeline-frame-resolution"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/track.rs",
+      "mode": "100644",
+      "blob": "cebbd4974a581a0a92db11e3817a978a840468a4",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.wasm-tween-matching.pyramidal-point-tracker"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/tween.rs",
+      "mode": "100644",
+      "blob": "7baf20dbf1de7eb714741c984a2eac9fb40255f1",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.wasm-geometry-ops.tween-interpolation-math"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/tweenmatch.rs",
+      "mode": "100644",
+      "blob": "e1e30c244feffe4d27ca730fff33defbfd3ffab1",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.wasm-tween-matching.align-pair",
+        "C03.wasm-tween-matching.auto-match-correspondence",
+        "C03.wasm-tween-matching.resample-stroke"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/src/vignette.wgsl",
+      "mode": "100644",
+      "blob": "30fcc80169375ca1c2108fa7100c46ff8f8393db",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C17.engines.geometry-wasm-shaders-and-tests"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "geometry-wasm/tests/dab_dense_overlap_repro.rs",
+      "mode": "100644",
+      "blob": "06bc2f86c552bc25e0fbd26d87ce3339d856cb1c",
+      "classification": "test",
+      "censusRefs": [
+        "C17.engines.geometry-wasm-shaders-and-tests"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "geometry-wasm/tests/effect_layer_overlay_repro.rs",
+      "mode": "100644",
+      "blob": "7e20f967aa18b249279803e8f8b5dc49fb8a60e3",
+      "classification": "test",
+      "censusRefs": [
+        "C17.engines.geometry-wasm-shaders-and-tests"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "geometry-wasm/tests/shader_library_validation.rs",
+      "mode": "100644",
+      "blob": "4950581213111db7d7f8543f4e0b4db14098ffeb",
+      "classification": "test",
+      "censusRefs": [
+        "C17.engines.geometry-wasm-shaders-and-tests"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "nemo-mcp/Cargo.lock",
+      "mode": "100644",
+      "blob": "361888b38b4b1122b0ec0f7d97301fd4555412c0",
+      "classification": "configuration",
+      "censusRefs": [
+        "C15.native.nemo-mcp-build-metadata"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "nemo-mcp/Cargo.toml",
+      "mode": "100644",
+      "blob": "ed5dac98f4aa7a2d189452b78021e5c3ace1e435",
+      "classification": "configuration",
+      "censusRefs": [
+        "C15.native.nemo-mcp-build-metadata"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "nemo-mcp/build.rs",
+      "mode": "100644",
+      "blob": "697ecd47534c364a2f565c45d267222fb63edada",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C07.mcp-server.binary-entrypoint"
+      ],
+      "reason": "Cargo build script; executable build tooling remains included."
+    },
+    {
+      "path": "nemo-mcp/src/capabilities.rs",
+      "mode": "100644",
+      "blob": "fb37a03b879ee832b07597f84906e82e50ab32e8",
+      "classification": "handwritten-runtime",
+      "censusRefs": [],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "nemo-mcp/src/capability_contract.rs",
+      "mode": "100644",
+      "blob": "99875018e75add0f135c8cef23da426a3cc735ba",
+      "classification": "handwritten-runtime",
+      "censusRefs": [],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "nemo-mcp/src/contract.rs",
+      "mode": "100644",
+      "blob": "6e79e3bdedbc801e6035149244b954a0f46df0d2",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C07.mcp-contract.request-response-types"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "nemo-mcp/src/contract_tests.rs",
+      "mode": "100644",
+      "blob": "905c1f910e3017711870f968df9bb2f5887a1a2e",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Private-surface Rust unit tests included through #[path]; test evidence, not runtime implementation."
+    },
+    {
+      "path": "nemo-mcp/src/lib.rs",
+      "mode": "100644",
+      "blob": "2d8f0dd07102d3b2aa1df154b84fcba7eeae5247",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C07.mcp-server.binary-entrypoint"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "nemo-mcp/src/main.rs",
+      "mode": "100644",
+      "blob": "d8a2c658cf196d367d175a914839aedae53ebcea",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C07.mcp-server.binary-entrypoint"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "nemo-mcp/src/registry.rs",
+      "mode": "100644",
+      "blob": "612cc458394721817d114c25ec1c157d558bbb73",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C07.mcp-server.discovery-registry"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "nemo-mcp/src/schema.rs",
+      "mode": "100644",
+      "blob": "54f5cc75e703b71f221f8a4650921ad9cebfb1d6",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C07.mcp-contract.schema-dump-binary"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "nemo-mcp/src/server.rs",
+      "mode": "100644",
+      "blob": "e5ed120636e641f40b323df4a4113e2897c4b665",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C07.mcp-server.tool-router"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "nemo-mcp/src/wire.rs",
+      "mode": "100644",
+      "blob": "42c2bc04d271be73296a79f11d41fe52ad622ab8",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C07.mcp-server.wire-framing"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "nemo-mcp/tests/stdio.rs",
+      "mode": "100644",
+      "blob": "56f5502091c2e65da5f67e6df7d65682a99811c3",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "nemo-mcp/tests/stdio_application.rs",
+      "mode": "100644",
+      "blob": "1ce47adbaae67a8c7a69e9e17e5da0be2a301100",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "nemo-mcp/tests/stdio_cancellation.rs",
+      "mode": "100644",
+      "blob": "756ee02252c1a9090ec8ee35528e5c03c4133234",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "nemo-mcp/tests/stdio_contract.rs",
+      "mode": "100644",
+      "blob": "e69163b4c40b863102d8f042d2fe2831b077d23d",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "nemo-mcp/tests/stdio_reconnect.rs",
+      "mode": "100644",
+      "blob": "3901d0c54adef100b255ef2ee0ba56e9eab31055",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "nemo-mcp/tests/stdio_rejection.rs",
+      "mode": "100644",
+      "blob": "5359726c5830382491798f1bee007748d0e34fb6",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "nemo-mcp/tests/stdio_roundtrip.rs",
+      "mode": "100644",
+      "blob": "ecf1ac4cc493214376dd3ca52ac8929488c0e21c",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "nemo-mcp/tests/transport.rs",
+      "mode": "100644",
+      "blob": "95501efbb0b2a8d8369cac557079a06a54798d41",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "package-lock.json",
+      "mode": "100644",
+      "blob": "d609c4b9778044222bddf7667bf9a4f7b4528215",
+      "classification": "configuration",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "package.json",
+      "mode": "100644",
+      "blob": "03ede6910b9c6876bed8ea7374c2f267cf8f69ec",
+      "classification": "configuration",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "playwright.config.cjs",
+      "mode": "100644",
+      "blob": "2d05ff7c085fb82bb29046df380af5cf7e5b96db",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "scripts/assert-no-private-labs.py",
+      "mode": "100755",
+      "blob": "caa43c10037a8e782a3a1ed24573b8154da98782",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.standalone-build-scripts"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/build-mcp-sidecar.cjs",
+      "mode": "100644",
+      "blob": "98a8266314a970bcf6a5c6bff825ea4f30e7e414",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.standalone-build-scripts"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/bundle-ffmpeg-dylibs.py",
+      "mode": "100755",
+      "blob": "2e8f015f077c20a9f3a8fa0bb4eb2c9165fe4d5d",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.standalone-build-scripts"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/dev_server.py",
+      "mode": "100644",
+      "blob": "d1edda4f9371b525a4e9af39ebb10ad196298aec",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.standalone-build-scripts"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/generate-third-party-notices.py",
+      "mode": "100644",
+      "blob": "d5c6140c8d347cd69a064ff7cdeaabc98c75db59",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.standalone-build-scripts"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/README.md",
+      "mode": "100644",
+      "blob": "4a5e62359ec93b6b6ce9f229ff6fcd11d1f04872",
+      "classification": "documentation",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "scripts/nemo/baseline.cjs",
+      "mode": "100644",
+      "blob": "f68a75b452f95b3b2107210d3602f8cd00a4dd3f",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/baseline.test.cjs",
+      "mode": "100644",
+      "blob": "63963e2b8d0e870348695883db3213f7d54e749c",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/boundaries-application.test.cjs",
+      "mode": "100644",
+      "blob": "95ef34b9c9e9c148ab59c86d779442624a976a80",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/boundaries-cli.test.cjs",
+      "mode": "100644",
+      "blob": "b7b36a5d3b19986e718e3683ea343844115fb442",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/boundaries-coverage.test.cjs",
+      "mode": "100644",
+      "blob": "01eefb3caa3d5ce3953bb4fb1593ce3f4dbe096b",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/boundaries-discovery.test.cjs",
+      "mode": "100644",
+      "blob": "73cb7af9c98e68d0e432939f79a656cec62031c9",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/boundaries-ratchet.test.cjs",
+      "mode": "100644",
+      "blob": "0bd1241aea4e429811505ee0759d6242ef664bdd",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/boundaries-repository.test.cjs",
+      "mode": "100644",
+      "blob": "f81565379a44ab5328100ad49d3ce91abd9688ae",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/boundaries-size.test.cjs",
+      "mode": "100644",
+      "blob": "a1b20f229b35d452a6bc4de8356e22e070ab6b01",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/boundaries.cjs",
+      "mode": "100644",
+      "blob": "5194d403e27d47953733968ea0469f1285014643",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/boundaries.test.cjs",
+      "mode": "100644",
+      "blob": "0dc9e95c1d5f35513c0637e76519b98e12356c83",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/browser-runtime.test.cjs",
+      "mode": "100644",
+      "blob": "ea95dc2ee2b589fdb12a5dd7ba01c4dd578acff8",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/browser.cjs",
+      "mode": "100644",
+      "blob": "b69150116c90ac139f4cbc340ac3c9bad81486f8",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/build-job.cjs",
+      "mode": "100644",
+      "blob": "4663728afcbfd0156db26376eb59b346f85d8090",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/build-job.test.cjs",
+      "mode": "100644",
+      "blob": "6aa3f8db8bd59742745ee77d03cee21757f2dd74",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/build-runtime.test.cjs",
+      "mode": "100644",
+      "blob": "f586a2f6864ddbd1726f610af6faeab14e598d32",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/build.cjs",
+      "mode": "100644",
+      "blob": "c737ecac15178cb3d9dd578ba7af45bfe7a4aa40",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/check.cjs",
+      "mode": "100755",
+      "blob": "9782fa4ad0c8944d4fffe29c7064eca18188285c",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/ci.cjs",
+      "mode": "100644",
+      "blob": "804f108f5e2e5acb99e5f222e15402419cf149d8",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/ci.test.cjs",
+      "mode": "100644",
+      "blob": "e374ad897e1a7495b1d4db5880679493eb0629d2",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/coverage-rust.cjs",
+      "mode": "100644",
+      "blob": "4017a01b505bf3d4b50886bd3e84bd55a8153961",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/coverage-rust.test.cjs",
+      "mode": "100644",
+      "blob": "6da11e32a6fe3e8327a4d61d9dcce18860d9fcc2",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/doctor.cjs",
+      "mode": "100755",
+      "blob": "7b8bc03d7c97cf5e3706f90595a2a3465b99f11c",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/inventory.cjs",
+      "mode": "100644",
+      "blob": "06da74c8952265aefb0e68cd698401a0dab63550",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/inventory.test.cjs",
+      "mode": "100644",
+      "blob": "1775778314bad235e8efcbac4974c03e233c3c2d",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/isolation.cjs",
+      "mode": "100644",
+      "blob": "49400f2f788d753aa614647c29714d0a0115df75",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/isolation.test.cjs",
+      "mode": "100644",
+      "blob": "363e4a36bc90a0b6e552fdce13b1e417a00a8b22",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/job.cjs",
+      "mode": "100755",
+      "blob": "1ece550752da3bd33b87f86470f13667ca0a33be",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/baseline-verdicts.cjs",
+      "mode": "100644",
+      "blob": "f696927b209cc494f0223a9b6c3ec87ff7e3dab7",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/baseline.cjs",
+      "mode": "100644",
+      "blob": "46534b6cb744e0f4b5a594e5e427c816326bb02f",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/boundaries-application.cjs",
+      "mode": "100644",
+      "blob": "268e20e02614b8df20a44ac22df68261f652e439",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/boundaries-coverage.cjs",
+      "mode": "100644",
+      "blob": "1479fa6e7c1749c85b48482a3bc7a5175a288fca",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/boundaries-discovery.cjs",
+      "mode": "100644",
+      "blob": "fb460902d2d715caeeff310d4d2c3f46c2ed0525",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/boundaries-ratchet.cjs",
+      "mode": "100644",
+      "blob": "73025938a20d4c5b154d1fa4bda202d487eb8b0b",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/boundaries-repository.cjs",
+      "mode": "100644",
+      "blob": "5e2937b8767bbfa7968b728de0322778cf9bf5ea",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/boundaries-resolver.cjs",
+      "mode": "100644",
+      "blob": "14d26db0c56d3e659170974a374e48caaba365ae",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/boundaries-size.cjs",
+      "mode": "100644",
+      "blob": "9c4e03dd870a535ea99231e77a48199a5a10ae8c",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/boundaries.cjs",
+      "mode": "100644",
+      "blob": "ff99f3283f7ebd0d631dc297c4ae6d6a3add6daa",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/browser-runtime.cjs",
+      "mode": "100644",
+      "blob": "bb9e87727e89253e53e7a8f84638df217b90877a",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/build-job.cjs",
+      "mode": "100644",
+      "blob": "cabf9f660bdc85d83937e15b9f959087ea556fc5",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/build-runtime.cjs",
+      "mode": "100644",
+      "blob": "50d3a7761663939e1ed098bfa0aedd18db03f797",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/capabilities.cjs",
+      "mode": "100644",
+      "blob": "1aed44e8dc28927ff4b1a3090f603a53dac55f8b",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/cli.cjs",
+      "mode": "100644",
+      "blob": "0bf04a003f2079c8a2a5d6605067ddec3cf1f18e",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/coverage-rust-job.cjs",
+      "mode": "100644",
+      "blob": "462940c67bf4b28a67e7c195269f1cbf38e80f53",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/coverage-rust.cjs",
+      "mode": "100644",
+      "blob": "e68939ace7368d462ccf5993151edb0324291429",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/identity.cjs",
+      "mode": "100644",
+      "blob": "5727ce83586a65a05f9351ead1173393fd49c1cd",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/inventory-bindings.cjs",
+      "mode": "100644",
+      "blob": "dbcfe149f92742d4e6ff5631944d9d732f18581f",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/inventory-lexer.cjs",
+      "mode": "100644",
+      "blob": "816d94c6f0da95a54f67df6f35a6c801f2e86be9",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/inventory-records.cjs",
+      "mode": "100644",
+      "blob": "501dcf01ad03e94f422667ba85aefa608dfc6d98",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/inventory-render.cjs",
+      "mode": "100644",
+      "blob": "d1c9c5ba12c709157eecd5739ff7c528904e7ca0",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/inventory-surfaces.cjs",
+      "mode": "100644",
+      "blob": "bac4dbc45041af1a5d80e6c5b922ed86490dffdf",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/isolation.cjs",
+      "mode": "100644",
+      "blob": "2c8769b3632ca6fcaac6cb7e6b4a27ea9c6a531c",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/jobs.cjs",
+      "mode": "100644",
+      "blob": "f23b335c2b2dc25aecb0d951dbb5de4aaa51e68b",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/native-process.cjs",
+      "mode": "100644",
+      "blob": "604c1cc8000e8d2c65c7b78d2adc69e6c42bd979",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/native-runtime.cjs",
+      "mode": "100644",
+      "blob": "4e75ab048c7cb271b7f5130118628c36d2e66da2",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/receipt.cjs",
+      "mode": "100644",
+      "blob": "ed6224a8631901b1290bd8241210717948e16194",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/lib/util.cjs",
+      "mode": "100644",
+      "blob": "e9a4eb12ad383dd6a3f8698a7975a448ad9a57d3",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-lib"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/native-runtime.test.cjs",
+      "mode": "100644",
+      "blob": "6bc7ad288e1416579d43e5ba0d42f87f3f9e46ef",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "scripts/nemo/native.cjs",
+      "mode": "100755",
+      "blob": "717b59294389f6e575d5e171e9569f2e109cde6d",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/nemo/verify.cjs",
+      "mode": "100755",
+      "blob": "8285e47a008344c36cf9099dc3f23970d0abf87d",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.scripts-nemo-core"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "scripts/rebuild-ffmpeg-lgpl.sh",
+      "mode": "100755",
+      "blob": "c430a55eab5ede823bd515f70f7a926892c2a712",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C13.tooling.standalone-build-scripts"
+      ],
+      "reason": "Tracked executable tool; requires explicit boundary/admission coverage."
+    },
+    {
+      "path": "src-tauri/.tauri_private_key.pub",
+      "mode": "100644",
+      "blob": "f363be21d832333a2ceb923883e632fd195031d5",
+      "classification": "configuration",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "src-tauri/Cargo.lock",
+      "mode": "100644",
+      "blob": "93b9ed4a8ec7d36dd52e1e72da0d9d59d7fd4f20",
+      "classification": "configuration",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "src-tauri/Cargo.toml",
+      "mode": "100644",
+      "blob": "ea051bb4a431bfa6c3d5aed1cc30f3f09f4a7c84",
+      "classification": "configuration",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "src-tauri/binaries/ffmpeg-aarch64-apple-darwin",
+      "mode": "100755",
+      "blob": "97b0232cd393bff08435b2b21217dd7c3772f184",
+      "classification": "vendor",
+      "censusRefs": [
+        "C15.native.ffmpeg-sidecar-binary"
+      ],
+      "reason": "Bundled third-party artifact; C18/C15 and THIRD_PARTY_NOTICES.md govern provenance, not extraction."
+    },
+    {
+      "path": "src-tauri/build.rs",
+      "mode": "100644",
+      "blob": "6e12fc9e81efd2553b32e00aca75d14dd0b32f1d",
+      "classification": "handwritten-tooling",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Cargo build script; executable build tooling remains included."
+    },
+    {
+      "path": "src-tauri/capabilities/default.json",
+      "mode": "100644",
+      "blob": "710deafc4f2b3f1a5b65772f41d15410c9c9f6d4",
+      "classification": "configuration",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "src-tauri/gen/schemas/acl-manifests.json",
+      "mode": "100644",
+      "blob": "caf31484018a7745680a003c5a784ad7f18dc220",
+      "classification": "generated",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "src-tauri/gen/schemas/capabilities.json",
+      "mode": "100644",
+      "blob": "e31722b1b204e8bd94295db66f97cba61107ce60",
+      "classification": "generated",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "src-tauri/gen/schemas/desktop-schema.json",
+      "mode": "100644",
+      "blob": "d9fac8946a3c06f724f9b3aafa2c1bfd7cdf8822",
+      "classification": "generated",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "src-tauri/gen/schemas/macOS-schema.json",
+      "mode": "100644",
+      "blob": "d9fac8946a3c06f724f9b3aafa2c1bfd7cdf8822",
+      "classification": "generated",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "src-tauri/icons/128x128.png",
+      "mode": "100644",
+      "blob": "e2e643ae274469d5a5539b9a2096169906b26fa5",
+      "classification": "static-data",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src-tauri/icons/128x128@2x.png",
+      "mode": "100644",
+      "blob": "d959ed0250f6ace13d60e753546f5b601e022648",
+      "classification": "static-data",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src-tauri/icons/32x32.png",
+      "mode": "100644",
+      "blob": "d79a953c204524d1244a9fdeb09859dfc40443d3",
+      "classification": "static-data",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src-tauri/icons/64x64.png",
+      "mode": "100644",
+      "blob": "d9e92b974f54ad0e937af2f273966f8e022528bd",
+      "classification": "static-data",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src-tauri/icons/icon.icns",
+      "mode": "100644",
+      "blob": "a552bc2bec1f3172c60b0aff95280559e10a5673",
+      "classification": "static-data",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Packaged icon asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src-tauri/icons/icon.ico",
+      "mode": "100644",
+      "blob": "f1f0026b7865534b8eac10dbde2265971e9b3603",
+      "classification": "static-data",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Packaged icon asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src-tauri/icons/icon.png",
+      "mode": "100644",
+      "blob": "2aa7795a6edf770764bdb3ba7fb568e50f83cfad",
+      "classification": "static-data",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src-tauri/src/application_mcp.rs",
+      "mode": "100644",
+      "blob": "41bb72706de0f777fa9290470829fad528a8f8a1",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C07.native-transport.tauri-listener"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src-tauri/src/lib.rs",
+      "mode": "100644",
+      "blob": "e874312da340e19be69c89e6c087c463c0558c6e",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.native-rust.bootstrap",
+        "C05.native-rust.ffmpeg-run-command",
+        "C05.native-rust.google-font-fetch",
+        "C05.native-rust.tablet-pressure-monitor"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src-tauri/src/main.rs",
+      "mode": "100644",
+      "blob": "9353d911e2608873f6c3318c5175465abe67729e",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.native-rust.bootstrap"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src-tauri/src/media_probe.rs",
+      "mode": "100644",
+      "blob": "b7ec336ab5f95eec1b91954775327b0108bf2f90",
+      "classification": "handwritten-runtime",
+      "censusRefs": [],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src-tauri/src/task_runtime.rs",
+      "mode": "100644",
+      "blob": "6014f26ec931ecc4ed6420326d98d71427a262bf",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.native-rust.task-runtime-isolation"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src-tauri/src/task_runtime/tests.rs",
+      "mode": "100644",
+      "blob": "d172cd02abff335ce690f62704f7942e2f6f4afd",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.native-rust.task-runtime-isolation"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src-tauri/src/vectorize.rs",
+      "mode": "100644",
+      "blob": "2f543a46fa47c57a75bee1f5bb61fe2566b18ca4",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.native-rust.image-vectorize-command"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src-tauri/src/video_decode.rs",
+      "mode": "100644",
+      "blob": "a33fed1f836466c8d897131cf769291787489f55",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.native-rust.video-decode"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src-tauri/tauri.conf.json",
+      "mode": "100644",
+      "blob": "d47c5bd1b4a133d1c267f32839a6525be99ea298",
+      "classification": "configuration",
+      "censusRefs": [
+        "C15.native.src-tauri-build-and-config"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "src/_headers",
+      "mode": "100644",
+      "blob": "2bf358fc016ae09c9fbd174bef04a24d279f7472",
+      "classification": "configuration",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "src/assets/reference-3d/ATTRIBUTION.md",
+      "mode": "100644",
+      "blob": "7e30f77bb62ea47729dc0ce9eb22b85c5460769e",
+      "classification": "documentation",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "src/assets/reference-3d/AvatarSample_D.vrm",
+      "mode": "100644",
+      "blob": "f7c64552fc28a8f7df76551fd8474b9325584400",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/assets/reference-3d/CC0_Rigged_Arms.obj",
+      "mode": "100644",
+      "blob": "ec7f25b02eb72bb2343e16cee81f716fa0dc56ec",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/assets/reference-3d/CC0_Rigged_Arms_Texture.png",
+      "mode": "100644",
+      "blob": "57158e97113f53581ffc568e6b1c5bd0ae9e0d6f",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/css/style.css",
+      "mode": "100644",
+      "blob": "383eeec4be64457fdc7f2028f6d9b04cac32dbc8",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.bootstrap.feature-flags",
+        "C06.labs.float-panel",
+        "C06.preferences.settings-modal-shell"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/css/tutorial.css",
+      "mode": "100644",
+      "blob": "3cbf86885e3c7b38ad60ce4844601ce5728771a1",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.tutorial-onboarding.core"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/favicon-32.png",
+      "mode": "100644",
+      "blob": "d07481e1509e924ba52af96c19ab80814c76f451",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/favicon-64.png",
+      "mode": "100644",
+      "blob": "7ef32e747fcd0a7932c421ec6e4e96cd919edd85",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/fonts/DejaVuSans-Bold.ttf",
+      "mode": "100644",
+      "blob": "1f22f07c99bd4d4b8fba9e00094df4e58e69def1",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/fonts/DejaVuSans.ttf",
+      "mode": "100644",
+      "blob": "5267218852f631928716a8005d7bf4b492aaf83d",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/fonts/DejaVuSerif-Bold.ttf",
+      "mode": "100644",
+      "blob": "d683eb282bc0e2ae21f0d45f47b639e400f295ac",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/fonts/DejaVuSerif.ttf",
+      "mode": "100644",
+      "blob": "39dd3946d3d06442d8d25556e7c1c37663893688",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/fonts/Inter-Regular.ttf",
+      "mode": "100644",
+      "blob": "047c92f6e2212473dc436020afed689527076d44",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/fonts/Manrope-Regular.ttf",
+      "mode": "100644",
+      "blob": "23dcf5e05a97f19a3567d40ebb3765580a4325f7",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/fonts/Roboto-Bold.ttf",
+      "mode": "100644",
+      "blob": "0b01e18cb1ab11e4bdb3befd3238dc3716d182d6",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/fonts/Roboto-Regular.ttf",
+      "mode": "100644",
+      "blob": "80614818b240055b58aa13ac5e0e030c6fe71c1f",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/index.html",
+      "mode": "100644",
+      "blob": "8c74bf01df9bca19856e83574d4f1808c26c76ca",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.bootstrap.feature-flags",
+        "C06.labs.float-panel",
+        "C06.preferences.settings-modal-shell",
+        "C06.preferences.shortcuts-system"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/abr-import.js",
+      "mode": "100644",
+      "blob": "99f90b7705cdb687bf75bb87835037e388e6d987",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.import.abr-parse"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/adapters/application-mcp.js",
+      "mode": "100644",
+      "blob": "a9c7d0f35c782c906a97369260fb624e35291b5d",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C07.native-transport.webview-adapter"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/ae-camera-export.js",
+      "mode": "100644",
+      "blob": "d3648d57d5f7cc39f52bcead10468f7cbd51ccfe",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.export.ae-camera-jsx"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/ag-psd.vendor.mjs",
+      "mode": "100644",
+      "blob": "f25b6a64352a1f556440f030feada980e3075aca",
+      "classification": "vendor",
+      "censusRefs": [
+        "C18.vendor.vendored-js-libraries"
+      ],
+      "reason": "Bundled third-party artifact; C18/C15 and THIRD_PARTY_NOTICES.md govern provenance, not extraction."
+    },
+    {
+      "path": "src/js/animation/curve.js",
+      "mode": "100644",
+      "blob": "c42f255ee8f204806e6d3b539951864c97a86cfd",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C02.math-kernels.curve-evaluator"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/app.js",
+      "mode": "100644",
+      "blob": "0831959f70612721f80717812838d19940d1f7c1",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.bootstrap.paper-dom-setup",
+        "C06.bootstrap.storage-key-migration",
+        "C06.preferences.user-profile"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/application/capability-registry.js",
+      "mode": "100644",
+      "blob": "984fd5981f4e1e011a0f4f99482bd422e82eb983",
+      "classification": "handwritten-runtime",
+      "censusRefs": [],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/application/opacity-application.js",
+      "mode": "100644",
+      "blob": "d0b10900eb36a43c66237473009027eaa6680d28",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C07.application-service.command-core"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/application/opacity-capability.js",
+      "mode": "100644",
+      "blob": "6e6d99fcc9ff6fb441b42377355424e1b4b8964b",
+      "classification": "handwritten-runtime",
+      "censusRefs": [],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/asset-tree.js",
+      "mode": "100644",
+      "blob": "a9cfc79050e98dd3a194e2eacfdea0c07400cd39",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C01.asset-tree.folder-widget",
+        "C04b.viewer-and-chrome.asset-tree"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/assets-panel.js",
+      "mode": "100644",
+      "blob": "0883507da4aad6338ba281def44b41c286944c34",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.docked-panels.assets-tab-switch"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/audio-bridge.js",
+      "mode": "100644",
+      "blob": "d31850ef282adc10f1832ff5220c4e7e6b032506",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.structure-audio.audio-data-playback",
+        "C04b.structure-audio.audio-timeline-ui"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/bitmap-brush.js",
+      "mode": "100644",
+      "blob": "455c18677512005b9c52446e251d18b7dc6dfbb4",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.brush-engine.bitmap-brush-bake-engine",
+        "C04b.brush-engine.bitmap-brush-preview-panel"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/bitmap-tip-picker.js",
+      "mode": "100644",
+      "blob": "dbdef74d4a46ac3dc68406d5f9b86e52b200dbf0",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.brush-engine.bitmap-tip-picker"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/bootstrap/opacity-application.js",
+      "mode": "100644",
+      "blob": "a2a8132c4e3db582ff73badcd33456e3f3c6ebbb",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C07.application-service.bootstrap-bindings"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/bpm-grid.js",
+      "mode": "100644",
+      "blob": "61422009a03476a253429e8b5b510535bc694279",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C02.markers-and-bpm.bpm-guides"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/brush-editor.js",
+      "mode": "100644",
+      "blob": "cbefdcf8dd28cdf85c149ee632434a7e39d0552d",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.brush-engine.brush-editor"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/brush-menu-bridge.js",
+      "mode": "100644",
+      "blob": "3966cf29ce7413d01af3d03473c1340c563a1952",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.paint-brush.brush-menu-popover"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/brush-preset-picker.js",
+      "mode": "100644",
+      "blob": "1d1798eec7170d6874a2291bde7812e0002ceb5f",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.brush-engine.brush-preset-picker"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/brush-tool-presets.js",
+      "mode": "100644",
+      "blob": "a08a444f7c8acca1bd9c9102f730119763f8d805",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.brush-engine.brush-tool-presets"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/camera.js",
+      "mode": "100644",
+      "blob": "5e4b8262b472ee64fda991c249995a74c98bafb0",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C02.camera.interaction-and-overlay-render",
+        "C02.camera.keyframe-model-and-viewport-lock"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/color-manager.js",
+      "mode": "100644",
+      "blob": "fa3bcc96836bb9bceb225a51fb2cd5fac1f77f06",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.js-effects-and-playback.color-manager-panel",
+        "C04b.color-tools.selected-colors-panel"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/color-picker.js",
+      "mode": "100644",
+      "blob": "9e6a1885a562094d33ab8b67ef5d2a3c5695943d",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.color-tools.popover-picker"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/comp-preview.js",
+      "mode": "100644",
+      "blob": "2aa2bc1d45995f95822ab10123425e6e81224106",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.viewer-and-chrome.comp-preview"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/custom-effects.js",
+      "mode": "100644",
+      "blob": "fcb37d784688bd719f3efa8a2c48a68f6a0895da",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.js-effects-and-playback.custom-effects-authoring",
+        "C04b.presets-and-effects.custom-wgsl-authoring"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/delaunator.vendor.js",
+      "mode": "100644",
+      "blob": "5579d52527bce6460f791aae91fec515c52546d9",
+      "classification": "vendor",
+      "censusRefs": [
+        "C18.vendor.vendored-js-libraries"
+      ],
+      "reason": "Bundled third-party artifact; C18/C15 and THIRD_PARTY_NOTICES.md govern provenance, not extraction."
+    },
+    {
+      "path": "src/js/domain/animation/expression-random.js",
+      "mode": "100644",
+      "blob": "0772395cd6398173e2984788916d96bc7dceec4a",
+      "classification": "handwritten-runtime",
+      "censusRefs": [],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/domain/animation/expression-time.js",
+      "mode": "100644",
+      "blob": "701d0c772e7b36397fec316e926394d9f54986c4",
+      "classification": "handwritten-runtime",
+      "censusRefs": [],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/domain/animation/opacity.js",
+      "mode": "100644",
+      "blob": "17478ea8cc5c2233f3cdac1284688a0af1144c36",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C02.math-kernels.opacity-domain-writers"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/domain/document/folder-codec.js",
+      "mode": "100644",
+      "blob": "80c6948c5409cd20e0d98054cc66db421ac3ce73",
+      "classification": "handwritten-runtime",
+      "censusRefs": [],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/draw-bridge.js",
+      "mode": "100644",
+      "blob": "0bb6a8d20e2ca66319205c44f18684bd2fc54dac",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.stroke-input.draw-commit-materialize",
+        "C04b.stroke-input.draw-gesture-lifecycle",
+        "C04b.stroke-input.draw-input-pipeline",
+        "C04b.stroke-input.draw-live-overlay"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/drop-import.js",
+      "mode": "100644",
+      "blob": "a5f7c966657d84fe4307c93845dc6ace8d85307b",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.import.drop-dispatch"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/effector-layer.js",
+      "mode": "100644",
+      "blob": "6783cc96d2df991ba0ab88d3edbc0bb2512c5c12",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.motion-extensions.effector-duplicator-layer"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/effects-panel.js",
+      "mode": "100644",
+      "blob": "d93d069b802d4fc9797c5b7f5b9c704aba6bf790",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.docked-panels.effects-stack",
+        "C04b.docked-panels.path-fx-stack"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/engine-bridge.js",
+      "mode": "100644",
+      "blob": "76bf313230872704017fdde97d6dbdc63dc7de6a",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.js-engine-bridge.bounded-image-store",
+        "C03.js-engine-bridge.build-scene-json",
+        "C03.js-engine-bridge.editor-overlay-builders",
+        "C03.js-engine-bridge.engine-lifecycle",
+        "C03.js-engine-bridge.preview-scale-calibration",
+        "C03.js-engine-bridge.public-api-surface",
+        "C03.js-engine-bridge.render-entry-points",
+        "C03.js-engine-bridge.retained-path-store",
+        "C03.js-engine-bridge.viewport-sync-and-coords"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/eraser-bridge.js",
+      "mode": "100644",
+      "blob": "dad48b13783c592cb28767706f8b29055cd46dba",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.stroke-input.eraser-tool"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/export.js",
+      "mode": "100644",
+      "blob": "81f8a62d08fd23bd0a3797e175338cfbd393cc31",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.export.browser-native-fallbacks",
+        "C05.export.engine-routing-gate",
+        "C05.export.frame-compositor",
+        "C05.export.lottie-bodymovin",
+        "C05.export.tauri-io-ffmpeg"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/expr-bake.js",
+      "mode": "100644",
+      "blob": "64bdee62a5a4967ec4b01ba34714c8d67a3d0546",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C02.expressions.expr-bake-to-keyframes"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/expr-code-panel.js",
+      "mode": "100644",
+      "blob": "942f3252e113c415e9da93b5657ad1e4ef3de7d9",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C02.expressions.expr-code-split-editor",
+        "C04b.docked-panels.expr-code-editor"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/expr-examples.js",
+      "mode": "100644",
+      "blob": "50d9d78733948943a1965051ad75cdee5c8895a1",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C02.expressions.expr-reference-library"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/expr-functions.js",
+      "mode": "100644",
+      "blob": "7e414936e64fee3ca7370144fcb246e8f5b574aa",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C02.expressions.expr-reference-library"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/feedback-bridge.js",
+      "mode": "100644",
+      "blob": "b87a6fc24b20f136c05df123d772b224e81ba212",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.content-tools.feedback-local-log-storage",
+        "C04b.content-tools.feedback-triage-sync",
+        "C04b.content-tools.feedback-worker-publish"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/figma-import.js",
+      "mode": "100644",
+      "blob": "6d9308093fdde5279464305e0473da9ce7ee54c7",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.import.figma-convert",
+        "C05.import.figma-network"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/fill-bridge.js",
+      "mode": "100644",
+      "blob": "9a34d25e295bad6f5750dcc4209cff2076dc2707",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.paint-brush.fill-bucket"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/geometry-wasm-loader.js",
+      "mode": "100644",
+      "blob": "ff094c330233bc80748e58c29edf49174ee8daf5",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.engine-readiness.wasm-engine-loaders"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/gpu-gate.js",
+      "mode": "100644",
+      "blob": "97e69309be27a63ade97d6ec9d3d85a12a6d9828",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.engine-readiness.wasm-engine-loaders"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/gradient-bridge.js",
+      "mode": "100644",
+      "blob": "1744e11507cfb27936eb5cbc0c51577b4dc597c8",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.paint-brush.gradient-fill"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/group-bridge.js",
+      "mode": "100644",
+      "blob": "1369b5c68f2c103e42d5eef6e41490f17a2f77a0",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.structure-audio.group-combine-model",
+        "C04b.structure-audio.group-combine-render-adapters",
+        "C04b.structure-audio.group-crud-nesting"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/history-panel.js",
+      "mode": "100644",
+      "blob": "9ca00b435f568fe4242bb11cefd56691cbbbb2af",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C01.history-panel.ui",
+        "C04b.docked-panels.history-panel"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/i18n.js",
+      "mode": "100644",
+      "blob": "f3621653d51da88adad907c28e4a9bbdfa80a487",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.bootstrap.sm-namespace-init",
+        "C06.i18n.translation-core"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/idb-store.js",
+      "mode": "100644",
+      "blob": "17fc7be9aba13784625261b496aee7120dc5245b",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C01.idb-store.kv"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/image-mesh-bridge.js",
+      "mode": "100644",
+      "blob": "530d1633b1bafc4d7af32172ac299633665bac9d",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.deform.image-mesh-editor",
+        "C04b.deform.image-mesh-shape-to-mask"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/image-mesh.js",
+      "mode": "100644",
+      "blob": "5211cb8ea692a4526a8a5a08037ce2efb8d081f2",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.animated-primitives.image-mesh"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/images.js",
+      "mode": "100644",
+      "blob": "5431d431aef0360d9e7b0c4c1fddc59358129486",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.footage-import.core"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/kitsu.js",
+      "mode": "100644",
+      "blob": "a8039fbdb0e74e7c2582d6df312363b1d937d9a1",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.media-misc.kitsu"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/auto-actions.js",
+      "mode": "100644",
+      "blob": "3a920b813c0eb5e7706bcd999f28d134270b48e3",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.dormant-unreachable"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/boil-effect.js",
+      "mode": "100644",
+      "blob": "745eb3c972a54d22e8811155e4ade36676d1d614",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.boil-effect"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/canvas-grid.js",
+      "mode": "100644",
+      "blob": "6a7b2a5f5a8d346a8fff69b1128667cbe456030f",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.canvas-grid"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/clip-mask-bake.js",
+      "mode": "100644",
+      "blob": "ef66566532b4649bae156cb51fc835fbba9fb94b",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.dormant-unreachable"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/command-palette.js",
+      "mode": "100644",
+      "blob": "ae744007dbe9f8d85ec1c9d2f0da4e39547b50f0",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.dormant-unreachable"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/flip-roll.js",
+      "mode": "100644",
+      "blob": "091da8adeebc438c19d178987d6d36ebe1cb725a",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.flip-roll"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/follow-path.js",
+      "mode": "100644",
+      "blob": "a03df0a159527324902ea83decb568f382ec73d6",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.follow-path"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/french-curve.js",
+      "mode": "100644",
+      "blob": "690681c69f01de87c731118a8dcfd9665a2fe6b1",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.french-curve"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/interval-assistant.js",
+      "mode": "100644",
+      "blob": "ae908ef2abb478f95b05c6b223aa2c0f42c11341",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.interval-assistant"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/labs-core.js",
+      "mode": "100644",
+      "blob": "868629cadb56d41600b55fba5ebd0715b2e5b96f",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.registry-core"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/labs-float-panel.js",
+      "mode": "100644",
+      "blob": "9b2f1cd31eae351f5ca21cbda9089ec5cfef0d10",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.float-panel"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/labs-panel.js",
+      "mode": "100644",
+      "blob": "d93ffbb2403c90eb000460b1a14930ba0551142f",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.settings-panel"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/lagoon-menu.js",
+      "mode": "100644",
+      "blob": "bc79d316281b9789ce12db51aa12b55308ed5758",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.lagoon-menu"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/layer-effects-bake.js",
+      "mode": "100644",
+      "blob": "9ad480bdd41f57781ba2f4ed88682a3ce8323aa3",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.dormant-unreachable"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/lipsync-assistant.js",
+      "mode": "100644",
+      "blob": "5db8edfbe106271655c1b5f6c950c9cadfba7f23",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.dormant-unreachable"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/mirror-check.js",
+      "mode": "100644",
+      "blob": "e58af0a574bfd8e1ce13dac00cb0e01ad46c8e07",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.mirror-check"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/move-to-layer.js",
+      "mode": "100644",
+      "blob": "f2d026db8c0b23ab1a47dbf73c0a6ef2c2f6e393",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.move-to-layer"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/multiframe-draw.js",
+      "mode": "100644",
+      "blob": "429222f366782ad14969679527647ec54ff5d6de",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.multiframe-draw"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/oca-export.js",
+      "mode": "100644",
+      "blob": "acf500da42e14ade8e9727d634d99fea7abea2e0",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.dormant-unreachable"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/out-of-pegs.js",
+      "mode": "100644",
+      "blob": "e7cf100215a5f20a21afb767bcc7c91a7f9046e3",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.out-of-pegs"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/pingpong-cycle.js",
+      "mode": "100644",
+      "blob": "99ce384eb9af6a0094b3dc25ebdc0934ada3ba4f",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.pingpong-cycle"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/pose-library.js",
+      "mode": "100644",
+      "blob": "ddc6a6b2b6dceec1bde5a8300dd4a5b7d39bdd77",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.pose-library"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/predictive-stroke.js",
+      "mode": "100644",
+      "blob": "8903afba06c64adb8e78bbc8ef24accc28344fb0",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.predictive-stroke"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/reference-3d.js",
+      "mode": "100644",
+      "blob": "5e22ee561c2c59d6fe77e0466990e484bd98ce9f",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.reference-3d"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/reference-fill.js",
+      "mode": "100644",
+      "blob": "7907f8d0f14cf3f511f49e59e27b4738a0f10ee6",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.reference-fill"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/retime-exposure.js",
+      "mode": "100644",
+      "blob": "1afaf47d38243d14a911e6e696e7197a26ae6c7a",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.retime-exposure"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/rig-deform.js",
+      "mode": "100644",
+      "blob": "1ba7a47667f2497329e6c1fd1156e4fb39b47836",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.dormant-unreachable"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/screentone-bake.js",
+      "mode": "100644",
+      "blob": "8dabac22be1ad50c2a2f347d447ee78ccda65b7f",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.dormant-unreachable"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/shader-effects-bake.js",
+      "mode": "100644",
+      "blob": "f7ed436218ca7fae79907daac7144c15bd5f6e07",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.dormant-unreachable"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/speed-lines.js",
+      "mode": "100644",
+      "blob": "921a89f98f321fcb765e56b9e6b85262099196b2",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.speed-lines"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/storyboard-mode.js",
+      "mode": "100644",
+      "blob": "7a23ef792ee8024f821df94dc23e2f0b4edf6a5f",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.dormant-unreachable"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/timelapse.js",
+      "mode": "100644",
+      "blob": "34f1a980d837933981fc621337bf81eb81aeb697",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.dormant-unreachable"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/timeline-markers.js",
+      "mode": "100644",
+      "blob": "081bea84095342b8323e3ce8279294cf0b38a78e",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.timeline-markers"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/timeline-zoom.js",
+      "mode": "100644",
+      "blob": "de95873e3e0b6cb01c22ada99a806c7ce9b686b7",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.dormant-timeline-zoom"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/vector-sculpt.js",
+      "mode": "100644",
+      "blob": "0b0afa9f14f5c497004993789d04445055fd2008",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.vector-sculpt"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/vector-trim.js",
+      "mode": "100644",
+      "blob": "9081994616cbabcceed62c5d63abe3e3eaaa9788",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.vector-trim"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/view-filter.js",
+      "mode": "100644",
+      "blob": "4f05aeb62fde515f6515791f822d4c2295481cf8",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.view-filter"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/labs/xsheet-panel.js",
+      "mode": "100644",
+      "blob": "5038f9bdf0dd8a735a036b3598607c6b01295b2f",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C06.labs.xsheet-panel"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/layer-inout.js",
+      "mode": "100644",
+      "blob": "131156e2f419e17e8669c1980c3ae0f77164e786",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C02.layer-inout.bar-rendering",
+        "C02.layer-inout.drag-and-batch-ops",
+        "C02.layer-inout.selection-and-marquee"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/layer-kind.js",
+      "mode": "100644",
+      "blob": "e239f247da077dd8923dac453bc35403f2603a01",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.timeline-panel-support.layer-kind-taxonomy"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/layer-scroll-sync.js",
+      "mode": "100644",
+      "blob": "55d1a52d757bc7682810eeb426a34b22a2c99d17",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.timeline-panel-support.scroll-and-zoom"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/linked-media.js",
+      "mode": "100644",
+      "blob": "ba81900d0ea1805fc206fc19ce992674522de6c5",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.media.linked-bulk-convert",
+        "C05.media.linked-resolve-core",
+        "C05.media.mode-setting-ui"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/lipsync.js",
+      "mode": "100644",
+      "blob": "c00c59ba4bc99dad139c9a5d5a8932768908ee74",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.media-misc.lipsync"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/lottie-preview.js",
+      "mode": "100644",
+      "blob": "37864a5eaea946a748dedf1e5c9752d6469719f6",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.media-misc.lottie-preview"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/markers.js",
+      "mode": "100644",
+      "blob": "695ed6f8a33b3daf0ff0f7edb8d3d5dd5301addd",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C02.markers-and-bpm.timeline-markers"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/media-library.js",
+      "mode": "100644",
+      "blob": "81197c0d2a4b1b4cf3e1191a857ee4efd34864be",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.media.library-canvas-actions",
+        "C05.media.library-panel"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/motion-graph.js",
+      "mode": "100644",
+      "blob": "1cf38f01aa8e140e905640e3e8042fe9fc0d97d2",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.motion-extensions.graph-editor"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/motion-preset-picker.js",
+      "mode": "100644",
+      "blob": "4ad998da8f082d69a0425191bb5b1d14847112cd",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.presets-and-effects.motion-preset-library"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/motion.js",
+      "mode": "100644",
+      "blob": "6617bac29042c22399cac202bf054c09e4fdf30e",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C02.expressions.expression-runtime",
+        "C02.motion-advanced.3d-layers-and-gizmo",
+        "C02.motion-advanced.canvas-drag-interactions",
+        "C02.motion-advanced.component-shape-tree",
+        "C02.motion-advanced.duplicator-and-effector-props",
+        "C02.motion-advanced.geometry-motion-integrations",
+        "C02.motion-advanced.mode-toggle-and-workspace-continuity",
+        "C02.motion-advanced.point-mapping-and-parent-chain",
+        "C02.motion-advanced.time-remap",
+        "C02.motion-advanced.transform-application",
+        "C02.properties-and-curves.curves-and-easing",
+        "C02.properties-and-curves.key-selection-and-clipboard",
+        "C02.properties-and-curves.keyframe-track-model",
+        "C02.properties-and-curves.properties-and-metadata"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/mp4box.all.min.js",
+      "mode": "100644",
+      "blob": "7e31a44b6235c4f80c3a42512291eb5a81c3e784",
+      "classification": "vendor",
+      "censusRefs": [
+        "C18.vendor.vendored-js-libraries"
+      ],
+      "reason": "Bundled third-party artifact; C18/C15 and THIRD_PARTY_NOTICES.md govern provenance, not extraction."
+    },
+    {
+      "path": "src/js/native-video-bridge.js",
+      "mode": "100644",
+      "blob": "3f822d087328e9481b546902c7ec4aa9bb5f4a2c",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.native-video.bench",
+        "C05.native-video.decode-session",
+        "C05.native-video.layer-lifecycle",
+        "C05.native-video.layer-sync"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/nemo-panel.js",
+      "mode": "100644",
+      "blob": "b463ea91e59d47bdf63a62cf4c861ea05a7a105a",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.docked-panels.scripting-panel-ui-builder"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/nemo-plugin.js",
+      "mode": "100644",
+      "blob": "0373f3e3c3deb1b410437afc98c31cbc805d1050",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.extensibility-api.scripting-and-plugins"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/nemo-script.js",
+      "mode": "100644",
+      "blob": "645e08bd5e5b83e27afa6bc1bd7c18806b6b3edd",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.extensibility-api.scripting-and-plugins"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/node-buffer-shim.vendor.mjs",
+      "mode": "100644",
+      "blob": "860121fd97c37e806e3004260e0daa98faf3a894",
+      "classification": "vendor",
+      "censusRefs": [
+        "C18.vendor.vendored-js-libraries"
+      ],
+      "reason": "Bundled third-party artifact; C18/C15 and THIRD_PARTY_NOTICES.md govern provenance, not extraction."
+    },
+    {
+      "path": "src/js/opentype.min.js",
+      "mode": "100644",
+      "blob": "5dbd60aac7ea3015fa16d8018101b68f1c77fa6d",
+      "classification": "vendor",
+      "censusRefs": [
+        "C18.vendor.vendored-js-libraries"
+      ],
+      "reason": "Bundled third-party artifact; C18/C15 and THIRD_PARTY_NOTICES.md govern provenance, not extraction."
+    },
+    {
+      "path": "src/js/p2p-contacts.js",
+      "mode": "100644",
+      "blob": "71fdd2e158e695f8c70d306c8a5bea5186bc5612",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.media-misc.p2p-contacts"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/palette-panel.js",
+      "mode": "100644",
+      "blob": "4ca7b56da4914eac271a2ddb233c6fbd829ef5da",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.docked-panels.palette-find-replace",
+        "C04b.docked-panels.palette-library"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/path-fx.js",
+      "mode": "100644",
+      "blob": "bcc09a28387279b5d54a81813f4dffb465d94160",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.js-effects-and-playback.path-fx-stack",
+        "C04b.brush-engine.path-fx"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/pen-bridge.js",
+      "mode": "100644",
+      "blob": "f0562ec0b1dc28a95b2e706bbc31ac1b91bcd101",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.stroke-input.pen-tool"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/perspective-bridge.js",
+      "mode": "100644",
+      "blob": "05a175d2f3fbae88aa2154b58006c4e48e5a2c33",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.canvas-aids.perspective-guides"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/playback-cache.js",
+      "mode": "100644",
+      "blob": "6f4ed928df4df043a43fee3ebd494d8bb2f977bf",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.js-effects-and-playback.playback-bake-cache"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/project-document.js",
+      "mode": "100644",
+      "blob": "57f87e3b991074d1055b57b09858331123dfc85e",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C01.project-document.validation"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/project-entry.js",
+      "mode": "100644",
+      "blob": "3716a64cf11c167792855243839aa011cd0a9562",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C01.project-entry.repaint"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/project.js",
+      "mode": "100644",
+      "blob": "e2248533b47b0a067a61e4b641f83c7d24b00e79",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C01.project.close-unsaved-work-guard",
+        "C01.project.document-io-and-dirty-tracking",
+        "C01.project.project-tabs",
+        "C01.project.start-screen",
+        "C01.project.team-sync",
+        "C01.project.version-history"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/psd-import-bridge.js",
+      "mode": "100644",
+      "blob": "2c99c73553c322072c625e0cbdc41235ccdccb51",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.import.psd-import"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/reference-bridge.js",
+      "mode": "100644",
+      "blob": "cd3dfd6a58279027ba0173acf30176c62c25ef95",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.canvas-aids.rotoscopy-reference"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/render-manager.js",
+      "mode": "100644",
+      "blob": "a2fe1618ed6848801b097be75de54e6225d8353c",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.js-effects-and-playback.render-manager-queue"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/rig-bridge.js",
+      "mode": "100644",
+      "blob": "61be688caf9dd5587e9b1a32bb32e700f441746b",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.deform.rig-tool"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/rig-widget.js",
+      "mode": "100644",
+      "blob": "2e2627dcd1ab9f16f254e2d90307bcc980fb35fb",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.animated-primitives.rig-widget-interaction-authoring",
+        "C04b.animated-primitives.rig-widget-model-overlay"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/rive-export.js",
+      "mode": "100644",
+      "blob": "b8d5af3a93b4b9753a7af1506b913ca7d6665765",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.export.rive-mcp"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/rulers-bridge.js",
+      "mode": "100644",
+      "blob": "3d66da51f80488d749198d6becf3d71dd47840a3",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.canvas-aids.manual-rulers-guides",
+        "C04b.canvas-aids.smart-alignment-guides"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/second-viewer.js",
+      "mode": "100644",
+      "blob": "b7d6036aaf0552a2e0e236b6ce29e4838a99c42e",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.viewer-and-chrome.second-viewer"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/select-bridge.js",
+      "mode": "100644",
+      "blob": "a831eb065ed611f70a77692c61846eaddcd97a5a",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04a.select.combine-hit-confirm",
+        "C04a.select.distort",
+        "C04a.select.handle-computation",
+        "C04a.select.hover-helpers",
+        "C04a.select.multi-layer-box",
+        "C04a.select.on-context",
+        "C04a.select.on-down",
+        "C04a.select.on-move",
+        "C04a.select.on-up",
+        "C04a.select.param-shape-handles",
+        "C04a.select.public-api-init",
+        "C04a.select.role-suggestions",
+        "C04a.select.tracked-role-attach",
+        "C04a.select.tween-toggle"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/shader-effects-library.js",
+      "mode": "100644",
+      "blob": "a9eef0ec6aa09043f5d7fd64b2eec0d481175040",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C03.js-effects-and-playback.shader-effects-library",
+        "C04b.presets-and-effects.shader-table-data-1",
+        "C04b.presets-and-effects.shader-table-data-2",
+        "C04b.presets-and-effects.shader-table-data-3",
+        "C04b.presets-and-effects.shader-table-registry"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/shadow-brush-bridge.js",
+      "mode": "100644",
+      "blob": "340131eb542b170ddec5d2ad2361480443304ba1",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.paint-brush.shadow-brush"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/shape-bridge.js",
+      "mode": "100644",
+      "blob": "c5bff69e826966df63a6575833a3f75c612eb3ab",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.stroke-input.shape-tools"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/shapes-panel.js",
+      "mode": "100644",
+      "blob": "39308190c370db01aaf88226e40c40ef24e42c68",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.docked-panels.shapes-drag-reorder-engine",
+        "C04b.docked-panels.shapes-tree-render"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/storyboard.js",
+      "mode": "100644",
+      "blob": "6e78255395aadbbf84e403f95ecdc9965ca08d03",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.storyboard-mode.core"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/stroke-modeler.js",
+      "mode": "100644",
+      "blob": "0002f33a0360dda48bfb3382e1619415c2c5464a",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.brush-engine.stroke-modeler"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/subselect-bridge.js",
+      "mode": "100644",
+      "blob": "724b88e5ed81d7153e7030c6863bba6bebdcc8a4",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04a.subselect.on-down",
+        "C04a.subselect.on-move-up-init",
+        "C04a.subselect.space-mapping"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/svg-import.js",
+      "mode": "100644",
+      "blob": "9a728f1d98a35a3f84b808036ea350ef7a8d1d02",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C05.import.svg-core"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/symmetry-bridge.js",
+      "mode": "100644",
+      "blob": "cbe767c84a514cd22091955d85cd840e54337bb6",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04a.symmetry.geometry-guide",
+        "C04a.symmetry.stroke-commit",
+        "C04a.symmetry.tool-interaction"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/text-animator-panel.js",
+      "mode": "100644",
+      "blob": "78cf523365dfc10debdbfd40fcb394929651baf9",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C02.text-animation.selectors-panel",
+        "C04b.docked-panels.text-animator-panel"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/text-animator.js",
+      "mode": "100644",
+      "blob": "a3883b0006264f47e5c124685ba98f6abfcfe519",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C02.text-animation.presets",
+        "C04b.animated-primitives.text-animator"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/text-selector.js",
+      "mode": "100644",
+      "blob": "f0973e341ad024c755cb3bd2b12752a90d89dbf3",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.animated-primitives.text-selector"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/timeline-zoom.js",
+      "mode": "100644",
+      "blob": "de4847fa99f2d855e306f2b23e994d4ce4e74e8e",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.timeline-panel-support.scroll-and-zoom"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/timeline.js",
+      "mode": "100644",
+      "blob": "cc4cfd27dc59d797c911d840dc46e2f816942123",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C01.timeline.autosave-tick",
+        "C02.playback-integration.camera-markers-bpm-row-integration",
+        "C02.playback-integration.motion-shape-tree-rendering",
+        "C02.playback-integration.onion-and-tween-controls-wiring",
+        "C02.playback-integration.playback-transport",
+        "C06.bootstrap.sm-namespace-init",
+        "C06.preferences.profile-fields-ui",
+        "C06.preferences.settings-modal-shell",
+        "C06.preferences.shortcuts-system",
+        "C06.preferences.sync-folder-ui"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/tools-panel-dock.js",
+      "mode": "100644",
+      "blob": "6838d6b98d18420dc37f160e43321ab378d9a16a",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.viewer-and-chrome.tools-panel-dock"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/tools.js",
+      "mode": "100644",
+      "blob": "3c25962dbe314d5e791489da30b2b642ff899357",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04a.boolean.flatten-combine",
+        "C04a.boolean.path-operations",
+        "C04a.brush.centerline-width-profile",
+        "C04a.brush.dab-shape-presets",
+        "C04a.brush.dab-stamping",
+        "C04a.brush.pressure-vector-brush-nib",
+        "C04a.brush.stroke-profiles",
+        "C04a.brush.taper-width-helpers",
+        "C04a.brush.texture-apply-placement",
+        "C04a.brush.trim-rebuild-outline",
+        "C04a.brush.variable-width-outline",
+        "C04a.fill.auto-gap-closure",
+        "C04a.fill.closing-lines",
+        "C04a.fill.find-wasm-js-raster",
+        "C04a.fill.graph-tracer",
+        "C04a.fill.match-merge",
+        "C04a.fill.propagation-frames",
+        "C04a.fill.regenerate-linked",
+        "C04a.tools.component-element-hit-geometry",
+        "C04a.tools.core-pointer-dispatch",
+        "C04a.tools.cursor-hover-overlays",
+        "C04a.tools.double-click-dispatch-zoom",
+        "C04a.tools.dynamic-shapes",
+        "C04a.tools.fs-select-hit-promote",
+        "C04a.tools.fs-select-region-ops",
+        "C04a.tools.misc-globals",
+        "C04a.tools.node-tangent-edit",
+        "C04a.tools.pen-tool-finalize",
+        "C04a.tools.point-type-conversion",
+        "C04a.tools.selection-clone-clipboard",
+        "C04a.tools.stroke-ownership-revision",
+        "C04a.tools.stylus-pressure-edit-guard",
+        "C04a.tools.transform-box-oriented",
+        "C04a.vecerase.precision-vector-eraser"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/tracker-panel.js",
+      "mode": "100644",
+      "blob": "df375af17bae20ec0c24d5e99929bbca7168eb52",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.docked-panels.tracker-panel"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/tracker.js",
+      "mode": "100644",
+      "blob": "d24ec9819246e8bf84746a60c86f075ba4200622",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.media-misc.tracker"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/transplant.js",
+      "mode": "100644",
+      "blob": "e2b35badebe115b05eecf9ae720ff55255d0e25d",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.app-utilities.project-transplant"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/tutorial.js",
+      "mode": "100644",
+      "blob": "bd4d5df417b0a9e2c0abf32340711d35aaf2d6c4",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.tutorial-onboarding.core"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/tweens.js",
+      "mode": "100644",
+      "blob": "861d37fc02242a5eac6b71daab811979e5ab9408",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C01.tweens.undo-redo-engine",
+        "C02.tween-engine.arc-rendering-and-reassignment",
+        "C02.tween-engine.feature-extraction-and-matching",
+        "C02.tween-engine.interpolation-core",
+        "C02.tween-engine.onion-skinning",
+        "C02.tween-engine.resampling-and-nonrigid-warping",
+        "C02.tween-engine.tween-generation-and-splitting"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/ui.js",
+      "mode": "100644",
+      "blob": "57da0ec7a3b672c6e76ea4fd18ae5bedcb18de30",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.editor-shell.context-menu-system",
+        "C04b.editor-shell.detachable-panel-sections-dnd",
+        "C04b.editor-shell.easing-curve-editor",
+        "C04b.editor-shell.fill-stroke-swatch-toggles",
+        "C04b.editor-shell.panel-layout-resize-and-workspace",
+        "C04b.editor-shell.scrub-input-mechanism",
+        "C04b.editor-shell.timeline-scrub-playhead",
+        "C04b.editor-shell.tooltip-system",
+        "C04b.editor-shell.work-area-and-onion-bar-drag"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/updater-bridge.js",
+      "mode": "100644",
+      "blob": "773ccbf163e2255f9e24b51a8c4c204121143842",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.app-utilities.updater-bridge"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/vector-text-bridge.js",
+      "mode": "100644",
+      "blob": "b7ba868854db6a13b23e87f3f8d992b01777da58",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.content-tools.google-fonts-live-fetch",
+        "C04b.content-tools.vector-text-glyphs"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/vectorize-bridge.js",
+      "mode": "100644",
+      "blob": "3d1e3f817e981cdebc86919502515da64663157e",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.content-tools.vectorize-orchestration",
+        "C04b.content-tools.vectorize-shape-fitting"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/vectorize-wasm-loader.js",
+      "mode": "100644",
+      "blob": "6afbf6b59380b9ae4c3aa26048b1db8e3a9d2a6d",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.engine-readiness.vectorize-worker-bridge"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/vectorize-worker.js",
+      "mode": "100644",
+      "blob": "b43cca314183b50b3d121c1b336d935b397a79a4",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C09.engine-readiness.vectorize-worker-bridge"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/js/viewtools-bridge.js",
+      "mode": "100644",
+      "blob": "593ab148b2f7cc2a6aa1eee17c6e6c0f2cf79ac5",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C04b.canvas-aids.viewport-tools"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "src/logo-128.png",
+      "mode": "100644",
+      "blob": "07f6b7aa974aa6e6c6f69c61a39e1474bddec40d",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/logo-64.png",
+      "mode": "100644",
+      "blob": "d6fa5c53c0a8c932e6a8871f9418185d51295b91",
+      "classification": "static-data",
+      "censusRefs": [
+        "C18.vendor.static-assets"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "src/paper-full.min.js",
+      "mode": "100644",
+      "blob": "11a760c45796d402a191f1a9cf8c650130699fcb",
+      "classification": "vendor",
+      "censusRefs": [
+        "C18.vendor.vendored-js-libraries"
+      ],
+      "reason": "Bundled third-party artifact; C18/C15 and THIRD_PARTY_NOTICES.md govern provenance, not extraction."
+    },
+    {
+      "path": "src/wasm-vectorize/package.json",
+      "mode": "100644",
+      "blob": "1816fd719c45949bab901e5d1923d48f81c3e61a",
+      "classification": "generated",
+      "censusRefs": [
+        "C18.vendor.wasm-generated-bindings"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "src/wasm-vectorize/vectorize_wasm.d.ts",
+      "mode": "100644",
+      "blob": "bdba3f6316bef758e5cbfdfdf33dc76aca2b610a",
+      "classification": "generated",
+      "censusRefs": [
+        "C18.vendor.wasm-generated-bindings"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "src/wasm-vectorize/vectorize_wasm.js",
+      "mode": "100644",
+      "blob": "55731085adcef264dffe00831e0a2a6a677382b8",
+      "classification": "generated",
+      "censusRefs": [
+        "C18.vendor.wasm-generated-bindings"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "src/wasm-vectorize/vectorize_wasm_bg.wasm",
+      "mode": "100644",
+      "blob": "a9bedda65c83e005275aa3b3671ee40d0ba4cd2c",
+      "classification": "generated",
+      "censusRefs": [
+        "C18.vendor.wasm-generated-bindings"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "src/wasm-vectorize/vectorize_wasm_bg.wasm.d.ts",
+      "mode": "100644",
+      "blob": "dc7defdc4820e2513d3ecd4f78c83bdbf559c1c3",
+      "classification": "generated",
+      "censusRefs": [
+        "C18.vendor.wasm-generated-bindings"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "src/wasm/geometry_wasm.d.ts",
+      "mode": "100644",
+      "blob": "54c5d49890672ee40ee088671282a25fac39a31e",
+      "classification": "generated",
+      "censusRefs": [
+        "C18.vendor.wasm-generated-bindings"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "src/wasm/geometry_wasm.js",
+      "mode": "100644",
+      "blob": "7c52450ebf4cfccc5061430589b31a639ca35991",
+      "classification": "generated",
+      "censusRefs": [
+        "C18.vendor.wasm-generated-bindings"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "src/wasm/geometry_wasm_bg.wasm",
+      "mode": "100644",
+      "blob": "806b4996b7606cb69b5a9457f6142c5b64555a08",
+      "classification": "generated",
+      "censusRefs": [
+        "C18.vendor.wasm-generated-bindings"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "src/wasm/geometry_wasm_bg.wasm.d.ts",
+      "mode": "100644",
+      "blob": "515ca538d29e43fa9b677ab73fb948c0df71e300",
+      "classification": "generated",
+      "censusRefs": [
+        "C18.vendor.wasm-generated-bindings"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "src/wasm/package.json",
+      "mode": "100644",
+      "blob": "9c998153a604cd422ddfdd0a1477313c548852e3",
+      "classification": "generated",
+      "censusRefs": [
+        "C18.vendor.wasm-generated-bindings"
+      ],
+      "reason": "Generated bindings/schema output; provenance retained in C18/C15 and existing build metadata."
+    },
+    {
+      "path": "tests/animation/boundaries.test.cjs",
+      "mode": "100644",
+      "blob": "d3a320f07c0ff360ebc73dd64e40445541caf309",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/animation/browser-acceptance.cjs",
+      "mode": "100644",
+      "blob": "6a1af5d605a9690db7e4cc44ecdb54b8972a7d48",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/animation/curve.test.cjs",
+      "mode": "100644",
+      "blob": "6d2edb1cbfe870b84c1ce7b1f38b4e78ce073ead",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/animation/fixtures/curve-workflow.json",
+      "mode": "100644",
+      "blob": "585a88531f65f00c4630fb85e4a614a7292913ef",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/animation/load-motion.cjs",
+      "mode": "100644",
+      "blob": "9b6c277d264c8a68c156003fb63adb51c8213e1b",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/animation/motion-facade.test.cjs",
+      "mode": "100644",
+      "blob": "01033a3c630253dff65bea5ad586ccaa2af3a82f",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/application-capability-registry.test.cjs",
+      "mode": "100644",
+      "blob": "1d9d33c8c6bae22eb766a9e81d1fa65299ee41ee",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/application-opacity-bootstrap.test.cjs",
+      "mode": "100644",
+      "blob": "b4d93f0e3348464430b47b2060d50246537ebcb8",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/application-opacity-capability.test.cjs",
+      "mode": "100644",
+      "blob": "7f69fc8e110b9ac11e70f608d32834c8ead89883",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/application-opacity-replay.test.cjs",
+      "mode": "100644",
+      "blob": "fdf27ef98bfca20844ea2898a7bffa6454857809",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/application-opacity.test.cjs",
+      "mode": "100644",
+      "blob": "5f43ce7f50c48b56408d12cc9a6dd50fe0ddfefd",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/bench/BROWSER_RENDER.md",
+      "mode": "100644",
+      "blob": "4d16a683fc4d8e70c496da2cb00063b8310840c9",
+      "classification": "documentation",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "tests/bench/README.md",
+      "mode": "100644",
+      "blob": "949b7f3fa61ed8730c698b266fce272ff90a69eb",
+      "classification": "documentation",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "tests/bench/browser-render.cjs",
+      "mode": "100644",
+      "blob": "0f795ee93b54516a8fb0f3355ac7072fa1ff4e8d",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/bench/run.cjs",
+      "mode": "100644",
+      "blob": "8d535469dd90aceaeaee3a98370786b847ecdfb7",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/browser/_negative-control.spec.cjs",
+      "mode": "100644",
+      "blob": "4ad172ce7e4f8f62e7aa0c1c2ed7b6ba77a454b7",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/browser/opacity-consumers.spec.cjs",
+      "mode": "100644",
+      "blob": "3b99cd2749be88d47fca3babda664d9784572db5",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/browser/opacity-ui-consumers.spec.cjs",
+      "mode": "100644",
+      "blob": "d1dc3e6442bf6b3d7c1566627907c7995d72627d",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/browser/preview-lifecycle.cjs",
+      "mode": "100644",
+      "blob": "b45aa801caeb28eac60284587142c880208ca6d1",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/browser/preview-lifecycle.spec.cjs",
+      "mode": "100644",
+      "blob": "04f6d06a3cf1a155474e22661f5bd3ac716219fb",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/browser/r06-isolated-preview.spec.cjs",
+      "mode": "100644",
+      "blob": "27298e35c273c8a1ce92d93a339a10f7e0e4d010",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/capability-v1-schema.test.cjs",
+      "mode": "100644",
+      "blob": "82d5806e75c87cf6637b6bbf79cfeb4e05220654",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/desktop/README.md",
+      "mode": "100644",
+      "blob": "86236d5e77088f787f922831635d7a8eae5a1aed",
+      "classification": "documentation",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "tests/desktop/native-harness.cjs",
+      "mode": "100644",
+      "blob": "daebeeb44669df643c06e0ffe8fe0d5cf8565a91",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/desktop/packaged-native.test.cjs",
+      "mode": "100644",
+      "blob": "8d79d7f9ae590bff0c2f8fef48b501253d060712",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/desktop/unit/native-harness.test.cjs",
+      "mode": "100644",
+      "blob": "45a2f1471733d32a1d1eb30c1ec361d44ad000e4",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/domain-expression-random.test.cjs",
+      "mode": "100644",
+      "blob": "e98867471483a863a6ccd31119b61513a9a51c0e",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/domain-expression-time.test.cjs",
+      "mode": "100644",
+      "blob": "3f78c04f40a809e82bbb445d770ca03a9c375357",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/domain-folder-codec.test.cjs",
+      "mode": "100644",
+      "blob": "246b45b636ec974ed57885830231887a5d3feb63",
+      "classification": "test",
+      "censusRefs": [],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/domain-opacity.test.cjs",
+      "mode": "100644",
+      "blob": "c55ab04e1b47f3841ffaf7113a6cafa1dee4b1e2",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/duplicator-hue.test.cjs",
+      "mode": "100644",
+      "blob": "a9d5de2afcfc26eab78002f548131177daadb164",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/easing-reference.test.cjs",
+      "mode": "100644",
+      "blob": "4ccd360b050a8a141f449eaf24c6c4f949547b41",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/expr-bake.test.cjs",
+      "mode": "100644",
+      "blob": "58f797bc5c7b321270cca1b098b4cb552f16e145",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/feedback-2026-08-22.test.cjs",
+      "mode": "100644",
+      "blob": "27d43cf974923f039a755451d92a8622b1e1156c",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/BROWSER_ACCEPTANCE.md",
+      "mode": "100644",
+      "blob": "be3b397911ece2b95e494c3eced3bae2c82a0cdf",
+      "classification": "documentation",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "tests/fixtures/README.md",
+      "mode": "100644",
+      "blob": "adf68e2c62b22884235e831f0cf3c7c82997c7c6",
+      "classification": "documentation",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "tests/fixtures/browser-acceptance.cjs",
+      "mode": "100644",
+      "blob": "6e46461a31349f49e8972dc2e837b297174867f2",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/components/expected.json",
+      "mode": "100644",
+      "blob": "a8fbfed24cefc2e02588063d97eb2e651d82091e",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/components/project.json",
+      "mode": "100644",
+      "blob": "4c88792332922083c6ae207b06c8b87a0c768cc1",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/coverage-negative-control.cjs",
+      "mode": "100644",
+      "blob": "39c3735bc7bd6cc7a876570763df89cd0e32ef14",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/export/assets/frames/frame_0001.png",
+      "mode": "100644",
+      "blob": "6e398e576185824f2cda83ea0db1365f5849e202",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/export/assets/frames/frame_0002.png",
+      "mode": "100644",
+      "blob": "738ab9fb7c8c2be034e556c7ad9c09814642a091",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/export/assets/frames/frame_0003.png",
+      "mode": "100644",
+      "blob": "267ca2ecb97c5bb5e44135a017b998c8de64b095",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/export/assets/frames/frame_0004.png",
+      "mode": "100644",
+      "blob": "25200409c63a14eb5852ad8e087437df74f4febb",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/export/assets/frames/frame_0005.png",
+      "mode": "100644",
+      "blob": "ea8d96603b27ff50a10aeaf178bc5b5b07d46497",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/export/assets/frames/frame_0006.png",
+      "mode": "100644",
+      "blob": "1764b8acd8bda29805d4cec6c75aabae926c7b4f",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/export/assets/frames/frame_0007.png",
+      "mode": "100644",
+      "blob": "55a71917be904ed4bcbc4b149e40e5b0cf3afb3d",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/export/assets/frames/frame_0008.png",
+      "mode": "100644",
+      "blob": "8e7d20c2460b09bc196f27184310499dada8b44d",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/export/assets/frames/frame_0009.png",
+      "mode": "100644",
+      "blob": "afef1b2bd03f4accdaf6e44c01a70c8d3e4b954e",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/export/assets/frames/frame_0010.png",
+      "mode": "100644",
+      "blob": "393c7c49abeee88845eeb38acbc093b66602baaa",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/export/assets/frames/frame_0011.png",
+      "mode": "100644",
+      "blob": "0602c792fb387dcac4e5c8ec1c93bb3dabe5aadd",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/export/assets/frames/frame_0012.png",
+      "mode": "100644",
+      "blob": "425f6a9a7a141c27e124c6149c4334087cddca1c",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/export/expected.json",
+      "mode": "100644",
+      "blob": "58d31508f1cc1dc2c581a6f93007941ae4e2fc27",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/export/project.json",
+      "mode": "100644",
+      "blob": "ae964ac48168b2754cc6eedf7392e2baeaec4f47",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/expression-props/expected.json",
+      "mode": "100644",
+      "blob": "1b55b0052470b779f0c6033596b4b7353ce9a270",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/expression-props/project.json",
+      "mode": "100644",
+      "blob": "a9c98a3e7c930fbefac00c9a36b4f7f42f6257d8",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/fixtures.test.cjs",
+      "mode": "100644",
+      "blob": "66d160430b0e47855aeae74877826a8ff2a3e098",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/generate.cjs",
+      "mode": "100644",
+      "blob": "33ddb2bd0ae5a9011dd5ba999a4faee4470df626",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/held-frames/expected.json",
+      "mode": "100644",
+      "blob": "cad4e584ec5254fbd54b86c4a3a861f825fb657d",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/held-frames/project.json",
+      "mode": "100644",
+      "blob": "4f79ed070f478b0710074d6487fc625f2549bb6a",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/interaction/expected.json",
+      "mode": "100644",
+      "blob": "12b1f0771f59cf07a407d7dafa4ac22ebd387523",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/interaction/gesture.json",
+      "mode": "100644",
+      "blob": "49ce3474340f05a946a4594661fd6474ecc75574",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/interaction/project.json",
+      "mode": "100644",
+      "blob": "41ec4b4747d4dfd3316f198960487d86eeff9787",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/keyed-props/expected.json",
+      "mode": "100644",
+      "blob": "5556265fa756ad2e8b5755fdf0b992eb9cc721c8",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/keyed-props/project.json",
+      "mode": "100644",
+      "blob": "458783164c6e1d72562fa2ac900f3602c2c08397",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/lib/corpus.cjs",
+      "mode": "100644",
+      "blob": "f8d97553921b18c0a667c3c48ccce24ebef57540",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/lib/png.cjs",
+      "mode": "100644",
+      "blob": "4b3d3e9204a7498e359b4d9955c63b1ae2da88a5",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/lib/reference.cjs",
+      "mode": "100644",
+      "blob": "4ea14b136922a05a2791ab65d88b6c312444901d",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/lib/rng.cjs",
+      "mode": "100644",
+      "blob": "f54ea4e7551dbfd0fdd31a5524c4e39a387866ab",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/lib/sandbox.cjs",
+      "mode": "100644",
+      "blob": "d572f60e0e4db74174eb761df4e853f9dcb65d3e",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/lib/sandbox.test.cjs",
+      "mode": "100644",
+      "blob": "d4a6f1163337567530cadeaddd33ece7c6fb1b81",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/manifest.json",
+      "mode": "100644",
+      "blob": "2f06388ca355a1e9e576b776a0971f5d0d7c951e",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/masks-alpha/expected.json",
+      "mode": "100644",
+      "blob": "abc4c89a917ce3b094ef679246b9e58c114162e9",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/masks-alpha/project.json",
+      "mode": "100644",
+      "blob": "954cd184759e9cd1e0fd4087dfd1b6996d73cdbf",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/media/assets/embedded.png",
+      "mode": "100644",
+      "blob": "286d5a4877380ac9b503e0155059b5ac9d08862c",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/media/assets/linked.png",
+      "mode": "100644",
+      "blob": "580d5592bc6cd48b32a13d806d35c0e7fcaf498a",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/media/expected.json",
+      "mode": "100644",
+      "blob": "eee35000912af0783ec344c38ddb6190fcf28623",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/media/project.json",
+      "mode": "100644",
+      "blob": "e9b603a1aed26c04a02ecee1066fb9a5a8af4ffc",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/mesh/assets/image.png",
+      "mode": "100644",
+      "blob": "536e9a171a79a98b0409c0fd5f9713a74ea75283",
+      "classification": "static-data",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Binary/media/design fixture or static asset; identity frozen, no handwritten control logic."
+    },
+    {
+      "path": "tests/fixtures/mesh/expected.json",
+      "mode": "100644",
+      "blob": "0784ddfac29769d38d2840ca7c87e7980247796c",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/mesh/project.json",
+      "mode": "100644",
+      "blob": "3673fb218619258bac3cbc96881ea83e34491808",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/migration/expected.json",
+      "mode": "100644",
+      "blob": "42e8e00316bd45299b33d94b199e2d854e834f54",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/migration/project.json",
+      "mode": "100644",
+      "blob": "278f5b1bca2e02e8641e5c03b712bd2022fa053e",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/static-props/expected.json",
+      "mode": "100644",
+      "blob": "634d3a69f630707cd7730a334d3273b7ac3d9c9a",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/static-props/project.json",
+      "mode": "100644",
+      "blob": "faac0470aa3ce4dc6dae353de69e5d66579037f8",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/text/expected.json",
+      "mode": "100644",
+      "blob": "c4ae2a65b097809aa1b5f8ae55c67b24879a99c1",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/fixtures/text/project.json",
+      "mode": "100644",
+      "blob": "a680310e4ac7e101e6d212f424c21b6bad301255",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/integration/r06-browser-runtime.test.cjs",
+      "mode": "100644",
+      "blob": "4ed333e316e8f6547e4bee0c03400ad584779afe",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-baseline.test.cjs",
+      "mode": "100644",
+      "blob": "2092a8276db29e8870d5a962e2bf2573489a1c44",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-bench.test.cjs",
+      "mode": "100644",
+      "blob": "cc9104e408410aef3adaa39274f0c66311bcee00",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-boundaries-ratchet.test.cjs",
+      "mode": "100644",
+      "blob": "69d96bbf1cc28982f8b7f9a020323bd982d8f1ed",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-boundaries-rust.test.cjs",
+      "mode": "100644",
+      "blob": "01ed472c678b3c09e63f3f26d2907ba6707e75ad",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-boundaries.test.cjs",
+      "mode": "100644",
+      "blob": "e940f10e0fd65fa8a955ece8db7341b0508d83d5",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-browser-runtime.test.cjs",
+      "mode": "100644",
+      "blob": "98cfa0dc363d60f93cf300b3ac47ab5798d06358",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-build-job.test.cjs",
+      "mode": "100644",
+      "blob": "0bcb366e80fd61a629a67e25c59edc8d4c686d65",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-build-runtime.test.cjs",
+      "mode": "100644",
+      "blob": "59792c455945cce846b9cf78ab754663061136bd",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-ci.test.cjs",
+      "mode": "100644",
+      "blob": "6d2ce50acbe5cad722ecafd389ee6f860cc417d9",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-coverage-job.test.cjs",
+      "mode": "100644",
+      "blob": "15cb4dc546154458a968e371cfb250c3af9153ab",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-desktop-harness.test.cjs",
+      "mode": "100644",
+      "blob": "79d436483fbab7ca2e01e8e5025caddf282fe88e",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-desktop-job.test.cjs",
+      "mode": "100644",
+      "blob": "e334050cf0eacfda91d82bb404c75ffbcf450b4d",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-exclusion-provenance.test.cjs",
+      "mode": "100644",
+      "blob": "06422067acdca5909c48169d03d89531345b7b18",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-fixtures.test.cjs",
+      "mode": "100644",
+      "blob": "90849ad607d0c3dab2a125eda003d09b1a69ac66",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-inventory-records.test.cjs",
+      "mode": "100644",
+      "blob": "28c9be9096d3b440401f7c9a8d0adaad4d58e82a",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-inventory-swatch.test.cjs",
+      "mode": "100644",
+      "blob": "9ffb027651286f360057f1c98db91ad0cd175170",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-inventory.test.cjs",
+      "mode": "100644",
+      "blob": "b9399d71c581d0628ff109e6bf4335b17e4a6a1d",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-isolation.test.cjs",
+      "mode": "100644",
+      "blob": "f615efea120d2ec7054e0752027a3d63ce3e9330",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-mcp-adapter.test.cjs",
+      "mode": "100644",
+      "blob": "3723b790863947b9a51832f5de4d8d4e51b2016f",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-mcp-boundaries.test.cjs",
+      "mode": "100644",
+      "blob": "c640ada841474b590eb0f5a9b4f7132b412cfa50",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-mcp-bundle.test.cjs",
+      "mode": "100644",
+      "blob": "ada8331fcf57ceb21c542116b86108671354bbb3",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-mcp-contract-schema.test.cjs",
+      "mode": "100644",
+      "blob": "626d7f85231e41d5cb52121c3d7604ebe4a22dd9",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-native-ffmpeg-preflight.test.cjs",
+      "mode": "100644",
+      "blob": "e7b642d11df21c726ab6ab4d1327814618b9f817",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-native-runtime.test.cjs",
+      "mode": "100644",
+      "blob": "7df0f6d23a748b2b0321ecd444931027a4826de4",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/nemo-third-party-notices.test.cjs",
+      "mode": "100644",
+      "blob": "54fed2242fe84c35f2a47d5ba0102115105a6bd8",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.nemo-tooling-test-suite"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/performance-regressions.test.cjs",
+      "mode": "100644",
+      "blob": "bdf43314287d0308548b3207fa55c28c69cc82fe",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/project-entry-repaint.test.cjs",
+      "mode": "100644",
+      "blob": "5fef4f254ff4b6c35e4a4fa8d082be597f5a3391",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/project-open.test.cjs",
+      "mode": "100644",
+      "blob": "2bce7ed08a1cda2830d18b207abcd2b5fd2de658",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "tests/text-selector.test.cjs",
+      "mode": "100644",
+      "blob": "4a6b068a91440254284b5a341a4445bdc1229f88",
+      "classification": "test",
+      "censusRefs": [
+        "C13.tooling.browser-and-app-test-suites"
+      ],
+      "reason": "Test code or fixture supporting named consumer checks; not proof that those checks passed."
+    },
+    {
+      "path": "vectorize-core/Cargo.lock",
+      "mode": "100644",
+      "blob": "f1b4cf210a1090a8a3a4d06c93df8a0db3ed3d4f",
+      "classification": "configuration",
+      "censusRefs": [
+        "C17.engines.vectorize-engine-crates"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "vectorize-core/Cargo.toml",
+      "mode": "100644",
+      "blob": "a967b15e7449d9d823494a2331d2dc0a24c2786d",
+      "classification": "configuration",
+      "censusRefs": [
+        "C17.engines.vectorize-engine-crates"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "vectorize-core/src/lib.rs",
+      "mode": "100644",
+      "blob": "56b17d8dfe9d0902598be9b201a6c4dda5d261fa",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C17.engines.vectorize-engine-crates"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "vectorize-wasm/Cargo.lock",
+      "mode": "100644",
+      "blob": "f174dbb2e1cc9588852b9c5fd9d7c3b8a0b1a79f",
+      "classification": "configuration",
+      "censusRefs": [
+        "C17.engines.vectorize-engine-crates"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "vectorize-wasm/Cargo.toml",
+      "mode": "100644",
+      "blob": "75b5d5312a62d8f20114cc801f2063799949fd15",
+      "classification": "configuration",
+      "censusRefs": [
+        "C17.engines.vectorize-engine-crates"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "vectorize-wasm/src/lib.rs",
+      "mode": "100644",
+      "blob": "2faf45fd45526a8cea4e940aaeedf199c5f3c4b5",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C17.engines.vectorize-engine-crates"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "worker-feedback/README.md",
+      "mode": "100644",
+      "blob": "9fd55db7b5f4131d06f942962eaaf94027ff495d",
+      "classification": "documentation",
+      "censusRefs": [
+        "C15.native.feedback-worker-service"
+      ],
+      "reason": "Tracked prose/license reference; not executable runtime or tooling."
+    },
+    {
+      "path": "worker-feedback/src/index.js",
+      "mode": "100644",
+      "blob": "1be49a96a68656d658ed5578a497459bfc2fe922",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C15.native.feedback-worker-service"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "worker-feedback/wrangler.jsonc",
+      "mode": "100644",
+      "blob": "5552f1d25988bf7b9a98c8c98cc62a3440af713e",
+      "classification": "configuration",
+      "censusRefs": [
+        "C15.native.feedback-worker-service"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    },
+    {
+      "path": "worker/index.js",
+      "mode": "100644",
+      "blob": "440c98597ef37a4b485aace5de45ffd3a88dec2e",
+      "classification": "handwritten-runtime",
+      "censusRefs": [
+        "C15.native.web-deploy-worker"
+      ],
+      "reason": "Tracked handwritten runtime/presentation/shader source; inclusion does not establish a complete responsibility map."
+    },
+    {
+      "path": "wrangler.jsonc",
+      "mode": "100644",
+      "blob": "4a31b78da943b1d6dc745657d5477cbddba5b1c2",
+      "classification": "configuration",
+      "censusRefs": [
+        "C13.tooling.ci-workflows-and-root-config",
+        "C15.native.web-deploy-worker"
+      ],
+      "reason": "Tracked configuration, schema, lock or metadata consumer; retained explicitly rather than excluded as documentation."
+    }
+  ]
+}

--- a/engineering/remediation/EXECUTION_PLAN.en.md
+++ b/engineering/remediation/EXECUTION_PLAN.en.md
@@ -354,6 +354,8 @@ The initial board contains **59 leaves: 33 owned by Ilya and 26 by Cyrill**. The
 
   Limit: Do not confuse 902 inventory rows with 902 separate capabilities, or classify every large data table as a code monolith.
 
+  Admission is split before implementation: [P03A / #1116](https://github.com/mysteropodes/nemo/issues/1116) freezes the source index and rejects false completeness claims. [Index contract](../inventory/REMEDIATION_SCOPE.md). P03 remains open for bounded timeline/Motion gap mapping and linked extraction-leaf admission; pending packet references are not Ready tasks.
+
 - [x] **[F01 / #1047](https://github.com/mysteropodes/nemo/issues/1047) — Review the existing Honey installed-package evidence**
 
   Owner **Cyrill/O** · skill `validation` · `opus` / **high**. Predecessors: none; claim the file/runtime slot.

--- a/engineering/remediation/EXECUTION_PLAN.fr.md
+++ b/engineering/remediation/EXECUTION_PLAN.fr.md
@@ -350,6 +350,8 @@ Le tableau initial contient **59 tâches élémentaires : 33 sous la responsabil
 
   Limite : Ne pas confondre les 902 lignes d’inventaire avec 902 capacités distinctes, ni classer chaque grande table de données comme monolithe de code.
 
+  Admission découpée avant implémentation : [P03A / #1116](https://github.com/mysteropodes/nemo/issues/1116) fige l’index source et rejette les déclarations de complétude non prouvées. [Contrat de l’index](../inventory/REMEDIATION_SCOPE.md). P03 reste ouvert pour la cartographie bornée des lacunes timeline/Motion et l’admission des feuilles d’extraction liées ; les références de paquets en attente ne sont pas des tâches Ready.
+
 - [ ] **[F01 / #1047](https://github.com/mysteropodes/nemo/issues/1047) — Examiner les preuves existantes de Honey sur le paquet installé**
 
   Responsable **Cyrill/O** · compétence `validation` · `opus` / **high**. Prédécesseurs : aucun ; réserver les fichiers et l’environnement d’exécution.

--- a/scripts/nemo/ci.test.cjs
+++ b/scripts/nemo/ci.test.cjs
@@ -71,11 +71,9 @@ test('tooling coverage profiles every current scripts/nemo CommonJS source', () 
   const profile = JSON.parse(fs.readFileSync(path.join(ROOT, ci.PROFILE), 'utf8'));
   const result = ci.toolingCoverage(profile, ROOT);
   assert.equal(result.ok, true);
-  // 55 + T04's four Rust-coverage sources + T02's lib/baseline-verdicts.cjs.
-  // Neither side of this rebase conflict was right alone: 59 drops T02's new
-  // module, 56 drops T04's four.
-  assert.equal(result.sourcePathCount, 60);
-  assert.equal(result.declaredPathCount, 60);
+  // 60 retained tooling sources plus P03A's frozen-census checker.
+  assert.equal(result.sourcePathCount, 61);
+  assert.equal(result.declaredPathCount, 61);
   const incomplete = structuredClone(profile);
   incomplete.modules = incomplete.modules.filter((module) => module.id !== 'nemo.lib.boundariesApplication');
   const rejected = ci.toolingCoverage(incomplete, ROOT);

--- a/scripts/nemo/remediation-scope.cjs
+++ b/scripts/nemo/remediation-scope.cjs
@@ -1,0 +1,138 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { execFileSync } = require('node:child_process');
+
+const INDEX = 'engineering/inventory/remediation-scope.json';
+const CLASSIFICATIONS = new Set([
+  'handwritten-runtime', 'handwritten-tooling', 'test', 'configuration',
+  'documentation', 'vendor', 'generated', 'static-data',
+]);
+const EXCLUSIONS = new Set(['documentation', 'vendor', 'generated', 'static-data']);
+
+function digest(entries) {
+  const rows = entries.map(({ mode, blob, path: name }) => `${mode} ${blob} ${name}\n`);
+  return crypto.createHash('sha256').update(rows.join('')).digest('hex');
+}
+
+function trackedSource(root, commit) {
+  if (!/^[0-9a-f]{40}$/.test(commit)) throw new Error('source commit must be a full Git SHA');
+  const output = execFileSync('git', ['ls-tree', '-rz', '--full-tree', commit], { cwd: root });
+  return output.toString('utf8').split('\0').filter(Boolean).map((record) => {
+    const match = /^(\d{6}) (\w+) ([0-9a-f]{40})\t(.+)$/.exec(record);
+    if (!match || match[2] !== 'blob') throw new Error('unsupported source tree entry');
+    return { mode: match[1], blob: match[3], path: match[4] };
+  }).sort((a, b) => a.path < b.path ? -1 : a.path > b.path ? 1 : 0);
+}
+
+function verifyScope(scope, source, censuses) {
+  const errors = [];
+  const check = (ok, message) => { if (!ok) errors.push(message); };
+  check(scope.schema === 'nemo.remediation-scope/1', 'unsupported scope schema');
+  check(scope.complete === false, 'completeness must remain false until P03 admission is implemented');
+  check(scope.source?.fileCount === source.length, 'source count mismatch');
+  check(scope.source?.sha256 === digest(source), 'source digest mismatch');
+  const actual = new Map(source.map((entry) => [entry.path, entry]));
+  const packets = new Map();
+  const censusIds = new Set();
+  const expectedGaps = new Map();
+  for (const census of censuses) {
+    const { document, path: filename, blob } = census;
+    const id = document.census_id;
+    check(!censusIds.has(id), `duplicate census ${id}`);
+    censusIds.add(id);
+    const pin = scope.censuses?.find((entry) => entry.id === id);
+    check(pin?.path === filename && pin?.blob === blob
+      && pin?.sourceCommit === document.source_sha, `census pin mismatch: ${id}`);
+    for (const area of document.areas || []) {
+      // Supplements replace C08's preliminary packets; its documentation map remains.
+      if (id === 'C08' && area.area !== 'documentation-and-process') continue;
+      for (const packet of area.packets || []) {
+        check(!packets.has(packet.id), `duplicate packet ${packet.id}`);
+        packets.set(packet.id, id);
+      }
+    }
+    for (const [index, note] of (document.uncovered_responsibilities || []).entries()) {
+      expectedGaps.set(`${id}:${index + 1}`, note);
+    }
+  }
+  check(scope.censuses?.length === censusIds.size, 'census set mismatch');
+  const seen = new Set();
+  const counts = {};
+  let previous = '';
+  const unmapped = [];
+  for (const entry of scope.files || []) {
+    check(typeof entry.path === 'string' && entry.path > previous, `paths not unique/sorted: ${entry.path}`);
+    previous = entry.path;
+    check(!seen.has(entry.path), `duplicate source path: ${entry.path}`);
+    seen.add(entry.path);
+    const original = actual.get(entry.path);
+    check(original?.blob === entry.blob && original?.mode === entry.mode, `source identity mismatch: ${entry.path}`);
+    check(CLASSIFICATIONS.has(entry.classification), `invalid classification: ${entry.path}`);
+    check(typeof entry.reason === 'string' && entry.reason.trim().length > 0, `missing classification reason: ${entry.path}`);
+    check(Array.isArray(entry.censusRefs), `missing census references: ${entry.path}`);
+    for (const ref of entry.censusRefs || []) check(packets.has(ref), `unknown census packet: ${ref}`);
+    if (!EXCLUSIONS.has(entry.classification) && !entry.censusRefs?.length) unmapped.push(entry.path);
+    counts[entry.classification] = (counts[entry.classification] || 0) + 1;
+  }
+  for (const name of actual.keys()) check(seen.has(name), `missing source path: ${name}`);
+  check(seen.size === actual.size, 'indexed source count mismatch');
+  check(JSON.stringify(Object.entries(counts).sort()) === JSON.stringify(Object.entries(scope.counts || {}).sort()), 'classification counts mismatch');
+  const listedPackets = scope.packets || [];
+  check(listedPackets.length === packets.size, 'packet count mismatch');
+  const packetIds = new Set();
+  for (const packet of listedPackets) {
+    check(!packetIds.has(packet.id), `duplicate indexed packet: ${packet.id}`);
+    packetIds.add(packet.id);
+    check(packets.get(packet.id) === packet.census, `packet provenance mismatch: ${packet.id}`);
+    check(packet.admission === 'pending', `unsupported admission claim: ${packet.id}`);
+  }
+  const gaps = scope.uncoveredResponsibilities || [];
+  check(gaps.length === expectedGaps.size, 'uncovered responsibility count mismatch');
+  const gapIds = new Set();
+  for (const gap of gaps) {
+    check(!gapIds.has(gap.id), `duplicate uncovered responsibility: ${gap.id}`);
+    gapIds.add(gap.id);
+    check(expectedGaps.get(gap.id) === gap.note, `uncovered responsibility changed: ${gap.id}`);
+    check(gap.disposition === 'needs-reconciliation', `unsupported gap disposition: ${gap.id}`);
+  }
+  return {
+    integrity: errors.length ? 'fail' : 'pass', complete: false, errors,
+    sourceFiles: source.length, indexedFiles: seen.size, counts,
+    pendingPackets: packets.size, unreconciledResponsibilities: expectedGaps.size, unmapped,
+  };
+}
+
+function inspect(root, scope, sourceCommit = scope.source?.commit) {
+  const source = trackedSource(root, sourceCommit);
+  const pins = trackedSource(root, scope.source?.commit);
+  const censuses = pins.filter((entry) => /^engineering\/inventory\/census\/[^/]+\.json$/.test(entry.path))
+    .map((entry) => ({ ...entry, document: JSON.parse(execFileSync('git',
+      ['show', `${scope.source.commit}:${entry.path}`], { cwd: root, encoding: 'utf8' })) }));
+  return verifyScope(scope, source, censuses);
+}
+
+function main(args = process.argv.slice(2), root = path.resolve(__dirname, '../..')) {
+  try {
+    const integrityOnly = args.includes('--integrity-only');
+    const sourceIndex = args.indexOf('--source');
+    const sourceCommit = sourceIndex < 0 ? undefined : args[sourceIndex + 1];
+    const allowed = integrityOnly ? ['--integrity-only'] : [];
+    if (sourceIndex >= 0) allowed.push('--source', sourceCommit);
+    if (args.length !== allowed.length || args.some((arg) => !allowed.includes(arg))) {
+      throw new Error('usage: remediation-scope.cjs [--integrity-only] [--source FULL_SHA]');
+    }
+    const scope = JSON.parse(fs.readFileSync(path.join(root, INDEX), 'utf8'));
+    const result = inspect(root, scope, sourceCommit);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return result.integrity === 'pass' && (integrityOnly || result.complete) ? 0 : 1;
+  } catch (error) {
+    process.stderr.write(`remediation scope check failed: ${error.message}\n`);
+    return 1;
+  }
+}
+
+if (require.main === module) process.exitCode = main();
+module.exports = { digest, trackedSource, verifyScope, inspect, main };

--- a/tests/nemo-remediation-scope.test.cjs
+++ b/tests/nemo-remediation-scope.test.cjs
@@ -1,0 +1,156 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync, spawnSync } = require('node:child_process');
+const checker = require('../scripts/nemo/remediation-scope.cjs');
+
+const commit = 'a'.repeat(40);
+const source = [
+  { path: 'README.md', mode: '100644', blob: '1'.repeat(40) },
+  { path: 'src/main.js', mode: '100644', blob: '2'.repeat(40) },
+];
+const census = {
+  path: 'engineering/inventory/census/C01.json', blob: '3'.repeat(40),
+  document: { census_id: 'C01', source_sha: commit,
+    areas: [{ area: 'runtime', packets: [{ id: 'C01.main' }] }],
+    uncovered_responsibilities: ['A real unresolved consumer'],
+  },
+};
+function manifest() {
+  return {
+    schema: 'nemo.remediation-scope/1', complete: false,
+    source: { commit, fileCount: 2, sha256: checker.digest(source) },
+    censuses: [{ id: 'C01', path: census.path, blob: census.blob, sourceCommit: commit }],
+    packets: [{ id: 'C01.main', census: 'C01', admission: 'pending' }],
+    uncoveredResponsibilities: [{ id: 'C01:1', note: 'A real unresolved consumer', disposition: 'needs-reconciliation' }],
+    counts: { documentation: 1, 'handwritten-runtime': 1 },
+    files: source.map((entry, index) => ({ ...entry,
+      classification: index ? 'handwritten-runtime' : 'documentation',
+      censusRefs: index ? ['C01.main'] : [], reason: index ? 'Executable source' : 'Prose',
+    })),
+  };
+}
+function verify(scope = manifest(), entries = source, partitions = [census]) {
+  return checker.verifyScope(scope, entries, partitions);
+}
+
+test('frozen integrity is separate from unresolved responsibility/packet acceptance', () => {
+  const result = verify();
+  assert.equal(result.integrity, 'pass');
+  assert.equal(result.complete, false);
+  assert.equal(result.pendingPackets, 1);
+  assert.equal(result.unreconciledResponsibilities, 1);
+  assert.deepEqual(result.unmapped, []);
+  const scope = manifest(); scope.files[1].censusRefs = [];
+  assert.deepEqual(verify(scope).unmapped, ['src/main.js']);
+});
+
+test('independent digest covers ordering, path, mode and blob identity', () => {
+  assert.equal(checker.digest(source), '2489be4ffbf9ce6bb4b53ed4a44c367ad332fcba29dadaea289f3dca41e6ab64');
+  for (const key of ['path', 'mode', 'blob']) {
+    const changed = structuredClone(source); changed[1][key] += 'x';
+    assert.notEqual(checker.digest(changed), checker.digest(source));
+  }
+  assert.notEqual(checker.digest([...source].reverse()), checker.digest(source));
+});
+
+const corruptions = {
+  'missing file': (x) => x.files.pop(),
+  'duplicate file': (x) => x.files.push(x.files[1]),
+  'extra file': (x) => x.files.push({ ...x.files[1], path: 'src/unaccounted.js' }),
+  'unsorted paths': (x) => x.files.reverse(),
+  'changed content': (x) => { x.files[1].blob = '9'.repeat(40); },
+  'changed mode': (x) => { x.files[1].mode = '100755'; },
+  'changed count': (x) => { x.source.fileCount++; },
+  'changed digest': (x) => { x.source.sha256 = '0'.repeat(64); },
+  'changed classification count': (x) => { x.counts.documentation++; },
+  'unknown classification': (x) => { x.files[1].classification = 'trust-me'; },
+  'missing rationale': (x) => { delete x.files[1].reason; },
+  'missing references': (x) => { delete x.files[1].censusRefs; },
+  'invented packet': (x) => { x.files[1].censusRefs = ['fake']; },
+  'missing census': (x) => { x.censuses = []; },
+  'duplicate census pin': (x) => x.censuses.push(x.censuses[0]),
+  'changed census pin': (x) => { x.censuses[0].blob = '4'.repeat(40); },
+  'changed census source': (x) => { x.censuses[0].sourceCommit = '5'.repeat(40); },
+  'missing packet': (x) => { x.packets = []; },
+  'duplicate packet': (x) => x.packets.push(x.packets[0]),
+  'changed packet provenance': (x) => { x.packets[0].census = 'C09'; },
+  'unreviewed admission': (x) => { x.packets[0].admission = 'accepted'; },
+  'missing gap': (x) => { x.uncoveredResponsibilities = []; },
+  'duplicate gap': (x) => x.uncoveredResponsibilities.push(x.uncoveredResponsibilities[0]),
+  'changed gap': (x) => { x.uncoveredResponsibilities[0].note = 'silently repaired'; },
+  'unreviewed gap closure': (x) => { x.uncoveredResponsibilities[0].disposition = 'resolved'; },
+  'false complete': (x) => { x.complete = true; },
+  'unknown schema': (x) => { x.schema = 'future'; },
+};
+for (const [name, corrupt] of Object.entries(corruptions)) {
+  test(`rejects ${name}`, () => {
+    const scope = manifest(); corrupt(scope);
+    const result = verify(scope);
+    assert.equal(result.integrity, 'fail');
+    assert.equal(result.complete, false);
+    assert.ok(result.errors.length > 0);
+  });
+}
+
+test('candidate additions, deletions and byte changes cannot reuse the frozen pass', () => {
+  assert.equal(verify(manifest(), [...source, { ...source[1], path: 'src/added.js' }]).integrity, 'fail');
+  assert.equal(verify(manifest(), [source[0]]).integrity, 'fail');
+  assert.equal(verify(manifest(), [source[0], { ...source[1], blob: '0'.repeat(40) }]).integrity, 'fail');
+});
+
+test('C08 documentation references survive while supplemental drafts do not count twice', () => {
+  const c08 = structuredClone(census); c08.document.census_id = 'C08';
+  c08.document.areas = [
+    { area: 'remaining-browser-modules', packets: [{ id: 'C08.superseded' }] },
+    { area: 'documentation-and-process', packets: [{ id: 'C08.docs' }] },
+  ];
+  c08.document.uncovered_responsibilities = [];
+  const scope = manifest();
+  scope.censuses.push({ id: 'C08', path: c08.path, blob: c08.blob, sourceCommit: commit });
+  scope.packets.push({ id: 'C08.docs', census: 'C08', admission: 'pending' });
+  assert.equal(verify(scope, source, [census, c08]).integrity, 'pass');
+  assert.equal(verify(scope, source, [census, census]).integrity, 'fail');
+});
+
+test('real Git/CLI checks fixed source and rejects changed candidates and malformed input', (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nemo-scope-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const git = (...args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+  git('init', '--quiet');
+  fs.mkdirSync(path.join(root, 'engineering/inventory/census'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'src/main.js'), 'module.exports = 7;\n');
+  fs.writeFileSync(path.join(root, census.path), JSON.stringify(census.document));
+  git('add', '.');
+  git('-c', 'user.name=Fixture', '-c', 'user.email=fixture@example.invalid', 'commit', '--quiet', '-m', 'fixture');
+  const sha = git('rev-parse', 'HEAD');
+  const entries = checker.trackedSource(root, sha);
+  const scope = manifest();
+  scope.source = { commit: sha, fileCount: entries.length, sha256: checker.digest(entries) };
+  scope.censuses[0].blob = entries[0].blob;
+  scope.files = entries.map((entry, i) => ({ ...entry, classification: i ? 'handwritten-runtime' : 'documentation', censusRefs: i ? ['C01.main'] : [], reason: 'fixture' }));
+  fs.writeFileSync(path.join(root, 'engineering/inventory/remediation-scope.json'), JSON.stringify(scope));
+  assert.equal(checker.inspect(root, scope).integrity, 'pass');
+  const run = (args) => spawnSync(process.execPath, ['-e',
+    `process.exitCode = require(${JSON.stringify(require.resolve('../scripts/nemo/remediation-scope.cjs'))}).main(JSON.parse(process.argv[1]), process.argv[2]);`,
+    JSON.stringify(args), root], { encoding: 'utf8' });
+  assert.equal(run(['--integrity-only']).status, 0);
+  assert.equal(run([]).status, 1);
+  for (const args of [['--bad'], ['--source'], ['--source', 'HEAD'], ['--integrity-only', '--integrity-only']]) {
+    assert.equal(run(args).status, 1);
+  }
+  fs.writeFileSync(path.join(root, 'src/added.js'), 'module.exports = 9;\n');
+  git('add', 'src/added.js');
+  git('-c', 'user.name=Fixture', '-c', 'user.email=fixture@example.invalid', 'commit', '--quiet', '-m', 'added');
+  const candidate = git('rev-parse', 'HEAD');
+  const result = run(['--integrity-only', '--source', candidate]);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /missing source path: src\/added.js/);
+  assert.throws(() => checker.trackedSource(root, '--help'), /full Git SHA/);
+  fs.writeFileSync(path.join(root, 'engineering/inventory/remediation-scope.json'), '{');
+  assert.equal(run([]).status, 1);
+});


### PR DESCRIPTION
P03's accepted census still contains unresolved responsibilities and unadmitted packet groups. This freezes all 657 tracked paths at `59a5a38`, pins the census inputs, and preserves 329 packet references plus18 historical gap notes without claiming the extraction queue is complete.

The repository checker separates frozen-index integrity from completeness. Negative controls reject missing/duplicate paths, changed bytes/modes, stale census pins, dropped gaps and invented acceptance. `--integrity-only` passes the frozen source; the default completeness gate intentionally fails pending P03 admission. EN/FR plan links identify this bounded split. The existing tooling-count regression includes the new checker (61 sources).

Validation at `c21569e429fa56d9410d64c765fb6c703e662e72`: independent Terra/medium technical review clean; normal local verify5/5 jobs pass (doctor,check,inventory,772 Node passes/2 skipped,15 Rust passes); focused scope+CI74/74; new checker coverage100%lines/83.82%branches/100%functions; tooling boundary/size ratchet passes. The baseline comparator remains informationally inconclusive because its adopted source differs. An earlier full run's native source-identity mismatch did not recur in targeted base/candidate checks or the final full verification; its original receipt is retained in the issue.

No runtime behavior changed. Browser/native acceptance and final remediation gates remain outside this repository-only leaf. No hosted product CI or release.

Closes #1116. P03/#1005 remains open for bounded gap mapping and executable-leaf admission.
